### PR TITLE
feat(admin): admin panel — dashboard, users, moderation, promotions, requests

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  Request,
+  ForbiddenException,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+// Admin emails are comma-separated in ADMIN_EMAILS env var.
+// Same pattern as PromotionsController — no ADMIN role in DB yet.
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? '').split(',').filter(Boolean);
+
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  /** GET /admin/stats — dashboard totals */
+  @Get('stats')
+  @UseGuards(JwtAuthGuard)
+  getStats(@Request() req: any) {
+    this.assertAdmin(req.user.email);
+    return this.adminService.getStats();
+  }
+
+  /** GET /admin/users — all users, optional ?role=CLIENT|SPECIALIST */
+  @Get('users')
+  @UseGuards(JwtAuthGuard)
+  getUsers(@Request() req: any, @Query('role') role?: string) {
+    this.assertAdmin(req.user.email);
+    return this.adminService.getUsers(role);
+  }
+
+  /** GET /admin/specialists — all specialist profiles */
+  @Get('specialists')
+  @UseGuards(JwtAuthGuard)
+  getSpecialists(@Request() req: any) {
+    this.assertAdmin(req.user.email);
+    return this.adminService.getSpecialists();
+  }
+
+  /** GET /admin/requests — all platform requests */
+  @Get('requests')
+  @UseGuards(JwtAuthGuard)
+  getAllRequests(@Request() req: any) {
+    this.assertAdmin(req.user.email);
+    return this.adminService.getAllRequests();
+  }
+
+  private assertAdmin(email: string) {
+    if (!ADMIN_EMAILS.includes(email)) {
+      throw new ForbiddenException('Admin access required');
+    }
+  }
+}

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getStats() {
+    const now = new Date();
+    const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    const [
+      totalUsers,
+      totalSpecialists,
+      activePromotions,
+      monthPromotions,
+    ] = await Promise.all([
+      this.prisma.user.count(),
+      this.prisma.user.count({ where: { role: 'SPECIALIST' } }),
+      this.prisma.promotion.count({ where: { expiresAt: { gt: now } } }),
+      this.prisma.promotion.count({ where: { createdAt: { gte: firstOfMonth } } }),
+    ]);
+
+    return {
+      totalUsers,
+      totalSpecialists,
+      activePromotions,
+      // Mock revenue: count of promotions this month (no real payments yet)
+      revenueThisMonth: monthPromotions,
+    };
+  }
+
+  async getUsers(role?: string) {
+    const where: any = {};
+    if (role === 'CLIENT' || role === 'SPECIALIST') {
+      where.role = role;
+    }
+
+    return this.prisma.user.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        createdAt: true,
+        lastLoginAt: true,
+        specialistProfile: {
+          select: { nick: true, cities: true, services: true },
+        },
+      },
+    });
+  }
+
+  async getSpecialists() {
+    return this.prisma.specialistProfile.findMany({
+      orderBy: { updatedAt: 'desc' },
+      include: {
+        user: {
+          select: { id: true, email: true, createdAt: true, lastLoginAt: true },
+        },
+      },
+    });
+  }
+
+  async getAllRequests() {
+    return this.prisma.request.findMany({
+      orderBy: { createdAt: 'desc' },
+      include: {
+        client: { select: { id: true, email: true } },
+        _count: { select: { responses: true } },
+      },
+    });
+  }
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { SpecialistsModule } from './specialists/specialists.module';
 import { RequestsModule } from './requests/requests.module';
 import { PromotionsModule } from './promotions/promotions.module';
 import { UsersModule } from './users/users.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { UsersModule } from './users/users.module';
     RequestsModule,
     PromotionsModule,
     UsersModule,
+    AdminModule,
   ],
   controllers: [AppController],
 })

