### PR TITLE
fix: migrate AsyncStorage token storage to SecureStore adapter

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { secureStorage } from '../stores/storage';
 
 const BASE_URL =
   process.env.EXPO_PUBLIC_API_URL ?? 'https://p2ptax.smartlaunchhub.com/api';
@@ -24,36 +24,36 @@ function emitUnauthorized() {
 // Token storage helpers
 export async function getToken(): Promise<string | null> {
   try {
-    return await AsyncStorage.getItem(TOKEN_KEY);
+    return await secureStorage.getItem(TOKEN_KEY);
   } catch {
     return null;
   }
 }
 
 export async function setToken(token: string): Promise<void> {
-  await AsyncStorage.setItem(TOKEN_KEY, token);
+  await secureStorage.setItem(TOKEN_KEY, token);
 }
 
 export async function clearToken(): Promise<void> {
-  await AsyncStorage.removeItem(TOKEN_KEY);
+  await secureStorage.removeItem(TOKEN_KEY);
 }
 
 const REFRESH_TOKEN_KEY = '@p2ptax_refresh_token';
 
 export async function getRefreshToken(): Promise<string | null> {
   try {
-    return await AsyncStorage.getItem(REFRESH_TOKEN_KEY);
+    return await secureStorage.getItem(REFRESH_TOKEN_KEY);
   } catch {
     return null;
   }
 }
 
 export async function setRefreshToken(token: string): Promise<void> {
-  await AsyncStorage.setItem(REFRESH_TOKEN_KEY, token);
+  await secureStorage.setItem(REFRESH_TOKEN_KEY, token);
 }
 
 export async function clearRefreshToken(): Promise<void> {
-  await AsyncStorage.removeItem(REFRESH_TOKEN_KEY);
+  await secureStorage.removeItem(REFRESH_TOKEN_KEY);
 }
 
 // Refresh in-flight guard to avoid concurrent refresh calls

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { setToken, clearToken, onUnauthorized } from '../lib/api';
+import { secureStorage } from './storage';
 
 const TOKEN_KEY = '@p2ptax_token';
 const USER_KEY = '@p2ptax_user';
@@ -81,8 +81,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     async function restore() {
       try {
         const [token, userJson] = await Promise.all([
-          AsyncStorage.getItem(TOKEN_KEY),
-          AsyncStorage.getItem(USER_KEY),
+          secureStorage.getItem(TOKEN_KEY),
+          secureStorage.getItem(USER_KEY),
         ]);
 
         if (!cancelled) {
@@ -109,8 +109,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const unsubscribe = onUnauthorized(() => {
       dispatch({ type: 'LOGOUT' });
       Promise.all([
-        AsyncStorage.removeItem(TOKEN_KEY),
-        AsyncStorage.removeItem(USER_KEY),
+        secureStorage.removeItem(TOKEN_KEY),
+        secureStorage.removeItem(USER_KEY),
       ]).catch(() => {});
     });
     return unsubscribe;
@@ -119,7 +119,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const login = useCallback(async (token: string, user: AuthUser) => {
     await Promise.all([
       setToken(token),
-      AsyncStorage.setItem(USER_KEY, JSON.stringify(user)),
+      secureStorage.setItem(USER_KEY, JSON.stringify(user)),
     ]);
     dispatch({ type: 'LOGIN', payload: { token, user } });
   }, []);
@@ -127,7 +127,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     await Promise.all([
       clearToken(),
-      AsyncStorage.removeItem(USER_KEY),
+      secureStorage.removeItem(USER_KEY),
     ]);
     dispatch({ type: 'LOGOUT' });
   }, []);
@@ -139,12 +139,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Called after onboarding completes — clears isNewUser flag and stores username
   const completeOnboarding = useCallback(async (username: string) => {
     dispatch({ type: 'SET_USERNAME', payload: username });
-    // Persist updated user (isNewUser=false, username set) to AsyncStorage
-    const userJson = await AsyncStorage.getItem(USER_KEY);
+    // Persist updated user (isNewUser=false, username set) to secure storage
+    const userJson = await secureStorage.getItem(USER_KEY);
     if (userJson) {
       const existing = JSON.parse(userJson) as AuthUser;
       const updated: AuthUser = { ...existing, username, isNewUser: false };
-      await AsyncStorage.setItem(USER_KEY, JSON.stringify(updated));
+      await secureStorage.setItem(USER_KEY, JSON.stringify(updated));
     }
   }, []);
 

--- a/stores/storage.ts
+++ b/stores/storage.ts
@@ -1,0 +1,64 @@
+import { Platform } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+
+// Unified secure storage adapter.
+// - Web: localStorage (synchronous API wrapped in Promises)
+// - Native (iOS/Android): expo-secure-store (Keychain / Keystore)
+//
+// Note: SecureStore on iOS has a ~2048-byte value limit per key.
+// Values exceeding this will throw; the adapter catches and re-throws
+// with a descriptive message so callers can handle it gracefully.
+
+const secureStorage = {
+  async getItem(key: string): Promise<string | null> {
+    if (Platform.OS === 'web') {
+      try {
+        return localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    }
+    try {
+      return await SecureStore.getItemAsync(key);
+    } catch {
+      return null;
+    }
+  },
+
+  async setItem(key: string, value: string): Promise<void> {
+    if (Platform.OS === 'web') {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // localStorage may be unavailable in private mode — swallow silently
+      }
+      return;
+    }
+    try {
+      await SecureStore.setItemAsync(key, value);
+    } catch (err) {
+      // Most common cause: value exceeds 2048-byte iOS Keychain limit
+      console.warn(`[secureStorage] setItem failed for key "${key}":`, err);
+      throw err;
+    }
+  },
+
+  // SecureStore uses deleteItemAsync, not removeItem
+  async removeItem(key: string): Promise<void> {
+    if (Platform.OS === 'web') {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // swallow
+      }
+      return;
+    }
+    try {
+      await SecureStore.deleteItemAsync(key);
+    } catch {
+      // Key may not exist — treat as success
+    }
+  },
+};
+
+export { secureStorage };


### PR DESCRIPTION
## Summary
- Create `stores/storage.ts` — unified secure storage adapter: `expo-secure-store` on native (iOS Keychain / Android Keystore), `localStorage` on web
- Replace all 6 `AsyncStorage` calls in `lib/api.ts` with adapter
- Replace all 8 `AsyncStorage` calls in `stores/authStore.ts` with adapter

## Key details
- `removeItem` correctly maps to `SecureStore.deleteItemAsync` (not removeItemAsync)
- `setItem` has try/catch with `console.warn` to surface 2048-byte iOS Keychain limit failures
- `getItem` / `removeItem` on native swallow errors gracefully (key not found = null/noop)
- `settings.tsx` notification preference left on AsyncStorage (non-sensitive, intentional)

## Test plan
- [ ] `npx tsc --noEmit` — no new errors
- [ ] Web: login, verify token appears in `localStorage` under `@p2ptax_token`
- [ ] Web: page refresh restores session
- [ ] Web: logout clears token from localStorage

Closes #1690