### PR TITLE
fix(landing): add 'Лента запросов' to header nav + fix Sidebar router.replace→push

### DIFF
--- a/components/LandingHeader.tsx
+++ b/components/LandingHeader.tsx
@@ -41,6 +41,12 @@ export function LandingHeader() {
               <Text style={styles.navLink}>Специалисты</Text>
             </TouchableOpacity>
             <TouchableOpacity
+              onPress={() => router.push('/requests')}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.navLink}>Лента запросов</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
               onPress={() => {
                 if (Platform.OS === 'web') {
                   document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' });
@@ -112,6 +118,13 @@ export function LandingHeader() {
             style={styles.mobileMenuItem}
           >
             <Text style={styles.mobileMenuText}>Специалисты</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => { setMenuOpen(false); router.push('/requests'); }}
+            activeOpacity={0.7}
+            style={styles.mobileMenuItem}
+          >
+            <Text style={styles.mobileMenuText}>Лента запросов</Text>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => {

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -51,7 +51,7 @@ export function Sidebar({ items, userEmail, onLogout, width }: SidebarProps) {
             <TouchableOpacity
               key={item.route}
               style={[styles.navItem, active && styles.navItemActive]}
-              onPress={() => router.replace(item.route as any)}
+              onPress={() => router.push(item.route as any)}
               activeOpacity={0.75}
             >
               <Ionicons name={item.icon} size={18} color={active ? Colors.brandPrimary : Colors.textMuted} />


### PR DESCRIPTION
## Summary
- **LandingHeader**: добавлена кнопка «Лента запросов» в desktop nav (между «Специалисты» и «Как работает») и в mobile dropdown (с `setMenuOpen(false)` перед навигацией)
- **Sidebar**: `router.replace` → `router.push` — фикс навигации на внешние роуты (например `/requests`) из-под `(dashboard)` layout

## Test plan
- [ ] Открыть https://p2ptax.smartlaunchhub.com/ неавторизованным
- [ ] Нажать «Лента запросов» в хедере (desktop) → переход на /requests
- [ ] На мобильном: открыть burger-меню → нажать «Лента запросов» → переход на /requests, меню закрывается
- [ ] Авторизоваться как специалист → сайдбар → «Лента запросов» → переход на /requests

Trinity: #1726

🤖 Generated with [Claude Code](https://claude.com/claude-code)