### PR TITLE
feat: responsive adaptive layout mobile/tablet/desktop (#1673)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,12 +1,35 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { View, ActivityIndicator } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { useAuth } from '../../stores/authStore';
 import { Colors } from '../../constants/Colors';
+import { ResponsiveLayout } from '../../components/ResponsiveLayout';
+import { SidebarNavItem } from '../../components/Sidebar';
+import { useBreakpoints } from '../../hooks/useBreakpoints';
+
+const CLIENT_NAV_ITEMS: SidebarNavItem[] = [
+  { label: 'Главная', icon: '🏠', route: '/(dashboard)', segment: 'index' },
+  { label: 'Мои запросы', icon: '📋', route: '/(dashboard)/requests', segment: 'requests' },
+  { label: 'Сообщения', icon: '💬', route: '/(dashboard)/messages', segment: 'messages' },
+  { label: 'Специалисты', icon: '🔍', route: '/specialists', segment: 'specialists' },
+  { label: 'Лента запросов', icon: '📰', route: '/requests', segment: 'requests' },
+  { label: 'Настройки', icon: '⚙', route: '/(dashboard)/settings', segment: 'settings' },
+];
+
+const SPECIALIST_NAV_ITEMS: SidebarNavItem[] = [
+  { label: 'Главная', icon: '🏠', route: '/(dashboard)', segment: 'index' },
+  { label: 'Мой профиль', icon: '👤', route: '/(dashboard)/profile', segment: 'profile' },
+  { label: 'Сообщения', icon: '💬', route: '/(dashboard)/messages', segment: 'messages' },
+  { label: 'Запросы города', icon: '📍', route: '/(dashboard)/city-requests', segment: 'city-requests' },
+  { label: 'Лента запросов', icon: '📰', route: '/requests', segment: 'requests' },
+  { label: 'Продвижение', icon: '🚀', route: '/(dashboard)/promotion', segment: 'promotion' },
+  { label: 'Настройки', icon: '⚙', route: '/(dashboard)/settings', segment: 'settings' },
+];
 
 export default function DashboardLayout() {
-  const { user, isLoading } = useAuth();
+  const { user, isLoading, logout } = useAuth();
   const router = useRouter();
+  const { isMobile } = useBreakpoints();
 
   useEffect(() => {
     if (isLoading) return;
@@ -14,6 +37,11 @@ export default function DashboardLayout() {
       router.replace('/(auth)/email?role=CLIENT');
     }
   }, [user, isLoading, router]);
+
+  const handleLogout = useCallback(async () => {
+    await logout();
+    router.replace('/');
+  }, [logout, router]);
 
   if (isLoading || !user) {
     return (
@@ -23,13 +51,25 @@ export default function DashboardLayout() {
     );
   }
 
-  return (
+  const navItems = user.role === 'SPECIALIST' ? SPECIALIST_NAV_ITEMS : CLIENT_NAV_ITEMS;
+
+  const stack = (
     <Stack
       screenOptions={{
         headerShown: false,
         contentStyle: { backgroundColor: Colors.bgPrimary },
-        animation: 'slide_from_right',
+        animation: isMobile ? 'slide_from_right' : 'none',
       }}
     />
+  );
+
+  return (
+    <ResponsiveLayout
+      navItems={navItems}
+      userEmail={user.email}
+      onLogout={handleLogout}
+    >
+      {stack}
+    </ResponsiveLayout>
   );
 }

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -15,6 +15,7 @@ import { api, ApiError } from '../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { Header } from '../../components/Header';
 import { Button } from '../../components/Button';
+import { useBreakpoints } from '../../hooks/useBreakpoints';
 
 interface MyRequest {
   id: string;
@@ -30,6 +31,7 @@ interface ThreadItem {
 export default function DashboardHub() {
   const router = useRouter();
   const { user, logout } = useAuth();
+  const { isMobile } = useBreakpoints();
   const [requestCount, setRequestCount] = useState(0);
   const [activeCount, setActiveCount] = useState(0);
   const [threadCount, setThreadCount] = useState(0);
@@ -55,7 +57,6 @@ export default function DashboardHub() {
   }, []);
 
   // Check if SPECIALIST has filled their profile; redirect to profile setup if not.
-  // Only runs once on mount, not on refresh, to avoid re-redirecting after profile is saved.
   useEffect(() => {
     if (!user || user.role !== 'SPECIALIST') return;
 
@@ -66,7 +67,6 @@ export default function DashboardHub() {
         if (err instanceof ApiError && err.status === 404) {
           router.replace('/(dashboard)/specialist-profile');
         }
-        // Any other error (network, 500, etc.) — silently ignore, stay on dashboard
       }
     }
 
@@ -87,6 +87,64 @@ export default function DashboardHub() {
     router.replace('/');
   }
 
+  // --- Desktop/tablet: welcome + stats view (sidebar handles navigation) ---
+  if (!isMobile) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <ScrollView
+          contentContainerStyle={styles.scrollWide}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              tintColor={Colors.brandPrimary}
+            />
+          }
+        >
+          <View style={styles.wideContainer}>
+            <Text style={styles.wideGreeting}>
+              Добро пожаловать,
+            </Text>
+            <Text style={styles.wideEmail}>
+              {user?.email ?? ''}
+            </Text>
+
+            {loading ? (
+              <ActivityIndicator size="large" color={Colors.brandPrimary} style={{ marginTop: Spacing['3xl'] }} />
+            ) : (
+              <View style={styles.statsRow}>
+                <View style={styles.statCard}>
+                  <Text style={styles.statValue}>{requestCount}</Text>
+                  <Text style={styles.statLabel}>Всего запросов</Text>
+                </View>
+                <View style={styles.statCard}>
+                  <Text style={styles.statValue}>{activeCount}</Text>
+                  <Text style={styles.statLabel}>Активных запросов</Text>
+                </View>
+                <View style={styles.statCard}>
+                  <Text style={styles.statValue}>{threadCount}</Text>
+                  <Text style={styles.statLabel}>Диалогов</Text>
+                </View>
+              </View>
+            )}
+
+            {!loading && user?.role !== 'SPECIALIST' && (
+              <Button
+                onPress={() => router.push('/(dashboard)/requests/new')}
+                variant="primary"
+                style={styles.wideCreateBtn}
+              >
+                Создать запрос
+              </Button>
+            )}
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  // --- Mobile: original hub navigation cards ---
   return (
     <SafeAreaView style={styles.safe}>
       <Header
@@ -211,6 +269,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.bgPrimary,
   },
+  // Mobile
   scroll: {
     flexGrow: 1,
     alignItems: 'center',
@@ -275,5 +334,55 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.sm,
     color: Colors.statusError,
     fontWeight: Typography.fontWeight.medium,
+  },
+  // Desktop / tablet
+  scrollWide: {
+    flexGrow: 1,
+    paddingVertical: Spacing['4xl'],
+    paddingHorizontal: Spacing['3xl'],
+  },
+  wideContainer: {
+    gap: Spacing['2xl'],
+  },
+  wideGreeting: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  wideEmail: {
+    fontSize: Typography.fontSize.lg,
+    color: Colors.textSecondary,
+    marginTop: -Spacing.lg,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: Spacing.xl,
+    flexWrap: 'wrap',
+  },
+  statCard: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: Spacing['2xl'],
+    minWidth: 160,
+    flex: 1,
+    alignItems: 'center',
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  statValue: {
+    fontSize: Typography.fontSize['3xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+  },
+  statLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+  },
+  wideCreateBtn: {
+    alignSelf: 'flex-start',
+    minWidth: 200,
   },
 });

--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -17,6 +17,7 @@ import { Header } from '../../../components/Header';
 import { Button } from '../../../components/Button';
 import { Card } from '../../../components/Card';
 import { EmptyState } from '../../../components/EmptyState';
+import { useBreakpoints } from '../../../hooks/useBreakpoints';
 
 interface ResponseItem {
   id: string;
@@ -41,6 +42,7 @@ type Tab = 'active' | 'closed';
 
 export default function MyRequestsScreen() {
   const router = useRouter();
+  const { isMobile, numColumns } = useBreakpoints();
   const [items, setItems] = useState<RequestItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -107,7 +109,7 @@ export default function MyRequestsScreen() {
   function renderItem({ item }: { item: RequestItem }) {
     return (
       <TouchableOpacity
-        style={styles.cardWrapper}
+        style={isMobile ? styles.cardWrapperMobile : styles.cardWrapperGrid}
         onPress={() => router.push(`/(dashboard)/requests/${item.id}`)}
         activeOpacity={0.75}
       >
@@ -170,10 +172,10 @@ export default function MyRequestsScreen() {
 
   return (
     <SafeAreaView style={styles.safe}>
-      <Header title="Мои запросы" showBack />
+      <Header title="Мои запросы" showBack={isMobile} />
 
       {/* Tabs */}
-      <View style={styles.tabs}>
+      <View style={[styles.tabs, !isMobile && styles.tabsWide]}>
         <TouchableOpacity
           style={[styles.tab, tab === 'active' && styles.tabActive]}
           onPress={() => setTab('active')}
@@ -192,11 +194,18 @@ export default function MyRequestsScreen() {
         </TouchableOpacity>
       </View>
 
+      {/* key={numColumns} forces FlatList remount when columns change on resize */}
       <FlatList
+        key={numColumns}
         data={filtered}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
+        numColumns={numColumns}
+        contentContainerStyle={[
+          styles.listContent,
+          !isMobile && styles.listContentWide,
+        ]}
+        columnWrapperStyle={numColumns > 1 ? styles.columnWrapper : undefined}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -230,7 +239,7 @@ export default function MyRequestsScreen() {
         }
         ListFooterComponent={
           !loading && filtered.length > 0 ? (
-            <View style={styles.footerBtn}>
+            <View style={[styles.footerBtn, !isMobile && styles.footerBtnWide]}>
               <Button
                 onPress={() => router.push('/(dashboard)/requests/new')}
                 variant="primary"
@@ -261,6 +270,10 @@ const styles = StyleSheet.create({
     maxWidth: 430,
     width: '100%',
   },
+  tabsWide: {
+    maxWidth: 500,
+    alignSelf: 'flex-start',
+  },
   tab: {
     flex: 1,
     height: 40,
@@ -284,14 +297,29 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
     fontWeight: Typography.fontWeight.semibold,
   },
+  // Mobile: centered, single column
   listContent: {
     paddingHorizontal: Spacing.lg,
     paddingBottom: Spacing['3xl'],
     alignItems: 'center',
   },
-  cardWrapper: {
+  // Wide: stretch
+  listContentWide: {
+    alignItems: 'stretch',
+  },
+  columnWrapper: {
+    gap: Spacing.md,
+    marginBottom: Spacing.md,
+  },
+  // Mobile card
+  cardWrapperMobile: {
     width: '100%',
     maxWidth: 430,
+    marginTop: Spacing.md,
+  },
+  // Grid card
+  cardWrapperGrid: {
+    flex: 1,
     marginTop: Spacing.md,
   },
   metaRow: {
@@ -387,6 +415,9 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 430,
     paddingTop: Spacing.xl,
+  },
+  footerBtnWide: {
+    maxWidth: 250,
   },
   createBtn: {
     width: '100%',

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -9,6 +9,7 @@ import {
 import { useRouter } from 'expo-router';
 import { Button } from '../components/Button';
 import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
+import { useBreakpoints } from '../hooks/useBreakpoints';
 
 const FEATURES = [
   'Проверенные специалисты',
@@ -18,69 +19,146 @@ const FEATURES = [
 
 export default function LandingScreen() {
   const router = useRouter();
+  const { isMobile, isDesktop } = useBreakpoints();
 
+  // Mobile: stacked single column (original)
+  if (isMobile) {
+    return (
+      <SafeAreaView style={styles.safe}>
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.container}>
+            {/* Hero */}
+            <View style={styles.hero}>
+              <View style={styles.logoCircle}>
+                <Text style={styles.logoEmoji}>⚖️</Text>
+              </View>
+              <Text style={styles.appName}>Налоговик</Text>
+              <Text style={styles.tagline}>
+                Найди специалиста по налогам{'\n'}в своём городе
+              </Text>
+            </View>
+
+            {/* Features */}
+            <View style={styles.features}>
+              {FEATURES.map((f) => (
+                <View key={f} style={styles.featureRow}>
+                  <Text style={styles.featureCheck}>✓</Text>
+                  <Text style={styles.featureText}>{f}</Text>
+                </View>
+              ))}
+            </View>
+
+            {/* Quick access */}
+            <View style={styles.quickAccess}>
+              <Button
+                onPress={() => router.push('/specialists')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Каталог специалистов
+              </Button>
+              <Button
+                onPress={() => router.push('/requests')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Лента запросов
+              </Button>
+            </View>
+
+            {/* CTAs */}
+            <View style={styles.ctas}>
+              <Button
+                onPress={() => router.push('/(auth)/email?role=CLIENT')}
+                variant="primary"
+                style={styles.btn}
+              >
+                Войти как заказчик
+              </Button>
+              <Button
+                onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Я специалист / Зарегистрироваться
+              </Button>
+            </View>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  // Tablet / Desktop: two-column layout
   return (
     <SafeAreaView style={styles.safe}>
       <ScrollView
-        contentContainerStyle={styles.scroll}
+        contentContainerStyle={styles.scrollWide}
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.container}>
-          {/* Hero */}
-          <View style={styles.hero}>
+        <View style={[styles.wideContainer, isDesktop && styles.wideContainerDesktop]}>
+          {/* Left: Hero + features */}
+          <View style={styles.wideLeft}>
             <View style={styles.logoCircle}>
               <Text style={styles.logoEmoji}>⚖️</Text>
             </View>
             <Text style={styles.appName}>Налоговик</Text>
-            <Text style={styles.tagline}>
-              Найди специалиста по налогам{'\n'}в своём городе
+            <Text style={[styles.tagline, styles.taglineWide]}>
+              Найди специалиста по налогам в своём городе
             </Text>
+
+            <View style={styles.features}>
+              {FEATURES.map((f) => (
+                <View key={f} style={styles.featureRow}>
+                  <Text style={styles.featureCheck}>✓</Text>
+                  <Text style={styles.featureText}>{f}</Text>
+                </View>
+              ))}
+            </View>
           </View>
 
-          {/* Features */}
-          <View style={styles.features}>
-            {FEATURES.map((f) => (
-              <View key={f} style={styles.featureRow}>
-                <Text style={styles.featureCheck}>✓</Text>
-                <Text style={styles.featureText}>{f}</Text>
-              </View>
-            ))}
-          </View>
+          {/* Right: Actions */}
+          <View style={styles.wideRight}>
+            <Text style={styles.actionTitle}>Начать работу</Text>
 
-          {/* Quick access */}
-          <View style={styles.quickAccess}>
-            <Button
-              onPress={() => router.push('/specialists')}
-              variant="secondary"
-              style={styles.btn}
-            >
-              Каталог специалистов
-            </Button>
-            <Button
-              onPress={() => router.push('/requests')}
-              variant="secondary"
-              style={styles.btn}
-            >
-              Лента запросов
-            </Button>
-          </View>
+            <View style={styles.quickAccess}>
+              <Button
+                onPress={() => router.push('/specialists')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Каталог специалистов
+              </Button>
+              <Button
+                onPress={() => router.push('/requests')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Лента запросов
+              </Button>
+            </View>
 
-          {/* CTAs */}
-          <View style={styles.ctas}>
-            <Button
-              onPress={() => router.push('/(auth)/email?role=CLIENT')}
-              variant="primary"
-              style={styles.btn}
-            >
-              Войти как заказчик
-            </Button>
-            <Button
-              onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
-              variant="secondary"
-              style={styles.btn}
-            >
-              Я специалист / Зарегистрироваться
-            </Button>
+            <View style={styles.divider} />
+
+            <View style={styles.ctas}>
+              <Button
+                onPress={() => router.push('/(auth)/email?role=CLIENT')}
+                variant="primary"
+                style={styles.btn}
+              >
+                Войти как заказчик
+              </Button>
+              <Button
+                onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+                variant="secondary"
+                style={styles.btn}
+              >
+                Я специалист / Зарегистрироваться
+              </Button>
+            </View>
           </View>
         </View>
       </ScrollView>
@@ -93,6 +171,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.bgPrimary,
   },
+  // ---- Mobile styles ----
   scroll: {
     flexGrow: 1,
     alignItems: 'center',
@@ -105,6 +184,50 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: Spacing['3xl'],
   },
+  // ---- Wide styles ----
+  scrollWide: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingVertical: Spacing['4xl'],
+    paddingHorizontal: Spacing['3xl'],
+  },
+  wideContainer: {
+    flexDirection: 'row',
+    gap: Spacing['4xl'],
+    alignItems: 'flex-start',
+    maxWidth: 900,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  wideContainerDesktop: {
+    maxWidth: 1100,
+  },
+  wideLeft: {
+    flex: 1,
+    gap: Spacing['2xl'],
+    paddingTop: Spacing['2xl'],
+  },
+  wideRight: {
+    width: 340,
+    gap: Spacing.xl,
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.xl,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: Spacing['2xl'],
+  },
+  actionTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginBottom: Spacing.sm,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginVertical: Spacing.sm,
+  },
+  // Shared
   hero: {
     alignItems: 'center',
     gap: Spacing.lg,
@@ -134,6 +257,9 @@ const styles = StyleSheet.create({
     color: Colors.textSecondary,
     textAlign: 'center',
     lineHeight: 26,
+  },
+  taglineWide: {
+    textAlign: 'left',
   },
   features: {
     width: '100%',

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -16,6 +16,7 @@ import { Input } from '../../components/Input';
 import { EmptyState } from '../../components/EmptyState';
 import { Header } from '../../components/Header';
 import { Button } from '../../components/Button';
+import { useBreakpoints } from '../../hooks/useBreakpoints';
 
 interface RequestItem {
   id: string;
@@ -37,6 +38,7 @@ interface FeedResponse {
 }
 
 export default function RequestsFeedScreen() {
+  const { isMobile, numColumns } = useBreakpoints();
   const [items, setItems] = useState<RequestItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -110,7 +112,7 @@ export default function RequestsFeedScreen() {
 
   function renderItem({ item }: { item: RequestItem }) {
     return (
-      <View style={styles.cardWrapper}>
+      <View style={isMobile ? styles.cardWrapperMobile : styles.cardWrapperGrid}>
         <Card padding={Spacing.lg}>
           {/* City + date row */}
           <View style={styles.metaRow}>
@@ -159,11 +161,18 @@ export default function RequestsFeedScreen() {
     <SafeAreaView style={styles.safe}>
       <Header title="Лента запросов" />
 
+      {/* key={numColumns} forces FlatList remount when columns change on resize */}
       <FlatList
+        key={numColumns}
         data={items}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
+        numColumns={numColumns}
+        contentContainerStyle={[
+          styles.listContent,
+          !isMobile && styles.listContentWide,
+        ]}
+        columnWrapperStyle={numColumns > 1 ? styles.columnWrapper : undefined}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -173,7 +182,7 @@ export default function RequestsFeedScreen() {
           />
         }
         ListHeaderComponent={
-          <View style={styles.filtersBox}>
+          <View style={[styles.filtersBox, !isMobile && styles.filtersBoxWide]}>
             <Input
               label="Город"
               value={cityFilter}
@@ -215,7 +224,7 @@ export default function RequestsFeedScreen() {
         }
         ListFooterComponent={
           hasMore ? (
-            <View style={styles.loadMoreBox}>
+            <View style={[styles.loadMoreBox, !isMobile && styles.loadMoreBoxWide]}>
               <Button
                 onPress={handleLoadMore}
                 variant="secondary"
@@ -238,10 +247,19 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.bgPrimary,
   },
+  // Mobile: centered, single column
   listContent: {
     paddingHorizontal: Spacing.lg,
     paddingBottom: Spacing['3xl'],
     alignItems: 'center',
+  },
+  // Wide: stretch to fill, grid takes over
+  listContentWide: {
+    alignItems: 'stretch',
+  },
+  columnWrapper: {
+    gap: Spacing.md,
+    marginBottom: Spacing.md,
   },
   filtersBox: {
     width: '100%',
@@ -250,14 +268,22 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.lg,
     paddingBottom: Spacing.xl,
   },
+  filtersBoxWide: {
+    maxWidth: 600,
+  },
   totalText: {
     fontSize: Typography.fontSize.sm,
     color: Colors.textMuted,
   },
-  cardWrapper: {
+  // Mobile: centered single column, maxWidth 430
+  cardWrapperMobile: {
     width: '100%',
     maxWidth: 430,
     marginBottom: Spacing.md,
+  },
+  // Grid: flex 1 fills column, gutter from columnWrapper
+  cardWrapperGrid: {
+    flex: 1,
   },
   metaRow: {
     flexDirection: 'row',
@@ -343,6 +369,9 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: 430,
     paddingTop: Spacing.md,
+  },
+  loadMoreBoxWide: {
+    maxWidth: 300,
   },
   loadMoreBtn: {
     width: '100%',

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -19,6 +19,7 @@ import { Avatar } from '../../components/Avatar';
 import { EmptyState } from '../../components/EmptyState';
 import { Header } from '../../components/Header';
 import { Stars } from '../../components/Stars';
+import { useBreakpoints } from '../../hooks/useBreakpoints';
 
 interface SpecialistItem {
   id: string;
@@ -39,6 +40,7 @@ const SORT_OPTIONS: { label: string; value: string }[] = [
 
 export default function SpecialistsCatalogScreen() {
   const router = useRouter();
+  const { isMobile, numColumns, contentMaxWidth } = useBreakpoints();
 
   const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -93,13 +95,14 @@ export default function SpecialistsCatalogScreen() {
 
   function renderSpecialist({ item }: { item: SpecialistItem }) {
     const hasFamiliar = item.badges.includes('familiar');
-    const isPromoted = item.promoted;
 
     return (
       <TouchableOpacity
         onPress={() => router.push(`/specialists/${item.nick}`)}
         activeOpacity={0.8}
-        style={styles.cardWrapper}
+        // On mobile: full-width with maxWidth 430 (via listContent alignItems center)
+        // On multi-column: flex: 1 so columns fill evenly, with margin for gutter
+        style={isMobile ? styles.cardWrapperMobile : styles.cardWrapperGrid}
       >
         <Card padding={Spacing.lg}>
           <View style={styles.cardHeader}>
@@ -161,15 +164,25 @@ export default function SpecialistsCatalogScreen() {
     );
   }
 
+  // Filters bar — width adapts to breakpoint
+  const filtersMaxWidth = isMobile ? 430 : (contentMaxWidth as number);
+
   return (
     <SafeAreaView style={styles.safe}>
       <Header title="Каталог специалистов" />
 
+      {/* key={numColumns} forces FlatList remount when columns change on resize */}
       <FlatList
+        key={numColumns}
         data={specialists}
         keyExtractor={(item) => item.id}
         renderItem={renderSpecialist}
-        contentContainerStyle={styles.listContent}
+        numColumns={numColumns}
+        contentContainerStyle={[
+          styles.listContent,
+          !isMobile && styles.listContentWide,
+        ]}
+        columnWrapperStyle={numColumns > 1 ? styles.columnWrapper : undefined}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
@@ -179,7 +192,7 @@ export default function SpecialistsCatalogScreen() {
           />
         }
         ListHeaderComponent={
-          <View style={styles.filters}>
+          <View style={[styles.filters, { maxWidth: filtersMaxWidth }]}>
             {/* City filter chips */}
             {availableCities.length > 0 && (
               <View>
@@ -281,14 +294,23 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: Colors.bgPrimary,
   },
+  // Mobile: centered single column
   listContent: {
     paddingHorizontal: Spacing.lg,
     paddingBottom: Spacing['3xl'],
     alignItems: 'center',
   },
+  // Wide (tablet/desktop): align to start so grid fills from left
+  listContentWide: {
+    alignItems: 'stretch',
+  },
+  // Grid column spacing
+  columnWrapper: {
+    gap: Spacing.md,
+    marginBottom: Spacing.md,
+  },
   filters: {
     width: '100%',
-    maxWidth: 430,
     gap: Spacing.md,
     paddingTop: Spacing.lg,
     paddingBottom: Spacing.xl,
@@ -368,10 +390,15 @@ const styles = StyleSheet.create({
   sortTabTextActive: {
     color: Colors.textPrimary,
   },
-  cardWrapper: {
+  // Mobile card: centered single column, maxWidth 430
+  cardWrapperMobile: {
     width: '100%',
     maxWidth: 430,
     marginBottom: Spacing.md,
+  },
+  // Grid card: flex 1 fills column evenly (gutter handled by columnWrapper gap)
+  cardWrapperGrid: {
+    flex: 1,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Colors, Spacing, Typography } from '../constants/Colors';
+import { useBreakpoints } from '../hooks/useBreakpoints';
 
 interface HeaderProps {
   title: string;
@@ -18,6 +19,7 @@ interface HeaderProps {
 
 export function Header({ title, showBack = false, rightAction, onBackPress }: HeaderProps) {
   const router = useRouter();
+  const { isMobile } = useBreakpoints();
 
   const handleBack = () => {
     if (onBackPress) {
@@ -27,23 +29,49 @@ export function Header({ title, showBack = false, rightAction, onBackPress }: He
     }
   };
 
+  // On desktop/tablet, align title left (sidebar handles branding)
+  // On mobile, keep centered layout
+  const titleStyle = isMobile ? styles.titleCentered : styles.titleLeft;
+
   return (
     <View style={styles.container}>
-      <View style={styles.left}>
-        {showBack && (
-          <TouchableOpacity onPress={handleBack} style={styles.backBtn} hitSlop={12}>
-            <Text style={styles.backIcon}>{'←'}</Text>
-          </TouchableOpacity>
-        )}
-      </View>
+      {isMobile ? (
+        // Mobile: left spacer | centered title | right action
+        <>
+          <View style={styles.left}>
+            {showBack && (
+              <TouchableOpacity onPress={handleBack} style={styles.backBtn} hitSlop={12}>
+                <Text style={styles.backIcon}>{'←'}</Text>
+              </TouchableOpacity>
+            )}
+          </View>
 
-      <Text style={styles.title} numberOfLines={1}>
-        {title}
-      </Text>
+          <Text style={titleStyle} numberOfLines={1}>
+            {title}
+          </Text>
 
-      <View style={styles.right}>
-        {rightAction ?? null}
-      </View>
+          <View style={styles.right}>
+            {rightAction ?? null}
+          </View>
+        </>
+      ) : (
+        // Desktop/tablet: back (if needed) | left-aligned title | right spacer + action
+        <>
+          {showBack && (
+            <TouchableOpacity onPress={handleBack} style={styles.backBtn} hitSlop={12}>
+              <Text style={styles.backIcon}>{'←'}</Text>
+            </TouchableOpacity>
+          )}
+
+          <Text style={titleStyle} numberOfLines={1}>
+            {title}
+          </Text>
+
+          <View style={styles.rightWide}>
+            {rightAction ?? null}
+          </View>
+        </>
+      )}
     </View>
   );
 }
@@ -53,13 +81,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     height: 56,
-    paddingHorizontal: Spacing.lg,
+    paddingHorizontal: Spacing.xl,
     backgroundColor: Colors.bgSecondary,
     borderBottomWidth: 1,
     borderBottomColor: Colors.border,
-    // Extra top padding for web/status bar
     paddingTop: Platform.OS === 'web' ? 0 : 0,
   },
+  // Mobile layout pieces
   left: {
     width: 48,
     alignItems: 'flex-start',
@@ -68,12 +96,26 @@ const styles = StyleSheet.create({
     width: 48,
     alignItems: 'flex-end',
   },
-  title: {
+  // Wide layout: pushes actions to the far right
+  rightWide: {
+    marginLeft: 'auto' as any,
+    alignItems: 'flex-end',
+  },
+  // Title variants
+  titleCentered: {
     flex: 1,
     textAlign: 'center',
     fontSize: Typography.fontSize.md,
     fontWeight: Typography.fontWeight.semibold,
     color: Colors.textPrimary,
+  },
+  titleLeft: {
+    flex: 1,
+    textAlign: 'left',
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    marginLeft: Spacing.sm,
   },
   backBtn: {
     padding: Spacing.xs,

--- a/components/ResponsiveLayout.tsx
+++ b/components/ResponsiveLayout.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useBreakpoints } from '../hooks/useBreakpoints';
+import { Sidebar, SidebarNavItem } from './Sidebar';
+import { Colors } from '../constants/Colors';
+
+interface ResponsiveLayoutProps {
+  children: React.ReactNode;
+  navItems: SidebarNavItem[];
+  userEmail?: string;
+  onLogout?: () => void;
+}
+
+/**
+ * Wraps content with a sidebar on tablet/desktop.
+ * On mobile, renders children directly without sidebar.
+ */
+export function ResponsiveLayout({
+  children,
+  navItems,
+  userEmail,
+  onLogout,
+}: ResponsiveLayoutProps) {
+  const { isMobile, sidebarWidth } = useBreakpoints();
+
+  if (isMobile) {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Sidebar
+        items={navItems}
+        userEmail={userEmail}
+        onLogout={onLogout}
+        width={sidebarWidth}
+      />
+      <View style={styles.content}>
+        {children}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: Colors.bgPrimary,
+  },
+  content: {
+    flex: 1,
+    overflow: 'hidden' as any,
+  },
+});

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { useRouter, useSegments } from 'expo-router';
+import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
+
+export interface SidebarNavItem {
+  label: string;
+  icon: string;
+  route: string;
+  /** Segment to match for active state, e.g. "index" or "requests" */
+  segment?: string;
+}
+
+interface SidebarProps {
+  items: SidebarNavItem[];
+  userEmail?: string;
+  onLogout?: () => void;
+  width: number;
+}
+
+export function Sidebar({ items, userEmail, onLogout, width }: SidebarProps) {
+  const router = useRouter();
+  const segments = useSegments();
+
+  function isActive(item: SidebarNavItem): boolean {
+    // Match by last segment or explicit segment override
+    const last = segments[segments.length - 1] ?? '';
+    const target = item.segment ?? item.route.split('/').pop() ?? '';
+    return last === target;
+  }
+
+  return (
+    <View style={[styles.sidebar, { width }]}>
+      {/* Logo / App name */}
+      <View style={styles.brand}>
+        <Text style={styles.brandIcon}>{'⚖'}</Text>
+        <Text style={styles.brandName}>Налоговик</Text>
+      </View>
+
+      {/* Nav items */}
+      <View style={styles.nav}>
+        {items.map((item) => {
+          const active = isActive(item);
+          return (
+            <TouchableOpacity
+              key={item.route}
+              style={[styles.navItem, active && styles.navItemActive]}
+              onPress={() => router.replace(item.route as any)}
+              activeOpacity={0.75}
+            >
+              <Text style={styles.navIcon}>{item.icon}</Text>
+              <Text style={[styles.navLabel, active && styles.navLabelActive]}>
+                {item.label}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+
+      {/* Bottom: user info + logout */}
+      <View style={styles.bottom}>
+        {userEmail ? (
+          <Text style={styles.userEmail} numberOfLines={1}>
+            {userEmail}
+          </Text>
+        ) : null}
+        {onLogout ? (
+          <TouchableOpacity onPress={onLogout} style={styles.logoutBtn} activeOpacity={0.7}>
+            <Text style={styles.logoutText}>Выйти</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sidebar: {
+    backgroundColor: Colors.bgSecondary,
+    borderRightWidth: 1,
+    borderRightColor: Colors.border,
+    flexDirection: 'column',
+    paddingTop: Spacing['3xl'],
+    paddingBottom: Spacing['2xl'],
+    paddingHorizontal: Spacing.md,
+  },
+  brand: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.sm,
+    marginBottom: Spacing['3xl'],
+  },
+  brandIcon: {
+    fontSize: Typography.fontSize.xl,
+  },
+  brandName: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  nav: {
+    flex: 1,
+    gap: Spacing.xs,
+  },
+  navItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.md,
+  },
+  navItemActive: {
+    backgroundColor: Colors.brandPrimary + '22', // 13% opacity tint
+    borderWidth: 1,
+    borderColor: Colors.brandPrimary + '44',
+  },
+  navIcon: {
+    fontSize: Typography.fontSize.base,
+    width: 20,
+    textAlign: 'center',
+  },
+  navLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  navLabelActive: {
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  bottom: {
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    paddingTop: Spacing.lg,
+    gap: Spacing.sm,
+  },
+  userEmail: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    paddingHorizontal: Spacing.sm,
+  },
+  logoutBtn: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.md,
+  },
+  logoutText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -114,3 +114,8 @@ export const BorderRadius = {
   xl: 20,
   full: 9999,
 } as const;
+
+export const Breakpoints = {
+  tablet: 768,
+  desktop: 1024,
+} as const;

--- a/hooks/useBreakpoints.ts
+++ b/hooks/useBreakpoints.ts
@@ -1,0 +1,50 @@
+import { useWindowDimensions } from 'react-native';
+import { Breakpoints } from '../constants/Colors';
+
+export type Breakpoint = 'mobile' | 'tablet' | 'desktop';
+
+export interface BreakpointValues {
+  width: number;
+  breakpoint: Breakpoint;
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+  /** Number of columns for catalog grids */
+  numColumns: number;
+  /** Max content width for centered layouts */
+  contentMaxWidth: number | string;
+  /** Sidebar width when visible */
+  sidebarWidth: number;
+}
+
+export function useBreakpoints(): BreakpointValues {
+  const { width } = useWindowDimensions();
+
+  const isDesktop = width >= Breakpoints.desktop;
+  const isTablet = !isDesktop && width >= Breakpoints.tablet;
+  const isMobile = !isDesktop && !isTablet;
+
+  let breakpoint: Breakpoint = 'mobile';
+  if (isDesktop) breakpoint = 'desktop';
+  else if (isTablet) breakpoint = 'tablet';
+
+  // Grid columns for FlatList catalogs
+  const numColumns = isDesktop ? 3 : isTablet ? 2 : 1;
+
+  // Max width for centered single-column content
+  const contentMaxWidth: number | string = isDesktop ? 1200 : isTablet ? 900 : 430;
+
+  // Sidebar width
+  const sidebarWidth = isDesktop ? 240 : 200;
+
+  return {
+    width,
+    breakpoint,
+    isMobile,
+    isTablet,
+    isDesktop,
+    numColumns,
+    contentMaxWidth,
+    sidebarWidth,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useBreakpoints` hook with breakpoints: mobile <768px, tablet 768-1024px, desktop >1024px
- Add `Sidebar` component with nav links (role-based), user email, logout
- Add `ResponsiveLayout` wrapper — shows sidebar + content on tablet/desktop, passthrough on mobile
- Dashboard layout wraps Stack in ResponsiveLayout; dashboard index shows stats view on desktop
- Specialists catalog, requests feed, dashboard requests all use `numColumns` (1/2/3) with `key={numColumns}` on FlatList
- Header adapts: centered title on mobile, left-aligned on desktop
- Landing page: two-column hero/actions layout on tablet/desktop

## Test plan
- [ ] Mobile (<768px): visual identical to before — no sidebar, no grid, original hub cards in dashboard
- [ ] Tablet (768-1024px): sidebar appears with nav links, specialists show 2-column grid
- [ ] Desktop (>1024px): wider sidebar (240px), 3-column specialist/request grids, stats view in dashboard
- [ ] Resize browser through all breakpoints — FlatList remounts correctly (key={numColumns})
- [ ] Sidebar links use router.replace (no stack buildup)
- [ ] TypeScript: only pre-existing 3 errors, zero new