--- a/app/(admin)/_layout.tsx
+++ b/app/(admin)/_layout.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useAuth } from '../../stores/authStore';
+import { isAdmin } from '../../lib/adminEmails';
+import { Colors } from '../../constants/Colors';
+
+export default function AdminLayout() {
+  const { user, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!user || !isAdmin(user.email)) {
+      router.replace('/(dashboard)');
+    }
+  }, [user, isLoading, router]);
+
+  if (isLoading || !user || !isAdmin(user.email)) {
+    return (
+      <View style={{ flex: 1, backgroundColor: Colors.bgPrimary, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+        animation: 'slide_from_right',
+      }}
+    />
+  );
+}

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -1,0 +1,232 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+interface Stats {
+  totalUsers: number;
+  totalSpecialists: number;
+  activePromotions: number;
+  revenueThisMonth: number;
+}
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  sub?: string;
+  onPress?: () => void;
+}
+
+function StatCard({ label, value, sub, onPress }: StatCardProps) {
+  const inner = (
+    <View style={styles.statCard}>
+      <Text style={styles.statValue}>{value}</Text>
+      <Text style={styles.statLabel}>{label}</Text>
+      {sub ? <Text style={styles.statSub}>{sub}</Text> : null}
+    </View>
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={onPress} activeOpacity={0.75} style={styles.statCardWrap}>
+        {inner}
+      </TouchableOpacity>
+    );
+  }
+  return <View style={styles.statCardWrap}>{inner}</View>;
+}
+
+export default function AdminDashboard() {
+  const router = useRouter();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<Stats>('/admin/stats');
+      setStats(data);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load stats');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchStats(); }, [fetchStats]);
+
+  const handleRefresh = () => { setRefreshing(true); fetchStats(true); };
+
+  const navItems = [
+    { label: 'Пользователи', route: '/(admin)/users' as const, icon: 'U' },
+    { label: 'Модерация', route: '/(admin)/moderation' as const, icon: 'M' },
+    { label: 'Продвижения', route: '/(admin)/promotions' as const, icon: 'P' },
+    { label: 'Запросы', route: '/(admin)/requests' as const, icon: 'R' },
+  ];
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Админ-панель" />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+        }
+      >
+        <View style={styles.container}>
+          <Text style={styles.sectionTitle}>Статистика</Text>
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+          ) : error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : stats ? (
+            <View style={styles.statsGrid}>
+              <StatCard label="Пользователей" value={stats.totalUsers} onPress={() => router.push('/(admin)/users')} />
+              <StatCard label="Исполнителей" value={stats.totalSpecialists} onPress={() => router.push('/(admin)/moderation')} />
+              <StatCard label="Активных продвижений" value={stats.activePromotions} onPress={() => router.push('/(admin)/promotions')} />
+              <StatCard label="Продвижений за месяц" value={stats.revenueThisMonth} sub="(оплат этого месяца)" />
+            </View>
+          ) : null}
+
+          <Text style={styles.sectionTitle}>Разделы</Text>
+          <View style={styles.navList}>
+            {navItems.map((item) => (
+              <TouchableOpacity
+                key={item.route}
+                style={styles.navItem}
+                onPress={() => router.push(item.route)}
+                activeOpacity={0.75}
+              >
+                <View style={styles.navIcon}>
+                  <Text style={styles.navIconText}>{item.icon}</Text>
+                </View>
+                <Text style={styles.navLabel}>{item.label}</Text>
+                <Text style={styles.navArrow}>{'>'}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginTop: Spacing.md,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.md,
+  },
+  statCardWrap: {
+    width: '47%',
+  },
+  statCard: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: 4,
+    ...Shadows.sm,
+  },
+  statValue: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textAccent,
+  },
+  statLabel: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  statSub: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  navList: {
+    gap: Spacing.sm,
+  },
+  navItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Shadows.sm,
+  },
+  navIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: Spacing.md,
+  },
+  navIconText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textAccent,
+  },
+  navLabel: {
+    flex: 1,
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  navArrow: {
+    fontSize: 16,
+    color: Colors.textMuted,
+  },
+});

