### PR TITLE
feat: specialist catalog + profile + requests feed (#1540)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,8 +14,11 @@ function RootNavigator() {
     if (isLoading) return;
 
     const inAuthGroup = segments[0] === '(auth)';
+    // Public routes that guests can access freely
+    const isPublicRoute =
+      segments[0] === 'specialists' || segments[0] === 'requests';
 
-    if (!user && !inAuthGroup && segments[0] !== undefined) {
+    if (!user && !inAuthGroup && !isPublicRoute && segments[0] !== undefined) {
       // Not authenticated and trying to access a protected route → landing
       router.replace('/');
     } else if (user && inAuthGroup) {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -47,6 +47,24 @@ export default function LandingScreen() {
             ))}
           </View>
 
+          {/* Quick access */}
+          <View style={styles.quickAccess}>
+            <Button
+              onPress={() => router.push('/specialists')}
+              variant="secondary"
+              style={styles.btn}
+            >
+              Каталог специалистов
+            </Button>
+            <Button
+              onPress={() => router.push('/requests')}
+              variant="secondary"
+              style={styles.btn}
+            >
+              Лента запросов
+            </Button>
+          </View>
+
           {/* CTAs */}
           <View style={styles.ctas}>
             <Button
@@ -139,6 +157,10 @@ const styles = StyleSheet.create({
   featureText: {
     fontSize: Typography.fontSize.base,
     color: Colors.textSecondary,
+  },
+  quickAccess: {
+    width: '100%',
+    gap: Spacing.md,
   },
   ctas: {
     width: '100%',

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+} from 'react-native';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { Card } from '../../components/Card';
+import { Input } from '../../components/Input';
+import { EmptyState } from '../../components/EmptyState';
+import { Header } from '../../components/Header';
+import { Button } from '../../components/Button';
+
+interface RequestItem {
+  id: string;
+  description: string;
+  city: string;
+  status: string;
+  createdAt: string;
+  client: { id: string; email: string };
+  _count: { responses: number };
+}
+
+interface FeedResponse {
+  items: RequestItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export default function RequestsFeedScreen() {
+  const [items, setItems] = useState<RequestItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [cityFilter, setCityFilter] = useState('');
+
+  const fetchFeed = useCallback(
+    async (opts: { pageNum?: number; replace?: boolean; isRefresh?: boolean } = {}) => {
+      const { pageNum = 1, replace = true, isRefresh = false } = opts;
+
+      if (replace && !isRefresh) setLoading(true);
+      if (!replace) setLoadingMore(true);
+      setError('');
+
+      try {
+        const params = new URLSearchParams();
+        if (cityFilter.trim()) params.set('city', cityFilter.trim());
+        params.set('page', String(pageNum));
+        const data = await api.get<FeedResponse>(`/requests?${params.toString()}`);
+
+        if (replace || isRefresh) {
+          setItems(data.items);
+        } else {
+          setItems((prev) => [...prev, ...data.items]);
+        }
+        setTotal(data.total);
+        setPage(data.page);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(err.message);
+        } else {
+          setError('Не удалось загрузить запросы.');
+        }
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+        setRefreshing(false);
+      }
+    },
+    [cityFilter],
+  );
+
+  // Debounce city filter
+  useEffect(() => {
+    const timer = setTimeout(() => fetchFeed({ replace: true }), cityFilter ? 400 : 0);
+    return () => clearTimeout(timer);
+  }, [fetchFeed, cityFilter]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchFeed({ replace: true, isRefresh: true });
+  }
+
+  function handleLoadMore() {
+    if (loadingMore || items.length >= total) return;
+    fetchFeed({ pageNum: page + 1, replace: false });
+  }
+
+  function formatDate(iso: string) {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function renderItem({ item }: { item: RequestItem }) {
+    return (
+      <View style={styles.cardWrapper}>
+        <Card padding={Spacing.lg}>
+          {/* City + date row */}
+          <View style={styles.metaRow}>
+            <View style={styles.cityChip}>
+              <Text style={styles.cityText}>{item.city}</Text>
+            </View>
+            <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
+          </View>
+
+          {/* Description */}
+          <Text style={styles.description} numberOfLines={4}>
+            {item.description}
+          </Text>
+
+          {/* Footer */}
+          <View style={styles.footer}>
+            <Text style={styles.responsesText}>
+              Откликов: {item._count.responses}
+            </Text>
+            <View style={styles.statusChip}>
+              <Text style={styles.statusText}>Открыт</Text>
+            </View>
+          </View>
+        </Card>
+      </View>
+    );
+  }
+
+  const hasMore = items.length < total;
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Лента запросов" />
+
+      <FlatList
+        data={items}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        ListHeaderComponent={
+          <View style={styles.filtersBox}>
+            <Input
+              label="Город"
+              value={cityFilter}
+              onChangeText={setCityFilter}
+              placeholder="Например, Тбилиси"
+              autoCapitalize="words"
+            />
+            {total > 0 && (
+              <Text style={styles.totalText}>
+                Найдено запросов: {total}
+              </Text>
+            )}
+          </View>
+        }
+        ListEmptyComponent={
+          loading ? (
+            <View style={styles.loadingBox}>
+              <ActivityIndicator size="large" color={Colors.brandPrimary} />
+            </View>
+          ) : error ? (
+            <EmptyState
+              icon="⚠️"
+              title="Ошибка загрузки"
+              subtitle={error}
+              ctaLabel="Повторить"
+              onCtaPress={() => fetchFeed()}
+            />
+          ) : (
+            <EmptyState
+              icon="📋"
+              title="Запросов пока нет"
+              subtitle={
+                cityFilter
+                  ? `Нет открытых запросов в городе "${cityFilter}"`
+                  : 'Нет открытых запросов. Проверьте позже.'
+              }
+            />
+          )
+        }
+        ListFooterComponent={
+          hasMore ? (
+            <View style={styles.loadMoreBox}>
+              <Button
+                onPress={handleLoadMore}
+                variant="secondary"
+                loading={loadingMore}
+                disabled={loadingMore}
+                style={styles.loadMoreBtn}
+              >
+                Загрузить ещё
+              </Button>
+            </View>
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    alignItems: 'center',
+  },
+  filtersBox: {
+    width: '100%',
+    maxWidth: 430,
+    gap: Spacing.sm,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.xl,
+  },
+  totalText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  cardWrapper: {
+    width: '100%',
+    maxWidth: 430,
+    marginBottom: Spacing.md,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  cityChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  dateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  description: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+    marginBottom: Spacing.md,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  responsesText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  statusChip: {
+    backgroundColor: '#1a3a1e',
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  statusText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  loadingBox: {
+    paddingTop: Spacing['4xl'],
+    alignItems: 'center',
+  },
+  loadMoreBox: {
+    width: '100%',
+    maxWidth: 430,
+    paddingTop: Spacing.md,
+  },
+  loadMoreBtn: {
+    width: '100%',
+  },
+});

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,0 +1,333 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { api, ApiError } from '../../lib/api';
+import { useAuth } from '../../stores/authStore';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { Card } from '../../components/Card';
+import { Badge } from '../../components/Badge';
+import { Avatar } from '../../components/Avatar';
+import { Button } from '../../components/Button';
+import { Header } from '../../components/Header';
+import { EmptyState } from '../../components/EmptyState';
+
+interface SpecialistProfile {
+  id: string;
+  nick: string;
+  cities: string[];
+  services: string[];
+  badges: string[];
+  contacts: string | null;
+  promoted: boolean;
+  promotionTier: number;
+  activity: { responseCount: number };
+  createdAt: string;
+}
+
+export default function SpecialistProfileScreen() {
+  const { nick } = useLocalSearchParams<{ nick: string }>();
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const [profile, setProfile] = useState<SpecialistProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!nick) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError('');
+      try {
+        const data = await api.get<SpecialistProfile>(`/specialists/${nick}`);
+        if (!cancelled) setProfile(data);
+      } catch (err) {
+        if (!cancelled) {
+          if (err instanceof ApiError && err.status === 404) {
+            setError('Специалист не найден');
+          } else {
+            setError('Не удалось загрузить профиль');
+          }
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [nick]);
+
+  function handleWrite() {
+    if (!user) {
+      router.push('/(auth)/email?role=CLIENT');
+      return;
+    }
+    // TODO: navigate to chat when chat screen is implemented
+    router.push('/(auth)/email?role=CLIENT');
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Профиль" showBack />
+        <View style={styles.centerBox}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Профиль" showBack />
+        <EmptyState
+          icon="⚠️"
+          title={error || 'Не удалось загрузить профиль'}
+          ctaLabel="Назад"
+          onCtaPress={() => router.back()}
+        />
+      </SafeAreaView>
+    );
+  }
+
+  const hasFamiliar = profile.badges.includes('familiar');
+  const isPromoted = profile.promoted;
+
+  // Activity rating: 0–100 score based on responseCount (capped at 50)
+  const activityScore = Math.min(100, Math.round((profile.activity.responseCount / 50) * 100));
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Профиль специалиста" showBack />
+
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.container}>
+          {/* Hero card */}
+          <Card style={styles.heroCard}>
+            <View style={styles.heroRow}>
+              <Avatar name={profile.nick} size="lg" />
+              <View style={styles.heroInfo}>
+                <Text style={styles.nick}>@{profile.nick}</Text>
+                {/* Badges */}
+                <View style={styles.badgesRow}>
+                  {isPromoted && <Badge variant="accent" label="Продвинутый" />}
+                  {hasFamiliar && <Badge variant="familiar" />}
+                </View>
+              </View>
+            </View>
+
+            {/* Cities */}
+            {profile.cities.length > 0 && (
+              <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>Города:</Text>
+                <Text style={styles.infoValue}>{profile.cities.join(', ')}</Text>
+              </View>
+            )}
+          </Card>
+
+          {/* Activity */}
+          <Card>
+            <Text style={styles.sectionTitle}>Рейтинг активности</Text>
+            <View style={styles.activityRow}>
+              <View style={styles.activityBar}>
+                <View
+                  style={[
+                    styles.activityFill,
+                    { width: `${activityScore}%` as `${number}%` },
+                  ]}
+                />
+              </View>
+              <Text style={styles.activityLabel}>{activityScore}/100</Text>
+            </View>
+            <Text style={styles.activityHint}>
+              Откликов на запросы: {profile.activity.responseCount}
+            </Text>
+          </Card>
+
+          {/* Services */}
+          {profile.services.length > 0 && (
+            <Card>
+              <Text style={styles.sectionTitle}>Услуги</Text>
+              <View style={styles.servicesList}>
+                {profile.services.map((svc, idx) => (
+                  <View key={idx} style={styles.serviceItem}>
+                    <Text style={styles.serviceBullet}>•</Text>
+                    <Text style={styles.serviceText}>{svc}</Text>
+                  </View>
+                ))}
+              </View>
+            </Card>
+          )}
+
+          {/* Contacts */}
+          {profile.contacts ? (
+            <Card>
+              <Text style={styles.sectionTitle}>Контакты</Text>
+              <Text style={styles.contactsText}>{profile.contacts}</Text>
+            </Card>
+          ) : null}
+
+          {/* Write button */}
+          <Button
+            onPress={handleWrite}
+            variant="primary"
+            style={styles.writeBtn}
+          >
+            {user ? 'Написать' : 'Написать (войдите)'}
+          </Button>
+
+          {!user && (
+            <Text style={styles.guestHint}>
+              Для связи со специалистом необходимо войти или зарегистрироваться
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingBottom: Spacing['3xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+    gap: Spacing.md,
+  },
+  centerBox: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroCard: {
+    gap: Spacing.md,
+  },
+  heroRow: {
+    flexDirection: 'row',
+    gap: Spacing.lg,
+    alignItems: 'flex-start',
+  },
+  heroInfo: {
+    flex: 1,
+    gap: Spacing.sm,
+    paddingTop: Spacing.xs,
+  },
+  nick: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  badgesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    flexWrap: 'wrap',
+  },
+  infoLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  infoValue: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    flex: 1,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    marginBottom: Spacing.md,
+  },
+  activityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  activityBar: {
+    flex: 1,
+    height: 8,
+    backgroundColor: Colors.bgSecondary,
+    borderRadius: BorderRadius.full,
+    overflow: 'hidden',
+  },
+  activityFill: {
+    height: '100%',
+    backgroundColor: Colors.brandPrimary,
+    borderRadius: BorderRadius.full,
+  },
+  activityLabel: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    width: 48,
+    textAlign: 'right',
+  },
+  activityHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    marginTop: Spacing.sm,
+  },
+  servicesList: {
+    gap: Spacing.sm,
+  },
+  serviceItem: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    alignItems: 'flex-start',
+  },
+  serviceBullet: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.brandPrimary,
+    lineHeight: 22,
+  },
+  serviceText: {
+    flex: 1,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  contactsText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  writeBtn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+  guestHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+});

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,0 +1,392 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { Card } from '../../components/Card';
+import { Badge } from '../../components/Badge';
+import { Avatar } from '../../components/Avatar';
+import { Input } from '../../components/Input';
+import { EmptyState } from '../../components/EmptyState';
+import { Header } from '../../components/Header';
+
+interface SpecialistItem {
+  id: string;
+  nick: string;
+  cities: string[];
+  services: string[];
+  badges: string[];
+  promoted: boolean;
+  promotionTier: number;
+  activity: { responseCount: number };
+}
+
+const SORT_OPTIONS: { label: string; value: string }[] = [
+  { label: 'По новизне', value: 'newest' },
+  { label: 'По активности', value: 'responses' },
+];
+
+export default function SpecialistsCatalogScreen() {
+  const router = useRouter();
+
+  const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  const [cityFilter, setCityFilter] = useState('');
+  const [badgeFilter, setBadgeFilter] = useState(false);
+  const [sort, setSort] = useState('newest');
+
+  const fetchSpecialists = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const params = new URLSearchParams();
+      if (cityFilter.trim()) params.set('city', cityFilter.trim());
+      if (badgeFilter) params.set('badge', 'familiar');
+      if (sort === 'responses') params.set('sort', 'responses');
+
+      const query = params.toString();
+      const data = await api.get<SpecialistItem[]>(
+        `/specialists${query ? `?${query}` : ''}`,
+      );
+      setSpecialists(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось загрузить список специалистов.');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [cityFilter, badgeFilter, sort]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => fetchSpecialists(), cityFilter ? 400 : 0);
+    return () => clearTimeout(timer);
+  }, [fetchSpecialists, cityFilter]);
+
+  // Fetch immediately when non-city filters change
+  useEffect(() => {
+    fetchSpecialists();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [badgeFilter, sort]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchSpecialists(true);
+  }
+
+  function renderSpecialist({ item }: { item: SpecialistItem }) {
+    const hasFamiliar = item.badges.includes('familiar');
+    const isPromoted = item.promoted;
+
+    return (
+      <TouchableOpacity
+        onPress={() => router.push(`/specialists/${item.nick}`)}
+        activeOpacity={0.8}
+        style={styles.cardWrapper}
+      >
+        <Card padding={Spacing.lg}>
+          <View style={styles.cardHeader}>
+            <Avatar name={item.nick} size="md" />
+            <View style={styles.cardInfo}>
+              <View style={styles.nickRow}>
+                <Text style={styles.nick} numberOfLines={1}>
+                  @{item.nick}
+                </Text>
+                {isPromoted && (
+                  <Badge variant="accent" label="Продвинутый" />
+                )}
+              </View>
+              {item.cities.length > 0 && (
+                <Text style={styles.cities} numberOfLines={1}>
+                  {item.cities.join(', ')}
+                </Text>
+              )}
+            </View>
+          </View>
+
+          {/* Badges row */}
+          {hasFamiliar && (
+            <View style={styles.badgesRow}>
+              <Badge variant="familiar" />
+            </View>
+          )}
+
+          {/* Services preview */}
+          {item.services.length > 0 && (
+            <View style={styles.servicesRow}>
+              {item.services.slice(0, 2).map((svc, idx) => (
+                <Text key={idx} style={styles.serviceChip} numberOfLines={1}>
+                  {svc}
+                </Text>
+              ))}
+              {item.services.length > 2 && (
+                <Text style={styles.serviceMore}>
+                  +{item.services.length - 2}
+                </Text>
+              )}
+            </View>
+          )}
+
+          {/* Footer */}
+          <View style={styles.cardFooter}>
+            <Text style={styles.activityText}>
+              Откликов: {item.activity.responseCount}
+            </Text>
+            <Text style={styles.writeLink}>Написать →</Text>
+          </View>
+        </Card>
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Каталог специалистов" />
+
+      <FlatList
+        data={specialists}
+        keyExtractor={(item) => item.id}
+        renderItem={renderSpecialist}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        ListHeaderComponent={
+          <View style={styles.filters}>
+            {/* City filter */}
+            <Input
+              label="Город"
+              value={cityFilter}
+              onChangeText={setCityFilter}
+              placeholder="Например, Москва"
+              autoCapitalize="words"
+            />
+
+            {/* Badge filter toggle */}
+            <TouchableOpacity
+              onPress={() => setBadgeFilter((v) => !v)}
+              style={[styles.badgeToggle, badgeFilter && styles.badgeToggleActive]}
+              activeOpacity={0.7}
+            >
+              <Text
+                style={[
+                  styles.badgeToggleText,
+                  badgeFilter && styles.badgeToggleTextActive,
+                ]}
+              >
+                Знакомый в налоговой
+              </Text>
+            </TouchableOpacity>
+
+            {/* Sort tabs */}
+            <View style={styles.sortRow}>
+              {SORT_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => setSort(opt.value)}
+                  style={[
+                    styles.sortTab,
+                    sort === opt.value && styles.sortTabActive,
+                  ]}
+                  activeOpacity={0.7}
+                >
+                  <Text
+                    style={[
+                      styles.sortTabText,
+                      sort === opt.value && styles.sortTabTextActive,
+                    ]}
+                  >
+                    {opt.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        }
+        ListEmptyComponent={
+          loading ? (
+            <View style={styles.loadingBox}>
+              <ActivityIndicator size="large" color={Colors.brandPrimary} />
+            </View>
+          ) : error ? (
+            <EmptyState
+              icon="⚠️"
+              title="Ошибка загрузки"
+              subtitle={error}
+              ctaLabel="Повторить"
+              onCtaPress={() => fetchSpecialists()}
+            />
+          ) : (
+            <EmptyState
+              icon="🔍"
+              title="Специалистов не найдено"
+              subtitle="Попробуйте изменить фильтры"
+            />
+          )
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    alignItems: 'center',
+  },
+  filters: {
+    width: '100%',
+    maxWidth: 430,
+    gap: Spacing.md,
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing.xl,
+  },
+  badgeToggle: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignSelf: 'flex-start',
+  },
+  badgeToggleActive: {
+    backgroundColor: '#2a2070',
+    borderColor: '#a5b4fc',
+  },
+  badgeToggleText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  badgeToggleTextActive: {
+    color: '#a5b4fc',
+  },
+  sortRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  sortTab: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+  },
+  sortTabActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  sortTabText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  sortTabTextActive: {
+    color: Colors.textPrimary,
+  },
+  cardWrapper: {
+    width: '100%',
+    maxWidth: 430,
+    marginBottom: Spacing.md,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+    alignItems: 'flex-start',
+  },
+  cardInfo: {
+    flex: 1,
+    gap: Spacing.xs,
+  },
+  nickRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    flexWrap: 'wrap',
+  },
+  nick: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  cities: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  badgesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+    marginTop: Spacing.sm,
+  },
+  servicesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+    marginTop: Spacing.sm,
+  },
+  serviceChip: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.sm,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  serviceMore: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: Spacing.md,
+    paddingTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  activityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  writeLink: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  loadingBox: {
+    paddingTop: Spacing['4xl'],
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## Summary

- `/specialists` — public catalog with city search, badge filter (familiar), sort by newest/responses. Cards show nick, city, services preview, activity count.
- `/specialists/:nick` — full profile: nick, cities, services list, activity bar (responseCount-based), badges (promoted/familiar), "Написать" button → redirects guest to `/(auth)/email?role=CLIENT`.
- `/requests` — public request feed with city filter and load-more pagination (20/page).
- `_layout.tsx` — fixed auth guard to whitelist `/specialists` and `/requests` as public routes (guests were being redirected to landing).
- `index.tsx` (landing) — added "Каталог специалистов" and "Лента запросов" quick-access buttons.

## API used
- `GET /api/specialists?city=&badge=&sort=` — catalog (public)
- `GET /api/specialists/:nick` — profile by nick (public)
- `GET /api/requests?city=&page=` — request feed (public)

## Test plan
- [ ] Open `/specialists` as guest — catalog loads, filter by city works, badge toggle works, sort tabs switch
- [ ] Click a specialist card → navigates to `/specialists/:nick`
- [ ] Click "Написать" as guest → redirected to `/(auth)/email?role=CLIENT`
- [ ] Open `/requests` as guest — feed loads, city filter works, load-more shows when items < total
- [ ] Landing page shows new quick-access buttons that navigate correctly
- [ ] TypeScript: `npx tsc --noEmit` passes clean

Closes #1540