### PR TITLE
fix: residual hardcoded hex → brand tokens

### DIFF
--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -409,7 +409,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   respondedBadge: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     borderRadius: BorderRadius.md,
     paddingVertical: Spacing.sm,
     alignItems: 'center',

--- a/app/(dashboard)/promotion.tsx
+++ b/app/(dashboard)/promotion.tsx
@@ -432,7 +432,7 @@ const styles = StyleSheet.create({
     minWidth: 110,
   },
   activePill: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     paddingHorizontal: Spacing.md,
     paddingVertical: 5,
     borderRadius: BorderRadius.full,

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -270,7 +270,7 @@ const styles = StyleSheet.create({
     borderRadius: BorderRadius.full,
   },
   statusChipClosed: {
-    backgroundColor: '#3a2a1e',
+    backgroundColor: Colors.statusBg.warning,
   },
   statusText: {
     fontSize: Typography.fontSize.xs,

--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -326,7 +326,7 @@ const styles = StyleSheet.create({
     borderRadius: BorderRadius.full,
   },
   statusChipClosed: {
-    backgroundColor: '#3a2a1e',
+    backgroundColor: Colors.statusBg.warning,
   },
   statusText: {
     fontSize: Typography.fontSize.xs,

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -186,13 +186,13 @@ const styles = StyleSheet.create({
     fontWeight: Typography.fontWeight.medium,
   },
   statusChip: {
-    backgroundColor: '#1a3a1e',
+    backgroundColor: Colors.statusBg.success,
     paddingHorizontal: Spacing.sm,
     paddingVertical: 3,
     borderRadius: BorderRadius.full,
   },
   statusChipClosed: {
-    backgroundColor: '#3a2a1e',
+    backgroundColor: Colors.statusBg.warning,
   },
   statusText: {
     fontSize: Typography.fontSize.xs,


### PR DESCRIPTION
Replaces 6 hardcoded hex values (#1a3a1e/#3a2a1e) with Colors.statusBg.success/warning in 5 dashboard files.

- responses.tsx: 2 replacements (statusChip + statusChipClosed)
- city-requests.tsx: 1 replacement (respondedBadge)
- promotion.tsx: 1 replacement (activePill)
- requests/index.tsx: 1 replacement (statusChipClosed)
- requests/[id].tsx: 1 replacement (statusChipClosed)

All Colors imports were already present. TypeScript errors unchanged (pre-existing socket.io-client issue only).

Closes #1612