--- a/app/(admin)/moderation.tsx
+++ b/app/(admin)/moderation.tsx
@@ -1,0 +1,251 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+interface SpecialistItem {
+  id: string;
+  nick: string;
+  cities: string[];
+  services: string[];
+  badges: string[];
+  contacts: string | null;
+  createdAt: string;
+  updatedAt: string;
+  user: {
+    id: string;
+    email: string;
+    createdAt: string;
+    lastLoginAt: string | null;
+  };
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+
+export default function AdminModeration() {
+  const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSpecialists = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<SpecialistItem[]>('/admin/specialists');
+      setSpecialists(data);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load specialists');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchSpecialists(); }, [fetchSpecialists]);
+
+  const handleRefresh = () => { setRefreshing(true); fetchSpecialists(true); };
+
+  const handleApprove = () => {
+    Alert.alert('Скоро', 'Модерация профилей будет доступна в следующей версии.');
+  };
+
+  const handleReject = () => {
+    Alert.alert('Скоро', 'Модерация профилей будет доступна в следующей версии.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Модерация" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+        }
+      >
+        <View style={styles.container}>
+          <Text style={styles.hint}>
+            Профили исполнителей. Кнопки одобрения/отклонения будут доступны после добавления статусов модерации.
+          </Text>
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+          ) : error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : specialists.length === 0 ? (
+            <Text style={styles.emptyText}>Нет профилей</Text>
+          ) : (
+            <View style={styles.list}>
+              {specialists.map((s) => (
+                <View key={s.id} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.nick}>@{s.nick}</Text>
+                    <Text style={styles.updateDate}>Обновлён: {formatDate(s.updatedAt)}</Text>
+                  </View>
+
+                  <Text style={styles.email} numberOfLines={1}>{s.user.email}</Text>
+
+                  {s.cities.length > 0 ? (
+                    <Text style={styles.detail}>
+                      <Text style={styles.detailLabel}>Города: </Text>
+                      {s.cities.join(', ')}
+                    </Text>
+                  ) : null}
+
+                  {s.services.length > 0 ? (
+                    <Text style={styles.detail} numberOfLines={2}>
+                      <Text style={styles.detailLabel}>Услуги: </Text>
+                      {s.services.join(', ')}
+                    </Text>
+                  ) : null}
+
+                  {s.badges.length > 0 ? (
+                    <Text style={styles.detail}>
+                      <Text style={styles.detailLabel}>Знаки: </Text>
+                      {s.badges.join(', ')}
+                    </Text>
+                  ) : null}
+
+                  <View style={styles.actionRow}>
+                    <TouchableOpacity style={styles.approveBtn} onPress={handleApprove} activeOpacity={0.75}>
+                      <Text style={styles.approveBtnText}>Одобрить</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.rejectBtn} onPress={handleReject} activeOpacity={0.75}>
+                      <Text style={styles.rejectBtnText}>Отклонить</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.md,
+  },
+  hint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    lineHeight: 18,
+    paddingVertical: Spacing.sm,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  list: {
+    gap: Spacing.sm,
+  },
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  nick: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textAccent,
+  },
+  updateDate: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  email: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  detail: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 18,
+  },
+  detailLabel: {
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  approveBtn: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.statusSuccess,
+    alignItems: 'center',
+  },
+  approveBtnText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.statusSuccess,
+  },
+  rejectBtn: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.statusError,
+    alignItems: 'center',
+  },
+  rejectBtnText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.statusError,
+  },
+});

