### PR TITLE
feat: chat WebSocket + REST threads/messages

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -1,0 +1,30 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ChatService } from './chat.service';
+
+@Controller('threads')
+@UseGuards(JwtAuthGuard)
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  @Get()
+  getThreads(@Request() req: { user: { id: string } }) {
+    return this.chatService.getThreads(req.user.id);
+  }
+
+  @Get(':id/messages')
+  getMessages(
+    @Request() req: { user: { id: string } },
+    @Param('id') threadId: string,
+    @Query('page') page?: string,
+  ) {
+    return this.chatService.getMessages(req.user.id, threadId, parseInt(page ?? '1', 10) || 1);
+  }
+}

--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -6,13 +6,14 @@ import {
   OnGatewayDisconnect,
   MessageBody,
   ConnectedSocket,
+  WsException,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { ChatService } from './chat.service';
 
-interface ChatMessage {
-  room: string;
-  text: string;
-  from?: string;
+interface AuthenticatedSocket extends Socket {
+  data: { userId: string; email: string; role: string };
 }
 
 @WebSocketGateway({
@@ -23,28 +24,148 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server!: Server;
 
-  handleConnection(client: Socket) {
-    console.log(`[Chat] Client connected: ${client.id}`);
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly chatService: ChatService,
+  ) {}
+
+  async handleConnection(client: AuthenticatedSocket) {
+    try {
+      const token = client.handshake.auth?.token;
+      if (!token) {
+        client.emit('error', { message: 'Authentication required' });
+        client.disconnect();
+        return;
+      }
+
+      const payload = this.jwtService.verify(token, {
+        secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+      });
+
+      client.data.userId = payload.sub;
+      client.data.email = payload.email;
+      client.data.role = payload.role;
+
+      console.log(`[Chat] Authenticated: ${client.data.email} (${client.id})`);
+    } catch {
+      client.emit('error', { message: 'Invalid token' });
+      client.disconnect();
+    }
   }
 
-  handleDisconnect(client: Socket) {
-    console.log(`[Chat] Client disconnected: ${client.id}`);
+  handleDisconnect(client: AuthenticatedSocket) {
+    console.log(`[Chat] Disconnected: ${client.data?.email ?? client.id}`);
   }
 
-  @SubscribeMessage('joinRoom')
-  handleJoinRoom(@ConnectedSocket() client: Socket, @MessageBody() room: string) {
+  @SubscribeMessage('join_thread')
+  async handleJoinThread(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { threadId: string },
+  ) {
+    if (!client.data?.userId) {
+      throw new WsException('Not authenticated');
+    }
+
+    const thread = await this.chatService.verifyParticipant(client.data.userId, data.threadId);
+    if (!thread) {
+      client.emit('error', { message: 'Thread not found or access denied' });
+      return;
+    }
+
+    const room = `thread:${data.threadId}`;
     client.join(room);
-    client.emit('joinedRoom', { room });
-    console.log(`[Chat] ${client.id} joined room: ${room}`);
+    client.emit('joined_thread', { threadId: data.threadId });
+    console.log(`[Chat] ${client.data.email} joined ${room}`);
   }
 
-  @SubscribeMessage('message')
-  handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: ChatMessage) {
-    this.server.to(data.room).emit('message', {
-      from: data.from ?? client.id,
-      text: data.text,
-      room: data.room,
-      ts: new Date().toISOString(),
+  @SubscribeMessage('send_message')
+  async handleSendMessage(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { threadId: string; content: string },
+  ) {
+    if (!client.data?.userId) {
+      throw new WsException('Not authenticated');
+    }
+
+    if (!data.content?.trim()) {
+      client.emit('error', { message: 'Content is required' });
+      return;
+    }
+
+    const thread = await this.chatService.verifyParticipant(client.data.userId, data.threadId);
+    if (!thread) {
+      client.emit('error', { message: 'Thread not found or access denied' });
+      return;
+    }
+
+    const message = await this.chatService.createMessage(
+      data.threadId,
+      client.data.userId,
+      data.content.trim(),
+    );
+
+    const room = `thread:${data.threadId}`;
+    this.server.to(room).emit('message_received', message);
+
+    // Email notification for offline recipient (TODO: implement email service)
+    try {
+      const recipientId =
+        thread.participant1Id === client.data.userId
+          ? thread.participant2Id
+          : thread.participant1Id;
+
+      const recipientOnline = this.isUserInRoom(recipientId, room);
+      if (!recipientOnline) {
+        console.log(`[Chat] TODO: send email notification to user ${recipientId}`);
+      }
+    } catch (err) {
+      console.error('[Chat] Email notification failed (non-blocking):', err);
+    }
+  }
+
+  @SubscribeMessage('typing')
+  async handleTyping(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { threadId: string },
+  ) {
+    if (!client.data?.userId) return;
+
+    const room = `thread:${data.threadId}`;
+    client.to(room).emit('typing', {
+      threadId: data.threadId,
+      userId: client.data.userId,
     });
+  }
+
+  @SubscribeMessage('mark_read')
+  async handleMarkRead(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { messageId: string },
+  ) {
+    if (!client.data?.userId) {
+      throw new WsException('Not authenticated');
+    }
+
+    const updated = await this.chatService.markRead(client.data.userId, data.messageId);
+    if (!updated) {
+      client.emit('error', { message: 'Message not found or access denied' });
+      return;
+    }
+
+    client.emit('message_read', { messageId: updated.id, readAt: updated.readAt });
+  }
+
+  /** Check if a user has any socket in a given room */
+  private isUserInRoom(userId: string, room: string): boolean {
+    const adapter = this.server.adapter as any;
+    const roomSockets: Set<string> | undefined = adapter.rooms?.get(room);
+    if (!roomSockets) return false;
+
+    const sockets = this.server.sockets as any;
+    for (const socketId of roomSockets) {
+      const socket = sockets.get?.(socketId) as AuthenticatedSocket | undefined;
+      if (socket?.data?.userId === userId) return true;
+    }
+    return false;
   }
 }

--- a/api/src/chat/chat.module.ts
+++ b/api/src/chat/chat.module.ts
@@ -1,7 +1,16 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
 import { ChatGateway } from './chat.gateway';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
 
 @Module({
-  providers: [ChatGateway],
+  imports: [
+    JwtModule.register({
+      secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+    }),
+  ],
+  controllers: [ChatController],
+  providers: [ChatGateway, ChatService],
 })
 export class ChatModule {}

--- a/api/src/chat/chat.service.ts
+++ b/api/src/chat/chat.service.ts
@@ -1,0 +1,125 @@
+import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ChatService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** List threads where user is participant, sorted by last message */
+  async getThreads(userId: string) {
+    const threads = await this.prisma.thread.findMany({
+      where: {
+        OR: [
+          { participant1Id: userId },
+          { participant2Id: userId },
+        ],
+      },
+      include: {
+        participant1: { select: { id: true, email: true, role: true } },
+        participant2: { select: { id: true, email: true, role: true } },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: { id: true, content: true, senderId: true, createdAt: true, readAt: true },
+        },
+      },
+    });
+
+    // Sort by last message date (threads with messages first, then by createdAt)
+    threads.sort((a, b) => {
+      const aDate = a.messages[0]?.createdAt ?? a.createdAt;
+      const bDate = b.messages[0]?.createdAt ?? b.createdAt;
+      return bDate.getTime() - aDate.getTime();
+    });
+
+    return threads.map((t) => ({
+      id: t.id,
+      participant1: t.participant1,
+      participant2: t.participant2,
+      lastMessage: t.messages[0] ?? null,
+      createdAt: t.createdAt,
+    }));
+  }
+
+  /** Get paginated messages for a thread (oldest first) */
+  async getMessages(userId: string, threadId: string, page: number) {
+    const thread = await this.prisma.thread.findUnique({ where: { id: threadId } });
+    if (!thread) throw new NotFoundException('Thread not found');
+    if (thread.participant1Id !== userId && thread.participant2Id !== userId) {
+      throw new ForbiddenException('Not a participant of this thread');
+    }
+
+    const take = 50;
+    const skip = (page - 1) * take;
+
+    const [messages, total] = await Promise.all([
+      this.prisma.message.findMany({
+        where: { threadId },
+        orderBy: { createdAt: 'asc' },
+        skip,
+        take,
+        select: {
+          id: true,
+          threadId: true,
+          senderId: true,
+          content: true,
+          readAt: true,
+          createdAt: true,
+        },
+      }),
+      this.prisma.message.count({ where: { threadId } }),
+    ]);
+
+    return { messages, total, page, pages: Math.ceil(total / take) };
+  }
+
+  /** Verify user is participant of thread */
+  async verifyParticipant(userId: string, threadId: string) {
+    const thread = await this.prisma.thread.findUnique({ where: { id: threadId } });
+    if (!thread) return null;
+    if (thread.participant1Id !== userId && thread.participant2Id !== userId) return null;
+    return thread;
+  }
+
+  /** Save a message to DB */
+  async createMessage(threadId: string, senderId: string, content: string) {
+    return this.prisma.message.create({
+      data: { threadId, senderId, content },
+      select: {
+        id: true,
+        threadId: true,
+        senderId: true,
+        content: true,
+        readAt: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  /** Mark message as read */
+  async markRead(userId: string, messageId: string) {
+    const message = await this.prisma.message.findUnique({
+      where: { id: messageId },
+      include: { thread: true },
+    });
+    if (!message) return null;
+
+    // Only the recipient (not the sender) can mark as read
+    const thread = message.thread;
+    if (thread.participant1Id !== userId && thread.participant2Id !== userId) return null;
+    if (message.senderId === userId) return message; // sender can't mark own message as read
+
+    return this.prisma.message.update({
+      where: { id: messageId },
+      data: { readAt: new Date() },
+      select: {
+        id: true,
+        threadId: true,
+        senderId: true,
+        content: true,
+        readAt: true,
+        createdAt: true,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Rewrote ChatGateway with JWT authentication via `handshake.auth.token`
- WebSocket events: `join_thread`, `send_message`, `message_received`, `typing`, `mark_read`
- REST endpoints: `GET /threads` (user's dialogs sorted by last message), `GET /threads/:id/messages?page=` (paginated, 50/page)
- ChatService: thread participant authorization, message DB persistence, read receipts
- Room naming convention: `thread:{threadId}` to avoid namespace collisions
- Offline email notification placeholder (console.log TODO)

## Test plan
- [ ] Connect via Socket.io to `/chat` namespace with JWT auth token
- [ ] `join_thread` with valid threadId — should join room
- [ ] `join_thread` with non-participant — should get error event
- [ ] `send_message` — message saved to DB and broadcast to room
- [ ] `typing` — broadcast to other participants only
- [ ] `mark_read` — updates readAt timestamp (only for recipient)
- [ ] `GET /api/threads` — returns user's threads with last message
- [ ] `GET /api/threads/:id/messages?page=1` — paginated messages

Generated with Claude Code