### PR TITLE
fix: /dashboard 404 for authenticated users

### DIFF
--- a/app/dashboard.tsx
+++ b/app/dashboard.tsx
@@ -1,0 +1,6 @@
+import { Redirect } from 'expo-router';
+
+// Redirect /dashboard → /(dashboard) so direct navigation to /dashboard works for authenticated users
+export default function DashboardRedirect() {
+  return <Redirect href="/(dashboard)" />;
+}


### PR DESCRIPTION
## Problem
Navigating directly to `/dashboard` returns 404 (hits `+not-found.tsx`) because Expo Router uses route groups with parentheses: `(dashboard)`. The URL `/dashboard` has no corresponding file.

## Fix
Added `app/dashboard.tsx` — a simple `<Redirect href="/(dashboard)" />` that catches the bare `/dashboard` path and forwards to the correct route group.

## Root Cause
Expo Router treats `(dashboard)` as a layout group (invisible in URL), so the real index lives at `/(dashboard)/index`. Any direct navigation to `/dashboard` finds no file and falls through to `+not-found.tsx`.

Fixes #1728