### PR TITLE
fix: унифицировать тему лендинга со светлой темой (#1731)

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -1,0 +1,25 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from 'react';
+
+// Background color matching the app's light theme (Colors.bgPrimary)
+// Prevents white flash on page load and mismatched background on overscroll
+const BG_PRIMARY = '#F4FBFC';
+
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="ru" style={{ backgroundColor: BG_PRIMARY }}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        <ScrollViewStyleReset />
+      </head>
+      <body style={{ backgroundColor: BG_PRIMARY }}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -382,7 +382,7 @@ export default function LandingScreen() {
         </View>
 
         {/* ===== SECTION 4: Typical tasks ===== */}
-        <View style={[styles.section, { backgroundColor: '#F4FBFC' }]}>
+        <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>
           <View style={[styles.sectionInner, innerStyle]}>
             <Text style={styles.sectionTitle}>{'\u0422\u0438\u043F\u0438\u0447\u043D\u044B\u0435 \u0437\u0430\u0434\u0430\u0447\u0438'}</Text>
             <Text style={styles.sectionSubtitle}>{'\u0427\u0442\u043E \u0440\u0435\u0448\u0430\u0435\u0442 \u043F\u043B\u0430\u0442\u0444\u043E\u0440\u043C\u0430'}</Text>
@@ -462,7 +462,7 @@ export default function LandingScreen() {
         </View>
 
         {/* ===== SECTION 6: Trust ===== */}
-        <View style={[styles.section, { backgroundColor: '#EBF3FB' }]}>
+        <View style={[styles.section, { backgroundColor: Colors.bgSecondary }]}>
           <View style={[styles.sectionInner, innerStyle]}>
             <Text style={styles.sectionTitle}>{'\u041A\u0430\u043A \u043C\u044B \u043F\u0440\u043E\u0432\u0435\u0440\u044F\u0435\u043C \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u043E\u0432'}</Text>
 
@@ -518,7 +518,7 @@ export default function LandingScreen() {
         </View>
 
         {/* ===== SECTION 8: FAQ ===== */}
-        <View style={[styles.section, { backgroundColor: '#F4FBFC' }]}>
+        <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>
           <View style={[styles.sectionInner, innerStyle]}>
             <Text style={styles.sectionTitle}>{'\u0427\u0430\u0441\u0442\u043E \u0437\u0430\u0434\u0430\u0432\u0430\u0435\u043C\u044B\u0435 \u0432\u043E\u043F\u0440\u043E\u0441\u044B'}</Text>
 
@@ -630,7 +630,7 @@ export default function LandingScreen() {
 const styles = StyleSheet.create({
   safe: {
     flex: 1,
-    backgroundColor: '#F4FBFC',
+    backgroundColor: Colors.bgPrimary,
   },
   scroll: {
     flexGrow: 1,
@@ -641,7 +641,7 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingVertical: 80,
     alignItems: 'center',
-    backgroundColor: '#F4FBFC',
+    backgroundColor: Colors.bgPrimary,
   },
   heroContent: {
     width: '100%',
@@ -751,7 +751,7 @@ const styles = StyleSheet.create({
   // ---- Stats Bar ----
   statsSection: {
     width: '100%',
-    backgroundColor: '#EBF3FB',
+    backgroundColor: Colors.bgSecondary,
     paddingVertical: 32,
     alignItems: 'center',
   },
@@ -917,7 +917,7 @@ const styles = StyleSheet.create({
     flex: 1,
     borderRadius: BorderRadius.lg,
     overflow: 'hidden',
-    backgroundColor: '#F4FBFC',
+    backgroundColor: Colors.bgPrimary,
   },
   forWhomCardWide: {},
   forWhomImage: {


### PR DESCRIPTION
## Summary
- Создан `app/+html.tsx` — Expo Router web shell с `backgroundColor: #F4FBFC` на `<html>` и `<body>`, устраняет белую вспышку при загрузке и отображение белого фона при перескролле страницы
- В `app/index.tsx` заменены все хардкод-значения `#F4FBFC` → `Colors.bgPrimary` и `#EBF3FB` → `Colors.bgSecondary` во всех секциях лендинга и стилях компонентов
- Тёмные блоки CTA Section 9 (`#0F2447`) и Footer (`#0F2447`) не тронуты — это намеренный дизайн

## Root cause
Без `+html.tsx` браузер использует стандартный белый фон `<body>`, что создаёт визуальный разрыв с лёгким голубым фоном (#F4FBFC) контента лендинга и внутренних страниц.

## Test plan
- [ ] Открыть https://p2ptax.smartlaunchhub.com — фон страницы #F4FBFC (не белый)
- [ ] Проскроллить лендинг вверх/вниз за пределы контента — нет белых вспышек
- [ ] Войти в дашборд — фон совпадает с лендингом
- [ ] TypeScript: `npx tsc --noEmit` — без новых ошибок

Trinity: #1731