### PR TITLE
fix: add OTP attempt counter (3 attempts -> 429)

### DIFF
--- a/api/prisma/migrations/20260402110000_add_otp_attempts/migration.sql
+++ b/api/prisma/migrations/20260402110000_add_otp_attempts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "otp_codes" ADD COLUMN "attempts" INTEGER NOT NULL DEFAULT 0;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -52,6 +52,7 @@ model OtpCode {
   code      String
   expiresAt DateTime
   usedAt    DateTime?
+  attempts  Int       @default(0)
   createdAt DateTime  @default(now())
 
   @@index([email])

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { Injectable, BadRequestException, UnauthorizedException, HttpException, HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
 import { Role } from '@prisma/client';
@@ -80,21 +80,35 @@ export class AuthService {
       throw new BadRequestException('OTP expired');
     }
 
-    if (record.code !== code) {
-      throw new UnauthorizedException('Invalid OTP');
-    }
-
-    // Mark used in DB — find latest unused OTP for this email
+    // Find latest unused OTP record in DB to track attempt counter
     const otpRecord = await this.prisma.otpCode.findFirst({
       where: { email: normalizedEmail, usedAt: null },
       orderBy: { createdAt: 'desc' },
     });
-    if (otpRecord) {
+
+    if (!otpRecord) {
+      throw new BadRequestException('OTP not found or expired');
+    }
+
+    // Check attempt counter BEFORE verifying the code
+    if (otpRecord.attempts >= 3) {
+      throw new HttpException('Too many OTP attempts', HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    if (record.code !== code) {
+      // Increment attempt counter, then reject
       await this.prisma.otpCode.update({
         where: { id: otpRecord.id },
-        data: { usedAt: new Date() },
+        data: { attempts: { increment: 1 } },
       });
+      throw new UnauthorizedException('Invalid OTP');
     }
+
+    // Code is correct — mark used
+    await this.prisma.otpCode.update({
+      where: { id: otpRecord.id },
+      data: { usedAt: new Date() },
+    });
 
     otpStore.delete(normalizedEmail);
 


### PR DESCRIPTION
## Summary
- Add `attempts Int @default(0)` to `OtpCode` model in Prisma schema
- Add migration `20260402110000_add_otp_attempts` (ALTER TABLE otp_codes ADD COLUMN attempts)
- In `verifyOtp`: lookup DB record first, check `attempts >= 3` → 429 BEFORE code check
- On wrong code: `attempts: { increment: 1 }` → 401
- On correct code: mark `usedAt`, no attempts increment

## Test plan
- [ ] Request OTP for test email
- [ ] POST /api/auth/verify-otp with wrong code → 401 (x3)
- [ ] POST /api/auth/verify-otp with any code (even correct) → 429
- [ ] Request new OTP → fresh attempts=0 → correct code works

Fixes #1635