### PR TITLE
feat(admin): user blocking — isBlocked field + JWT guard + admin toggle

### DIFF
--- a/api/prisma/migrations/20260403500000_add_user_is_blocked/migration.sql
+++ b/api/prisma/migrations/20260403500000_add_user_is_blocked/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "isBlocked" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User {
   email       String    @unique
   username    String?   @unique
   role               Role      @default(CLIENT)
+  isBlocked          Boolean   @default(false)
   emailNotifications Boolean   @default(true)
   createdAt          DateTime  @default(now())
   lastLoginAt        DateTime?

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,6 +1,9 @@
 import {
   Controller,
   Get,
+  Patch,
+  Param,
+  Body,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -24,6 +27,13 @@ export class AdminController {
   @UseGuards(JwtAuthGuard, AdminGuard)
   getUsers(@Query('role') role?: string) {
     return this.adminService.getUsers(role);
+  }
+
+  /** PATCH /admin/users/:id — block or unblock a user */
+  @Patch('users/:id')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  blockUser(@Param('id') id: string, @Body('isBlocked') isBlocked: boolean) {
+    return this.adminService.blockUser(id, isBlocked);
   }
 
   /** GET /admin/specialists — all specialist profiles */

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -43,6 +43,7 @@ export class AdminService {
         id: true,
         email: true,
         role: true,
+        isBlocked: true,
         createdAt: true,
         lastLoginAt: true,
         specialistProfile: {
@@ -60,6 +61,14 @@ export class AdminService {
           select: { id: true, email: true, createdAt: true, lastLoginAt: true },
         },
       },
+    });
+  }
+
+  async blockUser(id: string, isBlocked: boolean) {
+    return this.prisma.user.update({
+      where: { id },
+      data: { isBlocked },
+      select: { id: true, email: true, isBlocked: true },
     });
   }
 

--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, ForbiddenException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PrismaService } from '../prisma/prisma.service';
@@ -23,6 +23,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: JwtPayload) {
     const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
     if (!user) throw new UnauthorizedException();
+    if (user.isBlocked) throw new ForbiddenException('Account blocked');
     return { id: user.id, email: user.email, role: user.role };
   }
 }

