### PR TITLE
fix: max 5 active requests per client (#1650)

### DIFF
--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -17,6 +17,13 @@ export class RequestsService {
   constructor(private prisma: PrismaService) {}
 
   async create(clientId: string, dto: CreateRequestDto) {
+    const openCount = await this.prisma.request.count({
+      where: { clientId, status: RequestStatus.OPEN },
+    });
+    if (openCount >= 5) {
+      throw new BadRequestException('Maximum 5 active requests allowed');
+    }
+
     return this.prisma.request.create({
       data: {
         clientId,


### PR DESCRIPTION
## Summary
- Add OPEN request count check in `RequestsService.create()`
- Counts existing OPEN requests for the client before creating a new one
- Throws `400 BadRequestException('Maximum 5 active requests allowed')` if count >= 5

## Files changed
- `api/src/requests/requests.service.ts` — check added in `create()`, before `prisma.request.create`

## Test plan
- [ ] Client with 0–4 OPEN requests: create succeeds
- [ ] Client with 5 OPEN requests: create returns 400 with message "Maximum 5 active requests allowed"
- [ ] After closing/cancelling a request, client can create again

Trinity: #1650