### PR TITLE
fix: enforce status transitions on requests (#1648)

### DIFF
--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -146,6 +146,24 @@ export class RequestsService {
     if (!request) throw new NotFoundException('Request not found');
     if (request.clientId !== clientId) throw new ForbiddenException('Not your request');
 
+    // Guard: reject no-op transitions
+    if (request.status === status) {
+      throw new BadRequestException(`Request is already in status ${status}`);
+    }
+
+    // Transition matrix: defines all valid moves
+    const ALLOWED_TRANSITIONS: Partial<Record<RequestStatus, RequestStatus[]>> = {
+      [RequestStatus.OPEN]: [RequestStatus.CLOSED, RequestStatus.CANCELLED],
+      // CLOSED and CANCELLED are final — no transitions allowed
+    };
+
+    const allowed = ALLOWED_TRANSITIONS[request.status] ?? [];
+    if (!allowed.includes(status)) {
+      throw new BadRequestException(
+        `Cannot transition request from ${request.status} to ${status}`,
+      );
+    }
+
     return this.prisma.request.update({
       where: { id: requestId },
       data: { status },


### PR DESCRIPTION
## Summary
- Add transition matrix to `updateStatus()` in `requests.service.ts`
- `OPEN` → `CLOSED` or `CANCELLED` are the only valid moves
- `CLOSED` and `CANCELLED` are final states — any transition out returns `400 BadRequest`
- Same-status transition also rejected with `400 BadRequest`
- No schema changes needed (IN_PROGRESS not in Prisma enum — out of scope)

## Test plan
- [ ] PATCH /requests/:id with CLOSED→OPEN returns 400
- [ ] PATCH /requests/:id with CLOSED→CANCELLED returns 400
- [ ] PATCH /requests/:id with OPEN→OPEN returns 400
- [ ] PATCH /requests/:id with OPEN→CLOSED returns 200
- [ ] PATCH /requests/:id with OPEN→CANCELLED returns 200