### PR TITLE
refactor: AdminGuard replaces duplicate assertAdmin (#1693)

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -3,15 +3,10 @@ import {
   Get,
   Query,
   UseGuards,
-  Request,
-  ForbiddenException,
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-
-// Admin emails are comma-separated in ADMIN_EMAILS env var.
-// Same pattern as PromotionsController — no ADMIN role in DB yet.
-const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? '').split(',').filter(Boolean);
+import { AdminGuard } from '../auth/admin.guard';
 
 @Controller('admin')
 export class AdminController {
@@ -19,39 +14,29 @@ export class AdminController {
 
   /** GET /admin/stats — dashboard totals */
   @Get('stats')
-  @UseGuards(JwtAuthGuard)
-  getStats(@Request() req: any) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getStats() {
     return this.adminService.getStats();
   }
 
   /** GET /admin/users — all users, optional ?role=CLIENT|SPECIALIST */
   @Get('users')
-  @UseGuards(JwtAuthGuard)
-  getUsers(@Request() req: any, @Query('role') role?: string) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getUsers(@Query('role') role?: string) {
     return this.adminService.getUsers(role);
   }
 
   /** GET /admin/specialists — all specialist profiles */
   @Get('specialists')
-  @UseGuards(JwtAuthGuard)
-  getSpecialists(@Request() req: any) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getSpecialists() {
     return this.adminService.getSpecialists();
   }
 
   /** GET /admin/requests — all platform requests */
   @Get('requests')
-  @UseGuards(JwtAuthGuard)
-  getAllRequests(@Request() req: any) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getAllRequests() {
     return this.adminService.getAllRequests();
-  }
-
-  private assertAdmin(email: string) {
-    if (!ADMIN_EMAILS.includes(email)) {
-      throw new ForbiddenException('Admin access required');
-    }
   }
 }

--- a/api/src/auth/admin.guard.ts
+++ b/api/src/auth/admin.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+
+// Admin emails are comma-separated in ADMIN_EMAILS env var.
+// No ADMIN role in DB yet, so we check email directly.
+const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? '').split(',').filter(Boolean);
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!ADMIN_EMAILS.includes(user?.email)) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}

--- a/api/src/promotions/promotions.controller.ts
+++ b/api/src/promotions/promotions.controller.ts
@@ -7,19 +7,15 @@ import {
   Query,
   UseGuards,
   Request,
-  ForbiddenException,
 } from '@nestjs/common';
 import { PromotionsService } from './promotions.service';
 import { PurchasePromotionDto } from './dto/purchase-promotion.dto';
 import { UpdatePricesDto } from './dto/update-prices.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { Role } from '@prisma/client';
-
-// Admin emails — no ADMIN role in DB yet, so we check email directly.
-// TODO: add ADMIN role to Prisma enum when admin panel is built
-const ADMIN_EMAILS = (process.env.ADMIN_EMAILS ?? '').split(',').filter(Boolean);
 
 @Controller('promotions')
 export class PromotionsController {
@@ -42,9 +38,8 @@ export class PromotionsController {
 
   /** Admin: list all promotions */
   @Get('admin')
-  @UseGuards(JwtAuthGuard)
-  async adminList(@Request() req: any) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  async adminList() {
     return this.promotionsService.adminList();
   }
 
@@ -56,23 +51,15 @@ export class PromotionsController {
 
   /** Admin: get current prices */
   @Get('admin/prices')
-  @UseGuards(JwtAuthGuard)
-  async getPrices(@Request() req: any, @Query('city') city?: string) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  async getPrices(@Query('city') city?: string) {
     return this.promotionsService.getPrices(city);
   }
 
   /** Admin: update price for city+tier */
   @Patch('admin/prices')
-  @UseGuards(JwtAuthGuard)
-  async updatePrices(@Request() req: any, @Body() dto: UpdatePricesDto) {
-    this.assertAdmin(req.user.email);
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  async updatePrices(@Body() dto: UpdatePricesDto) {
     return this.promotionsService.updatePrices(dto);
-  }
-
-  private assertAdmin(email: string) {
-    if (!ADMIN_EMAILS.includes(email)) {
-      throw new ForbiddenException('Admin access required');
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Created `api/src/auth/admin.guard.ts` — reusable NestJS `CanActivate` guard that checks `ADMIN_EMAILS` env var
- Replaced `@UseGuards(JwtAuthGuard)` + manual `assertAdmin()` calls with `@UseGuards(JwtAuthGuard, AdminGuard)` in both controllers
- Removed private `assertAdmin` methods and duplicate `ADMIN_EMAILS` constants from `admin.controller.ts` and `promotions.controller.ts`

## Test plan
- [ ] Verify admin endpoints still return 403 for non-admin users
- [ ] Verify admin endpoints work for users in ADMIN_EMAILS