### PR TITLE
feat: Auth OTP+Roles — verify with role param, JWT refresh, RolesGuard

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Post, Body } from '@nestjs/common';
-import { IsEmail, IsString, Length } from 'class-validator';
+import { IsEmail, IsString, Length, IsOptional, IsIn } from 'class-validator';
 import { AuthService } from './auth.service';
 
 class RequestOtpDto {
@@ -14,6 +14,15 @@ class VerifyOtpDto {
   @IsString()
   @Length(6, 6)
   code!: string;
+
+  @IsOptional()
+  @IsIn(['client', 'specialist'])
+  role?: string;
+}
+
+class RefreshDto {
+  @IsString()
+  refreshToken!: string;
 }
 
 @Controller('auth')
@@ -27,6 +36,11 @@ export class AuthController {
 
   @Post('verify-otp')
   verifyOtp(@Body() body: VerifyOtpDto) {
-    return this.authService.verifyOtp(body.email, body.code);
+    return this.authService.verifyOtp(body.email, body.code, body.role);
+  }
+
+  @Post('refresh')
+  refresh(@Body() body: RefreshDto) {
+    return this.authService.refresh(body.refreshToken);
   }
 }

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -9,8 +9,8 @@ import { JwtStrategy } from './jwt.strategy';
   imports: [
     PassportModule,
     JwtModule.register({
+      // No global expiresIn — each jwt.sign call specifies its own expiry
       secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
-      signOptions: { expiresIn: '7d' },
     }),
   ],
   controllers: [AuthController],

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
+import { Role } from '@prisma/client';
 
 // In-memory OTP store: email -> { code, expiresAt }
 const otpStore = new Map<string, { code: string; expiresAt: Date }>();
@@ -15,12 +16,37 @@ function generateOtp(): string {
   return String(Math.floor(100000 + Math.random() * 900000));
 }
 
+function mapRole(role?: string): Role {
+  if (role === 'specialist') return Role.SPECIALIST;
+  return Role.CLIENT;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
 @Injectable()
 export class AuthService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwt: JwtService,
   ) {}
+
+  private generateTokens(user: { id: string; email: string; role: Role }): TokenPair {
+    const accessToken = this.jwt.sign(
+      { sub: user.id, email: user.email, role: user.role },
+      { expiresIn: '15m' },
+    );
+    const refreshToken = this.jwt.sign(
+      { sub: user.id },
+      {
+        secret: (process.env.JWT_SECRET ?? 'dev-secret-change-in-prod') + '-refresh',
+        expiresIn: '30d',
+      },
+    );
+    return { accessToken, refreshToken };
+  }
 
   async requestOtp(email: string): Promise<{ message: string }> {
     const code = generateOtp();
@@ -41,7 +67,7 @@ export class AuthService {
     return { message: 'OTP sent to email' };
   }
 
-  async verifyOtp(email: string, code: string): Promise<{ token: string }> {
+  async verifyOtp(email: string, code: string, role?: string): Promise<TokenPair> {
     const normalizedEmail = email.toLowerCase();
     const record = otpStore.get(normalizedEmail);
 
@@ -72,14 +98,38 @@ export class AuthService {
 
     otpStore.delete(normalizedEmail);
 
-    // Upsert user
+    // Check if user already exists to preserve existing role
+    const existingUser = await this.prisma.user.findUnique({
+      where: { email: normalizedEmail },
+    });
+
+    // Assign role only on first login; subsequent logins preserve existing role
+    const assignedRole = existingUser ? existingUser.role : mapRole(role);
+
     const user = await this.prisma.user.upsert({
       where: { email: normalizedEmail },
-      create: { email: normalizedEmail },
+      create: { email: normalizedEmail, role: assignedRole },
       update: { lastLoginAt: new Date() },
     });
 
-    const token = this.jwt.sign({ sub: user.id, email: user.email });
-    return { token };
+    return this.generateTokens(user);
+  }
+
+  async refresh(refreshToken: string): Promise<TokenPair> {
+    let payload: { sub: string };
+    try {
+      payload = this.jwt.verify(refreshToken, {
+        secret: (process.env.JWT_SECRET ?? 'dev-secret-change-in-prod') + '-refresh',
+      }) as { sub: string };
+    } catch {
+      throw new UnauthorizedException('Invalid or expired refresh token');
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    return this.generateTokens(user);
   }
 }

--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -2,10 +2,12 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from '../prisma/prisma.service';
+import { Role } from '@prisma/client';
 
 interface JwtPayload {
   sub: string;
   email: string;
+  role: Role;
 }
 
 @Injectable()
@@ -21,6 +23,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: JwtPayload) {
     const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
     if (!user) throw new UnauthorizedException();
-    return user;
+    return { id: user.id, email: user.email, role: user.role };
   }
 }

--- a/api/src/auth/roles.decorator.ts
+++ b/api/src/auth/roles.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '@prisma/client';
+
+export const ROLES_KEY = 'roles';
+
+/**
+ * Decorator to restrict a route to specific roles.
+ * Usage: @Roles(Role.CLIENT) or @Roles(Role.SPECIALIST)
+ */
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/api/src/auth/roles.guard.ts
+++ b/api/src/auth/roles.guard.ts
@@ -1,0 +1,24 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '@prisma/client';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // No @Roles() decorator — route is open to any authenticated user
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}


### PR DESCRIPTION
## Summary

- `verifyOtp` now accepts optional `role` param (`"client"` | `"specialist"`) — assigned only on first login, existing users keep their role
- `POST /auth/refresh` endpoint: validates refresh token (30d), returns new `accessToken`+`refreshToken` pair
- `generateTokens()`: access token 15m, refresh token 30d signed with `JWT_SECRET + '-refresh'`
- `JwtPayload` includes `role`; `JwtStrategy.validate()` returns `{ id, email, role }`
- `auth.module.ts`: removed global `expiresIn` from `JwtModule.register` — each `jwt.sign` call owns its expiry
- New: `roles.decorator.ts` — `@Roles(...Role[])` decorator
- New: `roles.guard.ts` — `RolesGuard implements CanActivate` using `Reflector`

## Test plan

- [ ] `POST /api/auth/request-otp` returns `{ message: "OTP sent to email" }`
- [ ] `POST /api/auth/verify-otp` with `role: "client"` returns `{ accessToken, refreshToken }`
- [ ] Decode accessToken — verify `role: "CLIENT"` claim present
- [ ] `POST /api/auth/refresh` with valid refreshToken returns new pair
- [ ] Second login with different role does NOT change user's role in DB
- [ ] TypeScript: `tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)