### PR TITLE
fix: sync BorderRadius tokens with brand (#1692)

### DIFF
--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -401,7 +401,7 @@ const styles = StyleSheet.create({
   sendBtn: {
     width: 40,
     height: 40,
-    borderRadius: 20,
+    borderRadius: BorderRadius.xl,
     backgroundColor: Colors.brandPrimary,
     alignItems: 'center',
     justifyContent: 'center',

--- a/app/(dashboard)/messages/index.tsx
+++ b/app/(dashboard)/messages/index.tsx
@@ -211,7 +211,7 @@ const styles = StyleSheet.create({
     right: 0,
     width: 10,
     height: 10,
-    borderRadius: 5,
+    borderRadius: BorderRadius.sm,
     backgroundColor: Colors.brandPrimary,
     borderWidth: 2,
     borderColor: Colors.bgPrimary,

--- a/app/(onboarding)/cities.tsx
+++ b/app/(onboarding)/cities.tsx
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
   progressDot: {
     width: 10,
     height: 10,
-    borderRadius: 5,
+    borderRadius: BorderRadius.sm,
     backgroundColor: Colors.border,
   },
   progressDotDone: {
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brandPrimary,
     width: 12,
     height: 12,
-    borderRadius: 6,
+    borderRadius: BorderRadius.sm,
   },
   progressLine: {
     width: 32,

--- a/app/(onboarding)/services.tsx
+++ b/app/(onboarding)/services.tsx
@@ -173,7 +173,7 @@ const styles = StyleSheet.create({
   progressDot: {
     width: 10,
     height: 10,
-    borderRadius: 5,
+    borderRadius: BorderRadius.sm,
     backgroundColor: Colors.border,
   },
   progressDotDone: {
@@ -183,7 +183,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.brandPrimary,
     width: 12,
     height: 12,
-    borderRadius: 6,
+    borderRadius: BorderRadius.sm,
   },
   progressLine: {
     width: 32,

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -108,9 +108,9 @@ export const Typography = {
 } as const;
 
 export const BorderRadius = {
-  sm: 6,
-  md: 10,
-  lg: 14,
+  sm: 8,
+  md: 12,
+  lg: 16,
   xl: 20,
   full: 9999,
 } as const;


### PR DESCRIPTION
## Summary
- Sync BorderRadius.sm/md/lg in Colors.ts with brand.html values (8/12/16)
- Replace hardcoded borderRadius values with design tokens in 4 component files

## Changed files
- constants/Colors.ts
- app/(dashboard)/messages/[threadId].tsx
- app/(dashboard)/messages/index.tsx
- app/(onboarding)/cities.tsx
- app/(onboarding)/services.tsx