### PR TITLE
fix(frontend): remove dead IN_PROGRESS status references

### DIFF
--- a/app/(dashboard)/requests/index.tsx
+++ b/app/(dashboard)/requests/index.tsx
@@ -94,16 +94,14 @@ export default function MyRequestsScreen() {
 
   const filtered = items.filter((r) =>
     tab === 'active'
-      ? r.status === 'OPEN' || r.status === 'IN_PROGRESS'
-      : r.status !== 'OPEN' && r.status !== 'IN_PROGRESS',
+      ? r.status === 'OPEN'
+      : r.status !== 'OPEN',
   );
 
   function getStatusConfig(status: string) {
     switch (status) {
       case 'OPEN':
         return { label: 'Открыт', bg: Colors.statusBg.info, color: Colors.brandPrimary };
-      case 'IN_PROGRESS':
-        return { label: 'В работе', bg: Colors.statusBg.success, color: Colors.statusSuccess };
       default:
         return { label: 'Закрыт', bg: Colors.statusBg.warning, color: Colors.textMuted };
     }


### PR DESCRIPTION
## Summary
- Remove `IN_PROGRESS` from active tab filter (`r.status === 'OPEN' || r.status === 'IN_PROGRESS'` → `r.status === 'OPEN'`)
- Remove `IN_PROGRESS` from archive tab filter (`r.status !== 'OPEN' && r.status !== 'IN_PROGRESS'` → `r.status !== 'OPEN'`)
- Remove dead `case 'IN_PROGRESS'` from `getStatusConfig` switch — `default` already handles CLOSED/CANCELLED correctly

`IN_PROGRESS` is not in Prisma `RequestStatus` enum (only `OPEN`, `CLOSED`, `CANCELLED`), so this code could never execute.

## Test plan
- [ ] Active tab shows only OPEN requests
- [ ] Archive tab shows CLOSED + CANCELLED requests
- [ ] `tsc --noEmit` passes (confirmed locally)

Trinity: #1994