### PR TITLE
fix: show specialist nick/displayName instead of email (#1799 #1797 #1798)

### DIFF
--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -19,10 +19,16 @@ import { EmptyState } from '../../../components/EmptyState';
 import { useBreakpoints } from '../../../hooks/useBreakpoints';
 import { useAuth } from '../../../stores/authStore';
 
+interface SpecialistProfile {
+  nick?: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
+
 interface ResponseItem {
   id: string;
   message: string;
-  specialist: { id: string; email: string };
+  specialist: { id: string; email: string; specialistProfile?: SpecialistProfile | null };
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary

- Update `ResponseItem.specialist` type in `requests/index.tsx` to include `specialistProfile` (nick, displayName, avatarUrl) — aligns TypeScript interface with actual API response shape
- Backend `findMy()` in `requests.service.ts` already returns `specialistProfile` with nick/displayName/avatarUrl
- Backend `getThreads()` in `chat.service.ts` already computes `name = displayName || nick || email prefix` for each participant
- Frontend `[id].tsx` (request detail) already renders `displayName || nick || email.split('@')[0]` for specialist name
- Frontend `messages/index.tsx` and `messages/[threadId].tsx` already use `participant.name` from backend

## Test plan
- [ ] Open a request with responses — specialist shows nick/displayName, not email
- [ ] Open messages list — threads show nick/displayName, not email
- [ ] Open a chat thread — header shows nick/displayName, not email
- [ ] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)