### PR TITLE
perf: filter specialists by city in DB query (#1695)

### DIFF
--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -55,7 +55,7 @@ export class RequestsService {
   ): Promise<void> {
     const cityLower = city.toLowerCase();
     const profiles = await this.prisma.specialistProfile.findMany({
-      where: {},
+      where: { cities: { has: cityLower } },
       include: { user: { select: { email: true } } },
     });
 


### PR DESCRIPTION
## Summary
- Replaces `where: {}` with `where: { cities: { has: cityLower } }` in `notifySpecialistsAsync`
- Avoids loading ALL specialist profiles into memory just to filter by city
- In-memory filter kept as secondary safety net for case variations

## Test plan
- [ ] Verify specialists in matching city still receive email notifications
- [ ] Verify specialists in other cities do NOT receive notifications