### PR TITLE
fix(badge): use 'familiar' slug for tax badge storage

### DIFF
--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -19,7 +19,7 @@ import { Header } from '../../components/Header';
 import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 
-const BADGE_TAX = 'Знакомый в налоговой';
+const BADGE_TAX = 'familiar';
 
 interface SpecialistProfile {
   id: string;


### PR DESCRIPTION
## Summary
- Fixed badge value mismatch in specialist profile edit screen
- `BADGE_TAX` constant changed from `'Знакомый в налоговой'` to `'familiar'`
- This makes save and load consistent with catalog filter (`?badge=familiar`) and public profile check (`badges.includes('familiar')`)

## Root cause
The badge was stored as the Russian display text, but `specialists/index.tsx` and `specialists/[nick].tsx` both checked for the `'familiar'` slug. Result: badge never appeared in catalog cards or public profiles, and the "Знакомый в налоговой" filter returned no results.

## Test plan
- [ ] Log in as specialist, go to Profile, toggle "Знакомый в налоговой" ON, save
- [ ] Go to Catalog — badge chip appears on specialist card
- [ ] Enable "Знакомый в налоговой" filter toggle — specialist appears in filtered results
- [ ] Open specialist's public profile — badge appears in hero card