### PR TITLE
fix: Лента запросов menu item routes to /requests

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -10,6 +10,7 @@ import { useBreakpoints } from '../../hooks/useBreakpoints';
 const CLIENT_NAV_ITEMS: SidebarNavItem[] = [
   { label: 'Главная', icon: 'home-outline', route: '/(dashboard)', segment: 'index' },
   { label: 'Мои запросы', icon: 'document-text-outline', route: '/(dashboard)/requests', segment: 'requests' },
+  { label: 'Лента запросов', icon: 'newspaper-outline', route: '/requests', segment: 'feed' },
   { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(dashboard)/messages', segment: 'messages' },
   { label: 'Специалисты', icon: 'search-outline', route: '/specialists', segment: 'specialists' },
   { label: 'Настройки', icon: 'settings-outline', route: '/(dashboard)/settings', segment: 'settings' },


### PR DESCRIPTION
Fixes #1727

Added 'Лента запросов' item to CLIENT_NAV_ITEMS in dashboard layout, pointing to /requests (public feed).

Previously the client sidebar had no such item — clients couldn't access the public requests feed from the sidebar.