### PR TITLE
feat: proactive token refresh (20min interval + visibilitychange)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,16 +1,69 @@
 import '../global.css';
-import React, { useEffect } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { ActivityIndicator, AppState, Platform, View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import Head from 'expo-router/head';
 import { AuthProvider, useAuth } from '../stores/authStore';
 import { isAdmin } from '../lib/adminEmails';
 import { Colors } from '../constants/Colors';
+import { tryRefreshTokens } from '../lib/api';
+
+const PROACTIVE_INTERVAL_MS = 20 * 60 * 1000; // 20 minutes
+const VISIBILITY_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+
+function useProactiveRefresh(isAuthenticated: boolean) {
+  const lastRefreshRef = useRef<number>(Date.now());
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    async function refresh() {
+      await tryRefreshTokens();
+      lastRefreshRef.current = Date.now();
+    }
+
+    // 20-minute interval refresh
+    const interval = setInterval(refresh, PROACTIVE_INTERVAL_MS);
+
+    if (Platform.OS === 'web') {
+      // Web: listen for tab visibility changes
+      const onVisibilityChange = () => {
+        if (
+          document.visibilityState === 'visible' &&
+          Date.now() - lastRefreshRef.current >= VISIBILITY_THRESHOLD_MS
+        ) {
+          refresh();
+        }
+      };
+      document.addEventListener('visibilitychange', onVisibilityChange);
+      return () => {
+        clearInterval(interval);
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+      };
+    } else {
+      // Native: listen for AppState changes (background → active)
+      const subscription = AppState.addEventListener('change', (nextState) => {
+        if (
+          nextState === 'active' &&
+          Date.now() - lastRefreshRef.current >= VISIBILITY_THRESHOLD_MS
+        ) {
+          refresh();
+        }
+      });
+      return () => {
+        clearInterval(interval);
+        subscription.remove();
+      };
+    }
+  }, [isAuthenticated]);
+}
 
 function RootNavigator() {
   const { user, isLoading } = useAuth();
   const segments = useSegments();
   const router = useRouter();
+
+  useProactiveRefresh(!!user);
 
   useEffect(() => {
     if (isLoading) return;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -38,6 +38,61 @@ export async function clearToken(): Promise<void> {
   await AsyncStorage.removeItem(TOKEN_KEY);
 }
 
+const REFRESH_TOKEN_KEY = '@p2ptax_refresh_token';
+
+export async function getRefreshToken(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(REFRESH_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function setRefreshToken(token: string): Promise<void> {
+  await AsyncStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+export async function clearRefreshToken(): Promise<void> {
+  await AsyncStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+// Refresh in-flight guard to avoid concurrent refresh calls
+let refreshPromise: Promise<boolean> | null = null;
+
+export async function tryRefreshTokens(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    try {
+      const refreshToken = await getRefreshToken();
+      if (!refreshToken) return false;
+
+      const url = `${BASE_URL}/auth/refresh`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+        credentials: 'include',
+      });
+
+      if (!response.ok) return false;
+
+      const data = await response.json() as { accessToken: string; refreshToken?: string };
+      await setToken(data.accessToken);
+      if (data.refreshToken) {
+        await setRefreshToken(data.refreshToken);
+      }
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
 // Core fetch helper
 async function request<T>(
   method: string,


### PR DESCRIPTION
## Summary
- Add `useProactiveRefresh` hook to `RootNavigator` in `app/_layout.tsx`
- `setInterval` every 20 min calls `tryRefreshTokens()`; web uses `visibilitychange`, native uses `AppState`
- Refresh only fires when >= 15 min since last refresh and user is authenticated
- Export `tryRefreshTokens` from `lib/api.ts` with refresh token helpers and in-flight dedup guard

## Test plan
- [ ] Authenticated user: leave app open 20+ min, check network tab for `/auth/refresh` call
- [ ] Web: switch tabs for 15+ min, return — refresh should trigger
- [ ] Native: background app for 15+ min, return — refresh should trigger
- [ ] Unauthenticated user: no refresh calls should fire
- [ ] `npx tsc --noEmit` — no new errors

Closes #1636