### PR TITLE
fix: check emailNotifications flag before sending emails (#1992)

### DIFF
--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -165,9 +165,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ): Promise<void> {
     const recipient = await this.prisma.user.findUnique({
       where: { id: recipientId },
-      select: { email: true },
+      select: { email: true, emailNotifications: true },
     });
-    if (recipient?.email) {
+    if (recipient?.email && recipient.emailNotifications) {
       this.emailService.notifyNewMessage(recipient.email, senderEmail, threadId);
     }
   }

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -57,11 +57,12 @@ export class RequestsService {
     // so we fetch all profiles and filter in JS with toLowerCase()
     const cityLower = city.toLowerCase();
     const profiles = await this.prisma.specialistProfile.findMany({
-      include: { user: { select: { email: true } } },
+      include: { user: { select: { email: true, emailNotifications: true } } },
     });
 
     const emails = profiles
       .filter((p) => p.cities.some((c) => c.toLowerCase() === cityLower))
+      .filter((p) => p.user.emailNotifications)
       .map((p) => p.user.email);
 
     if (emails.length > 0) {
@@ -148,7 +149,7 @@ export class RequestsService {
     // Check request exists and is open
     const request = await this.prisma.request.findUnique({
       where: { id: requestId },
-      include: { client: { select: { id: true, email: true } } },
+      include: { client: { select: { id: true, email: true, emailNotifications: true } } },
     });
     if (!request) throw new NotFoundException('Request not found');
     if (request.status !== RequestStatus.OPEN) {
@@ -203,7 +204,9 @@ export class RequestsService {
     });
 
     // Notify client about new response — fire-and-forget
-    this.emailService.notifyNewResponse(request.client.email, requestId, specialistId);
+    if (request.client.emailNotifications) {
+      this.emailService.notifyNewResponse(request.client.email, requestId, specialistId);
+    }
 
     return result;
   }


### PR DESCRIPTION
## Summary
- `respond()` in requests.service.ts: added `emailNotifications` to client select, wrapped `notifyNewResponse` call in `if (request.client.emailNotifications)`
- `notifySpecialistsAsync()` in requests.service.ts: added `emailNotifications` to user select, filter out profiles where `p.user.emailNotifications` is false before building emails array
- `notifyRecipientAsync()` in chat.gateway.ts: added `emailNotifications` to select, guard changed from `if (recipient?.email)` to `if (recipient?.email && recipient.emailNotifications)`

OTP emails (`sendOtp`) are NOT affected — they always send regardless of the flag.

## Test plan
- [ ] User with emailNotifications=false responds to request → client receives no email
- [ ] User with emailNotifications=false is offline in chat → receives no message notification email
- [ ] Specialist with emailNotifications=false → not included in new-request city notifications
- [ ] Users with emailNotifications=true continue to receive all emails as before