### PR TITLE
fix: centralize brand tokens (23 violations)

### DIFF
--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -192,11 +192,11 @@ const styles = StyleSheet.create({
     marginRight: Spacing.lg,
   },
   cardEmoji: {
-    fontSize: 22,
+    fontSize: Typography.fontSize.title,
   },
   cardContent: {
     flex: 1,
-    gap: 4,
+    gap: Spacing.xs,
   },
   cardTitle: {
     fontSize: Typography.fontSize.md,
@@ -208,7 +208,7 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
   },
   cardArrow: {
-    fontSize: 18,
+    fontSize: Typography.fontSize.lg,
     color: Colors.textMuted,
     marginLeft: Spacing.sm,
   },

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -239,7 +239,7 @@ const styles = StyleSheet.create({
   cityChip: {
     backgroundColor: Colors.bgSecondary,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
     borderWidth: 1,
     borderColor: Colors.borderLight,
@@ -250,9 +250,9 @@ const styles = StyleSheet.create({
     fontWeight: Typography.fontWeight.medium,
   },
   statusChip: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
   },
   statusChipClosed: {

--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -287,7 +287,7 @@ const styles = StyleSheet.create({
   cityChip: {
     backgroundColor: Colors.bgSecondary,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
     borderWidth: 1,
     borderColor: Colors.borderLight,
@@ -320,9 +320,9 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
   },
   statusChip: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
   },
   statusChipClosed: {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
     borderColor: Colors.brandPrimary,
   },
   logoEmoji: {
-    fontSize: 36,
+    fontSize: Typography.fontSize.display,
   },
   appName: {
     fontSize: Typography.fontSize['3xl'],

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -252,7 +252,7 @@ const styles = StyleSheet.create({
   cityChip: {
     backgroundColor: Colors.bgSecondary,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
     borderWidth: 1,
     borderColor: Colors.borderLight,
@@ -285,9 +285,9 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
   },
   statusChip: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
   },
   statusText: {

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -275,8 +275,8 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
   },
   badgeToggleActive: {
-    backgroundColor: '#2a2070',
-    borderColor: '#a5b4fc',
+    backgroundColor: Colors.statusBg.familiar,
+    borderColor: Colors.textFamiliar,
   },
   badgeToggleText: {
     fontSize: Typography.fontSize.sm,
@@ -284,7 +284,7 @@ const styles = StyleSheet.create({
     fontWeight: Typography.fontWeight.medium,
   },
   badgeToggleTextActive: {
-    color: '#a5b4fc',
+    color: Colors.textFamiliar,
   },
   sortRow: {
     flexDirection: 'row',

--- a/components/Badge.tsx
+++ b/components/Badge.tsx
@@ -11,12 +11,12 @@ interface BadgeProps {
 }
 
 const VARIANT_COLORS: Record<BadgeVariant, { bg: string; text: string }> = {
-  success: { bg: '#1a3a1e', text: Colors.statusSuccess },
-  warning: { bg: '#3a2c10', text: Colors.statusWarning },
-  error: { bg: '#3a1414', text: Colors.statusError },
-  info: { bg: '#132240', text: Colors.statusInfo },
-  accent: { bg: '#2a1f4a', text: Colors.textAccent },
-  familiar: { bg: '#2a2070', text: '#a5b4fc' },
+  success: { bg: Colors.statusBg.success, text: Colors.statusSuccess },
+  warning: { bg: Colors.statusBg.warning, text: Colors.statusWarning },
+  error: { bg: Colors.statusBg.error, text: Colors.statusError },
+  info: { bg: Colors.statusBg.info, text: Colors.statusInfo },
+  accent: { bg: Colors.statusBg.accent, text: Colors.textAccent },
+  familiar: { bg: Colors.statusBg.familiar, text: Colors.textFamiliar },
 };
 
 export function Badge({ variant = 'accent', label, style }: BadgeProps) {
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
   badge: {
     alignSelf: 'flex-start',
     paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
+    paddingVertical: Spacing.xxs,
     borderRadius: BorderRadius.full,
   },
   label: {

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
     gap: Spacing.md,
   },
   icon: {
-    fontSize: 48,
+    fontSize: Typography.fontSize.jumbo,
     marginBottom: Spacing.sm,
   },
   title: {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -76,10 +76,10 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
   },
   backBtn: {
-    padding: 4,
+    padding: Spacing.xs,
   },
   backIcon: {
-    fontSize: 20,
+    fontSize: Typography.fontSize.xl,
     color: Colors.textPrimary,
   },
 });

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -21,12 +21,26 @@ export const Colors = {
   statusError: '#ef4444',
   statusInfo: '#3b82f6',
 
+  // Status background tints (for badges)
+  statusBg: {
+    success: '#1a3a1e',
+    warning: '#3a2c10',
+    error: '#3a1414',
+    info: '#132240',
+    accent: '#2a1f4a',
+    familiar: '#2a2070',
+  },
+
+  // Extended text
+  textFamiliar: '#a5b4fc',
+
   // Borders
   border: '#2d2d4a',
   borderLight: '#3d3d5c',
 } as const;
 
 export const Spacing = {
+  xxs: 3,
   xs: 4,
   sm: 8,
   md: 12,
@@ -76,6 +90,9 @@ export const Typography = {
     xl: 20,
     '2xl': 24,
     '3xl': 30,
+    title: 22,
+    display: 36,
+    jumbo: 48,
   },
   fontWeight: {
     regular: '400' as const,


### PR DESCRIPTION
## Summary

- Adds `Colors.statusBg` (6 background tints) and `Colors.textFamiliar` to `Colors.ts` — eliminates 7 hardcoded hex values from Badge and 4 screens
- Adds `Spacing.xxs = 3` — replaces 11 hardcoded `paddingVertical: 3` / `gap: 4` / `padding: 4` occurrences
- Adds `Typography.fontSize.title = 22`, `display = 36`, `jumbo = 48` — replaces 5 hardcoded font sizes
- Zero visual change — pure design token centralization

Fixes #1587

## Files changed
- `constants/Colors.ts` — new tokens added
- `components/Badge.tsx`, `Header.tsx`, `EmptyState.tsx` — tokens applied
- `app/index.tsx`, `app/(dashboard)/index.tsx` — tokens applied
- `app/(dashboard)/requests/[id].tsx`, `app/(dashboard)/requests/index.tsx` — tokens applied
- `app/requests/index.tsx`, `app/specialists/index.tsx` — tokens applied

## Verification
Grep for all 7 off-brand hex values in `app/` returns 0 results. TypeScript: 0 errors.