### PR TITLE
feat: send OTP via email in production mode (#1691)

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, BadRequestException, UnauthorizedException, HttpException, HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../notifications/email.service';
 import { Role } from '@prisma/client';
 
 const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -33,6 +34,7 @@ export class AuthService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwt: JwtService,
+    private readonly emailService: EmailService,
   ) {}
 
   private generateTokens(user: { id: string; email: string; role: Role }): TokenPair {
@@ -59,9 +61,11 @@ export class AuthService {
       data: { email: email.toLowerCase(), code, expiresAt },
     });
 
-    // In dev mode: log code to console. In prod: send email (implement later)
+    // In dev mode: log code to console. In prod: send email via EmailService
     if (process.env.DEV_AUTH === 'true') {
       console.log(`[DEV] OTP for ${email}: ${code}`);
+    } else {
+      await this.emailService.sendOtp(email.toLowerCase(), code);
     }
 
     return { message: 'OTP sent to email' };

--- a/api/src/notifications/email.service.ts
+++ b/api/src/notifications/email.service.ts
@@ -89,6 +89,25 @@ export class EmailService {
     }
   }
 
+  /** Send a one-time password to the user */
+  async sendOtp(email: string, code: string): Promise<void> {
+    if (!this.transporter) {
+      this.logger.log(`[DEV] OTP for ${email}: ${code} (SMTP not configured, email not sent)`);
+      return;
+    }
+
+    try {
+      await this.send({
+        to: email,
+        subject: 'Ваш код для входа — Налоговик',
+        text: `Ваш код для входа: ${code}\n\nКод действителен 10 минут. Если вы не запрашивали код, проигнорируйте это письмо.`,
+      });
+      this.logger.log(`OTP email sent to ${email}`);
+    } catch (err) {
+      this.logger.error(`[sendOtp] Failed to send OTP email to ${email}`, err);
+    }
+  }
+
   private async send(opts: { to: string; subject: string; text: string }): Promise<void> {
     if (!this.transporter) return;
 


### PR DESCRIPTION
## Summary
- Added `sendOtp()` method to `EmailService` with graceful SMTP fallback
- Injected `EmailService` into `AuthService` (available via `@Global()` `NotificationsModule`)
- `requestOtp()` now calls `emailService.sendOtp()` when `DEV_AUTH !== 'true'`
- Dev mode unchanged: OTP = 000000, console.log only

## Test plan
- [ ] Verify dev mode still works (DEV_AUTH=true → 000000, no email sent)
- [ ] Verify prod mode sends email when SMTP is configured
- [ ] Verify graceful fallback when SMTP_HOST not set (logs instead of crashing)