### PR TITLE
feat: paid promotions module

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.15",
         "@nestjs/platform-socket.io": "^10.4.15",
+        "@nestjs/schedule": "^6.1.1",
         "@nestjs/websockets": "^10.4.15",
         "@prisma/client": "^6.6.0",
         "class-transformer": "^0.5.1",
@@ -282,6 +283,19 @@
       },
       "engines": {
         "node": ">=10.2.0"
+      }
+    },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
+      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@nestjs/websockets": {
@@ -574,6 +588,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.15",
@@ -1109,6 +1129,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1928,6 +1965,15 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.15",
     "@nestjs/platform-socket.io": "^10.4.15",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/websockets": "^10.4.15",
     "@prisma/client": "^6.6.0",
     "class-transformer": "^0.5.1",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,13 +1,23 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
 import { ChatModule } from './chat/chat.module';
 import { SpecialistsModule } from './specialists/specialists.module';
 import { RequestsModule } from './requests/requests.module';
+import { PromotionsModule } from './promotions/promotions.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, ChatModule, SpecialistsModule, RequestsModule],
+  imports: [
+    ScheduleModule.forRoot(),
+    PrismaModule,
+    AuthModule,
+    ChatModule,
+    SpecialistsModule,
+    RequestsModule,
+    PromotionsModule,
+  ],
   controllers: [AppController],
 })
 export class AppModule {}

--- a/api/src/promotions/dto/purchase-promotion.dto.ts
+++ b/api/src/promotions/dto/purchase-promotion.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsEnum } from 'class-validator';
+import { PromotionTier } from '@prisma/client';
+
+export class PurchasePromotionDto {
+  @IsString()
+  city!: string;
+
+  @IsEnum(PromotionTier)
+  tier!: PromotionTier;
+}

--- a/api/src/promotions/dto/update-prices.dto.ts
+++ b/api/src/promotions/dto/update-prices.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsEnum, IsNumber, Min } from 'class-validator';
+import { PromotionTier } from '@prisma/client';
+
+export class UpdatePricesDto {
+  @IsString()
+  city!: string;
+
+  @IsEnum(PromotionTier)
+  tier!: PromotionTier;
+
+  @IsNumber()
+  @Min(0)
+  price!: number;
+}

--- a/api/src/promotions/promotions.controller.ts
+++ b/api/src/promotions/promotions.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+  ForbiddenException,
+} from '@nestjs/common';
+import { PromotionsService } from './promotions.service';
+import { PurchasePromotionDto } from './dto/purchase-promotion.dto';
+import { UpdatePricesDto } from './dto/update-prices.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+
+// Admin emails — no ADMIN role in DB yet, so we check email directly.
+// TODO: add ADMIN role to Prisma enum when admin panel is built
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? '').split(',').filter(Boolean);
+
+@Controller('promotions')
+export class PromotionsController {
+  constructor(private readonly promotionsService: PromotionsService) {}
+
+  /** Specialist purchases a promotion */
+  @Post('purchase')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  purchase(@Request() req: any, @Body() dto: PurchasePromotionDto) {
+    return this.promotionsService.purchase(req.user.id, dto);
+  }
+
+  /** Get my promotions (any authenticated user, but mostly specialists) */
+  @Get('my')
+  @UseGuards(JwtAuthGuard)
+  getMyPromotions(@Request() req: any) {
+    return this.promotionsService.getMyPromotions(req.user.id);
+  }
+
+  /** Admin: list all promotions */
+  @Get('admin')
+  @UseGuards(JwtAuthGuard)
+  adminList(@Request() req: any) {
+    this.assertAdmin(req.user.email);
+    return this.promotionsService.adminList();
+  }
+
+  /** Admin: get current prices */
+  @Get('admin/prices')
+  @UseGuards(JwtAuthGuard)
+  getPrices(@Request() req: any, @Query('city') city?: string) {
+    this.assertAdmin(req.user.email);
+    return this.promotionsService.getPrices(city);
+  }
+
+  /** Admin: update price for city+tier */
+  @Patch('admin/prices')
+  @UseGuards(JwtAuthGuard)
+  updatePrices(@Request() req: any, @Body() dto: UpdatePricesDto) {
+    this.assertAdmin(req.user.email);
+    return this.promotionsService.updatePrices(dto);
+  }
+
+  private assertAdmin(email: string) {
+    if (!ADMIN_EMAILS.includes(email)) {
+      throw new ForbiddenException('Admin access required');
+    }
+  }
+}

--- a/api/src/promotions/promotions.module.ts
+++ b/api/src/promotions/promotions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PromotionsController } from './promotions.controller';
+import { PromotionsService } from './promotions.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PromotionsController],
+  providers: [PromotionsService],
+  exports: [PromotionsService],
+})
+export class PromotionsModule {}

