### PR TITLE
fix: add rate limiting to verify-otp endpoint

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -39,6 +39,8 @@ export class AuthController {
     return this.authService.requestOtp(body.email);
   }
 
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { ttl: 300000, limit: 10 } })
   @Post('verify-otp')
   verifyOtp(@Body() body: VerifyOtpDto) {
     return this.authService.verifyOtp(body.email, body.code, body.role);


### PR DESCRIPTION
## Summary
- Adds `@UseGuards(ThrottlerGuard)` and `@Throttle({ default: { ttl: 300000, limit: 10 } })` to `verifyOtp` method
- Limits OTP verification to 10 requests per 5 minutes (300000ms TTL)
- Prevents OTP brute-force attacks — without this, attacker could try all 1,000,000 possible 6-digit codes
- Same pattern as `requestOtp` which already had rate limiting (3 req/5min)

## Test plan
- [ ] Send 10 POST /auth/verify-otp requests rapidly → all succeed (or fail with 401 on wrong code)
- [ ] Send 11th request → must return 429 Too Many Requests
- [ ] Wait 5 minutes → rate limit resets, requests succeed again

Fixes Trinity task #1689