### PR TITLE
fix: CORS wildcard + JWT_SECRET fallback (#1590)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       - name: Deploy to server
+        env:
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
         run: |
           DEPLOY_DIR="/var/www/p2ptax"
 
@@ -76,6 +79,9 @@ jobs:
 
           # Write version info
           echo "{\"version\":\"$(git rev-parse --short HEAD)\",\"date\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" | sudo tee $DEPLOY_DIR/web/version.json
+
+          # Write .env for dotenv to pick up at runtime
+          printf "JWT_SECRET=%s\nALLOWED_ORIGINS=%s\n" "$JWT_SECRET" "$ALLOWED_ORIGINS" | sudo tee $DEPLOY_DIR/api/.env > /dev/null
 
           # Restart API (start from dist/main.js for NestJS)
           cd $DEPLOY_DIR/api

--- a/api/.env.example
+++ b/api/.env.example
@@ -3,3 +3,8 @@
 DATABASE_URL=
 PORT=3812
 NODE_ENV=development
+JWT_SECRET=
+# ALLOWED_ORIGINS: comma-separated list of allowed CORS origins
+# Local dev example: http://localhost:8081,http://localhost:19006,https://p2ptax.smartlaunchhub.com
+# Staging/prod: https://p2ptax.smartlaunchhub.com
+ALLOWED_ORIGINS=

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -10,7 +10,7 @@ import { JwtStrategy } from './jwt.strategy';
     PassportModule,
     JwtModule.register({
       // No global expiresIn — each jwt.sign call specifies its own expiry
-      secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+      secret: process.env.JWT_SECRET!,
     }),
   ],
   controllers: [AuthController],

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
     const refreshToken = this.jwt.sign(
       { sub: user.id },
       {
-        secret: (process.env.JWT_SECRET ?? 'dev-secret-change-in-prod') + '-refresh',
+        secret: process.env.JWT_SECRET! + '-refresh',
         expiresIn: '30d',
       },
     );
@@ -119,7 +119,7 @@ export class AuthService {
     let payload: { sub: string };
     try {
       payload = this.jwt.verify(refreshToken, {
-        secret: (process.env.JWT_SECRET ?? 'dev-secret-change-in-prod') + '-refresh',
+        secret: process.env.JWT_SECRET! + '-refresh',
       }) as { sub: string };
     } catch {
       throw new UnauthorizedException('Invalid or expired refresh token');

--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -16,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+      secretOrKey: process.env.JWT_SECRET!,
     });
   }
 

--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -18,7 +18,7 @@ interface AuthenticatedSocket extends Socket {
 
 @WebSocketGateway({
   namespace: '/chat',
-  cors: { origin: '*' },
+  cors: { origin: process.env.ALLOWED_ORIGINS?.split(',') || ['https://p2ptax.smartlaunchhub.com'] },
 })
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
@@ -39,7 +39,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
 
       const payload = this.jwtService.verify(token, {
-        secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+        secret: process.env.JWT_SECRET!,
       });
 
       client.data.userId = payload.sub;

--- a/api/src/chat/chat.module.ts
+++ b/api/src/chat/chat.module.ts
@@ -7,7 +7,7 @@ import { ChatService } from './chat.service';
 @Module({
   imports: [
     JwtModule.register({
-      secret: process.env.JWT_SECRET ?? 'dev-secret-change-in-prod',
+      secret: process.env.JWT_SECRET!,
     }),
   ],
   controllers: [ChatController],

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -6,11 +6,17 @@ import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required but not set');
+  }
+
   const app = await NestFactory.create(AppModule);
 
   app.setGlobalPrefix('api');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
-  app.enableCors();
+
+  const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || ['https://p2ptax.smartlaunchhub.com'];
+  app.enableCors({ origin: allowedOrigins });
 
   const port = process.env.PORT ?? 3812;
   await app.listen(port);


### PR DESCRIPTION
## Summary

- Replaces `app.enableCors()` (wildcard) with `ALLOWED_ORIGINS` env var — defaults to `https://p2ptax.smartlaunchhub.com`
- Removes hardcoded `'dev-secret-change-in-prod'` fallback from **6 locations**: `auth.module.ts`, `auth.service.ts` (x2), `jwt.strategy.ts`, `chat.module.ts`, `chat.gateway.ts`
- Adds fail-fast startup guard: server throws and refuses to start if `JWT_SECRET` is not set
- WebSocket gateway CORS restricted to same `ALLOWED_ORIGINS`
- `.env.example` updated with both new vars + local dev note
- `deploy.yml` updated: `JWT_SECRET` and `ALLOWED_ORIGINS` injected from GitHub secrets, written to `.env` on server for dotenv pickup

## Required GitHub Secrets (add before merging to staging)
- `JWT_SECRET` — strong random secret
- `ALLOWED_ORIGINS` — `https://p2ptax.smartlaunchhub.com`

## Required Doppler secrets (local dev)
- `JWT_SECRET` — any local value
- `ALLOWED_ORIGINS` — `http://localhost:8081,http://localhost:19006,https://p2ptax.smartlaunchhub.com`

Fixes #1590