### PR TITLE
fix: rate limit OTP endpoint (#1644)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^10.4.15",
         "@nestjs/platform-socket.io": "^10.4.15",
         "@nestjs/schedule": "^6.1.1",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^10.4.15",
         "@prisma/client": "^6.19.3",
         "class-transformer": "^0.5.1",
@@ -296,6 +297,17 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/websockets": {

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
     "@nestjs/platform-express": "^10.4.15",
     "@nestjs/platform-socket.io": "^10.4.15",
     "@nestjs/schedule": "^6.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^10.4.15",
     "@prisma/client": "^6.19.3",
     "class-transformer": "^0.5.1",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { PrismaModule } from './prisma/prisma.module';
@@ -13,6 +14,7 @@ import { ReviewsModule } from './reviews/reviews.module';
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot([{ ttl: 60000, limit: 60 }]),
     ScheduleModule.forRoot(),
     PrismaModule,
     AuthModule,

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { ThrottlerGuard, Throttle } from '@nestjs/throttler';
 import { IsEmail, IsString, Length, IsOptional, IsIn } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { AuthService } from './auth.service';
@@ -31,6 +32,8 @@ class RefreshDto {
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { ttl: 300000, limit: 3 } })
   @Post('request-otp')
   requestOtp(@Body() body: RequestOtpDto) {
     return this.authService.requestOtp(body.email);


### PR DESCRIPTION
## Summary
- Installs `@nestjs/throttler` v6
- Registers `ThrottlerModule.forRoot` globally with permissive default (60 req/min)
- Applies `@UseGuards(ThrottlerGuard)` + `@Throttle({ default: { ttl: 300000, limit: 3 } })` **only** on `POST /api/auth/request-otp`
- Other endpoints (`verify-otp`, `refresh`) are unaffected

## Security
Prevents OTP spam: attacker can send max 3 OTP requests per IP per 5 minutes. On the 4th request the API returns HTTP 429.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] POST `/api/auth/request-otp` 3 times rapidly → all succeed
- [ ] POST `/api/auth/request-otp` 4th time → HTTP 429 Too Many Requests
- [ ] POST `/api/auth/verify-otp` and `/api/auth/refresh` still work normally

Fixes #1644