### PR TITLE
fix: city match check on specialist respond (#1649)

### DIFF
--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -78,6 +78,22 @@ export class RequestsService {
       throw new BadRequestException('Request is not open for responses');
     }
 
+    // Check specialist's cities cover the request's city
+    const specialistProfile = await this.prisma.specialistProfile.findUnique({
+      where: { userId: specialistId },
+      select: { cities: true },
+    });
+    if (!specialistProfile) {
+      throw new BadRequestException('Specialist profile not found');
+    }
+    const requestCityLower = request.city.toLowerCase();
+    const coversCity = specialistProfile.cities.some(
+      (c) => c.toLowerCase() === requestCityLower,
+    );
+    if (!coversCity) {
+      throw new BadRequestException('Ваш профиль не обслуживает город этого запроса');
+    }
+
     // Check specialist hasn't already responded (@@unique will catch too, but better UX)
     const existing = await this.prisma.response.findUnique({
       where: { specialistId_requestId: { specialistId, requestId } },


### PR DESCRIPTION
## Summary
- Add city intersection check in `respond()` method of `RequestsService`
- Fetch specialist's `SpecialistProfile` before allowing response
- Compare `request.city` against `profile.cities` case-insensitively
- Throw `BadRequestException` if profile missing or city not covered

## Test plan
- [ ] Specialist with matching city in profile can respond
- [ ] Specialist with non-matching city gets 400 "Ваш профиль не обслуживает город этого запроса"
- [ ] Specialist with no profile gets 400 "Specialist profile not found"
- [ ] Specialist with empty cities array gets 400
- [ ] Case-insensitive match works (e.g. "Tbilisi" vs "tbilisi")