### PR TITLE
feat: start-dialog — POST /threads/start + frontend wiring

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -1,13 +1,16 @@
 import {
   Controller,
   Get,
+  Post,
   Param,
   Query,
+  Body,
   UseGuards,
   Request,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ChatService } from './chat.service';
+import { StartThreadDto } from './dto/start-thread.dto';
 
 @Controller('threads')
 @UseGuards(JwtAuthGuard)
@@ -17,6 +20,15 @@ export class ChatController {
   @Get()
   getThreads(@Request() req: { user: { id: string } }) {
     return this.chatService.getThreads(req.user.id);
+  }
+
+  // POST /threads/start — upsert thread between current user and otherUserId
+  @Post('start')
+  startThread(
+    @Request() req: { user: { id: string } },
+    @Body() dto: StartThreadDto,
+  ) {
+    return this.chatService.startThread(req.user.id, dto.otherUserId);
   }
 
   @Get(':id/messages')

--- a/api/src/chat/chat.service.ts
+++ b/api/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -71,6 +71,29 @@ export class ChatService {
     ]);
 
     return { messages, total, page, pages: Math.ceil(total / take) };
+  }
+
+  /** Upsert thread between two users. Returns { threadId } */
+  async startThread(userId: string, otherUserId: string) {
+    if (userId === otherUserId) {
+      throw new BadRequestException('Cannot start a thread with yourself');
+    }
+
+    // Verify the other user exists
+    const other = await this.prisma.user.findUnique({ where: { id: otherUserId } });
+    if (!other) throw new NotFoundException('User not found');
+
+    // Sort IDs to enforce unique constraint invariant: participant1Id < participant2Id
+    const [p1, p2] = [userId, otherUserId].sort();
+
+    const thread = await this.prisma.thread.upsert({
+      where: { participant1Id_participant2Id: { participant1Id: p1, participant2Id: p2 } },
+      create: { participant1Id: p1, participant2Id: p2 },
+      update: {},
+      select: { id: true },
+    });
+
+    return { threadId: thread.id };
   }
 
   /** Verify user is participant of thread */

--- a/api/src/chat/dto/start-thread.dto.ts
+++ b/api/src/chat/dto/start-thread.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class StartThreadDto {
+  @IsString()
+  @IsNotEmpty()
+  otherUserId!: string;
+}

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -9,7 +9,7 @@ import {
   RefreshControl,
   Alert,
 } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { api, ApiError } from '../../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 import { Header } from '../../../components/Header';
@@ -36,11 +36,13 @@ interface RequestDetail {
 
 export default function RequestDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
   const [request, setRequest] = useState<RequestDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
   const [closingId, setClosingId] = useState(false);
+  const [startingDialogId, setStartingDialogId] = useState<string | null>(null);
 
   const fetchDetail = useCallback(async (isRefresh = false) => {
     if (!id) return;
@@ -100,8 +102,18 @@ export default function RequestDetailScreen() {
     });
   }
 
-  function handleStartDialog() {
-    Alert.alert('Скоро', 'Функция диалогов будет доступна в ближайшее время');
+  async function handleStartDialog(specialistId: string) {
+    if (startingDialogId) return;
+    setStartingDialogId(specialistId);
+    try {
+      const resp = await api.post<{ threadId: string }>('/threads/start', { otherUserId: specialistId });
+      router.push(`/(dashboard)/messages/${resp.threadId}`);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось открыть диалог';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setStartingDialogId(null);
+    }
   }
 
   if (loading) {
@@ -194,8 +206,10 @@ export default function RequestDetailScreen() {
                 </View>
                 <Text style={styles.responseMessage}>{resp.message}</Text>
                 <Button
-                  onPress={handleStartDialog}
+                  onPress={() => handleStartDialog(resp.specialist.id)}
                   variant="secondary"
+                  loading={startingDialogId === resp.specialist.id}
+                  disabled={startingDialogId !== null}
                   style={styles.dialogBtn}
                 >
                   Начать диалог

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -6,6 +6,7 @@ import {
   SafeAreaView,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { api, ApiError } from '../../lib/api';
@@ -20,6 +21,7 @@ import { EmptyState } from '../../components/EmptyState';
 
 interface SpecialistProfile {
   id: string;
+  userId: string;
   nick: string;
   cities: string[];
   services: string[];
@@ -39,6 +41,7 @@ export default function SpecialistProfileScreen() {
   const [profile, setProfile] = useState<SpecialistProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [writingLoading, setWritingLoading] = useState(false);
 
   useEffect(() => {
     if (!nick) return;
@@ -67,12 +70,22 @@ export default function SpecialistProfileScreen() {
     return () => { cancelled = true; };
   }, [nick]);
 
-  function handleWrite() {
+  async function handleWrite() {
     if (!user) {
       router.push('/(auth)/email?role=CLIENT');
       return;
     }
-    router.push(`/(dashboard)/requests/new?specialist=${profile!.nick}`);
+    if (!profile || writingLoading) return;
+    setWritingLoading(true);
+    try {
+      const resp = await api.post<{ threadId: string }>('/threads/start', { otherUserId: profile.userId });
+      router.push(`/(dashboard)/messages/${resp.threadId}`);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось открыть диалог';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setWritingLoading(false);
+    }
   }
 
   if (loading) {
@@ -184,6 +197,8 @@ export default function SpecialistProfileScreen() {
           <Button
             onPress={handleWrite}
             variant="primary"
+            loading={writingLoading}
+            disabled={writingLoading}
             style={styles.writeBtn}
           >
             {user ? 'Написать' : 'Написать (войдите)'}


### PR DESCRIPTION
## Summary

- **Backend**: `POST /threads/start` (auth-guarded) — upserts thread between current user and `otherUserId`, returns `{ threadId }`. Participant IDs sorted before upsert to respect `@@unique([participant1Id, participant2Id])` invariant.
- **Frontend**: `requests/[id].tsx` — `handleStartDialog(specialistId)` replaces the Alert stub: calls `/threads/start`, then routes to `/(dashboard)/messages/:threadId`. Per-button loading state prevents double-tap.
- **Frontend**: `specialists/[nick].tsx` — `handleWrite` wired to same flow using `profile.userId`; added `userId` field to `SpecialistProfile` interface.

## Traps addressed

- IDs sorted with `.sort()` before upsert (not hardcoded order)
- `onPress={() => handleStartDialog(resp.specialist.id)}` — arrow function, not immediate call
- DTO field `otherUserId` matches on both frontend and backend

## Test plan

- [ ] Specialist responds to a request → client sees response → clicks "Начать диалог" → lands on thread screen
- [ ] Second click on same pair → no duplicate thread (upsert returns same threadId)
- [ ] Specialist profile "Написать" button navigates to thread
- [ ] Attempting to start thread with self → 400 BadRequest

🤖 Generated with [Claude Code](https://claude.com/claude-code)