### PR TITLE
fix: services price structure — fix onboarding bug + parse name/price (#1803)

### DIFF
--- a/api/prisma/migrations/20260403000000_fix_services_array/migration.sql
+++ b/api/prisma/migrations/20260403000000_fix_services_array/migration.sql
@@ -1,0 +1,9 @@
+-- Fix onboarding bug: split comma-joined service strings into proper arrays
+-- Profiles created via onboarding before this fix had services stored as
+-- a single-element array containing a comma-separated string, e.g.:
+--   ["Декларации 3-НДФЛ, Налоговые споры, Оптимизация налогов"]
+-- This migration splits them into proper multi-element arrays.
+UPDATE "specialist_profiles"
+SET services = string_to_array(services[1], ', ')
+WHERE array_length(services, 1) = 1
+  AND services[1] LIKE '%,%';

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -28,9 +28,10 @@ class SetupSpecialistProfileDto {
   @ArrayMinSize(1)
   cities!: string[];
 
-  @IsString()
-  @MinLength(1)
-  services!: string;
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMinSize(1)
+  services!: string[];
 
   @IsArray()
   @IsString({ each: true })

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -64,7 +64,7 @@ export class UsersService {
   async setupSpecialistProfile(
     userId: string,
     cities: string[],
-    services: string,
+    services: string[],
     fnsOffices?: string[],
   ): Promise<{ ok: true }> {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
@@ -79,8 +79,8 @@ export class UsersService {
 
     if (!user.username) throw new BadRequestException('Username must be set before creating specialist profile');
 
-    const trimmedServices = services.trim();
-    if (!trimmedServices) throw new BadRequestException('Services description cannot be empty');
+    const trimmedServices = services.map((s) => s.trim()).filter(Boolean);
+    if (trimmedServices.length === 0) throw new BadRequestException('Services description cannot be empty');
 
     const trimmedCities = cities.map((c) => c.trim()).filter(Boolean);
     if (trimmedCities.length === 0) throw new BadRequestException('At least one city must be selected');
@@ -97,7 +97,7 @@ export class UsersService {
           where: { userId },
           data: {
             cities: trimmedCities,
-            services: [trimmedServices],
+            services: trimmedServices,
             ...(trimmedFnsOffices.length > 0 && { fnsOffices: trimmedFnsOffices }),
           },
         }),
@@ -117,7 +117,7 @@ export class UsersService {
             userId,
             nick: user.username,
             cities: trimmedCities,
-            services: [trimmedServices],
+            services: trimmedServices,
             fnsOffices: trimmedFnsOffices,
             badges: [],
           },

--- a/app/(onboarding)/services.tsx
+++ b/app/(onboarding)/services.tsx
@@ -87,8 +87,8 @@ export default function ServicesScreen() {
 
   async function handleSubmit() {
     const trimmed = services.trim();
-    const combined = [...selectedChips, ...(trimmed ? [trimmed] : [])].join(', ');
-    if (!combined) {
+    const combined = [...selectedChips, ...(trimmed ? [trimmed] : [])];
+    if (combined.length === 0) {
       setError('Расскажите о своих услугах');
       return;
     }

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -372,12 +372,18 @@ export default function SpecialistProfileScreen() {
         <View style={styles.sectionCard}>
           <Text style={styles.sectionTitle}>Услуги и цены</Text>
           <View style={styles.servicesList}>
-            {profile.services.map((svc, idx) => (
-              <View key={idx} style={styles.serviceCard}>
-                <Text style={styles.serviceCheckmark}>{'\u2713'}</Text>
-                <Text style={styles.serviceText}>{svc}</Text>
-              </View>
-            ))}
+            {profile.services.map((svc, idx) => {
+              const separatorMatch = svc.match(/^(.+?)\s*(?:—|-{1,3})\s*(.+)$/);
+              const name = separatorMatch ? separatorMatch[1].trim() : svc.trim();
+              const price = separatorMatch ? separatorMatch[2].trim() : undefined;
+              return (
+                <View key={idx} style={styles.serviceCard}>
+                  <Text style={styles.serviceCheckmark}>{'\u2713'}</Text>
+                  <Text style={styles.serviceText}>{name}</Text>
+                  {price ? <Text style={styles.servicePrice}>{price}</Text> : null}
+                </View>
+              );
+            })}
           </View>
         </View>
       )}
@@ -810,6 +816,12 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: '#4A6B88',
     lineHeight: 22,
+  },
+  servicePrice: {
+    fontSize: 14,
+    color: '#1A5BA8',
+    fontWeight: '600',
+    flexShrink: 0,
   },
 
   // Experience


### PR DESCRIPTION
## Summary

- Fix onboarding: services sent as `string[]` array not comma-joined string
- Fix DTO: `services` field is now `string[]` with `@IsArray()` validation
- Fix `users.service.ts`: accept and store `string[]` directly, no single-element wrapping
- Public profile `[nick].tsx`: parse `"Name -- Price"` pattern in each service card, render price right-aligned in blue
- Data migration: split existing corrupted comma-joined arrays (e.g. `["A, B, C"]` → `["A", "B", "C"]`)

## Test plan

- [ ] Register new specialist via onboarding, pick chips + type custom service — verify profile shows separate cards
- [ ] Open existing specialist at `/specialists/<nick>` — services section shows individual cards, not one long string
- [ ] Add service with format `"Консультация — 5000 руб"` — public profile shows name left, price right in blue
- [ ] Services without price format render normally (name only, no price column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)