### PR TITLE
feat: requests API — 5 endpoints

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -4,9 +4,10 @@ import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { ChatModule } from './chat/chat.module';
 import { SpecialistsModule } from './specialists/specialists.module';
+import { RequestsModule } from './requests/requests.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, ChatModule, SpecialistsModule],
+  imports: [PrismaModule, AuthModule, ChatModule, SpecialistsModule, RequestsModule],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/api/src/requests/dto/create-request.dto.ts
+++ b/api/src/requests/dto/create-request.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class CreateRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  description!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  city!: string;
+}

--- a/api/src/requests/dto/respond-request.dto.ts
+++ b/api/src/requests/dto/respond-request.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class RespondRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  message!: string;
+}

--- a/api/src/requests/dto/update-request-status.dto.ts
+++ b/api/src/requests/dto/update-request-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { RequestStatus } from '@prisma/client';
+
+export class UpdateRequestStatusDto {
+  @IsEnum(RequestStatus)
+  status!: RequestStatus;
+}

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { RequestsService } from './requests.service';
+import { CreateRequestDto } from './dto/create-request.dto';
+import { RespondRequestDto } from './dto/respond-request.dto';
+import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '@prisma/client';
+
+@Controller('requests')
+export class RequestsController {
+  constructor(private readonly requestsService: RequestsService) {}
+
+  // POST /requests — client creates a request
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  create(@Request() req: any, @Body() dto: CreateRequestDto) {
+    return this.requestsService.create(req.user.id, dto);
+  }
+
+  // GET /requests/my — current user's requests (MUST be before :id route)
+  @Get('my')
+  @UseGuards(JwtAuthGuard)
+  getMy(@Request() req: any) {
+    return this.requestsService.findMy(req.user.id);
+  }
+
+  // GET /requests — public feed (specialists browse)
+  @Get()
+  getFeed(@Query('city') city?: string, @Query('page') page?: string) {
+    return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1);
+  }
+
+  // POST /requests/:id/respond — specialist responds to a request
+  @Post(':id/respond')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  respond(
+    @Request() req: any,
+    @Param('id') id: string,
+    @Body() dto: RespondRequestDto,
+  ) {
+    return this.requestsService.respond(req.user.id, id, dto);
+  }
+
+  // PATCH /requests/:id — client updates request status
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  updateStatus(
+    @Request() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpdateRequestStatusDto,
+  ) {
+    return this.requestsService.updateStatus(req.user.id, id, dto.status);
+  }
+}

--- a/api/src/requests/requests.module.ts
+++ b/api/src/requests/requests.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RequestsController } from './requests.controller';
+import { RequestsService } from './requests.service';
+
+@Module({
+  controllers: [RequestsController],
+  providers: [RequestsService],
+  exports: [RequestsService],
+})
+export class RequestsModule {}

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -1,0 +1,134 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateRequestDto } from './dto/create-request.dto';
+import { RespondRequestDto } from './dto/respond-request.dto';
+import { RequestStatus } from '@prisma/client';
+
+const PAGE_SIZE = 20;
+
+@Injectable()
+export class RequestsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(clientId: string, dto: CreateRequestDto) {
+    return this.prisma.request.create({
+      data: {
+        clientId,
+        description: dto.description,
+        city: dto.city,
+      },
+    });
+  }
+
+  async findFeed(city?: string, page = 1) {
+    const where: any = { status: RequestStatus.OPEN };
+    if (city) where.city = city;
+
+    const skip = (page - 1) * PAGE_SIZE;
+
+    const [items, total] = await Promise.all([
+      this.prisma.request.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: PAGE_SIZE,
+        include: {
+          client: { select: { id: true, email: true } },
+          _count: { select: { responses: true } },
+        },
+      }),
+      this.prisma.request.count({ where }),
+    ]);
+
+    return { items, total, page, pageSize: PAGE_SIZE };
+  }
+
+  async findMy(clientId: string) {
+    return this.prisma.request.findMany({
+      where: { clientId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        _count: { select: { responses: true } },
+        responses: {
+          include: {
+            specialist: { select: { id: true, email: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+  }
+
+  async respond(specialistId: string, requestId: string, dto: RespondRequestDto) {
+    // Check request exists and is open
+    const request = await this.prisma.request.findUnique({
+      where: { id: requestId },
+      include: { client: { select: { id: true, email: true } } },
+    });
+    if (!request) throw new NotFoundException('Request not found');
+    if (request.status !== RequestStatus.OPEN) {
+      throw new BadRequestException('Request is not open for responses');
+    }
+
+    // Check specialist hasn't already responded (@@unique will catch too, but better UX)
+    const existing = await this.prisma.response.findUnique({
+      where: { specialistId_requestId: { specialistId, requestId } },
+    });
+    if (existing) throw new ConflictException('Already responded to this request');
+
+    // Create response + thread in transaction
+    const result = await this.prisma.$transaction(async (tx) => {
+      const response = await tx.response.create({
+        data: {
+          specialistId,
+          requestId,
+          message: dto.message,
+        },
+      });
+
+      // Create thread: enforce participant1Id < participant2Id
+      const [p1, p2] =
+        specialistId < request.clientId
+          ? [specialistId, request.clientId]
+          : [request.clientId, specialistId];
+
+      const thread = await tx.thread.upsert({
+        where: { participant1Id_participant2Id: { participant1Id: p1, participant2Id: p2 } },
+        create: { participant1Id: p1, participant2Id: p2 },
+        update: {},
+      });
+
+      return { response, thread };
+    });
+
+    // Email notification to client (no mail service yet — log + TODO)
+    try {
+      // TODO: replace with real email service when available
+      console.log(
+        `[NOTIFY] New response to request ${requestId}. ` +
+          `Client: ${request.client.email}, Specialist: ${specialistId}`,
+      );
+    } catch (err) {
+      console.error('[NOTIFY] Failed to send email notification:', err);
+    }
+
+    return result;
+  }
+
+  async updateStatus(clientId: string, requestId: string, status: RequestStatus) {
+    const request = await this.prisma.request.findUnique({ where: { id: requestId } });
+    if (!request) throw new NotFoundException('Request not found');
+    if (request.clientId !== clientId) throw new ForbiddenException('Not your request');
+
+    return this.prisma.request.update({
+      where: { id: requestId },
+      data: { status },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- POST /requests — client creates request (description + city)
- GET /requests?city=&page= — public feed of open requests (paginated, 20/page)
- GET /requests/my — current user's requests with response details
- POST /requests/:id/respond — specialist responds + creates Thread (enforces @@unique)
- PATCH /requests/:id — client updates status (OPEN/CLOSED/CANCELLED)

## Details
- Role guards: CLIENT for create/update, SPECIALIST for respond
- Thread participant ordering enforced (p1 < p2)
- Email notification stubbed as console.log (no mail service yet)
- Zero new TypeScript errors

## Test plan
- [ ] POST /requests with CLIENT JWT
- [ ] GET /requests?city=Tbilisi — returns open requests
- [ ] GET /requests/my with JWT
- [ ] POST /requests/:id/respond with SPECIALIST JWT
- [ ] PATCH /requests/:id with CLIENT JWT — change status
- [ ] Verify duplicate respond returns 409

Generated with Claude Code