### PR TITLE
feat: add budget and category to request creation

### DIFF
--- a/api/prisma/migrations/20260402120000_add_request_budget_category/migration.sql
+++ b/api/prisma/migrations/20260402120000_add_request_budget_category/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "requests" ADD COLUMN "budget" INTEGER;
+ALTER TABLE "requests" ADD COLUMN "category" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -81,6 +81,8 @@ model Request {
   client      User          @relation(fields: [clientId], references: [id])
   description String
   city        String
+  budget      Int?
+  category    String?
   status      RequestStatus @default(OPEN)
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt

--- a/api/src/requests/dto/create-request.dto.ts
+++ b/api/src/requests/dto/create-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsOptional, IsInt, Min } from 'class-validator';
 
 export class CreateRequestDto {
   @IsString()
@@ -10,4 +10,14 @@ export class CreateRequestDto {
   @IsNotEmpty()
   @MaxLength(100)
   city!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  budget?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  category?: string;
 }

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -22,6 +22,8 @@ export class RequestsService {
         clientId,
         description: dto.description,
         city: dto.city,
+        budget: dto.budget ?? null,
+        category: dto.category ?? null,
       },
     });
   }

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -28,6 +28,8 @@ interface RequestDetail {
   id: string;
   description: string;
   city: string;
+  budget?: number | null;
+  category?: string | null;
   status: string;
   createdAt: string;
   _count: { responses: number };
@@ -172,6 +174,19 @@ export default function RequestDetailScreen() {
 
             <Text style={styles.description}>{request.description}</Text>
 
+            {(request.budget != null || request.category) ? (
+              <View style={styles.tagsRow}>
+                {request.category ? (
+                  <View style={styles.categoryChip}>
+                    <Text style={styles.categoryText}>{request.category}</Text>
+                  </View>
+                ) : null}
+                {request.budget != null ? (
+                  <Text style={styles.budgetText}>Бюджет: {request.budget.toLocaleString('ru-RU')} ₽</Text>
+                ) : null}
+              </View>
+            ) : null}
+
             <Text style={styles.dateLabel}>{formatDate(request.createdAt)}</Text>
 
             {request.status === 'OPEN' && (
@@ -293,6 +308,30 @@ const styles = StyleSheet.create({
   closeBtn: {
     marginTop: Spacing.lg,
     width: '100%',
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  categoryChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xxs,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  categoryText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  budgetText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
   },
   sectionTitle: {
     fontSize: Typography.fontSize.lg,

--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -29,6 +29,8 @@ interface RequestItem {
   id: string;
   description: string;
   city: string;
+  budget?: number | null;
+  category?: string | null;
   status: string;
   createdAt: string;
   _count: { responses: number };
@@ -122,6 +124,20 @@ export default function MyRequestsScreen() {
           <Text style={styles.description} numberOfLines={3}>
             {item.description}
           </Text>
+
+          {/* Budget + Category */}
+          {(item.budget != null || item.category) ? (
+            <View style={styles.tagsRow}>
+              {item.category ? (
+                <View style={styles.categoryChip}>
+                  <Text style={styles.categoryText}>{item.category}</Text>
+                </View>
+              ) : null}
+              {item.budget != null ? (
+                <Text style={styles.budgetText}>{item.budget.toLocaleString('ru-RU')} ₽</Text>
+              ) : null}
+            </View>
+          ) : null}
 
           {/* Footer */}
           <View style={styles.footer}>
@@ -338,6 +354,30 @@ const styles = StyleSheet.create({
   },
   closeBtn: {
     marginTop: Spacing.md,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.sm,
+  },
+  categoryChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xxs,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  categoryText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  budgetText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
   },
   loadingBox: {
     paddingTop: Spacing['4xl'],

--- a/app/(dashboard)/requests/new.tsx
+++ b/app/(dashboard)/requests/new.tsx
@@ -8,6 +8,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   Alert,
+  TouchableOpacity,
 } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { api, ApiError } from '../../../lib/api';
@@ -16,13 +17,26 @@ import { Header } from '../../../components/Header';
 import { Button } from '../../../components/Button';
 import { Input } from '../../../components/Input';
 
+const TAX_CATEGORIES = [
+  'НДС',
+  'НДФЛ',
+  'Налог на прибыль',
+  'УСН',
+  'ИП/ООО',
+  'Таможня',
+  'Налоговая проверка',
+  'Другое',
+];
+
 export default function CreateRequestScreen() {
   const router = useRouter();
   const { specialist } = useLocalSearchParams<{ specialist?: string }>();
   const [description, setDescription] = useState('');
   const [city, setCity] = useState('');
+  const [budget, setBudget] = useState('');
+  const [category, setCategory] = useState('');
   const [loading, setLoading] = useState(false);
-  const [errors, setErrors] = useState<{ description?: string; city?: string }>({});
+  const [errors, setErrors] = useState<{ description?: string; city?: string; budget?: string }>({});
 
   function validate(): boolean {
     const e: typeof errors = {};
@@ -32,6 +46,9 @@ export default function CreateRequestScreen() {
     if (!city.trim()) {
       e.city = 'Укажите город';
     }
+    if (budget.trim() && (isNaN(Number(budget)) || Number(budget) < 0 || !Number.isInteger(Number(budget)))) {
+      e.budget = 'Введите целое число';
+    }
     setErrors(e);
     return Object.keys(e).length === 0;
   }
@@ -40,10 +57,13 @@ export default function CreateRequestScreen() {
     if (!validate()) return;
     setLoading(true);
     try {
-      await api.post('/requests', {
+      const body: Record<string, unknown> = {
         description: description.trim(),
         city: city.trim(),
-      });
+      };
+      if (budget.trim()) body.budget = Number(budget.trim());
+      if (category) body.category = category;
+      await api.post('/requests', body);
       router.replace('/(dashboard)/requests');
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : 'Не удалось создать запрос';
@@ -105,6 +125,36 @@ export default function CreateRequestScreen() {
               autoCapitalize="words"
               error={errors.city}
             />
+
+            <Input
+              label="Бюджет (₽, необязательно)"
+              value={budget}
+              onChangeText={(t) => {
+                setBudget(t);
+                if (errors.budget) setErrors((e) => ({ ...e, budget: undefined }));
+              }}
+              placeholder="Например, 5000"
+              keyboardType="numeric"
+              error={errors.budget}
+            />
+
+            <View style={styles.field}>
+              <Text style={styles.label}>Категория (необязательно)</Text>
+              <View style={styles.chipsRow}>
+                {TAX_CATEGORIES.map((cat) => (
+                  <TouchableOpacity
+                    key={cat}
+                    style={[styles.chip, category === cat && styles.chipActive]}
+                    onPress={() => setCategory(category === cat ? '' : cat)}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={[styles.chipText, category === cat && styles.chipTextActive]}>
+                      {cat}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
 
             <Button
               onPress={handleSubmit}
@@ -172,5 +222,30 @@ const styles = StyleSheet.create({
   submitBtn: {
     width: '100%',
     marginTop: Spacing.md,
+  },
+  chipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  chipActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  chipText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  chipTextActive: {
+    color: Colors.textPrimary,
   },
 });

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -21,6 +21,8 @@ interface RequestItem {
   id: string;
   description: string;
   city: string;
+  budget?: number | null;
+  category?: string | null;
   status: string;
   createdAt: string;
   client: { id: string; email: string };
@@ -122,6 +124,20 @@ export default function RequestsFeedScreen() {
           <Text style={styles.description} numberOfLines={4}>
             {item.description}
           </Text>
+
+          {/* Budget + Category */}
+          {(item.budget != null || item.category) ? (
+            <View style={styles.tagsRow}>
+              {item.category ? (
+                <View style={styles.categoryChip}>
+                  <Text style={styles.categoryText}>{item.category}</Text>
+                </View>
+              ) : null}
+              {item.budget != null ? (
+                <Text style={styles.budgetText}>{item.budget.toLocaleString('ru-RU')} ₽</Text>
+              ) : null}
+            </View>
+          ) : null}
 
           {/* Footer */}
           <View style={styles.footer}>
@@ -293,6 +309,30 @@ const styles = StyleSheet.create({
   statusText: {
     fontSize: Typography.fontSize.xs,
     color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.sm,
+  },
+  categoryChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xxs,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  categoryText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  budgetText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
     fontWeight: Typography.fontWeight.medium,
   },
   loadingBox: {


### PR DESCRIPTION
## Summary
- Adds optional `budget` (Int) and `category` (String) fields to requests
- Prisma migration applied to remote DB (both fields nullable, zero downtime)
- Backend DTO validated: budget @IsInt @Min(0), category @IsString @MaxLength(100)
- Frontend: budget numeric input + 8 category chips on request creation form
- Budget/category displayed in: My Requests list, Request detail view, public feed

## Test plan
- [ ] Create request with budget + category → verify both saved and shown in My Requests
- [ ] Create request without budget/category → verify null fields render gracefully (no empty chips)
- [ ] Check public feed (app/requests) shows category chip and budget for specialists
- [ ] Request detail view shows budget with "Бюджет: X ₽" label and category chip
- [ ] Budget validation: non-integer or negative → frontend error, blocked from submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)