### PR TITLE
feat(promotions): 3-day expiry reminder email

### DIFF
--- a/api/prisma/migrations/20260403600000_add_promotion_reminder_sent/migration.sql
+++ b/api/prisma/migrations/20260403600000_add_promotion_reminder_sent/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "promotions" ADD COLUMN "reminderSent" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "promotions_reminderSent_expiresAt_idx" ON "promotions"("reminderSent", "expiresAt");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -153,10 +153,12 @@ model Promotion {
   city         String
   tier         PromotionTier
   expiresAt    DateTime
+  reminderSent Boolean       @default(false)
   createdAt    DateTime      @default(now())
 
   @@index([city, tier, expiresAt])
   @@index([specialistId])
+  @@index([reminderSent, expiresAt])
   @@map("promotions")
 }
 

--- a/api/src/auth/cleanup.service.ts
+++ b/api/src/auth/cleanup.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../notifications/email.service';
 
 @Injectable()
 export class CleanupService {
   private readonly logger = new Logger(CleanupService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly emailService: EmailService,
+  ) {}
 
   // Runs every hour at minute 0. All times are UTC.
   @Cron('0 * * * *')
@@ -33,5 +37,46 @@ export class CleanupService {
     });
 
     this.logger.log(`Deleted ${tokenCount} revoked refresh tokens`);
+  }
+
+  // Runs every day at 09:00 UTC. Sends reminder emails for promotions expiring within 3 days.
+  @Cron('0 9 * * *')
+  async sendPromotionExpiryReminders(): Promise<void> {
+    const now = new Date();
+    const threeDaysLater = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+    const promotions = await this.prisma.promotion.findMany({
+      where: {
+        reminderSent: false,
+        expiresAt: { gt: now, lte: threeDaysLater },
+      },
+      include: {
+        specialist: {
+          select: {
+            email: true,
+            emailNotifications: true,
+          },
+        },
+      },
+    });
+
+    const ids = promotions
+      .filter((p) => p.specialist.emailNotifications)
+      .map((p) => p.id);
+
+    for (const p of promotions) {
+      if (p.specialist.emailNotifications) {
+        await this.emailService.notifyPromotionExpiringSoon(p.specialist.email, p.city);
+      }
+    }
+
+    if (ids.length > 0) {
+      await this.prisma.promotion.updateMany({
+        where: { id: { in: ids }, reminderSent: false },
+        data: { reminderSent: true },
+      });
+    }
+
+    this.logger.log(`Promotion reminders sent: ${ids.length}`);
   }
 }

--- a/api/src/notifications/email.service.ts
+++ b/api/src/notifications/email.service.ts
@@ -89,6 +89,19 @@ export class EmailService {
     }
   }
 
+  /** Notify specialist that their promotion expires in 3 days */
+  async notifyPromotionExpiringSoon(specialistEmail: string, city: string): Promise<void> {
+    if (!process.env.SMTP_HOST) {
+      this.logger.log(`[DEV] Promotion expiry reminder → ${specialistEmail} for city ${city}`);
+      return;
+    }
+    await this.send({
+      to: specialistEmail,
+      subject: 'Продвижение истекает через 3 дня',
+      text: `Ваше продвижение в городе ${city} истекает через 3 дня.\n\nОбратитесь через чат для продления.`,
+    });
+  }
+
   /** Send a one-time password to the user */
   async sendOtp(email: string, code: string): Promise<void> {
     if (!this.transporter) {


### PR DESCRIPTION
- Prisma: reminderSent Boolean @default(false) on Promotion
- Migration: add_promotion_reminder_sent
- EmailService: notifyPromotionExpiringSoon()
- CleanupService: daily cron 09:00 UTC

Trinity: #1998