### PR TITLE
feat(admin): add admin panel nav link in settings

### DIFF
--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -14,6 +14,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
 import { useAuth } from '../../stores/authStore';
 import { api, ApiError } from '../../lib/api';
+import { isAdmin } from '../../lib/adminEmails';
 import { Header } from '../../components/Header';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 
@@ -143,6 +144,23 @@ export default function SettingsScreen() {
               )}
             </View>
           </View>
+
+          {/* Admin section — visible only for admin emails */}
+          {isAdmin(user?.email) ? (
+            <>
+              <Text style={styles.sectionTitle}>Администрирование</Text>
+              <View style={styles.card}>
+                <TouchableOpacity
+                  style={styles.row}
+                  onPress={() => router.push('/(admin)')}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.rowLabel}>Панель администратора</Text>
+                  <Text style={styles.rowArrow}>{'>'}</Text>
+                </TouchableOpacity>
+              </View>
+            </>
+          ) : null}
 
           {/* Actions section */}
           <Text style={styles.sectionTitle}>Действия</Text>


### PR DESCRIPTION
## Summary
- Added "Администрирование" section in Settings screen
- "Панель администратора" row visible only when `isAdmin(user.email)` is true
- Navigates to `/(admin)` dashboard on tap
- No changes to backend or admin screens themselves — all admin screens were already built

## Test plan
- [ ] Login as admin email → Settings → should see "Администрирование" section with "Панель администратора" row
- [ ] Tap row → navigates to admin dashboard
- [ ] Login as non-admin → Settings → section should NOT appear
- [ ] Verify `EXPO_PUBLIC_ADMIN_EMAILS` is set in Doppler stg config

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)