### PR TITLE
feat: specialist profiles CRUD API

### DIFF
--- a/api/prisma/migrations/20260402100000_add_contacts_to_specialist_profile/migration.sql
+++ b/api/prisma/migrations/20260402100000_add_contacts_to_specialist_profile/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "specialist_profiles" ADD COLUMN "contacts" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -66,6 +66,7 @@ model SpecialistProfile {
   cities   String[]
   services String[]
   badges   String[]
+  contacts String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { ChatModule } from './chat/chat.module';
+import { SpecialistsModule } from './specialists/specialists.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, ChatModule],
+  imports: [PrismaModule, AuthModule, ChatModule, SpecialistsModule],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/api/src/specialists/dto/create-specialist-profile.dto.ts
+++ b/api/src/specialists/dto/create-specialist-profile.dto.ts
@@ -1,0 +1,25 @@
+import { IsString, IsArray, IsOptional, MinLength, MaxLength } from 'class-validator';
+
+export class CreateSpecialistProfileDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(30)
+  nick!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  cities!: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  services!: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  badges?: string[];
+
+  @IsString()
+  @IsOptional()
+  contacts?: string;
+}

--- a/api/src/specialists/dto/update-specialist-profile.dto.ts
+++ b/api/src/specialists/dto/update-specialist-profile.dto.ts
@@ -1,0 +1,28 @@
+import { IsString, IsArray, IsOptional, MinLength, MaxLength } from 'class-validator';
+
+export class UpdateSpecialistProfileDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(30)
+  @IsOptional()
+  nick?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  cities?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  services?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  badges?: string[];
+
+  @IsString()
+  @IsOptional()
+  contacts?: string;
+}

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -1,0 +1,48 @@
+import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards, Request } from '@nestjs/common';
+import { SpecialistsService } from './specialists.service';
+import { CreateSpecialistProfileDto } from './dto/create-specialist-profile.dto';
+import { UpdateSpecialistProfileDto } from './dto/update-specialist-profile.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '@prisma/client';
+
+@Controller('specialists')
+export class SpecialistsController {
+  constructor(private readonly specialistsService: SpecialistsService) {}
+
+  @Post('profile')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  createProfile(@Request() req: any, @Body() dto: CreateSpecialistProfileDto) {
+    return this.specialistsService.createProfile(req.user.id, dto);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  getMyProfile(@Request() req: any) {
+    return this.specialistsService.getMyProfile(req.user.id);
+  }
+
+  @Patch('me')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  updateProfile(@Request() req: any, @Body() dto: UpdateSpecialistProfileDto) {
+    return this.specialistsService.updateProfile(req.user.id, dto);
+  }
+
+  @Get()
+  getCatalog(
+    @Query('city') city?: string,
+    @Query('badge') badge?: string,
+    @Query('sort') sort?: string,
+  ) {
+    return this.specialistsService.getCatalog(city, badge, sort);
+  }
+
+  @Get(':nick')
+  getProfile(@Param('nick') nick: string) {
+    return this.specialistsService.getProfile(nick);
+  }
+}

--- a/api/src/specialists/specialists.module.ts
+++ b/api/src/specialists/specialists.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SpecialistsService } from './specialists.service';
+import { SpecialistsController } from './specialists.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SpecialistsController],
+  providers: [SpecialistsService],
+})
+export class SpecialistsModule {}

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSpecialistProfileDto } from './dto/create-specialist-profile.dto';
+import { UpdateSpecialistProfileDto } from './dto/update-specialist-profile.dto';
+
+@Injectable()
+export class SpecialistsService {
+  constructor(private prisma: PrismaService) {}
+
+  async createProfile(userId: string, dto: CreateSpecialistProfileDto) {
+    const existing = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+    if (existing) throw new ConflictException('Profile already exists');
+
+    const nickTaken = await this.prisma.specialistProfile.findUnique({ where: { nick: dto.nick } });
+    if (nickTaken) throw new ConflictException('Nick already taken');
+
+    return this.prisma.specialistProfile.create({
+      data: {
+        userId,
+        nick: dto.nick,
+        cities: dto.cities,
+        services: dto.services,
+        badges: dto.badges ?? [],
+        contacts: dto.contacts,
+      },
+    });
+  }
+
+  async getMyProfile(userId: string) {
+    const profile = await this.prisma.specialistProfile.findUnique({
+      where: { userId },
+    });
+    if (!profile) throw new NotFoundException('Profile not found');
+
+    const activity = await this.computeActivity(userId);
+    return { ...profile, activity };
+  }
+
+  async updateProfile(userId: string, dto: UpdateSpecialistProfileDto) {
+    const profile = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+    if (!profile) throw new NotFoundException('Profile not found');
+
+    if (dto.nick && dto.nick !== profile.nick) {
+      const nickTaken = await this.prisma.specialistProfile.findUnique({ where: { nick: dto.nick } });
+      if (nickTaken) throw new ConflictException('Nick already taken');
+    }
+
+    return this.prisma.specialistProfile.update({
+      where: { userId },
+      data: dto,
+    });
+  }
+
+  async getProfile(nick: string) {
+    const profile = await this.prisma.specialistProfile.findUnique({
+      where: { nick },
+    });
+    if (!profile) throw new NotFoundException('Specialist not found');
+
+    const activity = await this.computeActivity(profile.userId);
+    return { ...profile, activity };
+  }
+
+  async getCatalog(city?: string, badge?: string, sort?: string) {
+    const now = new Date();
+    const where: any = {};
+    if (city) where.cities = { has: city };
+    if (badge) where.badges = { has: badge };
+
+    const profiles = await this.prisma.specialistProfile.findMany({
+      where,
+    });
+
+    // Get active promotions to rank promoted specialists first
+    const promoted = await this.prisma.promotion.findMany({
+      where: { expiresAt: { gt: now } },
+      select: { specialistId: true, tier: true },
+    });
+
+    // Map specialistId -> highest tier (TOP > FEATURED > BASIC)
+    const tierOrder: Record<string, number> = { TOP: 3, FEATURED: 2, BASIC: 1 };
+    const promotionMap = new Map<string, number>();
+    for (const p of promoted) {
+      const current = promotionMap.get(p.specialistId) ?? 0;
+      const tierVal = tierOrder[p.tier] ?? 0;
+      if (tierVal > current) promotionMap.set(p.specialistId, tierVal);
+    }
+
+    // Compute activity for all profiles
+    const userIds = profiles.map((p) => p.userId);
+    const responseCounts = await this.prisma.response.groupBy({
+      by: ['specialistId'],
+      where: { specialistId: { in: userIds } },
+      _count: { id: true },
+    });
+    const countMap = new Map(responseCounts.map((r) => [r.specialistId, r._count.id]));
+
+    // Build result with promotion rank and activity
+    const result = profiles.map((profile) => ({
+      ...profile,
+      promoted: promotionMap.has(profile.userId),
+      promotionTier: promotionMap.get(profile.userId) ?? 0,
+      activity: { responseCount: countMap.get(profile.userId) ?? 0 },
+    }));
+
+    // Sort: promoted first (by tier desc), then by sort param
+    result.sort((a, b) => {
+      if (b.promotionTier !== a.promotionTier) return b.promotionTier - a.promotionTier;
+      if (sort === 'responses') return (b.activity.responseCount) - (a.activity.responseCount);
+      // Default: newest first
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    });
+
+    return result;
+  }
+
+  private async computeActivity(userId: string) {
+    const responseCount = await this.prisma.response.count({
+      where: { specialistId: userId },
+    });
+    return { responseCount };
+  }
+}


### PR DESCRIPTION
## Summary
- SpecialistsModule with full CRUD for specialist profiles
- 5 endpoints: POST /specialists/profile, GET /specialists/me, PATCH /specialists/me, GET /specialists (catalog), GET /specialists/:nick
- Catalog supports ?city=, ?badge=, ?sort=responses filters; promoted specialists ranked first by tier
- Nick uniqueness validated before create/update (not just DB constraint)
- Activity rating (response count) computed dynamically from Response table
- Migration: adds `contacts String?` to specialist_profiles

## Test plan
- [ ] POST /specialists/profile with valid JWT (SPECIALIST role) — creates profile
- [ ] POST /specialists/profile with duplicate nick — returns 409
- [ ] GET /specialists/me — returns profile with activity stats
- [ ] PATCH /specialists/me — partial update works
- [ ] GET /specialists?city=Moscow — filters by city
- [ ] GET /specialists?badge=known_in_tax_office — filters by badge
- [ ] GET /specialists — promoted specialists appear first
- [ ] GET /specialists/:nick — public profile with activity
- [ ] TypeScript compiles clean (verified locally)