### PR TITLE
feat: Full DB schema — 7 models + enums

### DIFF
--- a/api/prisma/migrations/20260401000000_init_full_schema/migration.sql
+++ b/api/prisma/migrations/20260401000000_init_full_schema/migration.sql
@@ -1,0 +1,147 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('CLIENT', 'SPECIALIST');
+
+-- CreateEnum
+CREATE TYPE "RequestStatus" AS ENUM ('OPEN', 'CLOSED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "PromotionTier" AS ENUM ('BASIC', 'FEATURED', 'TOP');
+
+-- DropIndex
+DROP INDEX "otp_codes_email_key";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'CLIENT';
+
+-- CreateTable
+CREATE TABLE "specialist_profiles" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "nick" TEXT NOT NULL,
+    "cities" TEXT[],
+    "services" TEXT[],
+    "badges" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "specialist_profiles_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "requests" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "status" "RequestStatus" NOT NULL DEFAULT 'OPEN',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "responses" (
+    "id" TEXT NOT NULL,
+    "specialistId" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "responses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "threads" (
+    "id" TEXT NOT NULL,
+    "participant1Id" TEXT NOT NULL,
+    "participant2Id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "threads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "messages" (
+    "id" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "promotions" (
+    "id" TEXT NOT NULL,
+    "specialistId" TEXT NOT NULL,
+    "city" TEXT NOT NULL,
+    "tier" "PromotionTier" NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "promotions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "specialist_profiles_userId_key" ON "specialist_profiles"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "specialist_profiles_nick_key" ON "specialist_profiles"("nick");
+
+-- CreateIndex
+CREATE INDEX "requests_clientId_idx" ON "requests"("clientId");
+
+-- CreateIndex
+CREATE INDEX "requests_city_status_idx" ON "requests"("city", "status");
+
+-- CreateIndex
+CREATE INDEX "responses_requestId_idx" ON "responses"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "responses_specialistId_requestId_key" ON "responses"("specialistId", "requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "threads_participant1Id_participant2Id_key" ON "threads"("participant1Id", "participant2Id");
+
+-- CreateIndex
+CREATE INDEX "messages_threadId_idx" ON "messages"("threadId");
+
+-- CreateIndex
+CREATE INDEX "promotions_city_tier_expiresAt_idx" ON "promotions"("city", "tier", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "promotions_specialistId_idx" ON "promotions"("specialistId");
+
+-- CreateIndex
+CREATE INDEX "otp_codes_email_idx" ON "otp_codes"("email");
+
+-- AddForeignKey
+ALTER TABLE "specialist_profiles" ADD CONSTRAINT "specialist_profiles_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "requests" ADD CONSTRAINT "requests_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "responses" ADD CONSTRAINT "responses_specialistId_fkey" FOREIGN KEY ("specialistId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "responses" ADD CONSTRAINT "responses_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "requests"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_participant1Id_fkey" FOREIGN KEY ("participant1Id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_participant2Id_fkey" FOREIGN KEY ("participant2Id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "threads"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "promotions" ADD CONSTRAINT "promotions_specialistId_fkey" FOREIGN KEY ("specialistId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,25 +7,144 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  CLIENT
+  SPECIALIST
+}
+
+enum RequestStatus {
+  OPEN
+  CLOSED
+  CANCELLED
+}
+
+enum PromotionTier {
+  BASIC
+  FEATURED
+  TOP
+}
+
 model User {
   id          String    @id @default(cuid())
   email       String    @unique
+  role        Role      @default(CLIENT)
   createdAt   DateTime  @default(now())
   lastLoginAt DateTime?
-  messages    ChatMessage[]
+
+  // legacy chat (preserved for ChatGateway until task #1530)
+  chatMessages        ChatMessage[]
+
+  // new relations
+  specialistProfile   SpecialistProfile?
+  requests            Request[]
+  responses           Response[]
+  promotions          Promotion[]
+  threadsAsParticipant1 Thread[]        @relation("ThreadParticipant1")
+  threadsAsParticipant2 Thread[]        @relation("ThreadParticipant2")
+  sentMessages        Message[]
 
   @@map("users")
 }
 
 model OtpCode {
   id        String    @id @default(cuid())
-  email     String    @unique
+  email     String
   code      String
   expiresAt DateTime
   usedAt    DateTime?
   createdAt DateTime  @default(now())
 
+  @@index([email])
   @@map("otp_codes")
+}
+
+model SpecialistProfile {
+  id       String   @id @default(cuid())
+  userId   String   @unique
+  user     User     @relation(fields: [userId], references: [id])
+  nick     String   @unique
+  cities   String[]
+  services String[]
+  badges   String[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("specialist_profiles")
+}
+
+model Request {
+  id          String        @id @default(cuid())
+  clientId    String
+  client      User          @relation(fields: [clientId], references: [id])
+  description String
+  city        String
+  status      RequestStatus @default(OPEN)
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  responses   Response[]
+
+  @@index([clientId])
+  @@index([city, status])
+  @@map("requests")
+}
+
+model Response {
+  id           String   @id @default(cuid())
+  specialistId String
+  specialist   User     @relation(fields: [specialistId], references: [id])
+  requestId    String
+  request      Request  @relation(fields: [requestId], references: [id])
+  message      String
+  createdAt    DateTime @default(now())
+
+  @@unique([specialistId, requestId])
+  @@index([requestId])
+  @@map("responses")
+}
+
+model Thread {
+  id             String   @id @default(cuid())
+  participant1Id String
+  participant1   User     @relation("ThreadParticipant1", fields: [participant1Id], references: [id])
+  participant2Id String
+  participant2   User     @relation("ThreadParticipant2", fields: [participant2Id], references: [id])
+  createdAt      DateTime @default(now())
+
+  messages       Message[]
+
+  // participant1Id < participant2Id enforced at application level
+  @@unique([participant1Id, participant2Id])
+  @@map("threads")
+}
+
+model Message {
+  id        String    @id @default(cuid())
+  threadId  String
+  thread    Thread    @relation(fields: [threadId], references: [id])
+  senderId  String
+  sender    User      @relation(fields: [senderId], references: [id])
+  content   String
+  readAt    DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([threadId])
+  @@map("messages")
+}
+
+model Promotion {
+  id           String        @id @default(cuid())
+  specialistId String
+  specialist   User          @relation(fields: [specialistId], references: [id])
+  city         String
+  tier         PromotionTier
+  expiresAt    DateTime
+  createdAt    DateTime      @default(now())
+
+  @@index([city, tier, expiresAt])
+  @@index([specialistId])
+  @@map("promotions")
 }
 
 model ChatMessage {

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -28,11 +28,9 @@ export class AuthService {
 
     otpStore.set(email.toLowerCase(), { code, expiresAt });
 
-    // Store OTP in DB for audit (upsert)
-    await this.prisma.otpCode.upsert({
-      where: { email: email.toLowerCase() },
-      create: { email: email.toLowerCase(), code, expiresAt },
-      update: { code, expiresAt, usedAt: null },
+    // Store OTP in DB for audit (create new record per request)
+    await this.prisma.otpCode.create({
+      data: { email: email.toLowerCase(), code, expiresAt },
     });
 
     // In dev mode: log code to console. In prod: send email (implement later)
@@ -60,11 +58,17 @@ export class AuthService {
       throw new UnauthorizedException('Invalid OTP');
     }
 
-    // Mark used in DB
-    await this.prisma.otpCode.update({
-      where: { email: normalizedEmail },
-      data: { usedAt: new Date() },
+    // Mark used in DB — find latest unused OTP for this email
+    const otpRecord = await this.prisma.otpCode.findFirst({
+      where: { email: normalizedEmail, usedAt: null },
+      orderBy: { createdAt: 'desc' },
     });
+    if (otpRecord) {
+      await this.prisma.otpCode.update({
+        where: { id: otpRecord.id },
+        data: { usedAt: new Date() },
+      });
+    }
 
     otpStore.delete(normalizedEmail);
 


### PR DESCRIPTION
## Summary
- Adds 7 new models: SpecialistProfile, Request, Response, Thread, Message, Promotion
- Adds 3 enums: Role (CLIENT/SPECIALIST), RequestStatus (OPEN/CLOSED/CANCELLED), PromotionTier (BASIC/FEATURED/TOP)
- OtpCode: removed `@unique` from email field (allows multiple OTPs per email), added `@@index([email])`
- User: added `role Role @default(CLIENT)` field + all new relations
- ChatMessage preserved unchanged for ChatGateway (task #1530)
- auth.service.ts: replaced `upsert/update` by email with `create` + `findFirst+update` by id (required after OtpCode unique removal)
- Migration file: `api/prisma/migrations/20260401000000_init_full_schema/migration.sql`

## Test plan
- [ ] CI runs `prisma migrate deploy` successfully on staging DB
- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `psql \dt` shows: users, otp_codes, specialist_profiles, requests, responses, threads, messages, promotions, chat_messages
- [ ] `GET /api/health` returns 200

Closes #1520