### PR TITLE
fix: Написать button routes to request creation for auth users

### DIFF
--- a/app/(dashboard)/requests/new.tsx
+++ b/app/(dashboard)/requests/new.tsx
@@ -9,7 +9,7 @@ import {
   Platform,
   Alert,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { api, ApiError } from '../../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { Header } from '../../../components/Header';
@@ -18,6 +18,7 @@ import { Input } from '../../../components/Input';
 
 export default function CreateRequestScreen() {
   const router = useRouter();
+  const { specialist } = useLocalSearchParams<{ specialist?: string }>();
   const [description, setDescription] = useState('');
   const [city, setCity] = useState('');
   const [loading, setLoading] = useState(false);
@@ -68,6 +69,12 @@ export default function CreateRequestScreen() {
             <Text style={styles.subtitle}>
               Опишите вашу задачу, и специалисты откликнутся
             </Text>
+
+            {specialist ? (
+              <Text style={styles.specialistHint}>
+                Запрос будет виден специалисту @{specialist}
+              </Text>
+            ) : null}
 
             <View style={styles.field}>
               <Text style={styles.label}>Описание</Text>
@@ -138,6 +145,11 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.base,
     color: Colors.textSecondary,
     lineHeight: 22,
+  },
+  specialistHint: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
   },
   field: {
     gap: Spacing.xs,

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -72,8 +72,7 @@ export default function SpecialistProfileScreen() {
       router.push('/(auth)/email?role=CLIENT');
       return;
     }
-    // TODO: navigate to chat when chat screen is implemented
-    router.push('/(auth)/email?role=CLIENT');
+    router.push(`/(dashboard)/requests/new?specialist=${profile!.nick}`);
   }
 
   if (loading) {


### PR DESCRIPTION
## Summary

- `specialists/[nick].tsx`: `handleWrite` for authenticated users now navigates to `/(dashboard)/requests/new?specialist=<nick>` instead of incorrectly sending them to the auth screen
- `requests/new.tsx`: reads the `specialist` query param via `useLocalSearchParams`, displays a hint "Запрос будет виден специалисту @<nick>" when the param is present

## Test plan

- [ ] Open any specialist profile while logged in → click "Написать" → should land on new request screen with specialist hint visible
- [ ] Open any specialist profile while NOT logged in → click "Написать (войдите)" → should go to auth/email screen
- [ ] Open `/(dashboard)/requests/new` directly (no param) → no specialist hint shown, form works normally

Fixes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)