### PR TITLE
fix: promotion period taken from request, not hardcoded 30 days

### DIFF
--- a/api/src/promotions/dto/purchase-promotion.dto.ts
+++ b/api/src/promotions/dto/purchase-promotion.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEnum } from 'class-validator';
+import { IsString, IsEnum, IsOptional, IsIn } from 'class-validator';
 import { PromotionTier } from '@prisma/client';
 
 export class PurchasePromotionDto {
@@ -7,4 +7,10 @@ export class PurchasePromotionDto {
 
   @IsEnum(PromotionTier)
   tier!: PromotionTier;
+
+  // Promotion duration in months: 1 (default), 3 (-10%), 6 (-20%).
+  // Optional for backward compatibility — omitting defaults to 1 month.
+  @IsOptional()
+  @IsIn([1, 3, 6])
+  periodMonths?: 1 | 3 | 6 = 1;
 }

--- a/api/src/promotions/promotions.service.ts
+++ b/api/src/promotions/promotions.service.ts
@@ -58,17 +58,23 @@ export class PromotionsService {
       );
     }
 
-    const price = await this.getPrice(dto.city, dto.tier);
+    const months = dto.periodMonths ?? 1;
+    const basePrice = await this.getPrice(dto.city, dto.tier);
+
+    // Apply multi-month discount: 3 months = -10%, 6 months = -20%
+    const DISCOUNT: Record<number, number> = { 1: 0, 3: 0.1, 6: 0.2 };
+    const discount = DISCOUNT[months] ?? 0;
+    const price = Math.round(basePrice * months * (1 - discount));
 
     // TODO: Integrate Stripe when STRIPE_SECRET_KEY is added to Doppler
     // For now, mock payment: log and proceed
     this.logger.log(
-      `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} amount=${price} RUB`,
+      `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} months=${months} amount=${price} RUB`,
     );
 
-    // Create promotion: 30 days from now
+    // Set expiry based on requested period (calendar months from now)
     const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 30);
+    expiresAt.setMonth(expiresAt.getMonth() + months);
 
     const promotion = await this.prisma.promotion.create({
       data: {


### PR DESCRIPTION
## Summary
- `PurchasePromotionDto` gets optional `periodMonths?: 1 | 3 | 6` (default = 1, backward-compatible)
- `promotions.service.ts` reads `dto.periodMonths ?? 1` instead of hardcoded `+30 days`
- `expiresAt` set via `setMonth()` for correct calendar-month arithmetic
- Multi-month discounts applied: 3 months -10%, 6 months -20%
- Price in response reflects full multi-month total with discount

## Test plan
- [ ] POST `/promotions/purchase` without `periodMonths` → expiresAt ~1 month from now
- [ ] POST with `periodMonths: 3` → expiresAt ~3 months from now, price = base * 3 * 0.9
- [ ] POST with `periodMonths: 6` → expiresAt ~6 months from now, price = base * 6 * 0.8
- [ ] POST with invalid `periodMonths: 2` → 400 validation error

Fixes #2272

🤖 Generated with [Claude Code](https://claude.com/claude-code)