### PR TITLE
feat(rating): star rating system for specialists (#1494)

### DIFF
--- a/api/prisma/migrations/20260403100000_add_review_model/migration.sql
+++ b/api/prisma/migrations/20260403100000_add_review_model/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "reviews" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "specialistId" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "reviews_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "reviews_specialistId_idx" ON "reviews"("specialistId");
+
+-- CreateIndex
+CREATE INDEX "reviews_clientId_idx" ON "reviews"("clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reviews_clientId_specialistId_requestId_key" ON "reviews"("clientId", "specialistId", "requestId");
+
+-- AddForeignKey
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_specialistId_fkey" FOREIGN KEY ("specialistId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "requests"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -43,6 +43,8 @@ model User {
   threadsAsParticipant1 Thread[]        @relation("ThreadParticipant1")
   threadsAsParticipant2 Thread[]        @relation("ThreadParticipant2")
   sentMessages        Message[]
+  reviewsGiven        Review[]          @relation("ReviewClient")
+  reviewsReceived     Review[]          @relation("ReviewSpecialist")
 
   @@map("users")
 }
@@ -89,6 +91,7 @@ model Request {
   updatedAt   DateTime      @updatedAt
 
   responses   Response[]
+  reviews     Review[]
 
   @@index([clientId])
   @@index([city, status])
@@ -176,4 +179,22 @@ model ChatMessage {
 
   @@index([room])
   @@map("chat_messages")
+}
+
+model Review {
+  id           String   @id @default(cuid())
+  clientId     String
+  client       User     @relation("ReviewClient", fields: [clientId], references: [id])
+  specialistId String
+  specialist   User     @relation("ReviewSpecialist", fields: [specialistId], references: [id])
+  requestId    String
+  request      Request  @relation(fields: [requestId], references: [id])
+  rating       Int
+  comment      String?
+  createdAt    DateTime @default(now())
+
+  @@unique([clientId, specialistId, requestId])
+  @@index([specialistId])
+  @@index([clientId])
+  @@map("reviews")
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { RequestsModule } from './requests/requests.module';
 import { PromotionsModule } from './promotions/promotions.module';
 import { UsersModule } from './users/users.module';
 import { AdminModule } from './admin/admin.module';
+import { ReviewsModule } from './reviews/reviews.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { AdminModule } from './admin/admin.module';
     PromotionsModule,
     UsersModule,
     AdminModule,
+    ReviewsModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/reviews/dto/create-review.dto.ts
+++ b/api/src/reviews/dto/create-review.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsString, IsOptional, Min, Max, MinLength } from 'class-validator';
+
+export class CreateReviewDto {
+  @IsString()
+  @MinLength(1)
+  specialistNick!: string;
+
+  @IsString()
+  @MinLength(1)
+  requestId!: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating!: number;
+
+  @IsString()
+  @IsOptional()
+  comment?: string;
+}

--- a/api/src/reviews/reviews.controller.ts
+++ b/api/src/reviews/reviews.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ReviewsService } from './reviews.service';
+import { CreateReviewDto } from './dto/create-review.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { Role } from '@prisma/client';
+
+@Controller('reviews')
+export class ReviewsController {
+  constructor(private readonly reviewsService: ReviewsService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  create(@Request() req: any, @Body() dto: CreateReviewDto) {
+    return this.reviewsService.create(req.user.id, dto);
+  }
+
+  @Get('specialist/:nick')
+  listBySpecialist(
+    @Param('nick') nick: string,
+    @Query('page') page?: string,
+  ) {
+    return this.reviewsService.listBySpecialist(nick, page ? parseInt(page, 10) : 1);
+  }
+
+  @Get('eligibility/:nick')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  checkEligibility(@Request() req: any, @Param('nick') nick: string) {
+    return this.reviewsService.checkEligibility(req.user.id, nick);
+  }
+}

--- a/api/src/reviews/reviews.module.ts
+++ b/api/src/reviews/reviews.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReviewsController } from './reviews.controller';
+import { ReviewsService } from './reviews.service';
+
+@Module({
+  controllers: [ReviewsController],
+  providers: [ReviewsService],
+})
+export class ReviewsModule {}

--- a/api/src/reviews/reviews.service.ts
+++ b/api/src/reviews/reviews.service.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateReviewDto } from './dto/create-review.dto';
+import { RequestStatus } from '@prisma/client';
+
+const PAGE_SIZE = 20;
+
+@Injectable()
+export class ReviewsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(clientId: string, dto: CreateReviewDto) {
+    // Resolve specialist by nick
+    const specialistProfile = await this.prisma.specialistProfile.findUnique({
+      where: { nick: dto.specialistNick },
+    });
+    if (!specialistProfile) {
+      throw new NotFoundException('Specialist not found');
+    }
+    const specialistId = specialistProfile.userId;
+
+    // Validate request belongs to client and is CLOSED
+    const request = await this.prisma.request.findUnique({
+      where: { id: dto.requestId },
+    });
+    if (!request) {
+      throw new NotFoundException('Request not found');
+    }
+    if (request.clientId !== clientId) {
+      throw new ForbiddenException('This request does not belong to you');
+    }
+    if (request.status !== RequestStatus.CLOSED) {
+      throw new BadRequestException('Request must be CLOSED to leave a review');
+    }
+
+    // Validate specialist responded to this request
+    const response = await this.prisma.response.findUnique({
+      where: {
+        specialistId_requestId: {
+          specialistId,
+          requestId: dto.requestId,
+        },
+      },
+    });
+    if (!response) {
+      throw new BadRequestException('This specialist did not respond to this request');
+    }
+
+    // Check for duplicate
+    const existing = await this.prisma.review.findUnique({
+      where: {
+        clientId_specialistId_requestId: {
+          clientId,
+          specialistId,
+          requestId: dto.requestId,
+        },
+      },
+    });
+    if (existing) {
+      throw new ConflictException('You have already reviewed this specialist for this request');
+    }
+
+    return this.prisma.review.create({
+      data: {
+        clientId,
+        specialistId,
+        requestId: dto.requestId,
+        rating: dto.rating,
+        comment: dto.comment ?? null,
+      },
+    });
+  }
+
+  async listBySpecialist(nick: string, page = 1) {
+    const specialistProfile = await this.prisma.specialistProfile.findUnique({
+      where: { nick },
+    });
+    if (!specialistProfile) {
+      throw new NotFoundException('Specialist not found');
+    }
+    const specialistId = specialistProfile.userId;
+
+    const skip = (page - 1) * PAGE_SIZE;
+    const [items, total] = await Promise.all([
+      this.prisma.review.findMany({
+        where: { specialistId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: PAGE_SIZE,
+        select: {
+          id: true,
+          rating: true,
+          comment: true,
+          createdAt: true,
+          client: { select: { id: true, username: true, email: true } },
+        },
+      }),
+      this.prisma.review.count({ where: { specialistId } }),
+    ]);
+
+    return { items, total, page, pageSize: PAGE_SIZE };
+  }
+
+  /**
+   * Check if a client can review a specialist:
+   * - has a CLOSED request that the specialist responded to
+   * - hasn't already reviewed that request
+   * Returns { canReview: boolean, eligibleRequestId: string | null }
+   */
+  async checkEligibility(clientId: string, nick: string) {
+    const specialistProfile = await this.prisma.specialistProfile.findUnique({
+      where: { nick },
+    });
+    if (!specialistProfile) {
+      return { canReview: false, eligibleRequestId: null };
+    }
+    const specialistId = specialistProfile.userId;
+
+    // Find closed requests from this client that this specialist responded to
+    const responses = await this.prisma.response.findMany({
+      where: { specialistId },
+      select: { requestId: true },
+    });
+    const respondedRequestIds = responses.map((r) => r.requestId);
+
+    if (respondedRequestIds.length === 0) {
+      return { canReview: false, eligibleRequestId: null };
+    }
+
+    // Find closed requests belonging to this client among responded ones
+    const closedRequest = await this.prisma.request.findFirst({
+      where: {
+        id: { in: respondedRequestIds },
+        clientId,
+        status: RequestStatus.CLOSED,
+      },
+      select: { id: true },
+    });
+
+    if (!closedRequest) {
+      return { canReview: false, eligibleRequestId: null };
+    }
+
+    // Check if already reviewed
+    const alreadyReviewed = await this.prisma.review.findUnique({
+      where: {
+        clientId_specialistId_requestId: {
+          clientId,
+          specialistId,
+          requestId: closedRequest.id,
+        },
+      },
+    });
+
+    if (alreadyReviewed) {
+      return { canReview: false, eligibleRequestId: null };
+    }
+
+    return { canReview: true, eligibleRequestId: closedRequest.id };
+  }
+}

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -108,18 +108,44 @@ export class SpecialistsService {
     });
     const countMap = new Map(responseCounts.map((r) => [r.specialistId, r._count.id]));
 
