### PR TITLE
fix: resolve pre-existing TS errors (#1698)

### DIFF
--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -17,9 +17,11 @@ interface InputProps {
   error?: string;
   style?: ViewStyle;
   autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
+  autoCorrect?: boolean;
   keyboardType?: 'default' | 'email-address' | 'numeric' | 'phone-pad';
   autoFocus?: boolean;
   editable?: boolean;
+  maxLength?: number;
 }
 
 export function Input({
@@ -31,9 +33,11 @@ export function Input({
   error,
   style,
   autoCapitalize = 'none',
+  autoCorrect,
   keyboardType = 'default',
   autoFocus = false,
   editable = true,
+  maxLength,
 }: InputProps) {
   const [focused, setFocused] = useState(false);
 
@@ -47,9 +51,11 @@ export function Input({
         placeholderTextColor={Colors.textMuted}
         secureTextEntry={secureTextEntry}
         autoCapitalize={autoCapitalize}
+        autoCorrect={autoCorrect}
         keyboardType={keyboardType}
         autoFocus={autoFocus}
         editable={editable}
+        maxLength={maxLength}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         style={[


### PR DESCRIPTION
## Summary
- Install socket.io-client so its built-in v4 types are resolved (was missing from node_modules)
- Add `autoCorrect` and `maxLength` props to `Input` component interface and pass them through to `TextInput`

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] No regressions to existing Input usages (new props are optional)