### PR TITLE
fix: route specialist profile to edit cabinet (#1481)

### DIFF
--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -158,7 +158,7 @@ export default function DashboardHub() {
               {user?.role === 'SPECIALIST' && (
                 <TouchableOpacity
                   style={styles.card}
-                  onPress={() => router.push('/(dashboard)/specialist-profile')}
+                  onPress={() => router.push('/(dashboard)/profile')}
                   activeOpacity={0.75}
                 >
                   <View style={styles.cardIcon}>

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -12,6 +12,7 @@ import {
   TextInput,
   RefreshControl,
 } from 'react-native';
+import { useRouter } from 'expo-router';
 import { api, ApiError } from '../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { Header } from '../../components/Header';
@@ -30,6 +31,7 @@ interface SpecialistProfile {
 }
 
 export default function SpecialistProfileScreen() {
+  const router = useRouter();
   const [profile, setProfile] = useState<SpecialistProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -160,18 +162,8 @@ export default function SpecialistProfileScreen() {
   }
 
   if (error === 'profile_not_found') {
-    return (
-      <SafeAreaView style={styles.safe}>
-        <Header title="Мой профиль" showBack />
-        <View style={styles.center}>
-          <Text style={styles.emptyIcon}>{'👤'}</Text>
-          <Text style={styles.emptyTitle}>Профиль не создан</Text>
-          <Text style={styles.emptySubtitle}>
-            Обратитесь в поддержку или создайте профиль через API
-          </Text>
-        </View>
-      </SafeAreaView>
-    );
+    router.replace('/(dashboard)/specialist-profile');
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary
- `index.tsx`: \"Мой профиль\" card for specialists now routes to `/(dashboard)/profile` (edit cabinet) instead of `/(dashboard)/specialist-profile` (setup wizard)
- `profile.tsx`: `profile_not_found` state now does `router.replace('/(dashboard)/specialist-profile')` + `return null` instead of rendering a dead-end message; adds `useRouter` import

## Test plan
- [ ] Log in as SPECIALIST with existing profile → tap \"Мой профиль\" → lands on edit screen with data pre-filled
- [ ] Log in as SPECIALIST with no profile → auto-redirected to setup screen (existing behavior, unchanged)
- [ ] Navigate directly to `/profile` without a profile → silently redirected to setup screen

Trinity: #1481