### PR TITLE
feat: auth screens + landing page

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function AuthLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Button } from '../../components/Button';
+import { Input } from '../../components/Input';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { api, ApiError } from '../../lib/api';
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
+}
+
+export default function EmailScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ role?: string }>();
+  const role = params.role === 'SPECIALIST' ? 'SPECIALIST' : 'CLIENT';
+
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const roleLabel = role === 'SPECIALIST' ? 'специалиста' : 'заказчика';
+
+  async function handleSubmit() {
+    const trimmed = email.trim();
+    if (!isValidEmail(trimmed)) {
+      setError('Введите корректный email');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    try {
+      await api.post('/auth/request-otp', { email: trimmed });
+      router.push(
+        `/(auth)/otp?email=${encodeURIComponent(trimmed)}&role=${role}`,
+      );
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось отправить код. Попробуйте снова.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            {/* Back */}
+            <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+              <Text style={styles.backText}>← Назад</Text>
+            </TouchableOpacity>
+
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Войти как {roleLabel}</Text>
+              <Text style={styles.subtitle}>
+                Введите email — мы отправим код подтверждения
+              </Text>
+            </View>
+
+            {/* Form */}
+            <View style={styles.form}>
+              <Input
+                label="Email"
+                value={email}
+                onChangeText={(t) => {
+                  setEmail(t);
+                  if (error) setError('');
+                }}
+                placeholder="you@example.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoFocus
+                error={error}
+              />
+              <Button
+                onPress={handleSubmit}
+                loading={loading}
+                disabled={loading}
+                style={styles.btn}
+              >
+                Получить код
+              </Button>
+            </View>
+
+            <Text style={styles.hint}>
+              Нет аккаунта? Он создастся автоматически.
+            </Text>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  kav: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+  },
+  back: {
+    alignSelf: 'flex-start',
+    paddingVertical: Spacing.sm,
+  },
+  backText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.brandPrimary,
+  },
+  header: {
+    gap: Spacing.sm,
+    marginTop: Spacing.xl,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  form: {
+    gap: Spacing.lg,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+  hint: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -1,0 +1,341 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  TouchableOpacity,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Button } from '../../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { api, ApiError } from '../../lib/api';
+import { useAuth } from '../../stores/authStore';
+
+const CODE_LENGTH = 6;
+const RESEND_SECONDS = 60;
+
+interface VerifyOtpResponse {
+  accessToken: string;
+  refreshToken?: string;
+  user: {
+    userId: string;
+    email: string;
+    role: string;
+  };
+}
+
+export default function OtpScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ email?: string; role?: string }>();
+  const email = decodeURIComponent(params.email ?? '');
+  const role = params.role === 'SPECIALIST' ? 'SPECIALIST' : 'CLIENT';
+
+  const { login } = useAuth();
+
+  const [digits, setDigits] = useState<string[]>(Array(CODE_LENGTH).fill(''));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [timer, setTimer] = useState(RESEND_SECONDS);
+  const [resending, setResending] = useState(false);
+
+  const inputs = useRef<(TextInput | null)[]>([]);
+
+  // Countdown timer
+  useEffect(() => {
+    if (timer <= 0) return;
+    const id = setTimeout(() => setTimer((t) => t - 1), 1000);
+    return () => clearTimeout(id);
+  }, [timer]);
+
+  const code = digits.join('');
+
+  function handleDigitChange(value: string, index: number) {
+    // Accept paste of full code
+    if (value.length === CODE_LENGTH && /^\d+$/.test(value)) {
+      const next = value.split('').slice(0, CODE_LENGTH);
+      setDigits(next);
+      inputs.current[CODE_LENGTH - 1]?.focus();
+      return;
+    }
+
+    const digit = value.replace(/\D/g, '').slice(-1);
+    const next = [...digits];
+    next[index] = digit;
+    setDigits(next);
+    if (error) setError('');
+
+    if (digit && index < CODE_LENGTH - 1) {
+      inputs.current[index + 1]?.focus();
+    }
+  }
+
+  function handleKeyPress(key: string, index: number) {
+    if (key === 'Backspace' && !digits[index] && index > 0) {
+      const next = [...digits];
+      next[index - 1] = '';
+      setDigits(next);
+      inputs.current[index - 1]?.focus();
+    }
+  }
+
+  const handleVerify = useCallback(async () => {
+    if (code.length < CODE_LENGTH) {
+      setError('Введите все 6 цифр кода');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    try {
+      const res = await api.post<VerifyOtpResponse>('/auth/verify-otp', {
+        email,
+        code,
+        role,
+      });
+      await login(res.accessToken, {
+        userId: res.user.userId,
+        email: res.user.email,
+        role: res.user.role,
+      });
+      // Navigate based on role — expand when dashboards are ready
+      router.replace('/');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Неверный код. Попробуйте снова.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [code, email, role, login, router]);
+
+  // Auto-submit when all digits filled
+  useEffect(() => {
+    if (code.length === CODE_LENGTH && !loading) {
+      handleVerify();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code]);
+
+  async function handleResend() {
+    setResending(true);
+    setError('');
+    try {
+      await api.post('/auth/request-otp', { email });
+      setDigits(Array(CODE_LENGTH).fill(''));
+      setTimer(RESEND_SECONDS);
+      inputs.current[0]?.focus();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось отправить код.');
+      }
+    } finally {
+      setResending(false);
+    }
+  }
+
+  const isComplete = code.length === CODE_LENGTH;
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            {/* Back */}
+            <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+              <Text style={styles.backText}>← Назад</Text>
+            </TouchableOpacity>
+
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Введите код</Text>
+              <Text style={styles.subtitle}>
+                Отправили код на{' '}
+                <Text style={styles.emailHighlight}>{email}</Text>
+              </Text>
+            </View>
+
+            {/* OTP boxes */}
+            <View style={styles.otpRow}>
+              {digits.map((d, i) => (
+                <TextInput
+                  key={i}
+                  ref={(ref) => { inputs.current[i] = ref; }}
+                  value={d}
+                  onChangeText={(v) => handleDigitChange(v, i)}
+                  onKeyPress={({ nativeEvent }) =>
+                    handleKeyPress(nativeEvent.key, i)
+                  }
+                  keyboardType="number-pad"
+                  maxLength={CODE_LENGTH} // allow paste
+                  style={[
+                    styles.otpBox,
+                    d ? styles.otpBoxFilled : null,
+                    error ? styles.otpBoxError : null,
+                  ]}
+                  selectionColor={Colors.brandPrimary}
+                  textAlign="center"
+                />
+              ))}
+            </View>
+
+            {/* Error */}
+            {error ? <Text style={styles.error}>{error}</Text> : null}
+
+            {/* Submit */}
+            <Button
+              onPress={handleVerify}
+              loading={loading}
+              disabled={!isComplete || loading}
+              style={styles.btn}
+            >
+              Войти
+            </Button>
+
+            {/* Resend */}
+            <View style={styles.resendRow}>
+              {timer > 0 ? (
+                <Text style={styles.timerText}>
+                  Отправить повторно через {timer} с
+                </Text>
+              ) : (
+                <TouchableOpacity
+                  onPress={handleResend}
+                  disabled={resending}
+                >
+                  <Text style={styles.resendText}>
+                    {resending ? 'Отправляем...' : 'Отправить код повторно'}
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+
+            {/* Dev hint */}
+            {__DEV__ && (
+              <View style={styles.devHint}>
+                <Text style={styles.devHintText}>DEV: код — 000000</Text>
+              </View>
+            )}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  kav: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+    alignItems: 'center',
+  },
+  back: {
+    alignSelf: 'flex-start',
+    paddingVertical: Spacing.sm,
+  },
+  backText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.brandPrimary,
+  },
+  header: {
+    alignSelf: 'stretch',
+    gap: Spacing.sm,
+    marginTop: Spacing.xl,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  emailHighlight: {
+    color: Colors.textAccent,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  otpRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    justifyContent: 'center',
+  },
+  otpBox: {
+    width: 44,
+    height: 52,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  otpBoxFilled: {
+    borderColor: Colors.brandPrimary,
+  },
+  otpBoxError: {
+    borderColor: Colors.statusError,
+  },
+  error: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+  },
+  btn: {
+    width: '100%',
+  },
+  resendRow: {
+    alignItems: 'center',
+  },
+  timerText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  resendText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  devHint: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.sm,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.statusWarning,
+  },
+  devHintText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusWarning,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,51 @@
 import '../global.css';
-import { Stack } from 'expo-router';
-import { AuthProvider } from '../stores/authStore';
+import React, { useEffect } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { Stack, useRouter, useSegments } from 'expo-router';
+import { AuthProvider, useAuth } from '../stores/authStore';
+import { Colors } from '../constants/Colors';
+
+function RootNavigator() {
+  const { user, isLoading } = useAuth();
+  const segments = useSegments();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    const inAuthGroup = segments[0] === '(auth)';
+
+    if (!user && !inAuthGroup && segments[0] !== undefined) {
+      // Not authenticated and trying to access a protected route → landing
+      router.replace('/');
+    } else if (user && inAuthGroup) {
+      // Already authenticated and still in auth group → home
+      router.replace('/');
+    }
+  }, [user, isLoading, segments, router]);
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, backgroundColor: Colors.bgPrimary, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}
 
 export default function RootLayout() {
   return (
     <AuthProvider>
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          contentStyle: { backgroundColor: '#0f0f1a' },
-        }}
-      />
+      <RootNavigator />
     </AuthProvider>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,16 +1,151 @@
-import { View, Text, StyleSheet } from 'react-native';
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Button } from '../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
 
-export default function HomeScreen() {
+const FEATURES = [
+  'Проверенные специалисты',
+  'Быстро и удобно',
+  'Безопасная оплата',
+];
+
+export default function LandingScreen() {
+  const router = useRouter();
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>P2PTax</Text>
-      <Text style={styles.subtitle}>Налоговый информационный арбитраж</Text>
-    </View>
+    <SafeAreaView style={styles.safe}>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.container}>
+          {/* Hero */}
+          <View style={styles.hero}>
+            <View style={styles.logoCircle}>
+              <Text style={styles.logoEmoji}>⚖️</Text>
+            </View>
+            <Text style={styles.appName}>Налоговик</Text>
+            <Text style={styles.tagline}>
+              Найди специалиста по налогам{'\n'}в своём городе
+            </Text>
+          </View>
+
+          {/* Features */}
+          <View style={styles.features}>
+            {FEATURES.map((f) => (
+              <View key={f} style={styles.featureRow}>
+                <Text style={styles.featureCheck}>✓</Text>
+                <Text style={styles.featureText}>{f}</Text>
+              </View>
+            ))}
+          </View>
+
+          {/* CTAs */}
+          <View style={styles.ctas}>
+            <Button
+              onPress={() => router.push('/(auth)/email?role=CLIENT')}
+              variant="primary"
+              style={styles.btn}
+            >
+              Войти как заказчик
+            </Button>
+            <Button
+              onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+              variant="secondary"
+              style={styles.btn}
+            >
+              Я специалист / Зарегистрироваться
+            </Button>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 8 },
-  subtitle: { fontSize: 16, color: '#666' },
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['3xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    alignItems: 'center',
+    gap: Spacing['3xl'],
+  },
+  hero: {
+    alignItems: 'center',
+    gap: Spacing.lg,
+    marginTop: Spacing['4xl'],
+  },
+  logoCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.bgCard,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: Colors.brandPrimary,
+  },
+  logoEmoji: {
+    fontSize: 36,
+  },
+  appName: {
+    fontSize: Typography.fontSize['3xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    letterSpacing: 0.5,
+  },
+  tagline: {
+    fontSize: Typography.fontSize.lg,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 26,
+  },
+  features: {
+    width: '100%',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.xl,
+    gap: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  featureRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  featureCheck: {
+    fontSize: Typography.fontSize.md,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  featureText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+  },
+  ctas: {
+    width: '100%',
+    gap: Spacing.md,
+    marginBottom: Spacing['3xl'],
+  },
+  btn: {
+    width: '100%',
+  },
 });


### PR DESCRIPTION
## Summary

- Landing page (`app/index.tsx`) with hero section, brand logo, tagline, feature list and two role-selection CTAs
- `app/(auth)/_layout.tsx` — Stack layout group for auth screens
- `app/(auth)/email.tsx` — EmailScreen: email validation, POST `/auth/request-otp`, loading/error states
- `app/(auth)/otp.tsx` — OtpScreen: 6-box digit input, 60s resend timer, auto-submit on fill, POST `/auth/verify-otp`, calls `login()` from authStore before navigating
- `app/_layout.tsx` — protected routing: unauthenticated → `/`, authenticated in auth group → `/`, ActivityIndicator while `isLoading`

Task #1538