### PR TITLE
fix: auth guard on GET /api/requests, remove client email from feed (#1642)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -45,8 +45,9 @@ export class RequestsController {
     return this.requestsService.findMyResponses(req.user.id);
   }
 
-  // GET /requests — public feed (specialists browse)
+  // GET /requests — authenticated feed (specialists browse)
   @Get()
+  @UseGuards(JwtAuthGuard)
   getFeed(@Query('city') city?: string, @Query('page') page?: string) {
     return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1);
   }

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -41,7 +41,7 @@ export class RequestsService {
         skip,
         take: PAGE_SIZE,
         include: {
-          client: { select: { id: true, email: true } },
+          client: { select: { id: true } },
           _count: { select: { responses: true } },
         },
       }),

--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -31,7 +31,7 @@ interface RequestItem {
   city: string;
   status: string;
   createdAt: string;
-  client: { id: string; email: string };
+  client: { id: string };
   _count: { responses: number };
 }
 

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -25,7 +25,7 @@ interface RequestItem {
   category?: string | null;
   status: string;
   createdAt: string;
-  client: { id: string; email: string };
+  client: { id: string };
   _count: { responses: number };
 }
 


### PR DESCRIPTION
## Summary

- Adds `@UseGuards(JwtAuthGuard)` to `GET /requests` (the public feed endpoint) — was accessible without any token
- Removes `email: true` from `findFeed()` Prisma `client.select` — client PII no longer returned even to authenticated users
- Updates `RequestItem.client` TypeScript interface in both frontend screens to drop the `email` field (was declared but never rendered)

## Frontend check

Both callers (`app/requests/index.tsx` and `app/(dashboard)/city-requests.tsx`) use the authenticated `api` client that attaches the JWT — no unauthenticated usage found.

## Test plan

- `curl -s https://p2ptax.smartlaunchhub.com/api/requests` → should return `401 Unauthorized`
- Authenticated specialist browsing the feed should still work normally

Fixes #1642