--- a/api/src/promotions/promotions.service.ts
+++ b/api/src/promotions/promotions.service.ts
@@ -1,0 +1,170 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+import { PurchasePromotionDto } from './dto/purchase-promotion.dto';
+import { UpdatePricesDto } from './dto/update-prices.dto';
+import { PromotionTier } from '@prisma/client';
+
+// Default prices (rubles). Admin can override per city via updatePrices.
+// TODO: persist prices in DB (add PromotionPrice model) when admin pricing is needed
+const DEFAULT_PRICES: Record<PromotionTier, number> = {
+  BASIC: 500,
+  FEATURED: 1500,
+  TOP: 3000,
+};
+
+// In-memory price overrides (city:tier -> price). Resets on restart.
+// TODO: replace with DB table when persistence is needed
+const priceOverrides = new Map<string, number>();
+
+@Injectable()
+export class PromotionsService {
+  private readonly logger = new Logger(PromotionsService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Purchase a promotion for the authenticated specialist.
+   * Currently uses mock payment (no Stripe key configured).
+   */
+  async purchase(userId: string, dto: PurchasePromotionDto) {
+    // Verify user has a specialist profile
+    const profile = await this.prisma.specialistProfile.findUnique({
+      where: { userId },
+    });
+    if (!profile) {
+      throw new NotFoundException('Specialist profile not found. Create a profile first.');
+    }
+
+    // Check specialist operates in the requested city
+    if (!profile.cities.includes(dto.city)) {
+      throw new BadRequestException(
+        `You don't have city "${dto.city}" in your profile. Add it first.`,
+      );
+    }
+
+    // Check for existing active promotion in same city+tier
+    const existing = await this.prisma.promotion.findFirst({
+      where: {
+        specialistId: userId,
+        city: dto.city,
+        tier: dto.tier,
+        expiresAt: { gt: new Date() },
+      },
+    });
+    if (existing) {
+      throw new BadRequestException(
+        `You already have an active ${dto.tier} promotion in ${dto.city} until ${existing.expiresAt.toISOString()}`,
+      );
+    }
+
+    const price = this.getPrice(dto.city, dto.tier);
+
+    // TODO: Integrate Stripe when STRIPE_SECRET_KEY is added to Doppler
+    // For now, mock payment: log and proceed
+    this.logger.log(
+      `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} amount=${price} RUB`,
+    );
+
+    // Create promotion: 30 days from now
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + 30);
+
+    const promotion = await this.prisma.promotion.create({
+      data: {
+        specialistId: userId,
+        city: dto.city,
+        tier: dto.tier,
+        expiresAt,
+      },
+    });
+
+    return {
+      promotion,
+      payment: {
+        status: 'mock_paid',
+        amount: price,
+        currency: 'RUB',
+        note: 'Stripe integration pending. Payment simulated.',
+      },
+    };
+  }
+
+  /** Get promotions for the authenticated user */
+  async getMyPromotions(userId: string) {
+    return this.prisma.promotion.findMany({
+      where: { specialistId: userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /** Admin: list all promotions with specialist info */
+  async adminList() {
+    return this.prisma.promotion.findMany({
+      include: {
+        specialist: {
+          select: { id: true, email: true, specialistProfile: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /** Admin: update price for city+tier combination */
+  updatePrices(dto: UpdatePricesDto) {
+    const key = `${dto.city}:${dto.tier}`;
+    priceOverrides.set(key, dto.price);
+    this.logger.log(`Price updated: ${key} = ${dto.price} RUB`);
+    return {
+      city: dto.city,
+      tier: dto.tier,
+      price: dto.price,
+      note: 'Price stored in memory. Will reset on server restart. TODO: persist to DB.',
+    };
+  }
+
+  /** Admin: get current prices for all tiers, optionally filtered by city */
+  getPrices(city?: string) {
+    const tiers = Object.values(PromotionTier);
+    const result: Array<{ city: string; tier: PromotionTier; price: number }> = [];
+
+    if (city) {
+      for (const tier of tiers) {
+        result.push({ city, tier, price: this.getPrice(city, tier) });
+      }
+    } else {
+      // Return defaults + all overrides
+      for (const tier of tiers) {
+        result.push({ city: 'default', tier, price: DEFAULT_PRICES[tier] });
+      }
+      for (const [key, price] of priceOverrides.entries()) {
+        const [c, t] = key.split(':');
+        result.push({ city: c, tier: t as PromotionTier, price });
+      }
+    }
+
+    return result;
+  }
+
+  /** Hourly cron: deactivate expired promotions by deleting them */
+  @Cron(CronExpression.EVERY_HOUR)
+  async deactivateExpired() {
+    const { count } = await this.prisma.promotion.deleteMany({
+      where: { expiresAt: { lte: new Date() } },
+    });
+    if (count > 0) {
+      this.logger.log(`Deactivated ${count} expired promotion(s)`);
+    }
+  }
+
+  private getPrice(city: string, tier: PromotionTier): number {
+    const key = `${city}:${tier}`;
+    return priceOverrides.get(key) ?? DEFAULT_PRICES[tier];
+  }
+}


### PR DESCRIPTION
## Summary
- `PromotionsModule` with purchase, my-promotions, admin list, admin pricing endpoints
- Mock payment (Stripe key not yet in Doppler — TODO)
- Hourly cron deactivates expired promotions via `@nestjs/schedule`
- Admin auth via ADMIN_EMAILS env var (no ADMIN role in DB yet)
- Catalog ranking of promoted specialists already existed in `specialists.service.ts`

## Endpoints
- `POST /promotions/purchase` — specialist buys promotion (30 days)
- `GET /promotions/my` — own promotions
- `GET /promotions/admin` — all promotions (admin only)
- `GET /promotions/admin/prices` — current pricing
- `PATCH /promotions/admin/prices` — update city+tier price

## TODOs
- Add `STRIPE_SECRET_KEY` to Doppler and replace mock payment
- Add `ADMIN_EMAILS` to Doppler (comma-separated)
- Persist pricing in DB (currently in-memory, resets on restart)

## Test plan
- [ ] POST /promotions/purchase with specialist JWT — returns promotion + mock payment
- [ ] GET /promotions/my — returns list
- [ ] Duplicate purchase in same city+tier — returns 400
- [ ] Non-specialist purchase — returns 403
- [ ] Admin endpoints with non-admin email — returns 403
- [ ] TypeScript compiles cleanly

Generated with [Claude Code](https://claude.com/claude-code)