### PR TITLE
fix: chat header shows specialist nick instead of email

### DIFF
--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -36,11 +36,17 @@ interface MessagesResponse {
   pages: number;
 }
 
+interface SpecialistProfile {
+  nick: string;
+  displayName: string | null;
+}
+
 interface ThreadParticipant {
   id: string;
   email: string;
   role: string;
   name?: string;
+  specialistProfile?: SpecialistProfile | null;
 }
 
 interface ThreadItem {
@@ -107,7 +113,8 @@ export default function ThreadScreen() {
           thread.participant1.id === user.userId
             ? thread.participant2
             : thread.participant1;
-        setOtherName(other.name || other.email.split('@')[0]);
+        const profile = other.specialistProfile;
+        setOtherName(profile?.nick || profile?.displayName || other.email.split('@')[0]);
       }
     } catch {
       setLoadError(true);


### PR DESCRIPTION
Fixes #1732

## Root cause
The `ThreadParticipant` interface did not include `specialistProfile`, so the frontend relied on the computed `name` field from the API. The `name` field uses `displayName || nick || email_prefix` — if a specialist had set their `displayName` to their email, the header would show the email.

## Fix
- Added `SpecialistProfile` interface and `specialistProfile` field to `ThreadParticipant` in `[threadId].tsx`
- Updated `setOtherName` to use `nick` directly from `specialistProfile`: `nick || displayName || email_prefix`
- Nick is now always preferred over displayName, matching the expected UX