--- a/app/(admin)/users.tsx
+++ b/app/(admin)/users.tsx
@@ -19,6 +19,7 @@ interface UserItem {
   id: string;
   email: string;
   role: 'CLIENT' | 'SPECIALIST';
+  isBlocked: boolean;
   createdAt: string;
   lastLoginAt: string | null;
   specialistProfile: { nick: string; cities: string[]; services: string[] } | null;
@@ -43,6 +44,7 @@ export default function AdminUsers() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [blockingId, setBlockingId] = useState<string | null>(null);
 
   const fetchUsers = useCallback(async (role: RoleFilter, isRefresh = false) => {
     if (!isRefresh) setLoading(true);
@@ -67,8 +69,32 @@ export default function AdminUsers() {
 
   const handleRefresh = () => { setRefreshing(true); fetchUsers(filter, true); };
 
-  const handleBlock = () => {
-    Alert.alert('Скоро', 'Блокировка пользователей будет доступна в следующей версии.');
+  const handleBlock = async (user: UserItem) => {
+    if (blockingId) return;
+    const nextBlocked = !user.isBlocked;
+    const label = nextBlocked ? 'заблокировать' : 'разблокировать';
+    Alert.alert(
+      nextBlocked ? 'Блокировка' : 'Разблокировка',
+      `${label.charAt(0).toUpperCase() + label.slice(1)} пользователя ${user.email}?`,
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: nextBlocked ? 'Заблокировать' : 'Разблокировать',
+          style: nextBlocked ? 'destructive' : 'default',
+          onPress: async () => {
+            setBlockingId(user.id);
+            try {
+              await api.patch(`/admin/users/${user.id}`, { isBlocked: nextBlocked });
+              setUsers(prev => prev.map(u => u.id === user.id ? { ...u, isBlocked: nextBlocked } : u));
+            } catch (e: any) {
+              Alert.alert('Ошибка', e?.message ?? 'Не удалось обновить статус');
+            } finally {
+              setBlockingId(null);
+            }
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -107,13 +133,18 @@ export default function AdminUsers() {
           ) : (
             <View style={styles.list}>
               {users.map((u) => (
-                <View key={u.id} style={styles.card}>
+                <View key={u.id} style={[styles.card, u.isBlocked && styles.cardBlocked]}>
                   <View style={styles.cardHeader}>
                     <Text style={styles.email} numberOfLines={1}>{u.email}</Text>
-                    <Badge
-                      variant={u.role === 'SPECIALIST' ? 'accent' : 'info'}
-                      label={u.role === 'SPECIALIST' ? 'Исполнитель' : 'Клиент'}
-                    />
+                    <View style={{ flexDirection: 'row', gap: Spacing.xs }}>
+                      {u.isBlocked && (
+                        <Badge variant="error" label="Заблокирован" />
+                      )}
+                      <Badge
+                        variant={u.role === 'SPECIALIST' ? 'accent' : 'info'}
+                        label={u.role === 'SPECIALIST' ? 'Исполнитель' : 'Клиент'}
+                      />
+                    </View>
                   </View>
                   {u.specialistProfile ? (
                     <Text style={styles.cardMeta} numberOfLines={1}>
@@ -123,8 +154,19 @@ export default function AdminUsers() {
                   <View style={styles.cardFooter}>
                     <Text style={styles.cardDate}>Рег: {formatDate(u.createdAt)}</Text>
                     <Text style={styles.cardDate}>Вход: {formatDate(u.lastLoginAt)}</Text>
-                    <TouchableOpacity onPress={handleBlock} style={styles.blockBtn} activeOpacity={0.75}>
-                      <Text style={styles.blockBtnText}>Блок</Text>
+                    <TouchableOpacity
+                      onPress={() => handleBlock(u)}
+                      style={[styles.blockBtn, u.isBlocked && styles.unblockBtn]}
+                      activeOpacity={0.75}
+                      disabled={blockingId === u.id}
+                    >
+                      {blockingId === u.id ? (
+                        <ActivityIndicator size="small" color={u.isBlocked ? Colors.brandPrimary : Colors.statusError} />
+                      ) : (
+                        <Text style={[styles.blockBtnText, u.isBlocked && styles.unblockBtnText]}>
+                          {u.isBlocked ? 'Разблок' : 'Блок'}
+                        </Text>
+                      )}
                     </TouchableOpacity>
                   </View>
                 </View>
@@ -231,6 +273,10 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.xs,
     color: Colors.textMuted,
   },
+  cardBlocked: {
+    borderColor: Colors.statusError,
+    opacity: 0.85,
+  },
   blockBtn: {
     marginLeft: 'auto',
     paddingHorizontal: Spacing.md,
@@ -238,10 +284,19 @@ const styles = StyleSheet.create({
     borderRadius: BorderRadius.sm,
     borderWidth: 1,
     borderColor: Colors.statusError,
+    minWidth: 60,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   blockBtnText: {
     fontSize: Typography.fontSize.xs,
     color: Colors.statusError,
     fontWeight: Typography.fontWeight.medium,
+  },
+  unblockBtn: {
+    borderColor: Colors.brandPrimary,
+  },
+  unblockBtnText: {
+    color: Colors.brandPrimary,
   },
 });


### PR DESCRIPTION
## Summary
- Prisma: `isBlocked Boolean @default(false)` on User model
- Migration: `20260403500000_add_user_is_blocked`
- JwtStrategy: returns 403 ForbiddenException if `user.isBlocked`
- `PATCH /admin/users/:id` to toggle block status
- Frontend toggle in admin/users with loading state, color feedback

Trinity: #1999