### PR TITLE
fix: add @types/nodemailer (#1697)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18,7 +18,6 @@
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/websockets": "^10.4.15",
         "@prisma/client": "^6.19.3",
-        "@types/nodemailer": "^7.0.11",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv": "^16.6.1",
@@ -32,6 +31,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.13.0",
+        "@types/nodemailer": "^7.0.11",
         "@types/passport-jwt": "^4.0.1",
         "prisma": "^6.19.3",
         "ts-node-dev": "^2.0.0",
@@ -623,6 +623,7 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
       "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,6 @@
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^10.4.15",
     "@prisma/client": "^6.19.3",
-    "@types/nodemailer": "^7.0.11",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^16.6.1",
@@ -36,6 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.0",
+    "@types/nodemailer": "^7.0.11",
     "@types/passport-jwt": "^4.0.1",
     "prisma": "^6.19.3",
     "ts-node-dev": "^2.0.0",


### PR DESCRIPTION
## Summary
- Moves `@types/nodemailer` from `dependencies` to `devDependencies` (correct placement for type packages)
- Installs the package so TypeScript resolves nodemailer types in `email.service.ts`
- `npx tsc --noEmit` shows zero nodemailer errors after fix

## Test plan
- [ ] `npx tsc --noEmit` in `api/` returns no nodemailer-related errors