### PR TITLE
feat(specialists): city filter chips + /specialists/cities endpoint

### DIFF
--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -32,6 +32,11 @@ export class SpecialistsController {
     return this.specialistsService.updateProfile(req.user.id, dto);
   }
 
+  @Get('cities')
+  getAvailableCities() {
+    return this.specialistsService.getAvailableCities();
+  }
+
   @Get()
   getCatalog(
     @Query('city') city?: string,

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -61,6 +61,19 @@ export class SpecialistsService {
     return { ...profile, activity };
   }
 
+  async getAvailableCities(): Promise<string[]> {
+    const profiles = await this.prisma.specialistProfile.findMany({
+      select: { cities: true },
+    });
+    const citySet = new Set<string>();
+    for (const profile of profiles) {
+      for (const city of profile.cities) {
+        if (city && city.trim()) citySet.add(city.trim());
+      }
+    }
+    return Array.from(citySet).sort((a, b) => a.localeCompare(b, 'ru'));
+  }
+
   async getCatalog(city?: string, badge?: string, sort?: string) {
     const now = new Date();
     const where: any = {};

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   SafeAreaView,
   FlatList,
+  ScrollView,
   TouchableOpacity,
   ActivityIndicator,
   RefreshControl,
@@ -15,7 +16,6 @@ import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Color
 import { Card } from '../../components/Card';
 import { Badge } from '../../components/Badge';
 import { Avatar } from '../../components/Avatar';
-import { Input } from '../../components/Input';
 import { EmptyState } from '../../components/EmptyState';
 import { Header } from '../../components/Header';
 
@@ -44,8 +44,14 @@ export default function SpecialistsCatalogScreen() {
   const [error, setError] = useState('');
 
   const [cityFilter, setCityFilter] = useState('');
+  const [availableCities, setAvailableCities] = useState<string[]>([]);
   const [badgeFilter, setBadgeFilter] = useState(false);
   const [sort, setSort] = useState('newest');
+
+  // Load available cities once on mount
+  useEffect(() => {
+    api.get<string[]>('/specialists/cities').then(setAvailableCities).catch(() => {});
+  }, []);
 
   const fetchSpecialists = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
@@ -74,15 +80,9 @@ export default function SpecialistsCatalogScreen() {
   }, [cityFilter, badgeFilter, sort]);
 
   useEffect(() => {
-    const timer = setTimeout(() => fetchSpecialists(), cityFilter ? 400 : 0);
-    return () => clearTimeout(timer);
-  }, [fetchSpecialists, cityFilter]);
-
-  // Fetch immediately when non-city filters change
-  useEffect(() => {
     fetchSpecialists();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [badgeFilter, sort]);
+  }, [cityFilter, badgeFilter, sort]);
 
   function handleRefresh() {
     setRefreshing(true);
@@ -173,14 +173,34 @@ export default function SpecialistsCatalogScreen() {
         }
         ListHeaderComponent={
           <View style={styles.filters}>
-            {/* City filter */}
-            <Input
-              label="Город"
-              value={cityFilter}
-              onChangeText={setCityFilter}
-              placeholder="Например, Москва"
-              autoCapitalize="words"
-            />
+            {/* City filter chips */}
+            {availableCities.length > 0 && (
+              <View>
+                <Text style={styles.filterLabel}>Город</Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.cityChipsRow}
+                >
+                  {['', ...availableCities].map((city) => {
+                    const isAll = city === '';
+                    const isActive = cityFilter === city;
+                    return (
+                      <TouchableOpacity
+                        key={isAll ? '__all__' : city}
+                        onPress={() => setCityFilter(city)}
+                        style={[styles.cityChip, isActive && styles.cityChipActive]}
+                        activeOpacity={0.7}
+                      >
+                        <Text style={[styles.cityChipText, isActive && styles.cityChipTextActive]}>
+                          {isAll ? 'Все города' : city}
+                        </Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+            )}
 
             {/* Badge filter toggle */}
             <TouchableOpacity
@@ -265,6 +285,37 @@ const styles = StyleSheet.create({
     gap: Spacing.md,
     paddingTop: Spacing.lg,
     paddingBottom: Spacing.xl,
+  },
+  filterLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+    marginBottom: Spacing.sm,
+  },
+  cityChipsRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    paddingRight: Spacing.sm,
+  },
+  cityChip: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    backgroundColor: Colors.bgCard,
+  },
+  cityChipActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  cityChipText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  cityChipTextActive: {
+    color: Colors.textPrimary,
   },
   badgeToggle: {
     paddingVertical: Spacing.sm,


### PR DESCRIPTION
## Summary
- New backend endpoint `GET /specialists/cities` — returns sorted list of distinct non-empty cities from all specialist profiles
- Declared before `GET /specialists/:nick` in controller to prevent route conflict
- Frontend catalog screen: replaced free-text city `<Input>` with horizontal scrollable chip row
- First chip is "Все города" (all cities, selected by default); selecting any city immediately filters the list

## Test plan
- [ ] `curl https://p2ptax.smartlaunchhub.com/api/specialists/cities` returns JSON array of city strings
- [ ] Open `/specialists` catalog screen — city chips appear above badge filter
- [ ] Tap a city chip — list filters to specialists with that city
- [ ] Tap "Все города" — all specialists shown again
- [ ] No regression on badge filter and sort tabs