### PR TITLE
feat(auth): cron cleanup for expired OTP codes and revoked refresh tokens

### DIFF
--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
 import { EmailThrottlerGuard } from './email-throttler.guard';
+import { CleanupService } from './cleanup.service';
 
 @Module({
   imports: [
@@ -15,7 +16,7 @@ import { EmailThrottlerGuard } from './email-throttler.guard';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, EmailThrottlerGuard],
+  providers: [AuthService, JwtStrategy, EmailThrottlerGuard, CleanupService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/api/src/auth/cleanup.service.ts
+++ b/api/src/auth/cleanup.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class CleanupService {
+  private readonly logger = new Logger(CleanupService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Runs every hour at minute 0. All times are UTC.
+  @Cron('0 * * * *')
+  async cleanupExpiredOtpCodes(): Promise<void> {
+    const { count: otpCount } = await this.prisma.otpCode.deleteMany({
+      where: {
+        expiresAt: { lt: new Date() },
+      },
+    });
+
+    this.logger.log(`Deleted ${otpCount} expired OTP codes`);
+  }
+
+  // Runs every day at 03:00 UTC.
+  @Cron('0 3 * * *')
+  async cleanupRevokedRefreshTokens(): Promise<void> {
+    const { count: tokenCount } = await this.prisma.refreshToken.deleteMany({
+      where: {
+        OR: [
+          { revoked: true },
+          { expiresAt: { lt: new Date() } },
+        ],
+      },
+    });
+
+    this.logger.log(`Deleted ${tokenCount} revoked refresh tokens`);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `CleanupService` in `AuthModule` with two `@Cron` jobs
- Every hour: delete `OtpCode` records where `expiresAt < now`
- Daily at 03:00 UTC: delete `RefreshToken` records where `revoked = true` or `expiresAt < now`

## Details
`ScheduleModule.forRoot()` was already registered in `AppModule`. No new dependencies needed.

Closes #1993