### PR TITLE
fix: save refresh token on OTP login (#1687)

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -13,7 +13,7 @@ import {
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Button } from '../../components/Button';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
-import { api, ApiError } from '../../lib/api';
+import { api, ApiError, setRefreshToken } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 
 const CODE_LENGTH = 6;
@@ -98,6 +98,9 @@ export default function OtpScreen() {
         code,
         role: role.toLowerCase(),
       });
+      if (res.refreshToken) {
+        await setRefreshToken(res.refreshToken);
+      }
       await login(res.accessToken, {
         userId: res.user.userId,
         email: res.user.email,

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
-import { setToken, clearToken, onUnauthorized } from '../lib/api';
+import { setToken, clearToken, clearRefreshToken, onUnauthorized } from '../lib/api';
 import { secureStorage } from './storage';
 
 const TOKEN_KEY = '@p2ptax_token';
@@ -111,6 +111,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       Promise.all([
         secureStorage.removeItem(TOKEN_KEY),
         secureStorage.removeItem(USER_KEY),
+        clearRefreshToken(),
       ]).catch(() => {});
     });
     return unsubscribe;
@@ -127,6 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     await Promise.all([
       clearToken(),
+      clearRefreshToken(),
       secureStorage.removeItem(USER_KEY),
     ]);
     dispatch({ type: 'LOGOUT' });


### PR DESCRIPTION
## Summary
- Save `refreshToken` from verify-otp response via `setRefreshToken()` in `otp.tsx`
- Clear refresh token in `logout()` and `onUnauthorized` handler in `authStore.ts`
- Prevents users being kicked out after 15min access token expiry (refresh token was discarded)

## Changed files
- `app/(auth)/otp.tsx` — import and call `setRefreshToken` after OTP verify
- `stores/authStore.ts` — import and call `clearRefreshToken` in logout + onUnauthorized

## Test plan
- [ ] Login via OTP, verify refresh token is saved in storage
- [ ] Wait >15min, confirm session persists (token refreshes automatically)
- [ ] Logout, verify refresh token is cleared from storage