### PR TITLE
fix: badge label shows 'familiar' raw string in profile edit UI

### DIFF
--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -20,6 +20,7 @@ import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 
 const BADGE_TAX = 'familiar';
+const BADGE_TAX_LABEL = 'Знакомый в налоговой';
 
 interface SpecialistProfile {
   id: string;
@@ -207,7 +208,7 @@ export default function SpecialistProfileScreen() {
             <Text style={styles.sectionTitle}>Бейджи</Text>
             <View style={styles.badgeRow}>
               <View style={styles.badgeInfo}>
-                <Text style={styles.badgeLabel}>{BADGE_TAX}</Text>
+                <Text style={styles.badgeLabel}>{BADGE_TAX_LABEL}</Text>
                 <Text style={styles.badgeHint}>Подтверждённый контакт в ФНС</Text>
               </View>
               <Switch


### PR DESCRIPTION
## Summary
- Fixes #1641: badge toggle in profile edit UI was showing raw stored value `'familiar'` instead of a human-readable label
- Added `BADGE_TAX_LABEL = 'Знакомый в налоговой'` constant for display purposes
- `BADGE_TAX = 'familiar'` is unchanged and still used for storage logic

## Test plan
- Open profile edit screen as a specialist
- Badge toggle label should show "Знакомый в налоговой" (not "familiar")
- Toggling the badge and saving should still work correctly (stored value remains 'familiar')