### PR TITLE
feat(messaging): REST send endpoint + WS emit + REST fallback

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -2,20 +2,28 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
   Param,
   Query,
   Body,
   UseGuards,
   Request,
+  ForbiddenException,
+  NotFoundException,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ChatService } from './chat.service';
+import { ChatGateway } from './chat.gateway';
 import { StartThreadDto } from './dto/start-thread.dto';
+import { SendMessageDto } from './dto/send-message.dto';
 
 @Controller('threads')
 @UseGuards(JwtAuthGuard)
 export class ChatController {
-  constructor(private readonly chatService: ChatService) {}
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly chatGateway: ChatGateway,
+  ) {}
 
   @Get()
   getThreads(@Request() req: { user: { id: string } }) {
@@ -38,5 +46,50 @@ export class ChatController {
     @Query('page') page?: string,
   ) {
     return this.chatService.getMessages(req.user.id, threadId, parseInt(page ?? '1', 10) || 1);
+  }
+
+  // POST /threads/:id/messages — send a message via REST (fallback when WebSocket unavailable)
+  @Post(':id/messages')
+  async sendMessage(
+    @Request() req: { user: { id: string } },
+    @Param('id') threadId: string,
+    @Body() dto: SendMessageDto,
+  ) {
+    const thread = await this.chatService.verifyParticipant(req.user.id, threadId);
+    if (!thread) {
+      throw new NotFoundException('Thread not found or access denied');
+    }
+
+    const message = await this.chatService.createMessage(threadId, req.user.id, dto.content.trim());
+
+    // Notify connected participants in real time via WebSocket (same as gateway)
+    try {
+      this.chatGateway.server.to(`thread:${threadId}`).emit('message_received', message);
+    } catch {
+      // Non-blocking — WS emit failure must not fail the REST response
+    }
+
+    return message;
+  }
+
+  // PATCH /threads/:id/messages/:messageId/read — mark a message as read via REST
+  @Patch(':id/messages/:messageId/read')
+  async markMessageRead(
+    @Request() req: { user: { id: string } },
+    @Param('id') threadId: string,
+    @Param('messageId') messageId: string,
+  ) {
+    // Verify thread access first
+    const thread = await this.chatService.verifyParticipant(req.user.id, threadId);
+    if (!thread) {
+      throw new ForbiddenException('Thread not found or access denied');
+    }
+
+    const updated = await this.chatService.markRead(req.user.id, messageId);
+    if (!updated) {
+      throw new NotFoundException('Message not found or cannot be marked as read');
+    }
+
+    return updated;
   }
 }

--- a/api/src/chat/dto/send-message.dto.ts
+++ b/api/src/chat/dto/send-message.dto.ts
@@ -1,0 +1,8 @@
+import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+
+export class SendMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  content!: string;
+}

--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -172,11 +172,23 @@ export default function ThreadScreen() {
     setInput('');
     setSending(true);
 
-    if (socketRef.current?.connected) {
-      socketRef.current.emit('send_message', { threadId, content });
-      setSending(false);
-    } else {
-      // Fallback: not connected, just clear (WebSocket handles delivery)
+    try {
+      if (socketRef.current?.connected) {
+        // Primary path: send via WebSocket — gateway broadcasts message_received to room
+        socketRef.current.emit('send_message', { threadId, content });
+      } else {
+        // Fallback: WebSocket unavailable — send via REST, which also emits to WS room
+        const message = await api.post<Message>(`/threads/${threadId}/messages`, { content });
+        // Append locally so sender sees the message immediately without waiting for WS event
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === message.id)) return prev;
+          return [...prev, message];
+        });
+      }
+    } catch {
+      // Restore input on failure so user can retry
+      setInput(content);
+    } finally {
       setSending(false);
     }
   }


### PR DESCRIPTION
## Summary

- `POST /threads/:id/messages` — send a message via REST; saves to DB then emits `message_received` to the WebSocket room so connected participants get real-time delivery without needing the gateway
- `PATCH /threads/:id/messages/:messageId/read` — mark a message as read via REST
- `ChatGateway` injected into `ChatController` to reuse `server.to(room).emit()`
- `SendMessageDto` with `@MaxLength(2000)` validation
- `[threadId].tsx` `handleSend`: REST fallback when WebSocket is disconnected, appends message locally immediately, restores input on error

## Test plan

- [ ] `POST /api/threads/start` → get threadId
- [ ] `POST /api/threads/:id/messages` with `{"content":"hello"}` → returns message object
- [ ] Second user connected via WS receives `message_received` event after REST send
- [ ] `PATCH /api/threads/:id/messages/:messageId/read` → returns message with `readAt` set
- [ ] Open app, navigate Dashboard → Мои диалоги → open thread → send message while WS connected (primary path)
- [ ] Disconnect network, reconnect → REST fallback delivers message

Closes #1490