### PR TITLE
fix(auth): show friendly message on OTP rate limit

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -162,6 +162,11 @@ async function request<T>(
   }
 
   if (!response.ok) {
+    // 429 Too Many Requests — throttler fires a raw "ThrottlerException: Too Many Requests"
+    // message that is not user-friendly. Replace it here centrally for all screens.
+    if (response.status === 429) {
+      throw new ApiError(429, 'Слишком много попыток. Попробуйте через 5 минут.');
+    }
     let message = `HTTP ${response.status}`;
     try {
       const json = await response.json();


### PR DESCRIPTION
## Summary
- Перехватывает HTTP 429 (ThrottlerException) централизованно в `lib/api.ts`
- Показывает "Слишком много попыток. Попробуйте через 5 минут." вместо сырого "ThrottlerException: Too Many Requests"
- Покрывает все экраны сразу (email, otp и любые будущие)

## Test plan
- [ ] Открыть https://p2ptax.smartlaunchhub.com/email
- [ ] Ввести любой email и нажать "Получить код" 4 раза подряд
- [ ] Убедиться что показывается "Слишком много попыток. Попробуйте через 5 минут." (не сырая ошибка)

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)