+    // Compute rating aggregates for all profiles in one query
+    const ratingAggs = await this.prisma.review.groupBy({
+      by: ['specialistId'],
+      where: { specialistId: { in: userIds } },
+      _avg: { rating: true },
+      _count: { id: true },
+    });
+    const ratingMap = new Map(
+      ratingAggs.map((r) => [
+        r.specialistId,
+        { avgRating: r._avg.rating ?? null, reviewCount: r._count.id },
+      ]),
+    );
+
     // Build result with promotion rank and activity
-    const result = profiles.map((profile) => ({
-      ...profile,
-      promoted: promotionMap.has(profile.userId),
-      promotionTier: promotionMap.get(profile.userId) ?? 0,
-      activity: { responseCount: countMap.get(profile.userId) ?? 0 },
-    }));
+    const result = profiles.map((profile) => {
+      const ratingData = ratingMap.get(profile.userId);
+      return {
+        ...profile,
+        promoted: promotionMap.has(profile.userId),
+        promotionTier: promotionMap.get(profile.userId) ?? 0,
+        activity: {
+          responseCount: countMap.get(profile.userId) ?? 0,
+          avgRating: ratingData?.avgRating ?? null,
+          reviewCount: ratingData?.reviewCount ?? 0,
+        },
+      };
+    });
 
     // Sort: promoted first (by tier desc), then by sort param
     result.sort((a, b) => {
       if (b.promotionTier !== a.promotionTier) return b.promotionTier - a.promotionTier;
       if (sort === 'responses') return (b.activity.responseCount) - (a.activity.responseCount);
+      if (sort === 'rating') {
+        const aRating = a.activity.avgRating ?? 0;
+        const bRating = b.activity.avgRating ?? 0;
+        return bRating - aRating;
+      }
       // Default: newest first
       return b.createdAt.getTime() - a.createdAt.getTime();
     });
