### PR TITLE
fix: services dedup — index-based removal in profile edit (#1844)

### DIFF
--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -126,8 +126,8 @@ export default function SpecialistProfileScreen() {
     setServiceInput('');
   }
 
-  function removeService(svc: string) {
-    setServices((prev) => prev.filter((s) => s !== svc));
+  function removeService(idx: number) {
+    setServices((prev) => prev.filter((_, i) => i !== idx));
   }
 
   async function pickAvatar() {
@@ -370,7 +370,7 @@ export default function SpecialistProfileScreen() {
               {services.map((svc, idx) => (
                 <View key={`${svc}-${idx}`} style={styles.serviceRow}>
                   <Text style={styles.serviceText} numberOfLines={2}>{svc}</Text>
-                  <TouchableOpacity onPress={() => removeService(svc)} hitSlop={8}>
+                  <TouchableOpacity onPress={() => removeService(idx)} hitSlop={8}>
                     <Text style={styles.tagRemove}>{'×'}</Text>
                   </TouchableOpacity>
                 </View>


### PR DESCRIPTION
## Summary
- `removeService` in `profile.tsx` was filtering by string value (`s !== svc`), which removed ALL entries with the same string — making it impossible to have two services with identical names but different prices
- Changed to index-based filtering (`i !== idx`), matching the pattern already used in `specialist-profile.tsx` (creation screen)
- JSX call site updated to pass `idx` instead of `svc`

## Test plan
- [ ] Add "Консультация — 3000 руб" and "Консультация — 5000 руб" on profile edit screen
- [ ] Remove only one — verify the other stays in the list
- [ ] Save — verify both (or one) persist correctly in profile

Fixes #1844