### PR TITLE
feat: add username onboarding after first OTP login

### DIFF
--- a/api/prisma/migrations/20260403000000_add_username_to_user/migration.sql
+++ b/api/prisma/migrations/20260403000000_add_username_to_user/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "username" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_username_key" ON "users"("username");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -27,6 +27,7 @@ enum PromotionTier {
 model User {
   id          String    @id @default(cuid())
   email       String    @unique
+  username    String?   @unique
   role        Role      @default(CLIENT)
   createdAt   DateTime  @default(now())
   lastLoginAt DateTime?

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -26,6 +26,11 @@ export interface TokenPair {
   refreshToken: string;
 }
 
+export interface VerifyOtpResult extends TokenPair {
+  isNewUser: boolean;
+  user: { userId: string; email: string; role: string; username: string | null };
+}
+
 @Injectable()
 export class AuthService {
   constructor(
@@ -67,7 +72,7 @@ export class AuthService {
     return { message: 'OTP sent to email' };
   }
 
-  async verifyOtp(email: string, code: string, role?: string): Promise<TokenPair> {
+  async verifyOtp(email: string, code: string, role?: string): Promise<VerifyOtpResult> {
     const normalizedEmail = email.toLowerCase();
     const record = otpStore.get(normalizedEmail);
 
@@ -117,6 +122,8 @@ export class AuthService {
       where: { email: normalizedEmail },
     });
 
+    const isNewUser = !existingUser;
+
     // Assign role only on first login; subsequent logins preserve existing role
     const assignedRole = existingUser ? existingUser.role : mapRole(role);
 
@@ -126,7 +133,17 @@ export class AuthService {
       update: { lastLoginAt: new Date() },
     });
 
-    return this.generateTokens(user);
+    const tokens = this.generateTokens(user);
+    return {
+      ...tokens,
+      isNewUser,
+      user: {
+        userId: user.id,
+        email: user.email,
+        role: user.role,
+        username: user.username,
+      },
+    };
   }
 
   async refresh(refreshToken: string): Promise<TokenPair> {

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,11 +1,34 @@
-import { Controller, Delete, Request, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Patch, Body, Request, UseGuards } from '@nestjs/common';
+import { IsString, Length, Matches } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
+
+class SetUsernameDto {
+  @IsString()
+  @Length(3, 20)
+  @Matches(/^[a-zA-Z0-9_]+$/, { message: 'username can only contain letters, numbers, and underscores' })
+  username!: string;
+}
 
 @Controller('users')
 @UseGuards(JwtAuthGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  /** GET /users/me — return current user profile */
+  @Get('me')
+  getMe(@Request() req: { user: { id: string } }) {
+    return this.usersService.getMe(req.user.id);
+  }
+
+  /** PATCH /users/me/username — set or update username */
+  @Patch('me/username')
+  setUsername(
+    @Request() req: { user: { id: string } },
+    @Body() body: SetUsernameDto,
+  ) {
+    return this.usersService.setUsername(req.user.id, body.username);
+  }
 
   /** DELETE /users/me — permanently delete the authenticated user's account */
   @Delete('me')

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,9 +1,40 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 
 @Injectable()
 export class UsersService {
   constructor(private readonly prisma: PrismaService) {}
+
+  /** Return current user profile (id, email, role, username). */
+  async getMe(userId: string): Promise<{ id: string; email: string; role: string; username: string | null }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    return { id: user.id, email: user.email, role: user.role, username: user.username };
+  }
+
+  /** Set username for a user. 3-20 chars, alphanumeric + underscore, globally unique. */
+  async setUsername(userId: string, username: string): Promise<{ id: string; email: string; role: string; username: string }> {
+    if (username.length < 3 || username.length > 20) {
+      throw new BadRequestException('Username must be between 3 and 20 characters');
+    }
+    if (!USERNAME_REGEX.test(username)) {
+      throw new BadRequestException('Username can only contain letters, numbers, and underscores');
+    }
+
+    const taken = await this.prisma.user.findUnique({ where: { username } });
+    if (taken && taken.id !== userId) {
+      throw new ConflictException('Username already taken');
+    }
+
+    const user = await this.prisma.user.update({
+      where: { id: userId },
+      data: { username },
+    });
+
+    return { id: user.id, email: user.email, role: user.role, username: user.username! };
+  }
 
   /**
    * Delete a user and all related records.

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -22,10 +22,12 @@ const RESEND_SECONDS = 60;
 interface VerifyOtpResponse {
   accessToken: string;
   refreshToken?: string;
+  isNewUser: boolean;
   user: {
     userId: string;
     email: string;
     role: string;
+    username: string | null;
   };
 }
 
@@ -100,9 +102,15 @@ export default function OtpScreen() {
         userId: res.user.userId,
         email: res.user.email,
         role: res.user.role,
+        username: res.user.username,
+        isNewUser: res.isNewUser,
       });
-      // Navigate based on role — expand when dashboards are ready
-      router.replace('/');
+      // New users go to onboarding to pick a username; returning users go to dashboard
+      if (res.isNewUser) {
+        router.replace('/(onboarding)/username');
+      } else {
+        router.replace('/');
+      }
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err.message);

--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,0 +1,16 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function OnboardingLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+        animation: 'fade',
+        // Prevent going back to auth screens during onboarding
+        gestureEnabled: false,
+      }}
+    />
+  );
+}

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Button } from '../../components/Button';
+import { Input } from '../../components/Input';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { api, ApiError } from '../../lib/api';
+import { useAuth } from '../../stores/authStore';
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+
+function validateUsername(value: string): string | null {
+  if (value.length < 3) return 'Минимум 3 символа';
+  if (value.length > 20) return 'Максимум 20 символов';
+  if (!USERNAME_REGEX.test(value)) return 'Только буквы, цифры и символ _';
+  return null;
+}
+
+export default function UsernameScreen() {
+  const router = useRouter();
+  const { completeOnboarding } = useAuth();
+
+  const [username, setUsername] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  function handleChange(value: string) {
+    setUsername(value);
+    if (error) setError('');
+  }
+
+  async function handleSubmit() {
+    const trimmed = username.trim();
+    const validationError = validateUsername(trimmed);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+    try {
+      await api.patch('/users/me/username', { username: trimmed });
+      await completeOnboarding(trimmed);
+      router.replace('/');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError('Этот ник уже занят, попробуйте другой');
+      } else if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось сохранить ник. Попробуйте снова.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.title}>Придумайте ник</Text>
+              <Text style={styles.subtitle}>
+                Это ваш публичный псевдоним на платформе. Можно изменить позже.
+              </Text>
+            </View>
+
+            {/* Rules hint */}
+            <View style={styles.rulesBox}>
+              <Text style={styles.rulesText}>
+                3–20 символов: буквы, цифры, знак подчёркивания (_)
+              </Text>
+            </View>
+
+            {/* Form */}
+            <View style={styles.form}>
+              <Input
+                label="Ник"
+                value={username}
+                onChangeText={handleChange}
+                placeholder="например: ivan_petrov"
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoFocus
+                error={error}
+                maxLength={20}
+              />
+              <Button
+                onPress={handleSubmit}
+                loading={loading}
+                disabled={loading || username.trim().length < 3}
+                style={styles.btn}
+              >
+                Продолжить
+              </Button>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  kav: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+    justifyContent: 'center',
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+  },
+  header: {
+    gap: Spacing.sm,
+    marginTop: Spacing.xl,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  rulesBox: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  rulesText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  form: {
+    gap: Spacing.lg,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -71,9 +71,16 @@ function RootNavigator() {
     const inAuthGroup = segments[0] === '(auth)';
     const inDashboardGroup = segments[0] === '(dashboard)';
     const inAdminGroup = segments[0] === '(admin)';
+    const inOnboardingGroup = segments[0] === '(onboarding)';
     // Public routes that guests can access freely
     const isPublicRoute =
       segments[0] === 'specialists' || segments[0] === 'requests';
+
+    // New user must complete onboarding before accessing anything else
+    if (user && user.isNewUser && !inOnboardingGroup) {
+      router.replace('/(onboarding)/username');
+      return;
+    }
 
     if (!user && !inAuthGroup && !isPublicRoute && segments[0] !== undefined) {
       // Not authenticated and trying to access a protected route → landing

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -9,6 +9,8 @@ export interface AuthUser {
   userId: string;
   email: string;
   role: string;
+  username: string | null;
+  isNewUser: boolean;
 }
 
 interface AuthState {
@@ -21,7 +23,8 @@ type AuthAction =
   | { type: 'LOGIN'; payload: { token: string; user: AuthUser } }
   | { type: 'LOGOUT' }
   | { type: 'SET_LOADING'; payload: boolean }
-  | { type: 'RESTORE'; payload: { token: string; user: AuthUser } | null };
+  | { type: 'RESTORE'; payload: { token: string; user: AuthUser } | null }
+  | { type: 'SET_USERNAME'; payload: string };
 
 function authReducer(state: AuthState, action: AuthAction): AuthState {
   switch (action.type) {
@@ -42,6 +45,12 @@ function authReducer(state: AuthState, action: AuthAction): AuthState {
         token: action.payload?.token ?? null,
         isLoading: false,
       };
+    case 'SET_USERNAME':
+      if (!state.user) return state;
+      return {
+        ...state,
+        user: { ...state.user, username: action.payload, isNewUser: false },
+      };
     default:
       return state;
   }
@@ -57,6 +66,7 @@ interface AuthContextValue extends AuthState {
   login: (token: string, user: AuthUser) => Promise<void>;
   logout: () => Promise<void>;
   setLoading: (loading: boolean) => void;
+  completeOnboarding: (username: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -126,11 +136,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     dispatch({ type: 'SET_LOADING', payload: loading });
   }, []);
 
+  // Called after onboarding completes — clears isNewUser flag and stores username
+  const completeOnboarding = useCallback(async (username: string) => {
+    dispatch({ type: 'SET_USERNAME', payload: username });
+    // Persist updated user (isNewUser=false, username set) to AsyncStorage
+    const userJson = await AsyncStorage.getItem(USER_KEY);
+    if (userJson) {
+      const existing = JSON.parse(userJson) as AuthUser;
+      const updated: AuthUser = { ...existing, username, isNewUser: false };
+      await AsyncStorage.setItem(USER_KEY, JSON.stringify(updated));
+    }
+  }, []);
+
   const value: AuthContextValue = {
     ...state,
     login,
     logout,
     setLoading,
+    completeOnboarding,
   };
 
   return React.createElement(AuthContext.Provider, { value }, children);


### PR DESCRIPTION
## Summary
- New users (first OTP login) are redirected to an onboarding screen to pick a username (3-20 chars, alphanumeric + underscore)
- `isNewUser` flag returned from `POST /auth/verify-otp` and stored in authStore/AsyncStorage; cleared once onboarding completes
- DB migration adds nullable unique `username` column to `users` table
- New API endpoints: `GET /users/me` and `PATCH /users/me/username` (409 on conflict)
- `app/_layout.tsx` guard blocks `isNewUser` users from reaching dashboard until onboarding complete

## Test plan
- [ ] New user registers → after OTP → lands on `/onboarding/username` screen
- [ ] Enter invalid username (too short, bad chars) → see validation error
- [ ] Enter taken username → see 409 error message
- [ ] Enter valid username → saved → redirected to dashboard
- [ ] Existing user logs in → goes directly to dashboard (no onboarding)
- [ ] Session restore (page refresh) → username set → no onboarding redirect
- [ ] `GET /users/me` returns correct `username` field