@@ -128,9 +154,18 @@ export class SpecialistsService {
   }
 
   private async computeActivity(userId: string) {
-    const responseCount = await this.prisma.response.count({
-      where: { specialistId: userId },
-    });
-    return { responseCount };
+    const [responseCount, ratingAgg] = await Promise.all([
+      this.prisma.response.count({ where: { specialistId: userId } }),
+      this.prisma.review.aggregate({
+        where: { specialistId: userId },
+        _avg: { rating: true },
+        _count: { id: true },
+      }),
+    ]);
+    return {
+      responseCount,
+      avgRating: ratingAgg._avg.rating ?? null,
+      reviewCount: ratingAgg._count.id,
+    };
   }
 }

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   ScrollView,
   ActivityIndicator,
   Alert,
+  TouchableOpacity,
+  TextInput,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { api, ApiError } from '../../lib/api';
@@ -18,6 +20,7 @@ import { Avatar } from '../../components/Avatar';
 import { Button } from '../../components/Button';
 import { Header } from '../../components/Header';
 import { EmptyState } from '../../components/EmptyState';
+import { Stars } from '../../components/Stars';
 
 interface SpecialistProfile {
   id: string;
@@ -29,8 +32,28 @@ interface SpecialistProfile {
   contacts: string | null;
   promoted: boolean;
   promotionTier: number;
-  activity: { responseCount: number };
+  activity: { responseCount: number; avgRating: number | null; reviewCount: number };
   createdAt: string;
+}
+
+interface ReviewItem {
+  id: string;
+  rating: number;
+  comment: string | null;
+  createdAt: string;
+  client: { id: string; username: string | null; email: string };
+}
+
+interface ReviewsResponse {
+  items: ReviewItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+interface Eligibility {
+  canReview: boolean;
+  eligibleRequestId: string | null;
 }
 
 export default function SpecialistProfileScreen() {
@@ -42,6 +65,21 @@ export default function SpecialistProfileScreen() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [writingLoading, setWritingLoading] = useState(false);
+
+  // Reviews state
+  const [reviews, setReviews] = useState<ReviewItem[]>([]);
+  const [reviewsTotal, setReviewsTotal] = useState(0);
+  const [reviewsPage, setReviewsPage] = useState(1);
+  const [reviewsLoading, setReviewsLoading] = useState(false);
+
+  // Eligibility (only for logged-in clients)
+  const [eligibility, setEligibility] = useState<Eligibility | null>(null);
+
+  // Review form state
+  const [showReviewForm, setShowReviewForm] = useState(false);
+  const [reviewRating, setReviewRating] = useState(5);
+  const [reviewComment, setReviewComment] = useState('');
+  const [submitLoading, setSubmitLoading] = useState(false);
 
   useEffect(() => {
     if (!nick) return;
@@ -70,6 +108,40 @@ export default function SpecialistProfileScreen() {
     return () => { cancelled = true; };
   }, [nick]);
 
+  // Load reviews when profile is available
+  const loadReviews = useCallback(async (page: number) => {
+    if (!nick) return;
+    setReviewsLoading(true);
+    try {
+      const data = await api.get<ReviewsResponse>(`/reviews/specialist/${nick}?page=${page}`);
+      if (page === 1) {
+        setReviews(data.items);
+      } else {
+        setReviews((prev) => [...prev, ...data.items]);
+      }
+      setReviewsTotal(data.total);
+      setReviewsPage(page);
+    } catch {
+      // silently fail — reviews are supplementary
+    } finally {
+      setReviewsLoading(false);
+    }
+  }, [nick]);
+
+  useEffect(() => {
+    if (profile) {
+      loadReviews(1);
+    }
+  }, [profile, loadReviews]);
+
+  // Check eligibility for logged-in clients
+  useEffect(() => {
+    if (!nick || !user || user.role !== 'CLIENT') return;
+    api.get<Eligibility>(`/reviews/eligibility/${nick}`)
+      .then(setEligibility)
+      .catch(() => setEligibility(null));
+  }, [nick, user]);
+
   async function handleWrite() {
     if (!user) {
       router.push('/(auth)/email?role=CLIENT');
@@ -85,6 +157,32 @@ export default function SpecialistProfileScreen() {
       Alert.alert('Ошибка', msg);
     } finally {
       setWritingLoading(false);
+    }
+  }
+
+  async function handleSubmitReview() {
+    if (!eligibility?.eligibleRequestId || !profile) return;
+    setSubmitLoading(true);
+    try {
+      await api.post('/reviews', {
+        specialistNick: profile.nick,
+        requestId: eligibility.eligibleRequestId,
+        rating: reviewRating,
+        comment: reviewComment.trim() || undefined,
+      });
+      setShowReviewForm(false);
+      setReviewComment('');
+      setReviewRating(5);
+      setEligibility({ canReview: false, eligibleRequestId: null });
+      // Reload reviews and profile activity
+      loadReviews(1);
+      const updated = await api.get<SpecialistProfile>(`/specialists/${profile.nick}`);
+      setProfile(updated);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось отправить отзыв';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setSubmitLoading(false);
     }
   }
 
@@ -116,8 +214,10 @@ export default function SpecialistProfileScreen() {
   const hasFamiliar = profile.badges.includes('familiar');
   const isPromoted = profile.promoted;
 
-  // Activity rating: 0–100 score based on responseCount (capped at 50)
+  // Activity score: 0-100 based on responseCount (capped at 50)
   const activityScore = Math.min(100, Math.round((profile.activity.responseCount / 50) * 100));
+
+  const canShowMore = reviews.length < reviewsTotal;
 
   return (
     <SafeAreaView style={styles.safe}>
@@ -139,6 +239,13 @@ export default function SpecialistProfileScreen() {
                   {isPromoted && <Badge variant="accent" label="Продвинутый" />}
                   {hasFamiliar && <Badge variant="familiar" />}
                 </View>
+                {/* Star rating summary */}
+                <Stars
+                  rating={profile.activity.avgRating}
+                  reviewCount={profile.activity.reviewCount}
+                  size="md"
+                  showEmpty
+                />
               </View>
             </View>
 
@@ -153,7 +260,7 @@ export default function SpecialistProfileScreen() {
 
           {/* Activity */}
           <Card>
-            <Text style={styles.sectionTitle}>Рейтинг активности</Text>
+            <Text style={styles.sectionTitle}>Активность</Text>
             <View style={styles.activityRow}>
               <View style={styles.activityBar}>
                 <View
@@ -209,6 +316,114 @@ export default function SpecialistProfileScreen() {
               Для связи со специалистом необходимо войти или зарегистрироваться
             </Text>
           )}
+
+          {/* Reviews section */}
+          <Card>
+            <View style={styles.reviewsHeader}>
+              <Text style={styles.sectionTitle}>
+                Отзывы {reviewsTotal > 0 ? `(${reviewsTotal})` : ''}
+              </Text>
+              {eligibility?.canReview && !showReviewForm && (
+                <TouchableOpacity
+                  onPress={() => setShowReviewForm(true)}
+                  style={styles.leaveReviewBtn}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.leaveReviewBtnText}>Оставить отзыв</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+
+            {/* Review form */}
+            {showReviewForm && (
+              <View style={styles.reviewForm}>
+                <Text style={styles.reviewFormLabel}>Оценка</Text>
+                <View style={styles.starPicker}>
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <TouchableOpacity
+                      key={star}
+                      onPress={() => setReviewRating(star)}
+                      activeOpacity={0.7}
+                      style={styles.starBtn}
+                    >
+                      <Text style={[
+                        styles.starPickerChar,
+                        star <= reviewRating ? styles.starFilled : styles.starEmpty,
+                      ]}>
+                        {star <= reviewRating ? '★' : '☆'}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+                <Text style={styles.reviewFormLabel}>Комментарий (необязательно)</Text>
+                <TextInput
+                  style={styles.reviewInput}
+                  value={reviewComment}
+                  onChangeText={setReviewComment}
+                  placeholder="Расскажите о своём опыте..."
+                  placeholderTextColor={Colors.textMuted}
+                  multiline
+                  numberOfLines={3}
+                />
+                <View style={styles.reviewFormActions}>
+                  <TouchableOpacity
+                    onPress={() => { setShowReviewForm(false); setReviewComment(''); setReviewRating(5); }}
+                    style={styles.cancelBtn}
+                    activeOpacity={0.7}
+                  >
+                    <Text style={styles.cancelBtnText}>Отмена</Text>
+                  </TouchableOpacity>
+                  <Button
+                    onPress={handleSubmitReview}
+                    variant="primary"
+                    loading={submitLoading}
+                    disabled={submitLoading}
+                    style={styles.submitBtn}
+                  >
+                    Отправить
+                  </Button>
+                </View>
+              </View>
+            )}
+
+            {/* Reviews list */}
+            {reviews.length === 0 && !reviewsLoading ? (
+              <Text style={styles.noReviewsText}>Отзывов пока нет</Text>
+            ) : (
+              <View style={styles.reviewsList}>
+                {reviews.map((review) => (
+                  <View key={review.id} style={styles.reviewItem}>
+                    <View style={styles.reviewItemHeader}>
+                      <Text style={styles.reviewAuthor}>
+                        {review.client.username ? `@${review.client.username}` : review.client.email.split('@')[0]}
+                      </Text>
+                      <Stars rating={review.rating} size="sm" />
+                    </View>
+                    {review.comment ? (
+                      <Text style={styles.reviewComment}>{review.comment}</Text>
+                    ) : null}
+                    <Text style={styles.reviewDate}>
+                      {new Date(review.createdAt).toLocaleDateString('ru-RU')}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {reviewsLoading && (
+              <ActivityIndicator size="small" color={Colors.brandPrimary} style={styles.reviewsLoader} />
+            )}
+
+            {canShowMore && !reviewsLoading && (
+              <TouchableOpacity
+                onPress={() => loadReviews(reviewsPage + 1)}
+                style={styles.loadMoreBtn}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.loadMoreText}>Показать ещё</Text>
+              </TouchableOpacity>
+            )}
+          </Card>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -343,5 +558,130 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
     textAlign: 'center',
     lineHeight: 18,
+  },
+  // Reviews section
+  reviewsHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: Spacing.md,
+  },
+  leaveReviewBtn: {
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.brandPrimary,
+  },
+  leaveReviewBtnText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  noReviewsText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing.md,
+  },
+  reviewsList: {
+    gap: Spacing.md,
+  },
+  reviewItem: {
+    gap: Spacing.xs,
+    paddingBottom: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  reviewItemHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  reviewAuthor: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+  },
+  reviewComment: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+  },
+  reviewDate: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  reviewsLoader: {
+    marginTop: Spacing.md,
+  },
+  loadMoreBtn: {
+    marginTop: Spacing.md,
+    alignItems: 'center',
+    paddingVertical: Spacing.sm,
+  },
+  loadMoreText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  // Review form
+  reviewForm: {
+    gap: Spacing.sm,
+    marginBottom: Spacing.lg,
+    padding: Spacing.md,
+    backgroundColor: Colors.bgSecondary,
+    borderRadius: BorderRadius.md,
+  },
+  reviewFormLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  starPicker: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  starBtn: {
+    padding: Spacing.xs,
+  },
+  starPickerChar: {
+    fontSize: Typography.fontSize['2xl'],
+    lineHeight: 32,
+  },
+  starFilled: {
+    color: Colors.brandPrimary,
+  },
+  starEmpty: {
+    color: Colors.border,
+  },
+  reviewInput: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.md,
+    color: Colors.textPrimary,
+    fontSize: Typography.fontSize.sm,
+    backgroundColor: Colors.bgCard,
+    minHeight: 72,
+    textAlignVertical: 'top',
+  },
+  reviewFormActions: {
+    flexDirection: 'row',
+    gap: Spacing.md,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
+  cancelBtn: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+  },
+  cancelBtnText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  submitBtn: {
+    flex: 1,
+    maxWidth: 160,
   },
 });

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -18,6 +18,7 @@ import { Badge } from '../../components/Badge';
 import { Avatar } from '../../components/Avatar';
 import { EmptyState } from '../../components/EmptyState';
 import { Header } from '../../components/Header';
+import { Stars } from '../../components/Stars';
 
 interface SpecialistItem {
   id: string;
@@ -27,12 +28,13 @@ interface SpecialistItem {
   badges: string[];
   promoted: boolean;
   promotionTier: number;
-  activity: { responseCount: number };
+  activity: { responseCount: number; avgRating: number | null; reviewCount: number };
 }
 
 const SORT_OPTIONS: { label: string; value: string }[] = [
   { label: 'По новизне', value: 'newest' },
   { label: 'По активности', value: 'responses' },
+  { label: 'По рейтингу', value: 'rating' },
 ];
 
 export default function SpecialistsCatalogScreen() {
@@ -144,9 +146,17 @@ export default function SpecialistsCatalogScreen() {
 
           {/* Footer */}
           <View style={styles.cardFooter}>
-            <Text style={styles.activityText}>
-              Откликов: {item.activity.responseCount}
-            </Text>
+            <View style={styles.footerLeft}>
+              <Stars
+                rating={item.activity.avgRating}
+                reviewCount={item.activity.reviewCount}
+                size="sm"
+                showEmpty={false}
+              />
+              <Text style={styles.activityText}>
+                Откликов: {item.activity.responseCount}
+              </Text>
+            </View>
             <Text style={styles.writeLink}>Написать →</Text>
           </View>
         </Card>
@@ -426,6 +436,10 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.sm,
     borderTopWidth: 1,
     borderTopColor: Colors.border,
+  },
+  footerLeft: {
+    flex: 1,
+    gap: Spacing.xxs,
   },
   activityText: {
     fontSize: Typography.fontSize.xs,

--- a/components/Stars.tsx
+++ b/components/Stars.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Typography, Spacing } from '../constants/Colors';
+
+interface StarsProps {
+  rating: number | null;
+  reviewCount?: number;
+  size?: 'sm' | 'md';
+  showEmpty?: boolean;
+}
+
+export function Stars({ rating, reviewCount, size = 'sm', showEmpty = false }: StarsProps) {
+  const fontSize = size === 'md' ? Typography.fontSize.lg : Typography.fontSize.sm;
+
+  if (rating === null || rating === undefined) {
+    if (!showEmpty) return null;
+    return (
+      <View style={styles.row}>
+        <Text style={[styles.stars, { fontSize }]}>☆☆☆☆☆</Text>
+        <Text style={[styles.label, { fontSize: fontSize - 2 }]}>Нет отзывов</Text>
+      </View>
+    );
+  }
+
+  const rounded = Math.round(rating);
+  const filled = '★'.repeat(rounded);
+  const empty = '☆'.repeat(5 - rounded);
+
+  return (
+    <View style={styles.row}>
+      <Text style={[styles.stars, { fontSize }]}>
+        <Text style={styles.filledStars}>{filled}</Text>
+        <Text style={styles.emptyStars}>{empty}</Text>
+      </Text>
+      {reviewCount !== undefined && (
+        <Text style={[styles.label, { fontSize: size === 'md' ? Typography.fontSize.sm : Typography.fontSize.xs }]}>
+          {rating.toFixed(1)} ({reviewCount})
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  stars: {
+    lineHeight: 20,
+  },
+  filledStars: {
+    color: Colors.brandPrimary,
+  },
+  emptyStars: {
+    color: Colors.border,
+  },
+  label: {
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `Review` Prisma model with migration (clientId, specialistId, requestId, rating 1-5, comment)
- `ReviewsModule` with 3 endpoints: create review, list reviews by specialist, check eligibility
- Eligibility guard: request must be CLOSED and specialist must have responded to it
- `specialists.service` extended: batch-compute `avgRating`/`reviewCount` via `groupBy` (no N+1 queries)
- New sort option `sort=rating` in catalog
- `Stars` component: unicode ★/☆ display (sm/md sizes, showEmpty option)
- Catalog card: star rating + review count in card footer
- Specialist profile: star rating in hero card, reviews list with pagination, review form with star picker

## Test plan
- [ ] Open /specialists — cards show "Нет отзывов" for new specialists, stars for reviewed ones
- [ ] Open /specialists/:nick — hero shows stars, reviews section visible
- [ ] As CLIENT with a CLOSED request that specialist responded to: "Оставить отзыв" button appears
- [ ] Submit a review — rating updates on profile and catalog card
- [ ] As CLIENT without eligible request: no review button shown
- [ ] POST /reviews without CLOSED request returns 400
- [ ] Duplicate review returns 409
- [ ] Prisma migration runs via `prisma migrate deploy` in CI