### PR TITLE
feat: specialist dashboard — profile, city requests, responses, promotion (#1544)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -37,6 +37,14 @@ export class RequestsController {
     return this.requestsService.findMy(req.user.id);
   }
 
+  // GET /requests/my-responses — specialist's own responses with request info
+  @Get('my-responses')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  getMyResponses(@Request() req: any) {
+    return this.requestsService.findMyResponses(req.user.id);
+  }
+
   // GET /requests — public feed (specialists browse)
   @Get()
   getFeed(@Query('city') city?: string, @Query('page') page?: string) {

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -121,6 +121,24 @@ export class RequestsService {
     return result;
   }
 
+  async findMyResponses(specialistId: string) {
+    return this.prisma.response.findMany({
+      where: { specialistId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        request: {
+          select: {
+            id: true,
+            description: true,
+            city: true,
+            status: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+  }
+
   async updateStatus(clientId: string, requestId: string, status: RequestStatus) {
     const request = await this.prisma.request.findUnique({ where: { id: requestId } });
     if (!request) throw new NotFoundException('Request not found');

--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -1,0 +1,467 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  Modal,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+  Alert,
+} from 'react-native';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Button } from '../../components/Button';
+import { Card } from '../../components/Card';
+import { EmptyState } from '../../components/EmptyState';
+
+interface SpecialistProfile {
+  cities: string[];
+}
+
+interface RequestItem {
+  id: string;
+  description: string;
+  city: string;
+  status: string;
+  createdAt: string;
+  client: { id: string; email: string };
+  _count: { responses: number };
+}
+
+interface FeedResponse {
+  items: RequestItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export default function CityRequestsScreen() {
+  const [requests, setRequests] = useState<RequestItem[]>([]);
+  const [myCities, setMyCities] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [respondingId, setRespondingId] = useState<string | null>(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  // Track already-responded request IDs optimistically
+  const [respondedIds, setRespondedIds] = useState<Set<string>>(new Set());
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const profile = await api.get<SpecialistProfile>('/specialists/me');
+      const cities = profile.cities;
+      setMyCities(cities);
+
+      if (cities.length === 0) {
+        setRequests([]);
+        return;
+      }
+
+      // Fetch open requests for each city in parallel, deduplicate by id
+      const results = await Promise.all(
+        cities.map((city) =>
+          api
+            .get<FeedResponse>(`/requests?city=${encodeURIComponent(city)}`)
+            .then((res) => res.items)
+            .catch(() => [] as RequestItem[]),
+        ),
+      );
+
+      const seen = new Set<string>();
+      const merged: RequestItem[] = [];
+      for (const batch of results) {
+        for (const item of batch) {
+          if (!seen.has(item.id)) {
+            seen.add(item.id);
+            merged.push(item);
+          }
+        }
+      }
+
+      // Sort newest first
+      merged.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      setRequests(merged);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setError('no_profile');
+      } else {
+        setError(err instanceof ApiError ? err.message : 'Не удалось загрузить запросы');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchData(true);
+  }
+
+  function openRespond(id: string) {
+    setRespondingId(id);
+    setMessage('');
+    setModalVisible(true);
+  }
+
+  function closeModal() {
+    setModalVisible(false);
+    setRespondingId(null);
+    setMessage('');
+  }
+
+  async function submitResponse() {
+    if (!respondingId) return;
+    const trimmed = message.trim();
+    if (!trimmed) {
+      Alert.alert('Ошибка', 'Введите сообщение для отклика');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api.post(`/requests/${respondingId}/respond`, { message: trimmed });
+      setRespondedIds((prev) => new Set([...prev, respondingId]));
+      closeModal();
+      Alert.alert('Отклик отправлен', 'Клиент получит уведомление.');
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.status === 409
+            ? 'Вы уже откликались на этот запрос.'
+            : err.message
+          : 'Ошибка при отправке отклика';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function formatDate(iso: string) {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function renderItem({ item }: { item: RequestItem }) {
+    const alreadyResponded = respondedIds.has(item.id);
+    return (
+      <View style={styles.cardWrapper}>
+        <Card padding={Spacing.lg}>
+          <View style={styles.metaRow}>
+            <View style={styles.cityChip}>
+              <Text style={styles.cityText}>{item.city}</Text>
+            </View>
+            <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
+          </View>
+          <Text style={styles.description} numberOfLines={4}>
+            {item.description}
+          </Text>
+          <View style={styles.footer}>
+            <Text style={styles.responsesText}>Откликов: {item._count.responses}</Text>
+          </View>
+          {alreadyResponded ? (
+            <View style={styles.respondedBadge}>
+              <Text style={styles.respondedText}>Отклик отправлен</Text>
+            </View>
+          ) : (
+            <Button
+              onPress={() => openRespond(item.id)}
+              variant="primary"
+              style={styles.respondBtn}
+            >
+              Откликнуться
+            </Button>
+          )}
+        </Card>
+      </View>
+    );
+  }
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      );
+    }
+
+    if (error === 'no_profile') {
+      return (
+        <EmptyState
+          icon="👤"
+          title="Профиль не найден"
+          subtitle="Создайте профиль специалиста, чтобы видеть запросы в ваших городах"
+        />
+      );
+    }
+
+    if (error) {
+      return (
+        <EmptyState
+          icon="⚠️"
+          title="Ошибка загрузки"
+          subtitle={error}
+          ctaLabel="Повторить"
+          onCtaPress={() => fetchData()}
+        />
+      );
+    }
+
+    if (myCities.length === 0) {
+      return (
+        <EmptyState
+          icon="🏙️"
+          title="Нет городов в профиле"
+          subtitle="Добавьте города в профиль, чтобы видеть запросы"
+        />
+      );
+    }
+
+    if (requests.length === 0) {
+      return (
+        <EmptyState
+          icon="📭"
+          title="Нет открытых запросов"
+          subtitle={`В ваших городах (${myCities.join(', ')}) пока нет запросов`}
+        />
+      );
+    }
+
+    return null;
+  };
+
+  const content = renderContent();
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Запросы в моих городах" showBack />
+
+      {myCities.length > 0 && !loading && !error && (
+        <View style={styles.citiesBar}>
+          <Text style={styles.citiesText}>
+            {'Города: '}{myCities.join(', ')}
+          </Text>
+        </View>
+      )}
+
+      {content ? (
+        <View style={styles.contentFlex}>{content}</View>
+      ) : (
+        <FlatList
+          data={requests}
+          keyExtractor={(item) => item.id}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              tintColor={Colors.brandPrimary}
+            />
+          }
+        />
+      )}
+
+      {/* Respond modal */}
+      <Modal
+        visible={modalVisible}
+        transparent
+        animationType="slide"
+        onRequestClose={closeModal}
+      >
+        <KeyboardAvoidingView
+          style={styles.modalOverlay}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        >
+          <View style={styles.modalSheet}>
+            <Text style={styles.modalTitle}>Ваш отклик</Text>
+            <Text style={styles.modalHint}>Кратко опишите, как вы можете помочь</Text>
+            <TextInput
+              value={message}
+              onChangeText={setMessage}
+              placeholder="Здравствуйте! Я специалист по..."
+              placeholderTextColor={Colors.textMuted}
+              multiline
+              numberOfLines={4}
+              style={styles.messageInput}
+              autoFocus
+            />
+            <View style={styles.modalBtns}>
+              <Button onPress={closeModal} variant="ghost" style={styles.modalBtn}>
+                Отмена
+              </Button>
+              <Button
+                onPress={submitResponse}
+                variant="primary"
+                loading={submitting}
+                disabled={submitting}
+                style={styles.modalBtn}
+              >
+                Отправить
+              </Button>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  contentFlex: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  citiesBar: {
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm,
+    backgroundColor: Colors.bgSecondary,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    alignItems: 'center',
+  },
+  citiesText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    maxWidth: 430,
+    width: '100%',
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    alignItems: 'center',
+    paddingTop: Spacing.md,
+  },
+  cardWrapper: {
+    width: '100%',
+    maxWidth: 430,
+    marginBottom: Spacing.md,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  cityChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  dateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  description: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+    marginBottom: Spacing.md,
+  },
+  footer: {
+    paddingTop: Spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    marginBottom: Spacing.md,
+  },
+  responsesText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  respondBtn: {
+    width: '100%',
+  },
+  respondedBadge: {
+    backgroundColor: '#1a3a1e',
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.sm,
+    alignItems: 'center',
+  },
+  respondedText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  // Modal
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: Colors.bgCard,
+    borderTopLeftRadius: BorderRadius.xl,
+    borderTopRightRadius: BorderRadius.xl,
+    padding: Spacing['2xl'],
+    gap: Spacing.md,
+    alignSelf: 'center',
+    width: '100%',
+    maxWidth: 430,
+  },
+  modalTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  modalHint: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    marginTop: -Spacing.xs,
+  },
+  messageInput: {
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.lg,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    minHeight: 100,
+    textAlignVertical: 'top',
+  },
+  modalBtns: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  modalBtn: {
+    flex: 1,
+  },
+});

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -1,0 +1,486 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Switch,
+  Alert,
+  TextInput,
+  RefreshControl,
+} from 'react-native';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Button } from '../../components/Button';
+import { Input } from '../../components/Input';
+
+const BADGE_TAX = 'Знакомый в налоговой';
+
+interface SpecialistProfile {
+  id: string;
+  nick: string;
+  cities: string[];
+  services: string[];
+  badges: string[];
+  contacts: string | null;
+}
+
+export default function SpecialistProfileScreen() {
+  const [profile, setProfile] = useState<SpecialistProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  // Editable fields
+  const [nick, setNick] = useState('');
+  const [contacts, setContacts] = useState('');
+  const [cityInput, setCityInput] = useState('');
+  const [cities, setCities] = useState<string[]>([]);
+  const [serviceInput, setServiceInput] = useState('');
+  const [services, setServices] = useState<string[]>([]);
+  const [hasTaxBadge, setHasTaxBadge] = useState(false);
+
+  const fetchProfile = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const data = await api.get<SpecialistProfile>('/specialists/me');
+      setProfile(data);
+      setNick(data.nick);
+      setContacts(data.contacts ?? '');
+      setCities(data.cities);
+      setServices(data.services);
+      setHasTaxBadge(data.badges.includes(BADGE_TAX));
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        // No profile yet — will need to create one
+        setError('profile_not_found');
+      } else {
+        setError(err instanceof ApiError ? err.message : 'Не удалось загрузить профиль');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchProfile(true);
+  }
+
+  function addCity() {
+    const trimmed = cityInput.trim();
+    if (!trimmed) return;
+    if (cities.includes(trimmed)) {
+      Alert.alert('Уже добавлен', `Город "${trimmed}" уже в списке.`);
+      return;
+    }
+    setCities((prev) => [...prev, trimmed]);
+    setCityInput('');
+  }
+
+  function removeCity(city: string) {
+    setCities((prev) => prev.filter((c) => c !== city));
+  }
+
+  function addService() {
+    const trimmed = serviceInput.trim();
+    if (!trimmed) return;
+    setServices((prev) => [...prev, trimmed]);
+    setServiceInput('');
+  }
+
+  function removeService(svc: string) {
+    setServices((prev) => prev.filter((s) => s !== svc));
+  }
+
+  async function handleSave() {
+    if (!nick.trim()) {
+      Alert.alert('Ошибка', 'Ник не может быть пустым');
+      return;
+    }
+    setSaving(true);
+    try {
+      const badges = hasTaxBadge ? [BADGE_TAX] : [];
+      const updated = await api.patch<SpecialistProfile>('/specialists/me', {
+        nick: nick.trim(),
+        contacts: contacts.trim() || null,
+        cities,
+        services,
+        badges,
+      });
+      setProfile(updated);
+      Alert.alert('Сохранено', 'Профиль обновлён.');
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.status === 409
+            ? 'Этот ник уже занят, выберите другой.'
+            : err.message
+          : 'Ошибка при сохранении';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Мой профиль" showBack />
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error && error !== 'profile_not_found') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Мой профиль" showBack />
+        <View style={styles.center}>
+          <Text style={styles.errorText}>{error}</Text>
+          <Button onPress={() => fetchProfile()} variant="ghost" style={styles.retryBtn}>
+            Повторить
+          </Button>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error === 'profile_not_found') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Мой профиль" showBack />
+        <View style={styles.center}>
+          <Text style={styles.emptyIcon}>{'👤'}</Text>
+          <Text style={styles.emptyTitle}>Профиль не создан</Text>
+          <Text style={styles.emptySubtitle}>
+            Обратитесь в поддержку или создайте профиль через API
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Мой профиль" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+      >
+        <View style={styles.container}>
+          {/* Nick */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Основное</Text>
+            <Input
+              label="Ник (уникальный)"
+              value={nick}
+              onChangeText={setNick}
+              placeholder="moi_nik"
+              autoCapitalize="none"
+            />
+            <Input
+              label="Контакты (необязательно)"
+              value={contacts}
+              onChangeText={setContacts}
+              placeholder="Telegram: @username, тел: +7..."
+              autoCapitalize="sentences"
+              style={styles.inputGap}
+            />
+          </View>
+
+          {/* Badge toggle */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Бейджи</Text>
+            <View style={styles.badgeRow}>
+              <View style={styles.badgeInfo}>
+                <Text style={styles.badgeLabel}>{BADGE_TAX}</Text>
+                <Text style={styles.badgeHint}>Подтверждённый контакт в ФНС</Text>
+              </View>
+              <Switch
+                value={hasTaxBadge}
+                onValueChange={setHasTaxBadge}
+                trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
+                thumbColor={Colors.textPrimary}
+              />
+            </View>
+          </View>
+
+          {/* Cities */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Города работы</Text>
+            <View style={styles.addRow}>
+              <TextInput
+                value={cityInput}
+                onChangeText={setCityInput}
+                placeholder="Добавить город..."
+                placeholderTextColor={Colors.textMuted}
+                style={styles.addInput}
+                autoCapitalize="words"
+                returnKeyType="done"
+                onSubmitEditing={addCity}
+              />
+              <TouchableOpacity style={styles.addBtn} onPress={addCity}>
+                <Text style={styles.addBtnText}>{'+'}</Text>
+              </TouchableOpacity>
+            </View>
+            {cities.length === 0 && (
+              <Text style={styles.emptyHint}>Нет городов — добавьте хотя бы один</Text>
+            )}
+            <View style={styles.tagList}>
+              {cities.map((city) => (
+                <View key={city} style={styles.tag}>
+                  <Text style={styles.tagText}>{city}</Text>
+                  <TouchableOpacity onPress={() => removeCity(city)} hitSlop={8}>
+                    <Text style={styles.tagRemove}>{'×'}</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          {/* Services */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Услуги и цены</Text>
+            <Text style={styles.sectionHint}>Формат: "Название — 5000 руб"</Text>
+            <View style={styles.addRow}>
+              <TextInput
+                value={serviceInput}
+                onChangeText={setServiceInput}
+                placeholder="Консультация — 3000 руб"
+                placeholderTextColor={Colors.textMuted}
+                style={[styles.addInput, styles.addInputWide]}
+                autoCapitalize="sentences"
+                returnKeyType="done"
+                onSubmitEditing={addService}
+              />
+              <TouchableOpacity style={styles.addBtn} onPress={addService}>
+                <Text style={styles.addBtnText}>{'+'}</Text>
+              </TouchableOpacity>
+            </View>
+            {services.length === 0 && (
+              <Text style={styles.emptyHint}>Нет услуг — добавьте хотя бы одну</Text>
+            )}
+            <View style={styles.serviceList}>
+              {services.map((svc, idx) => (
+                <View key={`${svc}-${idx}`} style={styles.serviceRow}>
+                  <Text style={styles.serviceText} numberOfLines={2}>{svc}</Text>
+                  <TouchableOpacity onPress={() => removeService(svc)} hitSlop={8}>
+                    <Text style={styles.tagRemove}>{'×'}</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <Button
+            onPress={handleSave}
+            variant="primary"
+            loading={saving}
+            disabled={saving}
+            style={styles.saveBtn}
+          >
+            Сохранить профиль
+          </Button>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.xl,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing['2xl'],
+    gap: Spacing.md,
+  },
+  section: {
+    gap: Spacing.sm,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    marginBottom: 2,
+  },
+  sectionHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    marginBottom: Spacing.xs,
+  },
+  inputGap: {
+    marginTop: Spacing.sm,
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Shadows.sm,
+  },
+  badgeInfo: {
+    flex: 1,
+    gap: 3,
+  },
+  badgeLabel: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  badgeHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  addRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    alignItems: 'center',
+  },
+  addInput: {
+    flex: 1,
+    height: 44,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  addInputWide: {
+    flex: 1,
+  },
+  addBtn: {
+    width: 44,
+    height: 44,
+    backgroundColor: Colors.brandPrimary,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addBtnText: {
+    fontSize: 24,
+    color: Colors.textPrimary,
+    lineHeight: 28,
+  },
+  tagList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  tag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgSecondary,
+    borderRadius: BorderRadius.full,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+    gap: Spacing.xs,
+  },
+  tagText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  tagRemove: {
+    fontSize: 16,
+    color: Colors.textMuted,
+    lineHeight: 18,
+  },
+  serviceList: {
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  serviceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+  },
+  serviceText: {
+    flex: 1,
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  emptyHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    fontStyle: 'italic',
+  },
+  emptyIcon: {
+    fontSize: 48,
+    marginBottom: Spacing.sm,
+  },
+  emptyTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+  },
+  errorText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.statusError,
+    textAlign: 'center',
+  },
+  retryBtn: {
+    marginTop: Spacing.sm,
+  },
+  saveBtn: {
+    width: '100%',
+    marginTop: Spacing.md,
+    marginBottom: Spacing['3xl'],
+  },
+});

--- a/app/(dashboard)/promotion.tsx
+++ b/app/(dashboard)/promotion.tsx
@@ -1,0 +1,455 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+  Alert,
+} from 'react-native';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Button } from '../../components/Button';
+import { Card } from '../../components/Card';
+import { EmptyState } from '../../components/EmptyState';
+
+type PromotionTier = 'BASIC' | 'FEATURED' | 'TOP';
+
+interface PriceItem {
+  city: string;
+  tier: PromotionTier;
+  price: number;
+}
+
+interface Promotion {
+  id: string;
+  city: string;
+  tier: PromotionTier;
+  expiresAt: string;
+  createdAt: string;
+}
+
+interface SpecialistProfile {
+  cities: string[];
+}
+
+const TIER_LABELS: Record<PromotionTier, string> = {
+  BASIC: 'Базовый',
+  FEATURED: 'Продвинутый',
+  TOP: 'ТОП',
+};
+
+const TIER_ORDER: PromotionTier[] = ['BASIC', 'FEATURED', 'TOP'];
+
+const TIER_COLORS: Record<PromotionTier, string> = {
+  BASIC: Colors.statusInfo,
+  FEATURED: Colors.brandPrimary,
+  TOP: Colors.statusWarning,
+};
+
+export default function PromotionScreen() {
+  const [promotions, setPromotions] = useState<Promotion[]>([]);
+  const [prices, setPrices] = useState<PriceItem[]>([]);
+  const [myCities, setMyCities] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [purchasing, setPurchasing] = useState<string | null>(null); // city:tier
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const [myPromos, profile] = await Promise.all([
+        api.get<Promotion[]>('/promotions/my'),
+        api.get<SpecialistProfile>('/specialists/me'),
+      ]);
+
+      setPromotions(myPromos);
+      setMyCities(profile.cities);
+
+      // Fetch prices for each city
+      if (profile.cities.length > 0) {
+        const priceResults = await Promise.all(
+          profile.cities.map((city) =>
+            api
+              .get<PriceItem[]>(`/promotions/prices?city=${encodeURIComponent(city)}`)
+              .catch(() => [] as PriceItem[]),
+          ),
+        );
+        const allPrices = priceResults.flat();
+        setPrices(allPrices);
+      } else {
+        // Fall back to default prices
+        const defaultPrices = await api.get<PriceItem[]>('/promotions/prices').catch(() => []);
+        setPrices(defaultPrices);
+      }
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setError('no_profile');
+      } else {
+        setError(err instanceof ApiError ? err.message : 'Не удалось загрузить данные');
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchData(true);
+  }
+
+  function getActivePromo(city: string, tier: PromotionTier): Promotion | undefined {
+    const now = new Date();
+    return promotions.find(
+      (p) => p.city === city && p.tier === tier && new Date(p.expiresAt) > now,
+    );
+  }
+
+  function getPrice(city: string, tier: PromotionTier): number | null {
+    const item = prices.find((p) => p.city === city && p.tier === tier);
+    return item?.price ?? null;
+  }
+
+  async function handlePurchase(city: string, tier: PromotionTier) {
+    const price = getPrice(city, tier);
+    const key = `${city}:${tier}`;
+    setPurchasing(key);
+    try {
+      await api.post('/promotions/purchase', { city, tier });
+      Alert.alert(
+        'Оплата обрабатывается...',
+        `Продвижение "${TIER_LABELS[tier]}" в городе ${city}${price !== null ? ` на сумму ${price} руб.` : ''} будет активировано после подтверждения оплаты.`,
+      );
+      // Refresh to show updated promotion
+      await fetchData(true);
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.status === 400
+            ? err.message
+            : err.message
+          : 'Ошибка при оформлении';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setPurchasing(null);
+    }
+  }
+
+  function formatExpiry(iso: string) {
+    return new Date(iso).toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+  }
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Продвижение" showBack />
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error === 'no_profile') {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Продвижение" showBack />
+        <EmptyState
+          icon="👤"
+          title="Профиль не найден"
+          subtitle="Создайте профиль специалиста, чтобы управлять продвижением"
+        />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <Header title="Продвижение" showBack />
+        <EmptyState
+          icon="⚠️"
+          title="Ошибка загрузки"
+          subtitle={error}
+          ctaLabel="Повторить"
+          onCtaPress={() => fetchData()}
+        />
+      </SafeAreaView>
+    );
+  }
+
+  const activePrPromotions = promotions.filter(
+    (p) => new Date(p.expiresAt) > new Date(),
+  );
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Продвижение" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+      >
+        <View style={styles.container}>
+          {/* Active promotions section */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Активное продвижение</Text>
+            {activePrPromotions.length === 0 ? (
+              <View style={styles.noneCard}>
+                <Text style={styles.noneText}>Нет активного продвижения</Text>
+              </View>
+            ) : (
+              activePrPromotions.map((promo) => (
+                <View key={promo.id} style={styles.activePromoCard}>
+                  <View style={[styles.tierBadge, { backgroundColor: TIER_COLORS[promo.tier] + '22' }]}>
+                    <Text style={[styles.tierBadgeText, { color: TIER_COLORS[promo.tier] }]}>
+                      {TIER_LABELS[promo.tier]}
+                    </Text>
+                  </View>
+                  <View style={styles.activePromoInfo}>
+                    <Text style={styles.activePromoCity}>{promo.city}</Text>
+                    <Text style={styles.activePromoExpiry}>
+                      {'До: '}{formatExpiry(promo.expiresAt)}
+                    </Text>
+                  </View>
+                </View>
+              ))
+            )}
+          </View>
+
+          {/* Pricing by city */}
+          {myCities.length === 0 ? (
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>Тарифы</Text>
+              <View style={styles.noneCard}>
+                <Text style={styles.noneText}>
+                  Добавьте города в профиль, чтобы видеть тарифы
+                </Text>
+              </View>
+            </View>
+          ) : (
+            myCities.map((city) => (
+              <View key={city} style={styles.section}>
+                <Text style={styles.sectionTitle}>{city}</Text>
+                <Card padding={0}>
+                  {TIER_ORDER.map((tier, idx) => {
+                    const price = getPrice(city, tier);
+                    const active = getActivePromo(city, tier);
+                    const key = `${city}:${tier}`;
+                    const isBuying = purchasing === key;
+                    const isLast = idx === TIER_ORDER.length - 1;
+                    return (
+                      <View
+                        key={tier}
+                        style={[styles.priceRow, !isLast && styles.priceRowBorder]}
+                      >
+                        <View style={styles.priceLeft}>
+                          <View style={[styles.dot, { backgroundColor: TIER_COLORS[tier] }]} />
+                          <View style={styles.priceInfo}>
+                            <Text style={styles.tierName}>{TIER_LABELS[tier]}</Text>
+                            {active ? (
+                              <Text style={styles.activeUntil}>
+                                {'Активно до '}{formatExpiry(active.expiresAt)}
+                              </Text>
+                            ) : (
+                              <Text style={styles.priceVal}>
+                                {price !== null ? `${price} руб / 30 дней` : 'Уточните цену'}
+                              </Text>
+                            )}
+                          </View>
+                        </View>
+                        {active ? (
+                          <View style={styles.activePill}>
+                            <Text style={styles.activePillText}>Активно</Text>
+                          </View>
+                        ) : (
+                          <Button
+                            onPress={() => handlePurchase(city, tier)}
+                            variant="secondary"
+                            loading={isBuying}
+                            disabled={isBuying || purchasing !== null}
+                            style={styles.buyBtn}
+                          >
+                            Продвинуть
+                          </Button>
+                        )}
+                      </View>
+                    );
+                  })}
+                </Card>
+              </View>
+            ))
+          )}
+
+          <View style={styles.disclaimer}>
+            <Text style={styles.disclaimerText}>
+              {'Продвижение увеличивает ваш приоритет в каталоге. '}
+              {'Оплата обрабатывается после подтверждения. '}
+              {'Срок действия: 30 дней.'}
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.xl,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  section: {
+    gap: Spacing.sm,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  noneCard: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+  },
+  noneText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  activePromoCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.md,
+    ...Shadows.sm,
+  },
+  tierBadge: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 4,
+    borderRadius: BorderRadius.sm,
+  },
+  tierBadgeText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  activePromoInfo: {
+    flex: 1,
+    gap: 3,
+  },
+  activePromoCity: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  activePromoExpiry: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    gap: Spacing.md,
+  },
+  priceRowBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  priceLeft: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  priceInfo: {
+    flex: 1,
+    gap: 3,
+  },
+  tierName: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  priceVal: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  activeUntil: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+  },
+  buyBtn: {
+    paddingHorizontal: Spacing.md,
+    minWidth: 110,
+  },
+  activePill: {
+    backgroundColor: '#1a3a1e',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 5,
+    borderRadius: BorderRadius.full,
+  },
+  activePillText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  disclaimer: {
+    paddingVertical: Spacing.md,
+    paddingBottom: Spacing['3xl'],
+  },
+  disclaimerText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+});

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Card } from '../../components/Card';
+import { EmptyState } from '../../components/EmptyState';
+
+interface ResponseItem {
+  id: string;
+  message: string;
+  createdAt: string;
+  request: {
+    id: string;
+    description: string;
+    city: string;
+    status: string;
+    createdAt: string;
+  };
+}
+
+export default function MyResponsesScreen() {
+  const [responses, setResponses] = useState<ResponseItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+
+  const fetchResponses = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const data = await api.get<ResponseItem[]>('/requests/my-responses');
+      setResponses(data);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Не удалось загрузить отклики');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchResponses();
+  }, [fetchResponses]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchResponses(true);
+  }
+
+  function formatDate(iso: string) {
+    const d = new Date(iso);
+    return d.toLocaleDateString('ru-RU', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function renderItem({ item }: { item: ResponseItem }) {
+    const req = item.request;
+    const isOpen = req.status === 'OPEN';
+    return (
+      <View style={styles.cardWrapper}>
+        <Card padding={Spacing.lg}>
+          {/* Request meta */}
+          <View style={styles.metaRow}>
+            <View style={styles.cityChip}>
+              <Text style={styles.cityText}>{req.city}</Text>
+            </View>
+            <View style={[styles.statusChip, !isOpen && styles.statusChipClosed]}>
+              <Text style={[styles.statusText, !isOpen && styles.statusTextClosed]}>
+                {isOpen ? 'Открыт' : 'Закрыт'}
+              </Text>
+            </View>
+          </View>
+
+          {/* Request description */}
+          <Text style={styles.requestDesc} numberOfLines={3}>
+            {req.description}
+          </Text>
+
+          {/* Divider */}
+          <View style={styles.divider} />
+
+          {/* My response */}
+          <Text style={styles.responseLabel}>Мой отклик:</Text>
+          <Text style={styles.responseText} numberOfLines={3}>
+            {item.message}
+          </Text>
+
+          {/* Dates */}
+          <View style={styles.datesRow}>
+            <Text style={styles.dateText}>{'Отклик: '}{formatDate(item.createdAt)}</Text>
+            <Text style={styles.dateText}>{'Запрос: '}{formatDate(req.createdAt)}</Text>
+          </View>
+        </Card>
+      </View>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Мои отклики" showBack />
+      <FlatList
+        data={responses}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        ListEmptyComponent={
+          loading ? (
+            <View style={styles.loadingBox}>
+              <ActivityIndicator size="large" color={Colors.brandPrimary} />
+            </View>
+          ) : error ? (
+            <EmptyState
+              icon="⚠️"
+              title="Ошибка загрузки"
+              subtitle={error}
+              ctaLabel="Повторить"
+              onCtaPress={() => fetchResponses()}
+            />
+          ) : (
+            <EmptyState
+              icon="📩"
+              title="Нет откликов"
+              subtitle="Вы ещё не откликались ни на один запрос"
+            />
+          )
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    alignItems: 'center',
+    paddingTop: Spacing.md,
+  },
+  cardWrapper: {
+    width: '100%',
+    maxWidth: 430,
+    marginBottom: Spacing.md,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.sm,
+  },
+  cityChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  statusChip: {
+    backgroundColor: '#1a3a1e',
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  statusChipClosed: {
+    backgroundColor: '#3a2a1e',
+  },
+  statusText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  statusTextClosed: {
+    color: Colors.textMuted,
+  },
+  requestDesc: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+    marginBottom: Spacing.md,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginVertical: Spacing.md,
+  },
+  responseLabel: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textMuted,
+    marginBottom: Spacing.xs,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  responseText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+    fontStyle: 'italic',
+    marginBottom: Spacing.md,
+  },
+  datesRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+  },
+  dateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  loadingBox: {
+    paddingTop: Spacing['4xl'],
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## Summary

- `/dashboard/profile` — edit nick, cities, contacts, services (free-text with price), badge toggle for "Знакомый в налоговой"
- `/dashboard/city-requests` — open requests in specialist's cities with respond modal (message input)
- `/dashboard/responses` — specialist's own responses with request info, city, and status
- `/dashboard/promotion` — active promotions, per-city pricing table (BASIC/FEATURED/TOP), purchase button with Alert confirmation

## Backend change

Added `GET /requests/my-responses` endpoint (SPECIALIST role) — returns specialist's responses with associated request data. Minimal: one controller route + one service method.

## Patterns followed

- `StyleSheet.create` + `style=` everywhere (no className/NativeWind)
- `maxWidth: 430` on all containers
- Dark theme via `Colors`, `Spacing`, `Typography`, `BorderRadius`, `Shadows` from `constants/Colors.ts`
- Same component set: `Header`, `Button`, `Card`, `Input`, `EmptyState`

## Test plan

- [ ] Specialist login → navigate to `/dashboard/profile` — loads profile, can save
- [ ] City requests — shows open requests for specialist's cities, respond modal works
- [ ] Responses — lists specialist's past responses with status
- [ ] Promotion — shows prices per city, purchase triggers Alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)