### PR TITLE
fix: specialist role case mismatch

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { IsEmail, IsString, Length, IsOptional, IsIn } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { AuthService } from './auth.service';
 
 class RequestOtpDto {
@@ -16,6 +17,7 @@ class VerifyOtpDto {
   code!: string;
 
   @IsOptional()
+  @Transform(({ value }) => value?.toLowerCase())
   @IsIn(['client', 'specialist'])
   role?: string;
 }

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -94,7 +94,7 @@ export default function OtpScreen() {
       const res = await api.post<VerifyOtpResponse>('/auth/verify-otp', {
         email,
         code,
-        role,
+        role: role.toLowerCase(),
       });
       await login(res.accessToken, {
         userId: res.user.userId,


### PR DESCRIPTION
## Summary
- Fixes #1589
- Frontend sent `role: 'SPECIALIST'` (uppercase) but DTO validated `@IsIn(['client', 'specialist'])` (lowercase)
- With `whitelist: true` in ValidationPipe, the uppercase value was silently stripped → `mapRole(undefined)` → always `CLIENT`
- All specialists were being registered as clients

## Changes
- `app/(auth)/otp.tsx`: send `role.toLowerCase()` in POST body (display ternary at line 36 still uses uppercase, preserved)
- `api/src/auth/auth.controller.ts`: added `@Transform(({ value }) => value?.toLowerCase())` before `@IsIn` on `VerifyOtpDto.role` for defense-in-depth

## Test plan
- [ ] Register as specialist → verify returned `user.role` is `SPECIALIST`
- [ ] Register as client → verify returned `user.role` is `CLIENT`
- [ ] Existing user login preserves role (not overwritten)