### PR TITLE
fix: delete reviews before user delete to prevent FK violation (#1688)

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -107,6 +107,15 @@ export class UsersService {
     if (!user) throw new NotFoundException('User not found');
 
     await this.prisma.$transaction([
+      // Reviews given by user
+      this.prisma.review.deleteMany({ where: { clientId: userId } }),
+
+      // Reviews received by user
+      this.prisma.review.deleteMany({ where: { specialistId: userId } }),
+
+      // Reviews on user's requests (from other clients)
+      this.prisma.review.deleteMany({ where: { request: { clientId: userId } } }),
+
       // Messages sent by user
       this.prisma.message.deleteMany({ where: { senderId: userId } }),
 


### PR DESCRIPTION
## Summary
- Adds three `prisma.review.deleteMany` calls at the beginning of the `deleteUser()` transaction
- Deletes reviews where user is client (clientId), specialist (specialistId), or request owner
- Prevents FK constraint violation crash when deleting users who have reviews

## Test plan
- [ ] Create user with reviews (as client and/or specialist)
- [ ] DELETE /api/users/:id returns 200 OK without FK constraint crash