### PR TITLE
fix: remove contacts from public specialists list (#1643)

### DIFF
--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -124,13 +124,15 @@ export class SpecialistsService {
 
     // Build result with promotion rank and activity
     const result = profiles.map((profile) => {
-      const ratingData = ratingMap.get(profile.userId);
+      // contacts excluded from public list response (security: phone leak)
+      const { contacts: _contacts, ...rest } = profile;
+      const ratingData = ratingMap.get(rest.userId);
       return {
-        ...profile,
-        promoted: promotionMap.has(profile.userId),
-        promotionTier: promotionMap.get(profile.userId) ?? 0,
+        ...rest,
+        promoted: promotionMap.has(rest.userId),
+        promotionTier: promotionMap.get(rest.userId) ?? 0,
         activity: {
-          responseCount: countMap.get(profile.userId) ?? 0,
+          responseCount: countMap.get(rest.userId) ?? 0,
           avgRating: ratingData?.avgRating ?? null,
           reviewCount: ratingData?.reviewCount ?? 0,
         },


### PR DESCRIPTION
## Summary
- Security fix: `contacts` field (contains phone) was returned in `GET /api/specialists` with no authentication required
- Excluded `contacts` from `getCatalog()` response via destructuring before spread
- `contacts` still visible in `GET /api/specialists/:nick` (detail view)

## Changes
- `api/src/specialists/specialists.service.ts`: destructure `contacts` out before building list result

## Test plan
- [ ] `curl -s https://p2ptax.smartlaunchhub.com/api/specialists | jq '.[0].contacts'` → should return `null` or field absent
- [ ] `curl -s https://p2ptax.smartlaunchhub.com/api/specialists/NICK | jq '.contacts'` → still present in detail view