### PR TITLE
fix: replace hardcoded values with design tokens (#1694)

### DIFF
--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -226,7 +226,7 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
   },
   navArrow: {
-    fontSize: 16,
+    fontSize: Typography.fontSize.md,
     color: Colors.textMuted,
   },
 });

--- a/app/(admin)/promotions.tsx
+++ b/app/(admin)/promotions.tsx
@@ -395,13 +395,13 @@ const styles = StyleSheet.create({
     borderRadius: BorderRadius.full,
   },
   tierBASIC: {
-    backgroundColor: '#132240',
+    backgroundColor: Colors.statusBg.info,
   },
   tierFEATURED: {
-    backgroundColor: '#2a1f4a',
+    backgroundColor: Colors.statusBg.accent,
   },
   tierTOP: {
-    backgroundColor: '#3a2c10',
+    backgroundColor: Colors.statusBg.warning,
   },
   tierPillText: {
     fontSize: Typography.fontSize.xs,

--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -411,7 +411,7 @@ const styles = StyleSheet.create({
   },
   sendIcon: {
     color: '#fff',
-    fontSize: 18,
+    fontSize: Typography.fontSize.lg,
     fontWeight: Typography.fontWeight.bold,
   },
 });

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -393,7 +393,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   addBtnText: {
-    fontSize: 24,
+    fontSize: Typography.fontSize['2xl'],
     color: Colors.textPrimary,
     lineHeight: 28,
   },
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
     color: Colors.textSecondary,
   },
   tagRemove: {
-    fontSize: 16,
+    fontSize: Typography.fontSize.md,
     color: Colors.textMuted,
     lineHeight: 18,
   },
@@ -449,7 +449,7 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
   },
   emptyIcon: {
-    fontSize: 48,
+    fontSize: Typography.fontSize.jumbo,
     marginBottom: Spacing.sm,
   },
   emptyTitle: {

--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -271,7 +271,7 @@ const styles = StyleSheet.create({
     textAlign: 'right',
   },
   rowArrow: {
-    fontSize: 16,
+    fontSize: Typography.fontSize.md,
     color: Colors.textMuted,
     marginLeft: Spacing.sm,
   },

--- a/app/(dashboard)/specialist-profile.tsx
+++ b/app/(dashboard)/specialist-profile.tsx
@@ -272,7 +272,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   addBtnText: {
-    fontSize: 24,
+    fontSize: Typography.fontSize['2xl'],
     color: Colors.textPrimary,
     lineHeight: 28,
   },
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
     color: Colors.textSecondary,
   },
   tagRemove: {
-    fontSize: 16,
+    fontSize: Typography.fontSize.md,
     color: Colors.textMuted,
     lineHeight: 18,
   },


### PR DESCRIPTION
## Summary
- Replace 8 hardcoded `fontSize` values with `Typography.fontSize.*` tokens
- Replace 3 hardcoded hex color values with `Colors.statusBg.*` tokens
- 6 files changed, zero functional changes (values identical)

## Files
- `app/(admin)/index.tsx` — navArrow fontSize
- `app/(dashboard)/profile.tsx` — addBtnText, tagRemove, emptyIcon fontSize
- `app/(dashboard)/specialist-profile.tsx` — addBtnText, tagRemove fontSize
- `app/(dashboard)/messages/[threadId].tsx` — sendIcon fontSize
- `app/(dashboard)/settings.tsx` — rowArrow fontSize
- `app/(admin)/promotions.tsx` — tierBASIC/FEATURED/TOP backgroundColor