### PR TITLE
feat: onboarding steps 2+3 for specialists (#1651)

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Delete, Get, Patch, Body, Request, UseGuards } from '@nestjs/common';
-import { IsString, Length, Matches } from 'class-validator';
+import { IsString, IsArray, Length, Matches, MinLength, ArrayMinSize } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UsersService } from './users.service';
 
@@ -8,6 +8,17 @@ class SetUsernameDto {
   @Length(3, 20)
   @Matches(/^[a-zA-Z0-9_]+$/, { message: 'username can only contain letters, numbers, and underscores' })
   username!: string;
+}
+
+class SetupSpecialistProfileDto {
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMinSize(1)
+  cities!: string[];
+
+  @IsString()
+  @MinLength(1)
+  services!: string;
 }
 
 @Controller('users')
@@ -28,6 +39,19 @@ export class UsersController {
     @Body() body: SetUsernameDto,
   ) {
     return this.usersService.setUsername(req.user.id, body.username);
+  }
+
+  /**
+   * PATCH /users/me/specialist-profile — onboarding step 3.
+   * No role guard — any authenticated user can call this during onboarding.
+   * Creates SpecialistProfile (nick = username) and promotes user to SPECIALIST role.
+   */
+  @Patch('me/specialist-profile')
+  setupSpecialistProfile(
+    @Request() req: { user: { id: string } },
+    @Body() body: SetupSpecialistProfileDto,
+  ) {
+    return this.usersService.setupSpecialistProfile(req.user.id, body.cities, body.services);
   }
 
   /** DELETE /users/me — permanently delete the authenticated user's account */

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Role } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
@@ -34,6 +35,66 @@ export class UsersService {
     });
 
     return { id: user.id, email: user.email, role: user.role, username: user.username! };
+  }
+
+  /**
+   * Onboarding step 3: set cities + services, create SpecialistProfile, promote user to SPECIALIST.
+   * Nick is taken from the user's username (set in step 1).
+   * No role guard — called during onboarding before the role is assigned.
+   */
+  async setupSpecialistProfile(
+    userId: string,
+    cities: string[],
+    services: string,
+  ): Promise<{ ok: true }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    if (!user.username) throw new BadRequestException('Username must be set before creating specialist profile');
+
+    const trimmedServices = services.trim();
+    if (!trimmedServices) throw new BadRequestException('Services description cannot be empty');
+
+    const trimmedCities = cities.map((c) => c.trim()).filter(Boolean);
+    if (trimmedCities.length === 0) throw new BadRequestException('At least one city must be selected');
+
+    // Check for existing profile (idempotent — allow re-submission)
+    const existing = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+
+    if (existing) {
+      // Update existing profile and ensure role is SPECIALIST
+      await this.prisma.$transaction([
+        this.prisma.specialistProfile.update({
+          where: { userId },
+          data: { cities: trimmedCities, services: [trimmedServices] },
+        }),
+        this.prisma.user.update({
+          where: { id: userId },
+          data: { role: Role.SPECIALIST },
+        }),
+      ]);
+    } else {
+      // Check nick uniqueness (username is used as nick)
+      const nickTaken = await this.prisma.specialistProfile.findUnique({ where: { nick: user.username } });
+      if (nickTaken) throw new ConflictException('Nick already taken');
+
+      await this.prisma.$transaction([
+        this.prisma.specialistProfile.create({
+          data: {
+            userId,
+            nick: user.username,
+            cities: trimmedCities,
+            services: [trimmedServices],
+            badges: [],
+          },
+        }),
+        this.prisma.user.update({
+          where: { id: userId },
+          data: { role: Role.SPECIALIST },
+        }),
+      ]);
+    }
+
+    return { ok: true };
   }
 
   /**

--- a/app/(onboarding)/cities.tsx
+++ b/app/(onboarding)/cities.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Button } from '../../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+
+const GEORGIAN_CITIES = [
+  'Тбилиси',
+  'Батуми',
+  'Кутаиси',
+  'Рустави',
+  'Гори',
+  'Зугдиди',
+  'Поти',
+  'Сухуми',
+];
+
+export default function CitiesScreen() {
+  const router = useRouter();
+  const [selected, setSelected] = useState<string[]>([]);
+
+  function toggleCity(city: string) {
+    setSelected((prev) =>
+      prev.includes(city) ? prev.filter((c) => c !== city) : [...prev, city],
+    );
+  }
+
+  function handleContinue() {
+    router.push({
+      pathname: '/(onboarding)/services',
+      params: { cities: JSON.stringify(selected) },
+    });
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.container}>
+          {/* Progress indicator */}
+          <View style={styles.progressRow}>
+            <View style={[styles.progressDot, styles.progressDotDone]} />
+            <View style={styles.progressLine} />
+            <View style={[styles.progressDot, styles.progressDotActive]} />
+            <View style={styles.progressLine} />
+            <View style={styles.progressDot} />
+          </View>
+
+          {/* Header */}
+          <View style={styles.header}>
+            <Text style={styles.step}>Шаг 2 из 3</Text>
+            <Text style={styles.title}>Выберите города</Text>
+            <Text style={styles.subtitle}>
+              В каких городах Грузии вы оказываете услуги?
+            </Text>
+          </View>
+
+          {/* City chips */}
+          <View style={styles.chipsGrid}>
+            {GEORGIAN_CITIES.map((city) => {
+              const isSelected = selected.includes(city);
+              return (
+                <TouchableOpacity
+                  key={city}
+                  onPress={() => toggleCity(city)}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.chipText, isSelected && styles.chipTextSelected]}>
+                    {city}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+
+          {selected.length > 0 && (
+            <Text style={styles.selectedHint}>
+              Выбрано: {selected.join(', ')}
+            </Text>
+          )}
+
+          <Button
+            onPress={handleContinue}
+            disabled={selected.length === 0}
+            style={styles.btn}
+          >
+            Продолжить
+          </Button>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+    justifyContent: 'center',
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 0,
+    marginTop: Spacing.xl,
+  },
+  progressDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: Colors.border,
+  },
+  progressDotDone: {
+    backgroundColor: Colors.brandSecondary,
+  },
+  progressDotActive: {
+    backgroundColor: Colors.brandPrimary,
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  progressLine: {
+    width: 32,
+    height: 2,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
+  },
+  header: {
+    gap: Spacing.xs,
+  },
+  step: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  chipsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  chip: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    backgroundColor: Colors.bgCard,
+  },
+  chipSelected: {
+    borderColor: Colors.brandPrimary,
+    backgroundColor: Colors.statusBg.accent,
+  },
+  chipText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  chipTextSelected: {
+    color: Colors.textAccent,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  selectedHint: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    lineHeight: 18,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+});

