### PR TITLE
fix: add SEO meta tags

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import '../global.css';
 import React, { useEffect } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
+import Head from 'expo-router/head';
 import { AuthProvider, useAuth } from '../stores/authStore';
 import { Colors } from '../constants/Colors';
 
@@ -51,8 +52,17 @@ function RootNavigator() {
 
 export default function RootLayout() {
   return (
-    <AuthProvider>
-      <RootNavigator />
-    </AuthProvider>
+    <>
+      <Head>
+        <title>Налоговик — поиск налоговых специалистов</title>
+        <meta name="description" content="Найдите налогового специалиста или получите заявки от клиентов" />
+        <meta property="og:title" content="Налоговик" />
+        <meta property="og:description" content="Сервис поиска налоговых специалистов" />
+        <meta property="og:type" content="website" />
+      </Head>
+      <AuthProvider>
+        <RootNavigator />
+      </AuthProvider>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `<title>` tag: "Налоговик — поиск налоговых специалистов"
- Adds `<meta name="description">` for search engines
- Adds Open Graph tags: og:title, og:description, og:type
- Uses `expo-router/head` Head component in RootLayout

## Test plan
- [ ] Open web app, verify browser tab title shows "Налоговик — поиск налоговых специалистов"
- [ ] Inspect page source for meta description and og tags