### PR TITLE
fix(requests): make GET /requests/:id public, split owner vs public data

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -64,11 +64,11 @@ export class RequestsController {
     );
   }
 
-  // GET /requests/:id — client gets single request with responses
+  // GET /requests/:id — public, owner gets full data including responses
   @Get(':id')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(OptionalJwtAuthGuard)
   getById(@Request() req: any, @Param('id') id: string) {
-    return this.requestsService.findById(id, req.user.id);
+    return this.requestsService.findById(id, req.user?.id ?? null);
   }
 
   // POST /requests/:id/respond — specialist responds to a request

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -122,7 +122,7 @@ export class RequestsService {
     });
   }
 
-  async findById(requestId: string, userId: string) {
+  async findById(requestId: string, userId: string | null) {
     const request = await this.prisma.request.findUnique({
       where: { id: requestId },
       include: {
@@ -141,8 +141,14 @@ export class RequestsService {
       },
     });
     if (!request) throw new NotFoundException('Request not found');
-    if (request.clientId !== userId) throw new ForbiddenException('Not your request');
-    return request;
+
+    // Owner gets full data; everyone else gets public fields only (no clientId, no responses)
+    if (userId !== null && userId === request.clientId) {
+      return request;
+    }
+
+    const { clientId: _omit, responses: _resp, ...publicFields } = request;
+    return publicFields;
   }
 
   async respond(specialistId: string, requestId: string, dto: RespondRequestDto) {

--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -26,8 +26,9 @@ interface RequestDetail {
   category?: string | null;
   status: string;
   createdAt: string;
-  client: { id: string };
+  client?: { id: string };
   _count: { responses: number };
+  responses?: any[];
 }
 
 function formatDate(iso: string) {
@@ -59,37 +60,11 @@ export default function RequestDetailScreen() {
       setLoading(true);
       setError('');
       try {
-        // Try fetching the specific request from the feed endpoint
-        const params = new URLSearchParams();
-        params.set('page', '1');
-        const data = await api.get<{ items: RequestDetail[]; total: number }>(
-          `/requests?${params.toString()}`,
-        );
-        const found = data.items.find((item) => item.id === id);
-        if (found) {
-          if (!cancelled) setRequest(found);
-        } else {
-          // Try loading more pages to find the request
-          let page = 2;
-          let foundItem: RequestDetail | null = null;
-          while (page <= Math.ceil(data.total / 20) + 1 && !foundItem && !cancelled) {
-            const moreData = await api.get<{ items: RequestDetail[] }>(
-              `/requests?page=${page}`,
-            );
-            foundItem = moreData.items.find((item) => item.id === id) || null;
-            page++;
-          }
-          if (foundItem && !cancelled) {
-            setRequest(foundItem);
-          } else if (!cancelled) {
-            setError('Запрос не найден');
-          }
-        }
+        const data = await api.get<RequestDetail>(`/requests/${id}`);
+        if (!cancelled) setRequest(data);
       } catch (err) {
         if (!cancelled) {
-          if (err instanceof ApiError && err.status === 401) {
-            setError('Войдите чтобы увидеть детали запроса');
-          } else if (err instanceof ApiError) {
+          if (err instanceof ApiError) {
             setError(err.message);
           } else {
             setError('Не удалось загрузить запрос');


### PR DESCRIPTION
## Summary
- Add `OptionalJwtAuthGuard` — allows unauthenticated requests through without 403
- Apply it to `GET /requests/:id` (was `JwtAuthGuard`, causing 403 for all unauthenticated users)
- `findById` signature: `userId: string | null`
- Non-owner / unauthenticated: returns public fields only (`id`, `description`, `city`, `budget`, `category`, `status`, `createdAt`, `_count`) — no `clientId`, no `responses`
- Owner: returns full data including `responses` array
- Frontend `app/requests/[id].tsx`: replaced the broken feed-pagination workaround with a direct `api.get('/requests/' + id)` call

## Test plan
- [ ] Unauthenticated `GET /requests/:id` returns 200 with public fields
- [ ] Authenticated owner gets full data including `responses`
- [ ] Authenticated non-owner gets public fields only (no `clientId`, no `responses`)
- [ ] Frontend request detail page loads without login
- [ ] TS check: no new errors introduced

Closes #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)