--- a/app/(admin)/promotions.tsx
+++ b/app/(admin)/promotions.tsx
@@ -1,0 +1,422 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  TextInput,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+interface PromotionItem {
+  id: string;
+  city: string;
+  tier: 'BASIC' | 'FEATURED' | 'TOP';
+  expiresAt: string;
+  createdAt: string;
+  specialist: {
+    id: string;
+    email: string;
+    specialistProfile: { nick: string } | null;
+  };
+}
+
+interface PriceItem {
+  city: string;
+  tier: string;
+  price: number;
+}
+
+const TIER_LABELS: Record<string, string> = {
+  BASIC: 'Базовое',
+  FEATURED: 'Выделенное',
+  TOP: 'Топ',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+
+function isExpired(iso: string): boolean {
+  return new Date(iso) < new Date();
+}
+
+export default function AdminPromotions() {
+  const [promotions, setPromotions] = useState<PromotionItem[]>([]);
+  const [prices, setPrices] = useState<PriceItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Price edit state
+  const [editCity, setEditCity] = useState('');
+  const [editTier, setEditTier] = useState<'BASIC' | 'FEATURED' | 'TOP'>('BASIC');
+  const [editPrice, setEditPrice] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const fetchData = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const [promos, priceList] = await Promise.all([
+        api.get<PromotionItem[]>('/promotions/admin'),
+        api.get<PriceItem[]>('/promotions/admin/prices'),
+      ]);
+      setPromotions(promos);
+      setPrices(priceList);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load promotions');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const handleRefresh = () => { setRefreshing(true); fetchData(true); };
+
+  const handleSavePrice = async () => {
+    if (!editCity.trim()) {
+      Alert.alert('Ошибка', 'Введите город');
+      return;
+    }
+    const priceNum = parseInt(editPrice, 10);
+    if (isNaN(priceNum) || priceNum <= 0) {
+      Alert.alert('Ошибка', 'Введите корректную цену');
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.patch('/promotions/admin/prices', { city: editCity.trim(), tier: editTier, price: priceNum });
+      Alert.alert('Готово', `Цена обновлена: ${editCity} / ${editTier} = ${priceNum} руб.`);
+      setEditCity('');
+      setEditPrice('');
+      fetchData(true);
+    } catch (e: any) {
+      Alert.alert('Ошибка', e?.message ?? 'Не удалось обновить цену');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Продвижения" showBack />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+          }
+        >
+          <View style={styles.container}>
+            {/* Price editor */}
+            <Text style={styles.sectionTitle}>Настройка цен</Text>
+            <View style={styles.priceEditor}>
+              <TextInput
+                style={styles.input}
+                placeholder="Город"
+                placeholderTextColor={Colors.textMuted}
+                value={editCity}
+                onChangeText={setEditCity}
+                autoCapitalize="words"
+              />
+              <View style={styles.tierRow}>
+                {(['BASIC', 'FEATURED', 'TOP'] as const).map((t) => (
+                  <TouchableOpacity
+                    key={t}
+                    style={[styles.tierBtn, editTier === t && styles.tierBtnActive]}
+                    onPress={() => setEditTier(t)}
+                    activeOpacity={0.75}
+                  >
+                    <Text style={[styles.tierBtnText, editTier === t && styles.tierBtnTextActive]}>
+                      {TIER_LABELS[t]}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+              <TextInput
+                style={styles.input}
+                placeholder="Цена (руб.)"
+                placeholderTextColor={Colors.textMuted}
+                value={editPrice}
+                onChangeText={setEditPrice}
+                keyboardType="numeric"
+              />
+              <TouchableOpacity
+                style={[styles.saveBtn, saving && styles.saveBtnDisabled]}
+                onPress={handleSavePrice}
+                disabled={saving}
+                activeOpacity={0.75}
+              >
+                {saving ? (
+                  <ActivityIndicator size="small" color={Colors.textPrimary} />
+                ) : (
+                  <Text style={styles.saveBtnText}>Сохранить цену</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+
+            {/* Current prices */}
+            {prices.length > 0 ? (
+              <>
+                <Text style={styles.sectionTitle}>Текущие цены</Text>
+                <View style={styles.priceTable}>
+                  {prices.map((p, i) => (
+                    <View key={i} style={styles.priceRow}>
+                      <Text style={styles.priceCity}>{p.city}</Text>
+                      <Text style={styles.priceTier}>{TIER_LABELS[p.tier] ?? p.tier}</Text>
+                      <Text style={styles.priceValue}>{p.price} руб.</Text>
+                    </View>
+                  ))}
+                </View>
+              </>
+            ) : null}
+
+            {/* Active promotions list */}
+            <Text style={styles.sectionTitle}>
+              Активные продвижения
+              {promotions.length > 0 ? ` (${promotions.length})` : ''}
+            </Text>
+
+            {loading ? (
+              <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+            ) : error ? (
+              <Text style={styles.errorText}>{error}</Text>
+            ) : promotions.length === 0 ? (
+              <Text style={styles.emptyText}>Нет продвижений</Text>
+            ) : (
+              <View style={styles.list}>
+                {promotions.map((p) => (
+                  <View key={p.id} style={[styles.card, isExpired(p.expiresAt) && styles.cardExpired]}>
+                    <View style={styles.cardHeader}>
+                      <Text style={styles.cardNick}>
+                        {p.specialist.specialistProfile?.nick
+                          ? `@${p.specialist.specialistProfile.nick}`
+                          : p.specialist.email}
+                      </Text>
+                      <View style={[styles.tierPill, styles[`tier${p.tier}` as keyof typeof styles] as any]}>
+                        <Text style={styles.tierPillText}>{TIER_LABELS[p.tier]}</Text>
+                      </View>
+                    </View>
+                    <Text style={styles.cardCity}>{p.city}</Text>
+                    <Text style={[styles.cardExpiry, isExpired(p.expiresAt) && styles.cardExpiryExpired]}>
+                      {isExpired(p.expiresAt) ? 'Истёк' : 'До'}: {formatDate(p.expiresAt)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  flex: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.md,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginTop: Spacing.md,
+  },
+  priceEditor: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.md,
+    ...Shadows.sm,
+  },
+  input: {
+    height: 44,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    paddingHorizontal: Spacing.md,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    backgroundColor: Colors.bgSecondary,
+  },
+  tierRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  tierBtn: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+  },
+  tierBtnActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  tierBtnText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+  },
+  tierBtnTextActive: {
+    color: Colors.textPrimary,
+  },
+  saveBtn: {
+    height: 44,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.brandPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveBtnDisabled: {
+    opacity: 0.5,
+  },
+  saveBtnText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  priceTable: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    overflow: 'hidden',
+  },
+  priceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  priceCity: {
+    flex: 1,
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textPrimary,
+  },
+  priceTier: {
+    width: 90,
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  priceValue: {
+    width: 80,
+    textAlign: 'right',
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textAccent,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  list: {
+    gap: Spacing.sm,
+  },
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  cardExpired: {
+    borderColor: Colors.borderLight,
+    opacity: 0.6,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.sm,
+  },
+  cardNick: {
+    flex: 1,
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  tierPill: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  tierBASIC: {
+    backgroundColor: '#132240',
+  },
+  tierFEATURED: {
+    backgroundColor: '#2a1f4a',
+  },
+  tierTOP: {
+    backgroundColor: '#3a2c10',
+  },
+  tierPillText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  cardCity: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+  },
+  cardExpiry: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  cardExpiryExpired: {
+    color: Colors.statusError,
+  },
+});

--- a/app/(admin)/requests.tsx
+++ b/app/(admin)/requests.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Badge } from '../../components/Badge';
+
+interface RequestItem {
+  id: string;
+  description: string;
+  city: string;
+  status: 'OPEN' | 'CLOSED' | 'CANCELLED';
+  createdAt: string;
+  client: { id: string; email: string };
+  _count: { responses: number };
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  OPEN: 'Открыт',
+  CLOSED: 'Закрыт',
+  CANCELLED: 'Отменён',
+};
+
+const STATUS_BADGE: Record<string, 'success' | 'warning' | 'error'> = {
+  OPEN: 'success',
+  CLOSED: 'warning',
+  CANCELLED: 'error',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+
+export default function AdminRequests() {
+  const [requests, setRequests] = useState<RequestItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRequests = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<RequestItem[]>('/admin/requests');
+      setRequests(data);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load requests');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchRequests(); }, [fetchRequests]);
+
+  const handleRefresh = () => { setRefreshing(true); fetchRequests(true); };
+
+  // Simple counters
+  const openCount = requests.filter((r) => r.status === 'OPEN').length;
+  const closedCount = requests.filter((r) => r.status === 'CLOSED').length;
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Все запросы" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+        }
+      >
+        <View style={styles.container}>
+          {/* Summary row */}
+          {!loading && !error && requests.length > 0 ? (
+            <View style={styles.summaryRow}>
+              <View style={styles.summaryCard}>
+                <Text style={styles.summaryValue}>{requests.length}</Text>
+                <Text style={styles.summaryLabel}>Всего</Text>
+              </View>
+              <View style={styles.summaryCard}>
+                <Text style={[styles.summaryValue, { color: Colors.statusSuccess }]}>{openCount}</Text>
+                <Text style={styles.summaryLabel}>Открытых</Text>
+              </View>
+              <View style={styles.summaryCard}>
+                <Text style={[styles.summaryValue, { color: Colors.textMuted }]}>{closedCount}</Text>
+                <Text style={styles.summaryLabel}>Закрытых</Text>
+              </View>
+            </View>
+          ) : null}
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+          ) : error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : requests.length === 0 ? (
+            <Text style={styles.emptyText}>Нет запросов</Text>
+          ) : (
+            <View style={styles.list}>
+              {requests.map((r) => (
+                <View key={r.id} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.city}>{r.city}</Text>
+                    <Badge
+                      variant={STATUS_BADGE[r.status] ?? 'info'}
+                      label={STATUS_LABELS[r.status] ?? r.status}
+                    />
+                  </View>
+                  <Text style={styles.description} numberOfLines={2}>{r.description}</Text>
+                  <View style={styles.cardFooter}>
+                    <Text style={styles.meta} numberOfLines={1}>{r.client.email}</Text>
+                    <Text style={styles.meta}>{formatDate(r.createdAt)}</Text>
+                    <Text style={styles.responseCount}>
+                      {r._count.responses} отклик{r._count.responses === 1 ? '' : r._count.responses < 5 ? 'а' : 'ов'}
+                    </Text>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.md,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  summaryCard: {
+    flex: 1,
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+    gap: 4,
+  },
+  summaryValue: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textAccent,
+  },
+  summaryLabel: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  list: {
+    gap: Spacing.sm,
+  },
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.sm,
+  },
+  city: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  description: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 18,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  meta: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    flex: 1,
+  },
+  responseCount: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textAccent,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});

--- a/app/(admin)/users.tsx
+++ b/app/(admin)/users.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+  Alert,
+} from 'react-native';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Badge } from '../../components/Badge';
+
+interface UserItem {
+  id: string;
+  email: string;
+  role: 'CLIENT' | 'SPECIALIST';
+  createdAt: string;
+  lastLoginAt: string | null;
+  specialistProfile: { nick: string; cities: string[]; services: string[] } | null;
+}
+
+type RoleFilter = 'ALL' | 'CLIENT' | 'SPECIALIST';
+
+const FILTER_LABELS: Record<RoleFilter, string> = {
+  ALL: 'Все',
+  CLIENT: 'Клиенты',
+  SPECIALIST: 'Исполнители',
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
+}
+
+export default function AdminUsers() {
+  const [users, setUsers] = useState<UserItem[]>([]);
+  const [filter, setFilter] = useState<RoleFilter>('ALL');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUsers = useCallback(async (role: RoleFilter, isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const path = role === 'ALL' ? '/admin/users' : `/admin/users?role=${role}`;
+      const data = await api.get<UserItem[]>(path);
+      setUsers(data);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load users');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchUsers(filter); }, [fetchUsers, filter]);
+
+  const handleFilterChange = (f: RoleFilter) => {
+    setFilter(f);
+  };
+
+  const handleRefresh = () => { setRefreshing(true); fetchUsers(filter, true); };
+
+  const handleBlock = () => {
+    Alert.alert('Скоро', 'Блокировка пользователей будет доступна в следующей версии.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Пользователи" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+        }
+      >
+        <View style={styles.container}>
+          {/* Role filter tabs */}
+          <View style={styles.filterRow}>
+            {(Object.keys(FILTER_LABELS) as RoleFilter[]).map((f) => (
+              <TouchableOpacity
+                key={f}
+                style={[styles.filterTab, filter === f && styles.filterTabActive]}
+                onPress={() => handleFilterChange(f)}
+                activeOpacity={0.75}
+              >
+                <Text style={[styles.filterTabText, filter === f && styles.filterTabTextActive]}>
+                  {FILTER_LABELS[f]}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+          ) : error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : users.length === 0 ? (
+            <Text style={styles.emptyText}>Нет пользователей</Text>
+          ) : (
+            <View style={styles.list}>
+              {users.map((u) => (
+                <View key={u.id} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.email} numberOfLines={1}>{u.email}</Text>
+                    <Badge
+                      variant={u.role === 'SPECIALIST' ? 'accent' : 'info'}
+                      label={u.role === 'SPECIALIST' ? 'Исполнитель' : 'Клиент'}
+                    />
+                  </View>
+                  {u.specialistProfile ? (
+                    <Text style={styles.cardMeta} numberOfLines={1}>
+                      @{u.specialistProfile.nick} · {u.specialistProfile.cities.join(', ')}
+                    </Text>
+                  ) : null}
+                  <View style={styles.cardFooter}>
+                    <Text style={styles.cardDate}>Рег: {formatDate(u.createdAt)}</Text>
+                    <Text style={styles.cardDate}>Вход: {formatDate(u.lastLoginAt)}</Text>
+                    <TouchableOpacity onPress={handleBlock} style={styles.blockBtn} activeOpacity={0.75}>
+                      <Text style={styles.blockBtnText}>Блок</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.md,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  filterTab: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    alignItems: 'center',
+  },
+  filterTabActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  filterTabText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+  },
+  filterTabTextActive: {
+    color: Colors.textPrimary,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  list: {
+    gap: Spacing.sm,
+  },
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Spacing.sm,
+  },
+  email: {
+    flex: 1,
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  cardMeta: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  cardDate: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  blockBtn: {
+    marginLeft: 'auto',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 4,
+    borderRadius: BorderRadius.sm,
+    borderWidth: 1,
+    borderColor: Colors.statusError,
+  },
+  blockBtnText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import { AuthProvider, useAuth } from '../stores/authStore';
+import { isAdmin } from '../lib/adminEmails';
 import { Colors } from '../constants/Colors';
 
 function RootNavigator() {
@@ -15,6 +16,7 @@ function RootNavigator() {
 
     const inAuthGroup = segments[0] === '(auth)';
     const inDashboardGroup = segments[0] === '(dashboard)';
+    const inAdminGroup = segments[0] === '(admin)';
     // Public routes that guests can access freely
     const isPublicRoute =
       segments[0] === 'specialists' || segments[0] === 'requests';
@@ -27,6 +29,9 @@ function RootNavigator() {
       router.replace('/(dashboard)');
     } else if (user && !inDashboardGroup && !isPublicRoute && segments[0] === undefined) {
       // Authenticated user on landing → redirect to dashboard
+      router.replace('/(dashboard)');
+    } else if (user && inAdminGroup && !isAdmin(user.email)) {
+      // Non-admin trying to access admin section → redirect to dashboard
       router.replace('/(dashboard)');
     }
   }, [user, isLoading, segments, router]);

--- a/lib/adminEmails.ts
+++ b/lib/adminEmails.ts
@@ -1,0 +1,14 @@
+// Admin emails are loaded from EXPO_PUBLIC_ADMIN_EMAILS env var (comma-separated).
+// If the env var is not set (e.g. local dev without Doppler), falls back to dev email.
+// Never hardcode production emails here.
+const raw = process.env.EXPO_PUBLIC_ADMIN_EMAILS ?? 'dev@p2ptax.ru';
+
+export const ADMIN_EMAILS: string[] = raw
+  .split(',')
+  .map((e) => e.trim().toLowerCase())
+  .filter(Boolean);
+
+export function isAdmin(email: string | undefined): boolean {
+  if (!email) return false;
+  return ADMIN_EMAILS.includes(email.toLowerCase());
+}


### PR DESCRIPTION
## Summary

- **Backend**: new `AdminModule` with 4 endpoints: `GET /admin/stats`, `GET /admin/users`, `GET /admin/specialists`, `GET /admin/requests` — all guarded by `ADMIN_EMAILS` env var (consistent with existing `PromotionsController` pattern)
- **Frontend**: `app/(admin)/` route group with 5 screens:
  - `/admin` — dashboard with 4 stat cards (users, specialists, active promotions, month promotions)
  - `/admin/users` — users table with CLIENT/SPECIALIST/ALL filter tabs + block button (coming soon Alert)
  - `/admin/moderation` — all specialist profiles with approve/reject buttons (coming soon Alert)
  - `/admin/promotions` — active promotions list + price editor (uses existing `PATCH /promotions/admin/prices`)
  - `/admin/requests` — all platform requests with summary row (total/open/closed)
- **Auth**: `lib/adminEmails.ts` reads `EXPO_PUBLIC_ADMIN_EMAILS` from Doppler (set to `dev@p2ptax.ru` in dev config). Falls back to same value. No production emails in source.
- **Root layout**: `(admin)` group check added — non-admins redirected to `/(dashboard)`
- **Style**: `StyleSheet.create` throughout, dark theme using `Colors` constants, `maxWidth: 430` on all screens

## Test plan

- [ ] Log in as admin email → navigate to `/admin` → stat cards load
- [ ] `/admin/users` — filter tabs work, block button shows "coming soon" Alert
- [ ] `/admin/moderation` — specialist profiles list, approve/reject show Alert
- [ ] `/admin/promotions` — active promotions listed, price editor saves via `PATCH /promotions/admin/prices`
- [ ] `/admin/requests` — all requests with summary counts
- [ ] Log in as non-admin → `/admin` redirects to `/(dashboard)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)