### PR TITLE
fix(onboarding): replace Georgian cities placeholder with Russian city

### DIFF
--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -246,7 +246,7 @@ export default function RequestsFeedScreen() {
               label="Город"
               value={cityFilter}
               onChangeText={setCityFilter}
-              placeholder="Например, Тбилиси"
+              placeholder="Например, Москва"
               autoCapitalize="words"
             />
 


### PR DESCRIPTION
## Summary
- Replace placeholder "Например, Тбилиси" → "Например, Москва" in city filter on requests feed page
- Single-line change, no logic affected, TS passes clean

## Closes
Task #1729

## Test plan
- [ ] Open https://p2ptax.smartlaunchhub.com/requests
- [ ] City filter input shows "Например, Москва" as placeholder (was "Например, Тбилиси")

🤖 Generated with [Claude Code](https://claude.com/claude-code)