--- a/app/(onboarding)/services.tsx
+++ b/app/(onboarding)/services.tsx
@@ -1,0 +1,263 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Button } from '../../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { api, ApiError } from '../../lib/api';
+import { useAuth } from '../../stores/authStore';
+
+export default function ServicesScreen() {
+  const router = useRouter();
+  const { cities: citiesParam } = useLocalSearchParams<{ cities: string }>();
+  const { completeOnboarding, user } = useAuth();
+
+  const cities: string[] = citiesParam ? (JSON.parse(citiesParam) as string[]) : [];
+
+  const [services, setServices] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [focused, setFocused] = useState(false);
+
+  function handleChange(value: string) {
+    setServices(value);
+    if (error) setError('');
+  }
+
+  async function handleSubmit() {
+    const trimmed = services.trim();
+    if (!trimmed) {
+      setError('Расскажите о своих услугах');
+      return;
+    }
+    if (cities.length === 0) {
+      setError('Не выбраны города — вернитесь на предыдущий шаг');
+      return;
+    }
+
+    setError('');
+    setLoading(true);
+    try {
+      await api.patch('/users/me/specialist-profile', {
+        cities,
+        services: trimmed,
+      });
+      // Mark onboarding complete — sets isNewUser=false in store + AsyncStorage
+      await completeOnboarding(user?.username ?? '');
+      router.replace('/');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError('Профиль уже существует. Попробуйте войти снова.');
+      } else if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось сохранить профиль. Попробуйте снова.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            {/* Progress indicator */}
+            <View style={styles.progressRow}>
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotActive]} />
+            </View>
+
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.step}>Шаг 3 из 3</Text>
+              <Text style={styles.title}>Ваши услуги</Text>
+              <Text style={styles.subtitle}>
+                Расскажите, что вы умеете делать. Клиенты увидят это в вашем профиле.
+              </Text>
+            </View>
+
+            {/* Hint */}
+            <View style={styles.hintBox}>
+              <Text style={styles.hintText}>
+                Например: декларирование доходов, консультации по НДС, налоговое планирование
+              </Text>
+            </View>
+
+            {/* Textarea */}
+            <View style={styles.form}>
+              <View style={styles.textareaWrapper}>
+                <Text style={styles.inputLabel}>Описание услуг</Text>
+                <TextInput
+                  value={services}
+                  onChangeText={handleChange}
+                  placeholder="Опишите ваши услуги..."
+                  placeholderTextColor={Colors.textMuted}
+                  multiline
+                  numberOfLines={5}
+                  textAlignVertical="top"
+                  autoCapitalize="sentences"
+                  onFocus={() => setFocused(true)}
+                  onBlur={() => setFocused(false)}
+                  style={[
+                    styles.textarea,
+                    focused && styles.textareaFocused,
+                    !!error && styles.textareaError,
+                  ]}
+                />
+                {!!error && <Text style={styles.errorText}>{error}</Text>}
+              </View>
+
+              <Button
+                onPress={handleSubmit}
+                loading={loading}
+                disabled={loading || services.trim().length === 0}
+                style={styles.btn}
+              >
+                Завершить регистрацию
+              </Button>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  kav: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+    justifyContent: 'center',
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 0,
+    marginTop: Spacing.xl,
+  },
+  progressDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: Colors.border,
+  },
+  progressDotDone: {
+    backgroundColor: Colors.brandSecondary,
+  },
+  progressDotActive: {
+    backgroundColor: Colors.brandPrimary,
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  progressLine: {
+    width: 32,
+    height: 2,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
+  },
+  header: {
+    gap: Spacing.xs,
+  },
+  step: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  hintBox: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  hintText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    lineHeight: 18,
+  },
+  form: {
+    gap: Spacing.lg,
+  },
+  textareaWrapper: {
+    gap: Spacing.xs,
+  },
+  inputLabel: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+    marginBottom: 2,
+  },
+  textarea: {
+    minHeight: 120,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  textareaFocused: {
+    borderColor: Colors.brandPrimary,
+  },
+  textareaError: {
+    borderColor: Colors.statusError,
+  },
+  errorText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusError,
+    marginTop: 2,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+});

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -13,7 +13,6 @@ import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { api, ApiError } from '../../lib/api';
-import { useAuth } from '../../stores/authStore';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 
@@ -26,7 +25,6 @@ function validateUsername(value: string): string | null {
 
 export default function UsernameScreen() {
   const router = useRouter();
-  const { completeOnboarding } = useAuth();
 
   const [username, setUsername] = useState('');
   const [loading, setLoading] = useState(false);
@@ -49,8 +47,8 @@ export default function UsernameScreen() {
     setLoading(true);
     try {
       await api.patch('/users/me/username', { username: trimmed });
-      await completeOnboarding(trimmed);
-      router.replace('/');
+      // Do NOT call completeOnboarding here — onboarding continues in cities + services steps
+      router.replace('/(onboarding)/cities');
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
         setError('Этот ник уже занят, попробуйте другой');


### PR DESCRIPTION
## Summary

- Add PATCH /users/me/specialist-profile backend endpoint (JwtAuthGuard only, no role guard): creates SpecialistProfile with nick=username, sets role=SPECIALIST
- Add cities.tsx onboarding screen: chip multiselect for 8 Georgian cities (Tbilisi, Batumi, Kutaisi, Rustavi, Gori, Zugdidi, Poti, Sukhumi), min 1 required
- Add services.tsx onboarding screen: multiline textarea for services description, triggers profile creation + completeOnboarding() + navigation to /
- Update username.tsx: navigate to /(onboarding)/cities after step 1 instead of completing onboarding (defers completeOnboarding to step 3)
- Cities passed from cities.tsx to services.tsx via expo-router params as JSON string

## Flow

Register → username (step 1) → cities (step 2) → services (step 3) → dashboard

## Test plan

- [ ] New user signup: verify 3-step onboarding flow completes correctly
- [ ] Cities screen: at least 1 city required, chip toggle works, progress bar shows step 2
- [ ] Services screen: non-empty text required, receives cities from params
- [ ] After step 3: SpecialistProfile created in DB, user.role = SPECIALIST, isNewUser = false
- [ ] Idempotency: re-submitting services updates existing profile without error