### PR TITLE
fix: add public GET /promotions/prices endpoint (#1579)

### DIFF
--- a/api/src/promotions/promotions.controller.ts
+++ b/api/src/promotions/promotions.controller.ts
@@ -48,6 +48,12 @@ export class PromotionsController {
     return this.promotionsService.adminList();
   }
 
+  /** Public: get current prices (no auth required) */
+  @Get('prices')
+  getPublicPrices(@Query('city') city?: string) {
+    return this.promotionsService.getPrices(city);
+  }
+
   /** Admin: get current prices */
   @Get('admin/prices')
   @UseGuards(JwtAuthGuard)


### PR DESCRIPTION
## Summary
- Adds unauthenticated `GET /api/promotions/prices` endpoint
- Reuses existing `PromotionsService.getPrices()` method (same as admin endpoint)
- Supports optional `?city=` query param to filter by city
- Used by frontend to show pricing tiers before purchase

## Test plan
- [ ] `curl https://p2ptax.smartlaunchhub.com/api/promotions/prices` returns 200 with pricing array
- [ ] `curl https://p2ptax.smartlaunchhub.com/api/promotions/prices?city=Tbilisi` returns city-specific prices

Fixes #1579