### PR TITLE
feat: email change in settings (#1831)

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -37,6 +37,11 @@ export class AuthService {
     private readonly emailService: EmailService,
   ) {}
 
+  /** Public alias for generating tokens — used by UsersService for email change flow. */
+  async generateTokensPublic(user: { id: string; email: string; role: Role }): Promise<TokenPair> {
+    return this.generateTokens(user);
+  }
+
   private async generateTokens(user: { id: string; email: string; role: Role }): Promise<TokenPair> {
     const accessToken = this.jwt.sign(
       { sub: user.id, email: user.email, role: user.role },

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Delete, Get, Patch, Body, Request, UseGuards } from '@nestjs/common';
-import { IsString, IsArray, IsBoolean, IsOptional, IsIn, Length, Matches, MinLength, ArrayMinSize } from 'class-validator';
+import { Controller, Delete, Get, Patch, Post, Body, Request, UseGuards } from '@nestjs/common';
+import { IsString, IsArray, IsBoolean, IsOptional, IsIn, Length, Matches, MinLength, ArrayMinSize, IsEmail } from 'class-validator';
+import { Throttle } from '@nestjs/throttler';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { EmailThrottlerGuard } from '../auth/email-throttler.guard';
 import { UsersService } from './users.service';
 
 class SetUsernameDto {
@@ -36,6 +38,20 @@ class SetupSpecialistProfileDto {
   @IsString({ each: true })
   @IsOptional()
   fnsOffices?: string[];
+}
+
+class ChangeEmailRequestDto {
+  @IsEmail()
+  newEmail!: string;
+}
+
+class ChangeEmailConfirmDto {
+  @IsEmail()
+  newEmail!: string;
+
+  @IsString()
+  @Length(6, 6)
+  code!: string;
 }
 
 @Controller('users')
@@ -102,5 +118,35 @@ export class UsersController {
   @Delete('me')
   deleteMe(@Request() req: { user: { id: string } }) {
     return this.usersService.deleteUser(req.user.id);
+  }
+
+  /**
+   * POST /users/me/change-email/request
+   * Step 1: send OTP to the new email address.
+   * Throttled: max 3 requests per 5 minutes per IP.
+   */
+  @UseGuards(EmailThrottlerGuard)
+  @Throttle({ default: { ttl: 300000, limit: 3 } })
+  @Post('me/change-email/request')
+  requestEmailChange(
+    @Request() req: { user: { id: string } },
+    @Body() body: ChangeEmailRequestDto,
+  ) {
+    return this.usersService.requestEmailChange(req.user.id, body.newEmail);
+  }
+
+  /**
+   * POST /users/me/change-email/confirm
+   * Step 2: verify OTP, update email, return new tokens.
+   * Throttled: max 10 attempts per 5 minutes per IP.
+   */
+  @UseGuards(EmailThrottlerGuard)
+  @Throttle({ default: { ttl: 300000, limit: 10 } })
+  @Post('me/change-email/confirm')
+  confirmEmailChange(
+    @Request() req: { user: { id: string } },
+    @Body() body: ChangeEmailConfirmDto,
+  ) {
+    return this.usersService.confirmEmailChange(req.user.id, body.newEmail, body.code);
   }
 }

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,12 +1,19 @@
-import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { Role } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { AuthService, TokenPair } from '../auth/auth.service';
+import { EmailService } from '../notifications/email.service';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly authService: AuthService,
+    private readonly emailService: EmailService,
+  ) {}
 
   /** Return current user profile (id, email, role, username). */
   async getMe(userId: string): Promise<{ id: string; email: string; role: string; username: string | null }> {
@@ -155,6 +162,118 @@ export class UsersService {
     });
 
     return { emailNotifications: updated.emailNotifications };
+  }
+
+  /**
+   * Step 1: Request OTP sent to the NEW email address.
+   * Validates new email is not already registered, then sends OTP.
+   */
+  async requestEmailChange(userId: string, newEmail: string): Promise<{ message: string }> {
+    const normalizedEmail = newEmail.toLowerCase();
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    if (user.email === normalizedEmail) {
+      throw new BadRequestException('New email must be different from current email');
+    }
+
+    // Check new email is not already taken by another account
+    const taken = await this.prisma.user.findUnique({ where: { email: normalizedEmail } });
+    if (taken) {
+      throw new ConflictException('Email is already registered');
+    }
+
+    // Reuse OTP infrastructure — generate code, store in OtpCode table keyed by new email
+    const isDev = process.env.DEV_AUTH === 'true';
+    const code = isDev ? '000000' : String(Math.floor(100000 + Math.random() * 900000));
+    const expiresAt = new Date(Date.now() + OTP_TTL_MS);
+
+    await this.prisma.otpCode.create({
+      data: { email: normalizedEmail, code, expiresAt },
+    });
+
+    if (isDev) {
+      console.log(`[DEV] Email change OTP for ${normalizedEmail}: ${code}`);
+    } else {
+      await this.emailService.sendOtp(normalizedEmail, code);
+    }
+
+    return { message: 'OTP sent to new email' };
+  }
+
+  /**
+   * Step 2: Verify OTP for the new email, update email in DB, issue new tokens.
+   * Trap #3: re-checks email uniqueness to guard against race conditions.
+   */
+  async confirmEmailChange(
+    userId: string,
+    newEmail: string,
+    code: string,
+  ): Promise<TokenPair & { email: string }> {
+    const normalizedEmail = newEmail.toLowerCase();
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    if (user.email === normalizedEmail) {
+      throw new BadRequestException('New email must be different from current email');
+    }
+
+    // Find latest unused, non-expired OTP for the new email
+    const otpRecord = await this.prisma.otpCode.findFirst({
+      where: {
+        email: normalizedEmail,
+        usedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (!otpRecord) {
+      throw new BadRequestException('OTP not found or expired');
+    }
+
+    if (otpRecord.attempts >= 3) {
+      throw new UnauthorizedException('Too many OTP attempts');
+    }
+
+    if (otpRecord.code !== code) {
+      await this.prisma.otpCode.update({
+        where: { id: otpRecord.id },
+        data: { attempts: { increment: 1 } },
+      });
+      throw new UnauthorizedException('Invalid OTP');
+    }
+
+    // Mark OTP as used
+    await this.prisma.otpCode.update({
+      where: { id: otpRecord.id },
+      data: { usedAt: new Date() },
+    });
+
+    // Trap #3: re-check email uniqueness to guard against race condition
+    const takenNow = await this.prisma.user.findUnique({ where: { email: normalizedEmail } });
+    if (takenNow) {
+      throw new ConflictException('Email was just registered by another user. Please try a different email.');
+    }
+
+    // Update user email in DB
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: { email: normalizedEmail },
+    });
+
+    // Revoke all existing refresh tokens for this user (forces re-auth with new identity)
+    await this.prisma.refreshToken.updateMany({
+      where: { userId, revoked: false },
+      data: { revoked: true },
+    });
+
+    // Issue new token pair with updated email
+    const tokens = await this.authService.generateTokensPublic(updatedUser);
+
+    return { ...tokens, email: updatedUser.email };
   }
 
   /**

--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -9,6 +9,9 @@ import {
   Switch,
   Alert,
   ActivityIndicator,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
@@ -17,6 +20,8 @@ import { api, ApiError } from '../../lib/api';
 import { isAdmin } from '../../lib/adminEmails';
 import { Header } from '../../components/Header';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+
+type EmailChangeStep = 'viewing' | 'enterEmail' | 'enterOtp';
 
 interface MyReview {
   id: string;
@@ -34,13 +39,20 @@ const NOTIF_KEY = '@p2ptax_email_notif';
 
 export default function SettingsScreen() {
   const router = useRouter();
-  const { user, logout } = useAuth();
+  const { user, logout, updateEmail } = useAuth();
 
   const [emailNotif, setEmailNotif] = useState(true);
   const [notifLoading, setNotifLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [myReviews, setMyReviews] = useState<MyReview[]>([]);
   const [reviewsLoading, setReviewsLoading] = useState(false);
+
+  // Email change state machine
+  const [emailChangeStep, setEmailChangeStep] = useState<EmailChangeStep>('viewing');
+  const [newEmailInput, setNewEmailInput] = useState('');
+  const [otpInput, setOtpInput] = useState('');
+  const [emailChangeLoading, setEmailChangeLoading] = useState(false);
+  const [emailChangeError, setEmailChangeError] = useState<string | null>(null);
 
   // Load my reviews for CLIENT role
   useEffect(() => {
@@ -79,6 +91,66 @@ export default function SettingsScreen() {
     } catch {
       // Revert on failure
       setEmailNotif(!value);
+    }
+  }
+
+  function handleStartEmailChange() {
+    setNewEmailInput('');
+    setOtpInput('');
+    setEmailChangeError(null);
+    setEmailChangeStep('enterEmail');
+  }
+
+  function handleCancelEmailChange() {
+    setEmailChangeStep('viewing');
+    setNewEmailInput('');
+    setOtpInput('');
+    setEmailChangeError(null);
+  }
+
+  async function handleRequestOtp() {
+    const trimmed = newEmailInput.trim().toLowerCase();
+    if (!trimmed || !trimmed.includes('@')) {
+      setEmailChangeError('Введите корректный email');
+      return;
+    }
+    setEmailChangeError(null);
+    setEmailChangeLoading(true);
+    try {
+      await api.post('/users/me/change-email/request', { newEmail: trimmed });
+      setEmailChangeStep('enterOtp');
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось отправить код. Попробуйте позже.';
+      setEmailChangeError(msg);
+    } finally {
+      setEmailChangeLoading(false);
+    }
+  }
+
+  async function handleConfirmOtp() {
+    const trimmedEmail = newEmailInput.trim().toLowerCase();
+    const trimmedCode = otpInput.trim();
+    if (trimmedCode.length !== 6) {
+      setEmailChangeError('Введите 6-значный код');
+      return;
+    }
+    setEmailChangeError(null);
+    setEmailChangeLoading(true);
+    try {
+      const result = await api.post<{ accessToken: string; refreshToken: string; email: string }>(
+        '/users/me/change-email/confirm',
+        { newEmail: trimmedEmail, code: trimmedCode },
+      );
+      await updateEmail(result.email, result.accessToken, result.refreshToken);
+      setEmailChangeStep('viewing');
+      setNewEmailInput('');
+      setOtpInput('');
+      Alert.alert('Готово', 'Email успешно изменён');
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Неверный код или истёк срок действия.';
+      setEmailChangeError(msg);
+    } finally {
+      setEmailChangeLoading(false);
     }
   }
 
@@ -132,20 +204,116 @@ export default function SettingsScreen() {
     <SafeAreaView style={styles.safe}>
       <Header title="Настройки" showBack />
 
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
       <ScrollView
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
       >
         <View style={styles.container}>
           {/* Account section */}
           <Text style={styles.sectionTitle}>Аккаунт</Text>
           <View style={styles.card}>
-            <View style={styles.row}>
-              <Text style={styles.rowLabel}>Email</Text>
-              <Text style={styles.rowValue} numberOfLines={1}>
-                {user?.email ?? '—'}
-              </Text>
-            </View>
+            {/* Email row — collapses into edit form when changing */}
+            {emailChangeStep === 'viewing' && (
+              <TouchableOpacity
+                style={styles.row}
+                onPress={handleStartEmailChange}
+                activeOpacity={0.7}
+              >
+                <View style={styles.rowTextBlock}>
+                  <Text style={styles.rowLabel}>Email</Text>
+                  <Text style={styles.rowHint} numberOfLines={1}>{user?.email ?? '—'}</Text>
+                </View>
+                <Text style={styles.changeLink}>Изменить</Text>
+              </TouchableOpacity>
+            )}
+
+            {emailChangeStep === 'enterEmail' && (
+              <View style={styles.emailChangeBlock}>
+                <Text style={styles.emailChangeTitle}>Новый email</Text>
+                <TextInput
+                  style={styles.emailInput}
+                  value={newEmailInput}
+                  onChangeText={setNewEmailInput}
+                  placeholder="new@example.com"
+                  placeholderTextColor={Colors.textMuted}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  autoFocus
+                  editable={!emailChangeLoading}
+                />
+                {emailChangeError ? (
+                  <Text style={styles.emailChangeError}>{emailChangeError}</Text>
+                ) : null}
+                <View style={styles.emailChangeActions}>
+                  <TouchableOpacity
+                    style={[styles.emailChangeBtn, styles.emailChangeBtnSecondary]}
+                    onPress={handleCancelEmailChange}
+                    disabled={emailChangeLoading}
+                  >
+                    <Text style={styles.emailChangeBtnSecondaryText}>Отмена</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.emailChangeBtn, styles.emailChangeBtnPrimary, emailChangeLoading && styles.emailChangeBtnDisabled]}
+                    onPress={handleRequestOtp}
+                    disabled={emailChangeLoading}
+                  >
+                    {emailChangeLoading
+                      ? <ActivityIndicator size="small" color="#fff" />
+                      : <Text style={styles.emailChangeBtnPrimaryText}>Отправить код</Text>
+                    }
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+
+            {emailChangeStep === 'enterOtp' && (
+              <View style={styles.emailChangeBlock}>
+                <Text style={styles.emailChangeTitle}>Код из письма</Text>
+                <Text style={styles.emailChangeHint}>
+                  Код отправлен на {newEmailInput.trim().toLowerCase()}
+                </Text>
+                <TextInput
+                  style={styles.emailInput}
+                  value={otpInput}
+                  onChangeText={setOtpInput}
+                  placeholder="000000"
+                  placeholderTextColor={Colors.textMuted}
+                  keyboardType="number-pad"
+                  maxLength={6}
+                  autoFocus
+                  editable={!emailChangeLoading}
+                />
+                {emailChangeError ? (
+                  <Text style={styles.emailChangeError}>{emailChangeError}</Text>
+                ) : null}
+                <View style={styles.emailChangeActions}>
+                  <TouchableOpacity
+                    style={[styles.emailChangeBtn, styles.emailChangeBtnSecondary]}
+                    onPress={handleCancelEmailChange}
+                    disabled={emailChangeLoading}
+                  >
+                    <Text style={styles.emailChangeBtnSecondaryText}>Отмена</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.emailChangeBtn, styles.emailChangeBtnPrimary, emailChangeLoading && styles.emailChangeBtnDisabled]}
+                    onPress={handleConfirmOtp}
+                    disabled={emailChangeLoading}
+                  >
+                    {emailChangeLoading
+                      ? <ActivityIndicator size="small" color="#fff" />
+                      : <Text style={styles.emailChangeBtnPrimaryText}>Подтвердить</Text>
+                    }
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+
             <View style={styles.divider} />
             <View style={styles.row}>
               <Text style={styles.rowLabel}>Роль</Text>
@@ -273,6 +441,7 @@ export default function SettingsScreen() {
           </Text>
         </View>
       </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -396,5 +565,73 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.xs,
     color: Colors.textMuted,
     marginTop: 2,
+  },
+  changeLink: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+    marginLeft: Spacing.sm,
+  },
+  emailChangeBlock: {
+    paddingHorizontal: Spacing.xl,
+    paddingVertical: Spacing.lg,
+    gap: Spacing.sm,
+  },
+  emailChangeTitle: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  emailChangeHint: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+  emailInput: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    backgroundColor: Colors.bgPrimary,
+  },
+  emailChangeError: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+  },
+  emailChangeActions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  emailChangeBtn: {
+    flex: 1,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 40,
+  },
+  emailChangeBtnPrimary: {
+    backgroundColor: Colors.brandPrimary,
+  },
+  emailChangeBtnPrimaryText: {
+    color: '#fff',
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  emailChangeBtnSecondary: {
+    backgroundColor: Colors.bgPrimary,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  emailChangeBtnSecondaryText: {
+    color: Colors.textSecondary,
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  emailChangeBtnDisabled: {
+    opacity: 0.6,
   },
 });

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
-import { setToken, clearToken, clearRefreshToken, onUnauthorized, TOKEN_KEY, tryRefreshTokens, getToken } from '../lib/api';
+import { setToken, setRefreshToken, clearToken, clearRefreshToken, onUnauthorized, TOKEN_KEY, tryRefreshTokens, getToken } from '../lib/api';
 import { secureStorage } from './storage';
 
 const USER_KEY = '@p2ptax_user';
@@ -23,7 +23,8 @@ type AuthAction =
   | { type: 'LOGOUT' }
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'RESTORE'; payload: { token: string; user: AuthUser } | null }
-  | { type: 'SET_USERNAME'; payload: string };
+  | { type: 'SET_USERNAME'; payload: string }
+  | { type: 'SET_EMAIL'; payload: { email: string; token: string } };
 
 function authReducer(state: AuthState, action: AuthAction): AuthState {
   switch (action.type) {
@@ -50,6 +51,13 @@ function authReducer(state: AuthState, action: AuthAction): AuthState {
         ...state,
         user: { ...state.user, username: action.payload, isNewUser: false },
       };
+    case 'SET_EMAIL':
+      if (!state.user) return state;
+      return {
+        ...state,
+        token: action.payload.token,
+        user: { ...state.user, email: action.payload.email },
+      };
     default:
       return state;
   }
@@ -66,6 +74,7 @@ interface AuthContextValue extends AuthState {
   logout: () => Promise<void>;
   setLoading: (loading: boolean) => void;
   completeOnboarding: (username: string) => Promise<void>;
+  updateEmail: (email: string, accessToken: string, refreshToken: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -153,12 +162,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
+  // Called after successful email change — replaces email and new tokens in state + storage
+  const updateEmail = useCallback(async (email: string, accessToken: string, refreshToken: string) => {
+    await Promise.all([
+      setToken(accessToken),
+      setRefreshToken(refreshToken),
+    ]);
+    dispatch({ type: 'SET_EMAIL', payload: { email, token: accessToken } });
+    // Persist updated user email to secure storage
+    const userJson = await secureStorage.getItem(USER_KEY);
+    if (userJson) {
+      const existing = JSON.parse(userJson) as AuthUser;
+      const updated: AuthUser = { ...existing, email };
+      await secureStorage.setItem(USER_KEY, JSON.stringify(updated));
+    }
+  }, []);
+
   const value: AuthContextValue = {
     ...state,
     login,
     logout,
     setLoading,
     completeOnboarding,
+    updateEmail,
   };
 
   return React.createElement(AuthContext.Provider, { value }, children);


### PR DESCRIPTION
## Summary

- Add 2-step email change flow using existing OTP infrastructure
- `POST /users/me/change-email/request` — validates new email is free, sends OTP to new address (throttled 3/5min)
- `POST /users/me/change-email/confirm` — verifies OTP, updates email in DB, revokes all refresh tokens, returns new token pair
- `settings.tsx` — inline state machine: viewing → enterEmail → enterOtp → viewing, with TextInput, loading states, error messages
- `authStore` — new `updateEmail` action stores new email + new tokens in state and SecureStore

## Trap mitigations

- Race condition: email uniqueness re-checked in `confirmEmailChange` after OTP verify
- Circular dep: avoided by adding `generateTokensPublic` wrapper on `AuthService` (no forwardRef needed)
- Throttle: `@Throttle` + `EmailThrottlerGuard` on both new endpoints
- Stale JWT: old refresh tokens revoked, new token pair issued and stored immediately

## Test plan

- [ ] Login → Settings → tap email row → "Изменить" appears
- [ ] Enter new email → tap "Отправить код" → OTP sent (dev: 000000)
- [ ] Enter 000000 → tap "Подтвердить" → email updates in UI, stays logged in
- [ ] Try confirming with wrong code → error shown, attempt counter increments
- [ ] Try using same email → error "Email must be different"
- [ ] Try already-registered email → error "Email already registered"