### PR TITLE
fix: GET /requests public via OptionalJwtAuthGuard

### DIFF
--- a/api/src/auth/optional-jwt-auth.guard.ts
+++ b/api/src/auth/optional-jwt-auth.guard.ts
@@ -1,0 +1,14 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+
+  handleRequest(err: any, user: any) {
+    // Do NOT throw on missing/invalid token — just return null
+    return user || null;
+  }
+}

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -15,6 +15,7 @@ import { RespondRequestDto } from './dto/respond-request.dto';
 import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
 import { UpdateRequestDto } from './dto/update-request.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { Role } from '@prisma/client';
@@ -46,9 +47,9 @@ export class RequestsController {
     return this.requestsService.findMyResponses(req.user.id);
   }
 
-  // GET /requests — authenticated feed (specialists browse)
+  // GET /requests — public feed accessible without authentication
   @Get()
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(OptionalJwtAuthGuard)
   getFeed(
     @Query('city') city?: string,
     @Query('page') page?: string,


### PR DESCRIPTION
Fixes #1989. Replaces JwtAuthGuard with OptionalJwtAuthGuard on getFeed endpoint so unauthenticated users can access the public requests feed.