### PR TITLE
fix: set Express trust proxy for Cloudflare

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -13,6 +13,11 @@ async function bootstrap() {
 
   const app = await NestFactory.create(AppModule);
 
+  // Trust Cloudflare proxy so Express uses X-Forwarded-For as the real client IP.
+  // Without this, @nestjs/throttler uses the Cloudflare edge IP as the rate-limit key,
+  // making all rate limits ineffective (one shared bucket for all users).
+  app.set('trust proxy', 1);
+
   app.setGlobalPrefix('api');
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
 


### PR DESCRIPTION
## Summary
- Adds `app.set('trust proxy', 1)` to `api/src/main.ts` immediately after `NestFactory.create()`
- Without this setting, Express uses the Cloudflare edge server IP as the rate-limit key for `@nestjs/throttler`, making all rate limits effectively useless (all users share one bucket)
- With `trust proxy=1`, Express reads `X-Forwarded-For` header to get the real client IP

## Test plan
- [ ] Rate limiting now uses per-client IP instead of shared Cloudflare edge IP
- [ ] No regressions to existing API functionality

Fixes Trinity #1696