### PR TITLE
feat: SEO meta tags + category/budget filter on requests feed (#1793 #1801)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -49,8 +49,18 @@ export class RequestsController {
   // GET /requests — authenticated feed (specialists browse)
   @Get()
   @UseGuards(JwtAuthGuard)
-  getFeed(@Query('city') city?: string, @Query('page') page?: string) {
-    return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1);
+  getFeed(
+    @Query('city') city?: string,
+    @Query('page') page?: string,
+    @Query('category') category?: string,
+    @Query('maxBudget') maxBudget?: string,
+  ) {
+    return this.requestsService.findFeed(
+      city,
+      page ? parseInt(page, 10) : 1,
+      category,
+      maxBudget ? parseInt(maxBudget, 10) : undefined,
+    );
   }
 
   // GET /requests/:id — client gets single request with responses

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -69,13 +69,17 @@ export class RequestsService {
     }
   }
 
-  async findFeed(city?: string, page = 1) {
+  async findFeed(city?: string, page = 1, category?: string, maxBudget?: number) {
     // #1855: Sanitize page to prevent negative skip
     const pageNum = Math.max(1, parseInt(page as unknown as string) || 1);
 
     const where: any = { status: RequestStatus.OPEN };
     // #1849: Case-insensitive city filter
     if (city) where.city = { equals: city, mode: 'insensitive' };
+    // #1801: Category filter (case-insensitive contains)
+    if (category) where.category = { contains: category, mode: 'insensitive' };
+    // #1801: Max budget filter
+    if (maxBudget && maxBudget > 0) where.budget = { lte: maxBudget };
 
     const skip = (pageNum - 1) * PAGE_SIZE;
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,7 +10,10 @@ import {
   Image,
 } from 'react-native';
 import { useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
 import { Typography, BorderRadius } from '../constants/Colors';
+
+const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 import { useBreakpoints } from '../hooks/useBreakpoints';
 import { LandingHeader } from '../components/LandingHeader';
 
@@ -122,6 +125,13 @@ export default function LandingScreen() {
   return (
     <SafeAreaView style={styles.safe}>
       <Stack.Screen options={{ title: 'Налоговик — найдите налогового специалиста' }} />
+      <Head>
+        <title>Налоговик — найдите налогового специалиста</title>
+        <meta name="description" content="Налоговые консультанты и юристы в вашем городе. Опишите задачу бесплатно и получите предложения от проверенных специалистов." />
+        <meta property="og:title" content="Налоговик — найдите налогового специалиста" />
+        <meta property="og:description" content="Налоговые консультанты и юристы в вашем городе. Опишите задачу бесплатно и получите предложения от проверенных специалистов." />
+        <meta property="og:url" content={APP_URL} />
+      </Head>
       <ScrollView
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -11,6 +11,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
@@ -32,6 +33,15 @@ const CATEGORY_FILTERS = [
   { label: 'Вычеты', value: 'Вычеты' },
   { label: 'Аудит', value: 'Аудит' },
 ];
+
+const BUDGET_FILTERS = [
+  { label: 'Любой', value: 0 },
+  { label: 'до 5 000 ₽', value: 5000 },
+  { label: 'до 10 000 ₽', value: 10000 },
+  { label: 'до 50 000 ₽', value: 50000 },
+];
+
+const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 
 interface RequestItem {
   id: string;
@@ -65,6 +75,7 @@ export default function RequestsFeedScreen() {
   const [error, setError] = useState('');
   const [cityFilter, setCityFilter] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');
+  const [maxBudget, setMaxBudget] = useState(0);
   const [activeOnly, setActiveOnly] = useState(true);
 
   const fetchFeed = useCallback(
@@ -78,6 +89,9 @@ export default function RequestsFeedScreen() {
       try {
         const params = new URLSearchParams();
         if (cityFilter.trim()) params.set('city', cityFilter.trim());
+        // #1801: Pass category and maxBudget to API for server-side filtering
+        if (selectedCategory) params.set('category', selectedCategory);
+        if (maxBudget > 0) params.set('maxBudget', String(maxBudget));
         params.set('page', String(pageNum));
         const data = await api.get<FeedResponse>(`/requests?${params.toString()}`);
 
@@ -100,14 +114,19 @@ export default function RequestsFeedScreen() {
         setRefreshing(false);
       }
     },
-    [cityFilter],
+    [cityFilter, selectedCategory, maxBudget],
   );
 
-  // Debounce city filter
+  // Debounce city filter; reset page on any filter change
   useEffect(() => {
     const timer = setTimeout(() => fetchFeed({ replace: true }), cityFilter ? 400 : 0);
     return () => clearTimeout(timer);
   }, [fetchFeed, cityFilter]);
+
+  // Immediately refetch when category or budget changes
+  useEffect(() => {
+    fetchFeed({ replace: true });
+  }, [selectedCategory, maxBudget]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleRefresh() {
     setRefreshing(true);
@@ -180,25 +199,24 @@ export default function RequestsFeedScreen() {
     );
   }
 
-  // Client-side filtering by category and active status
+  // Client-side filter: activeOnly toggle (API returns OPEN only; toggle shows all when disabled)
   const filteredItems = useMemo(() => {
-    let result = items;
-    if (selectedCategory) {
-      result = result.filter((item) =>
-        item.category?.includes(selectedCategory) || item.description.includes(selectedCategory),
-      );
-    }
-    if (activeOnly) {
-      result = result.filter((item) => item.status === 'OPEN');
-    }
-    return result;
-  }, [items, selectedCategory, activeOnly]);
+    if (activeOnly) return items.filter((item) => item.status === 'OPEN');
+    return items;
+  }, [items, activeOnly]);
 
   const hasMore = items.length < total;
 
   return (
     <SafeAreaView style={styles.safe}>
       <Stack.Screen options={{ title: 'Лента запросов — Налоговик' }} />
+      <Head>
+        <title>Лента запросов — Налоговик</title>
+        <meta name="description" content="Открытые запросы на налоговые, юридические и бухгалтерские услуги. Найдите специалиста в вашем городе." />
+        <meta property="og:title" content="Лента запросов — Налоговик" />
+        <meta property="og:description" content="Открытые запросы на налоговые, юридические и бухгалтерские услуги. Найдите специалиста в вашем городе." />
+        <meta property="og:url" content={`${APP_URL}/requests`} />
+      </Head>
       <LandingHeader />
       <Header title="Лента запросов" />
 
@@ -251,6 +269,32 @@ export default function RequestsFeedScreen() {
                     >
                       <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
                         {cat.label}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </ScrollView>
+            </View>
+
+            {/* Budget filter chips */}
+            <View>
+              <Text style={styles.filterLabel}>Бюджет</Text>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.chipsRow}
+              >
+                {BUDGET_FILTERS.map((b) => {
+                  const isActive = b.value === maxBudget;
+                  return (
+                    <TouchableOpacity
+                      key={b.value}
+                      onPress={() => setMaxBudget(b.value)}
+                      style={[styles.chip, isActive && styles.chipActive]}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
+                        {b.label}
                       </Text>
                     </TouchableOpacity>
                   );

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -12,6 +12,9 @@ import {
   TextInput,
 } from 'react-native';
 import { useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
+
+const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 import { api, ApiError } from '../../lib/api';
 import { formatExperience, shortFnsLabel as formatFnsLabel } from '../../lib/format';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
@@ -228,6 +231,13 @@ export default function SpecialistsCatalogScreen() {
   return (
     <SafeAreaView style={styles.safe}>
       <Stack.Screen options={{ title: 'Каталог специалистов — Налоговик' }} />
+      <Head>
+        <title>Каталог специалистов — Налоговик</title>
+        <meta name="description" content="Каталог проверенных налоговых консультантов и юристов. Выберите специалиста по городу, категории и рейтингу." />
+        <meta property="og:title" content="Каталог специалистов — Налоговик" />
+        <meta property="og:description" content="Каталог проверенных налоговых консультантов и юристов. Выберите специалиста по городу, категории и рейтингу." />
+        <meta property="og:url" content={`${APP_URL}/specialists`} />
+      </Head>
       <LandingHeader />
       <Header title="Каталог специалистов" />
 


### PR DESCRIPTION
## Summary

- **#1793**: Added `<Head>` with `og:title`, `og:description`, `og:url` to landing page, requests feed, and specialists catalog using `expo-router/head`
- **#1801**: Moved category filter from client-side JS to server-side API call; added budget filter chips (any / ≤5k / ≤10k / ≤50k) with API support (`maxBudget` param via Prisma `lte`)

## API changes
- `RequestsService.findFeed()` now accepts `category` (case-insensitive contains) and `maxBudget` (lte)
- `RequestsController.getFeed()` passes `@Query('category')` and `@Query('maxBudget')` through

## Frontend changes
- `app/index.tsx` — Head with og: tags
- `app/requests/index.tsx` — Head tags + budget chip row + server-side category/budget params in fetchFeed
- `app/specialists/index.tsx` — Head with og: tags

## Test plan
- [ ] Landing page has og:title in page source
- [ ] Requests feed: selecting category chip refetches with `?category=НДФЛ`
- [ ] Requests feed: selecting budget chip refetches with `?maxBudget=5000`
- [ ] TypeScript: `npx tsc --noEmit` passes clean in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)