### PR TITLE
feat: ЛК заказчика — requests hub + create/view (#1542)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useAuth } from '../../stores/authStore';
+import { Colors } from '../../constants/Colors';
+
+export default function DashboardLayout() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!user) {
+      router.replace('/(auth)/email?role=CLIENT');
+    }
+  }, [user, isLoading, router]);
+
+  if (isLoading || !user) {
+    return (
+      <View style={{ flex: 1, backgroundColor: Colors.bgPrimary, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { useAuth } from '../../stores/authStore';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Button } from '../../components/Button';
+
+interface MyRequest {
+  id: string;
+  status: string;
+  _count: { responses: number };
+}
+
+interface ThreadItem {
+  id: string;
+  unreadCount?: number;
+}
+
+export default function DashboardHub() {
+  const router = useRouter();
+  const { user, logout } = useAuth();
+  const [requestCount, setRequestCount] = useState(0);
+  const [activeCount, setActiveCount] = useState(0);
+  const [threadCount, setThreadCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    try {
+      const [requests, threads] = await Promise.all([
+        api.get<MyRequest[]>('/requests/my'),
+        api.get<ThreadItem[]>('/threads').catch(() => [] as ThreadItem[]),
+      ]);
+      setRequestCount(requests.length);
+      setActiveCount(requests.filter((r) => r.status === 'OPEN').length);
+      setThreadCount(Array.isArray(threads) ? threads.length : 0);
+    } catch {
+      // silently fail, show 0
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchData(true);
+  }
+
+  async function handleLogout() {
+    await logout();
+    router.replace('/');
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header
+        title="Личный кабинет"
+        rightAction={
+          <TouchableOpacity onPress={handleLogout} hitSlop={12}>
+            <Text style={styles.logoutText}>Выйти</Text>
+          </TouchableOpacity>
+        }
+      />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+      >
+        <View style={styles.container}>
+          {/* Welcome */}
+          <Text style={styles.welcome}>
+            {user?.email ?? 'Заказчик'}
+          </Text>
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={{ marginTop: Spacing['3xl'] }} />
+          ) : (
+            <>
+              {/* Requests card */}
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => router.push('/(dashboard)/requests')}
+                activeOpacity={0.75}
+              >
+                <View style={styles.cardIcon}>
+                  <Text style={styles.cardEmoji}>{'📋'}</Text>
+                </View>
+                <View style={styles.cardContent}>
+                  <Text style={styles.cardTitle}>Мои запросы</Text>
+                  <Text style={styles.cardSub}>
+                    Всего: {requestCount} | Активных: {activeCount}
+                  </Text>
+                </View>
+                <Text style={styles.cardArrow}>{'>'}</Text>
+              </TouchableOpacity>
+
+              {/* Threads card */}
+              <TouchableOpacity
+                style={styles.card}
+                onPress={() => router.push('/(dashboard)/requests')}
+                activeOpacity={0.75}
+              >
+                <View style={styles.cardIcon}>
+                  <Text style={styles.cardEmoji}>{'💬'}</Text>
+                </View>
+                <View style={styles.cardContent}>
+                  <Text style={styles.cardTitle}>Мои диалоги</Text>
+                  <Text style={styles.cardSub}>
+                    Диалогов: {threadCount}
+                  </Text>
+                </View>
+                <Text style={styles.cardArrow}>{'>'}</Text>
+              </TouchableOpacity>
+
+              {/* Quick create */}
+              <Button
+                onPress={() => router.push('/(dashboard)/requests/new')}
+                variant="primary"
+                style={styles.createBtn}
+              >
+                Создать запрос
+              </Button>
+            </>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['3xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.lg,
+  },
+  welcome: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textSecondary,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.xl,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Shadows.md,
+  },
+  cardIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: Spacing.lg,
+  },
+  cardEmoji: {
+    fontSize: 22,
+  },
+  cardContent: {
+    flex: 1,
+    gap: 4,
+  },
+  cardTitle: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  cardSub: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  cardArrow: {
+    fontSize: 18,
+    color: Colors.textMuted,
+    marginLeft: Spacing.sm,
+  },
+  createBtn: {
+    width: '100%',
+    marginTop: Spacing.md,
+  },
+  logoutText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+  Alert,
+} from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { api, ApiError } from '../../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+import { Card } from '../../../components/Card';
+import { Button } from '../../../components/Button';
+import { EmptyState } from '../../../components/EmptyState';
+
+interface ResponseItem {
+  id: string;
+  message: string;
+  specialist: { id: string; email: string };
+  createdAt: string;
+}
+
+interface RequestDetail {
+  id: string;
+  description: string;
+  city: string;
+  status: string;
+  createdAt: string;
+  _count: { responses: number };
+  responses: ResponseItem[];
+}
+
+export default function RequestDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [request, setRequest] = useState<RequestDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [closingId, setClosingId] = useState(false);
+
+  const fetchDetail = useCallback(async (isRefresh = false) => {
+    if (!id) return;
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      // Use /requests/my and find by id
+      const all = await api.get<RequestDetail[]>('/requests/my');
+      const found = all.find((r) => r.id === id) ?? null;
+      if (!found) {
+        setError('Запрос не найден');
+      }
+      setRequest(found);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось загрузить запрос');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchDetail(true);
+  }
+
+  async function handleClose() {
+    if (!request) return;
+    setClosingId(true);
+    try {
+      await api.patch(`/requests/${request.id}`, { status: 'CLOSED' });
+      setRequest((prev) => prev ? { ...prev, status: 'CLOSED' } : prev);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Ошибка при закрытии';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setClosingId(false);
+    }
+  }
+
+  function formatDate(iso: string) {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function handleStartDialog() {
+    Alert.alert('Скоро', 'Функция диалогов будет доступна в ближайшее время');
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Запрос" showBack />
+        <View style={styles.loadingBox}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !request) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Запрос" showBack />
+        <EmptyState
+          icon="⚠️"
+          title="Ошибка"
+          subtitle={error || 'Запрос не найден'}
+          ctaLabel="Повторить"
+          onCtaPress={() => fetchDetail()}
+        />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Запрос" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+      >
+        <View style={styles.container}>
+          {/* Request info */}
+          <Card padding={Spacing.xl}>
+            <View style={styles.metaRow}>
+              <View style={styles.cityChip}>
+                <Text style={styles.cityText}>{request.city}</Text>
+              </View>
+              <View style={[styles.statusChip, request.status !== 'OPEN' && styles.statusChipClosed]}>
+                <Text style={[styles.statusText, request.status !== 'OPEN' && styles.statusTextClosed]}>
+                  {request.status === 'OPEN' ? 'Открыт' : 'Закрыт'}
+                </Text>
+              </View>
+            </View>
+
+            <Text style={styles.description}>{request.description}</Text>
+
+            <Text style={styles.dateLabel}>{formatDate(request.createdAt)}</Text>
+
+            {request.status === 'OPEN' && (
+              <Button
+                onPress={handleClose}
+                variant="danger"
+                loading={closingId}
+                disabled={closingId}
+                style={styles.closeBtn}
+              >
+                Закрыть запрос
+              </Button>
+            )}
+          </Card>
+
+          {/* Responses */}
+          <Text style={styles.sectionTitle}>
+            Отклики ({request.responses.length})
+          </Text>
+
+          {request.responses.length === 0 ? (
+            <View style={styles.emptyResponses}>
+              <Text style={styles.emptyText}>Пока нет откликов</Text>
+              <Text style={styles.emptySubtext}>Специалисты скоро увидят ваш запрос</Text>
+            </View>
+          ) : (
+            request.responses.map((resp) => (
+              <Card key={resp.id} padding={Spacing.lg}>
+                <View style={styles.responseHeader}>
+                  <Text style={styles.specialistEmail}>{resp.specialist.email}</Text>
+                  <Text style={styles.responseDateText}>{formatDate(resp.createdAt)}</Text>
+                </View>
+                <Text style={styles.responseMessage}>{resp.message}</Text>
+                <Button
+                  onPress={handleStartDialog}
+                  variant="secondary"
+                  style={styles.dialogBtn}
+                >
+                  Начать диалог
+                </Button>
+              </Card>
+            ))
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.lg,
+  },
+  loadingBox: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  cityChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  statusChip: {
+    backgroundColor: '#1a3a1e',
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  statusChipClosed: {
+    backgroundColor: '#3a2a1e',
+  },
+  statusText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  statusTextClosed: {
+    color: Colors.textMuted,
+  },
+  description: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 24,
+    marginBottom: Spacing.md,
+  },
+  dateLabel: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  closeBtn: {
+    marginTop: Spacing.lg,
+    width: '100%',
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    marginTop: Spacing.md,
+  },
+  emptyResponses: {
+    alignItems: 'center',
+    paddingVertical: Spacing['3xl'],
+    gap: Spacing.sm,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  emptySubtext: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  responseHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  specialistEmail: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textAccent,
+  },
+  responseDateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  responseMessage: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+    marginBottom: Spacing.md,
+  },
+  dialogBtn: {
+    width: '100%',
+  },
+});

--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -1,0 +1,354 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { api, ApiError } from '../../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+import { Button } from '../../../components/Button';
+import { Card } from '../../../components/Card';
+import { EmptyState } from '../../../components/EmptyState';
+
+interface ResponseItem {
+  id: string;
+  message: string;
+  specialist: { id: string; email: string };
+  createdAt: string;
+}
+
+interface RequestItem {
+  id: string;
+  description: string;
+  city: string;
+  status: string;
+  createdAt: string;
+  _count: { responses: number };
+  responses: ResponseItem[];
+}
+
+type Tab = 'active' | 'closed';
+
+export default function MyRequestsScreen() {
+  const router = useRouter();
+  const [items, setItems] = useState<RequestItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [tab, setTab] = useState<Tab>('active');
+  const [closingId, setClosingId] = useState<string | null>(null);
+
+  const fetchRequests = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const data = await api.get<RequestItem[]>('/requests/my');
+      setItems(data);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось загрузить запросы.');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchRequests(true);
+  }
+
+  async function handleClose(id: string) {
+    setClosingId(id);
+    try {
+      await api.patch(`/requests/${id}`, { status: 'CLOSED' });
+      setItems((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, status: 'CLOSED' } : r)),
+      );
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Ошибка при закрытии';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setClosingId(null);
+    }
+  }
+
+  const filtered = items.filter((r) =>
+    tab === 'active' ? r.status === 'OPEN' : r.status !== 'OPEN',
+  );
+
+  function formatDate(iso: string) {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function renderItem({ item }: { item: RequestItem }) {
+    return (
+      <TouchableOpacity
+        style={styles.cardWrapper}
+        onPress={() => router.push(`/(dashboard)/requests/${item.id}`)}
+        activeOpacity={0.75}
+      >
+        <Card padding={Spacing.lg}>
+          {/* City + date */}
+          <View style={styles.metaRow}>
+            <View style={styles.cityChip}>
+              <Text style={styles.cityText}>{item.city}</Text>
+            </View>
+            <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
+          </View>
+
+          {/* Description */}
+          <Text style={styles.description} numberOfLines={3}>
+            {item.description}
+          </Text>
+
+          {/* Footer */}
+          <View style={styles.footer}>
+            <Text style={styles.responsesText}>
+              Откликов: {item._count.responses}
+            </Text>
+            <View style={[styles.statusChip, item.status !== 'OPEN' && styles.statusChipClosed]}>
+              <Text style={[styles.statusText, item.status !== 'OPEN' && styles.statusTextClosed]}>
+                {item.status === 'OPEN' ? 'Открыт' : 'Закрыт'}
+              </Text>
+            </View>
+          </View>
+
+          {/* Close button for active */}
+          {item.status === 'OPEN' && (
+            <Button
+              onPress={() => handleClose(item.id)}
+              variant="ghost"
+              loading={closingId === item.id}
+              disabled={closingId === item.id}
+              style={styles.closeBtn}
+            >
+              Закрыть запрос
+            </Button>
+          )}
+        </Card>
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Мои запросы" showBack />
+
+      {/* Tabs */}
+      <View style={styles.tabs}>
+        <TouchableOpacity
+          style={[styles.tab, tab === 'active' && styles.tabActive]}
+          onPress={() => setTab('active')}
+        >
+          <Text style={[styles.tabText, tab === 'active' && styles.tabTextActive]}>
+            Активные
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, tab === 'closed' && styles.tabActive]}
+          onPress={() => setTab('closed')}
+        >
+          <Text style={[styles.tabText, tab === 'closed' && styles.tabTextActive]}>
+            Закрытые
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        ListEmptyComponent={
+          loading ? (
+            <View style={styles.loadingBox}>
+              <ActivityIndicator size="large" color={Colors.brandPrimary} />
+            </View>
+          ) : error ? (
+            <EmptyState
+              icon="⚠️"
+              title="Ошибка загрузки"
+              subtitle={error}
+              ctaLabel="Повторить"
+              onCtaPress={() => fetchRequests()}
+            />
+          ) : (
+            <EmptyState
+              icon="📋"
+              title={tab === 'active' ? 'Нет активных запросов' : 'Нет закрытых запросов'}
+              subtitle={tab === 'active' ? 'Создайте свой первый запрос' : undefined}
+              ctaLabel={tab === 'active' ? 'Создать запрос' : undefined}
+              onCtaPress={tab === 'active' ? () => router.push('/(dashboard)/requests/new') : undefined}
+            />
+          )
+        }
+        ListFooterComponent={
+          !loading && filtered.length > 0 ? (
+            <View style={styles.footerBtn}>
+              <Button
+                onPress={() => router.push('/(dashboard)/requests/new')}
+                variant="primary"
+                style={styles.createBtn}
+              >
+                Создать запрос
+              </Button>
+            </View>
+          ) : null
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  tabs: {
+    flexDirection: 'row',
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.sm,
+    gap: Spacing.sm,
+    alignSelf: 'center',
+    maxWidth: 430,
+    width: '100%',
+  },
+  tab: {
+    flex: 1,
+    height: 40,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgCard,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  tabActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  tabText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textMuted,
+  },
+  tabTextActive: {
+    color: Colors.textPrimary,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    alignItems: 'center',
+  },
+  cardWrapper: {
+    width: '100%',
+    maxWidth: 430,
+    marginTop: Spacing.md,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  cityChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  dateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  description: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+    marginBottom: Spacing.md,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  responsesText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  statusChip: {
+    backgroundColor: '#1a3a1e',
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  statusChipClosed: {
+    backgroundColor: '#3a2a1e',
+  },
+  statusText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  statusTextClosed: {
+    color: Colors.textMuted,
+  },
+  closeBtn: {
+    marginTop: Spacing.md,
+  },
+  loadingBox: {
+    paddingTop: Spacing['4xl'],
+    alignItems: 'center',
+  },
+  footerBtn: {
+    width: '100%',
+    maxWidth: 430,
+    paddingTop: Spacing.xl,
+  },
+  createBtn: {
+    width: '100%',
+  },
+});

--- a/app/(dashboard)/requests/new.tsx
+++ b/app/(dashboard)/requests/new.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  Alert,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { api, ApiError } from '../../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+import { Button } from '../../../components/Button';
+import { Input } from '../../../components/Input';
+
+export default function CreateRequestScreen() {
+  const router = useRouter();
+  const [description, setDescription] = useState('');
+  const [city, setCity] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errors, setErrors] = useState<{ description?: string; city?: string }>({});
+
+  function validate(): boolean {
+    const e: typeof errors = {};
+    if (description.trim().length < 3) {
+      e.description = 'Минимум 3 символа';
+    }
+    if (!city.trim()) {
+      e.city = 'Укажите город';
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  async function handleSubmit() {
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      await api.post('/requests', {
+        description: description.trim(),
+        city: city.trim(),
+      });
+      router.replace('/(dashboard)/requests');
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось создать запрос';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Новый запрос" showBack />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            <Text style={styles.subtitle}>
+              Опишите вашу задачу, и специалисты откликнутся
+            </Text>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>Описание</Text>
+              <View style={[styles.textareaWrapper, errors.description ? styles.textareaError : null]}>
+                <View style={styles.textarea}>
+                  <Input
+                    value={description}
+                    onChangeText={(t) => {
+                      setDescription(t);
+                      if (errors.description) setErrors((e) => ({ ...e, description: undefined }));
+                    }}
+                    placeholder="Опишите вашу задачу подробно..."
+                    autoCapitalize="sentences"
+                    error={errors.description}
+                  />
+                </View>
+              </View>
+            </View>
+
+            <Input
+              label="Город"
+              value={city}
+              onChangeText={(t) => {
+                setCity(t);
+                if (errors.city) setErrors((e) => ({ ...e, city: undefined }));
+              }}
+              placeholder="Например, Москва"
+              autoCapitalize="words"
+              error={errors.city}
+            />
+
+            <Button
+              onPress={handleSubmit}
+              variant="primary"
+              loading={loading}
+              disabled={loading}
+              style={styles.submitBtn}
+            >
+              Отправить запрос
+            </Button>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  flex: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.xl,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  field: {
+    gap: Spacing.xs,
+  },
+  label: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+    marginBottom: 2,
+  },
+  textareaWrapper: {
+    borderRadius: BorderRadius.md,
+  },
+  textareaError: {
+    // handled by Input component
+  },
+  textarea: {
+    minHeight: 48,
+  },
+  submitBtn: {
+    width: '100%',
+    marginTop: Spacing.md,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ function RootNavigator() {
     if (isLoading) return;
 
     const inAuthGroup = segments[0] === '(auth)';
+    const inDashboardGroup = segments[0] === '(dashboard)';
     // Public routes that guests can access freely
     const isPublicRoute =
       segments[0] === 'specialists' || segments[0] === 'requests';
@@ -22,8 +23,11 @@ function RootNavigator() {
       // Not authenticated and trying to access a protected route → landing
       router.replace('/');
     } else if (user && inAuthGroup) {
-      // Already authenticated and still in auth group → home
-      router.replace('/');
+      // Already authenticated and still in auth group → dashboard
+      router.replace('/(dashboard)');
+    } else if (user && !inDashboardGroup && !isPublicRoute && segments[0] === undefined) {
+      // Authenticated user on landing → redirect to dashboard
+      router.replace('/(dashboard)');
     }
   }, [user, isLoading, segments, router]);
 


### PR DESCRIPTION
## Summary
- Client dashboard group `(dashboard)/` with auth guard layout
- Hub screen showing requests count, threads count, quick create button
- My requests list with Active/Closed tabs and close action
- Create request form with description + city validation
- Request detail page with specialist responses and "start dialog" stub
- Root layout updated: authenticated users redirect to dashboard, auth group redirects to dashboard

## Files changed
- `app/(dashboard)/_layout.tsx` — auth guard + Stack layout
- `app/(dashboard)/index.tsx` — hub with stats cards
- `app/(dashboard)/requests/index.tsx` — my requests list
- `app/(dashboard)/requests/new.tsx` — create request form
- `app/(dashboard)/requests/[id].tsx` — request detail + responses
- `app/_layout.tsx` — auth redirect logic updated

## Test plan
- [ ] Login as CLIENT → should redirect to dashboard hub
- [ ] Hub shows request/thread counts
- [ ] Create request with description + city → appears in list
- [ ] Active/Closed tabs filter correctly
- [ ] Close request → moves to Closed tab
- [ ] Request detail shows specialist responses
- [ ] "Start dialog" button shows "coming soon" alert
- [ ] Logout button works from hub
- [ ] Unauthenticated users see landing, not dashboard
- [ ] Public routes (specialists, requests feed) still accessible