### PR TITLE
feat: complaint endpoint + UI button (UC-20)

### DIFF
--- a/api/prisma/migrations/20260406000000_add_complaint/migration.sql
+++ b/api/prisma/migrations/20260406000000_add_complaint/migration.sql
@@ -1,0 +1,26 @@
+-- CreateEnum
+CREATE TYPE "ComplaintReason" AS ENUM ('spam', 'fraud', 'inappropriate', 'other');
+
+-- CreateTable
+CREATE TABLE "complaints" (
+    "id" TEXT NOT NULL,
+    "reporterId" TEXT NOT NULL,
+    "targetUserId" TEXT NOT NULL,
+    "reason" "ComplaintReason" NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "complaints_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "complaints_targetUserId_idx" ON "complaints"("targetUserId");
+
+-- CreateIndex
+CREATE INDEX "complaints_reporterId_idx" ON "complaints"("reporterId");
+
+-- AddForeignKey
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_targetUserId_fkey" FOREIGN KEY ("targetUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -45,6 +45,8 @@ model User {
   reviewsGiven        Review[]          @relation("ReviewClient")
   reviewsReceived     Review[]          @relation("ReviewSpecialist")
   refreshTokens       RefreshToken[]
+  complaintsGiven     Complaint[]       @relation("ComplaintReporter")
+  complaintsReceived  Complaint[]       @relation("ComplaintTarget")
 
   @@map("users")
 }
@@ -206,4 +208,26 @@ model Review {
   @@index([specialistId])
   @@index([clientId])
   @@map("reviews")
+}
+
+enum ComplaintReason {
+  spam
+  fraud
+  inappropriate
+  other
+}
+
+model Complaint {
+  id           String          @id @default(cuid())
+  reporterId   String
+  reporter     User            @relation("ComplaintReporter", fields: [reporterId], references: [id])
+  targetUserId String
+  target       User            @relation("ComplaintTarget", fields: [targetUserId], references: [id])
+  reason       ComplaintReason
+  description  String?
+  createdAt    DateTime        @default(now())
+
+  @@index([targetUserId])
+  @@index([reporterId])
+  @@map("complaints")
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { PromotionsModule } from './promotions/promotions.module';
 import { UsersModule } from './users/users.module';
 import { AdminModule } from './admin/admin.module';
 import { ReviewsModule } from './reviews/reviews.module';
+import { ComplaintsModule } from './complaints/complaints.module';
 import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
@@ -27,6 +28,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     UsersModule,
     AdminModule,
     ReviewsModule,
+    ComplaintsModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/complaints/complaints.controller.ts
+++ b/api/src/complaints/complaints.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { ComplaintsService } from './complaints.service';
+import { CreateComplaintDto } from './dto/create-complaint.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
+
+@Controller('complaints')
+export class ComplaintsController {
+  constructor(private readonly complaintsService: ComplaintsService) {}
+
+  /** POST /complaints — submit a complaint (any authenticated user) */
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  create(@Request() req: any, @Body() dto: CreateComplaintDto) {
+    return this.complaintsService.create(req.user.id, dto);
+  }
+
+  /** GET /complaints/admin?page=N — list all complaints (admin only) */
+  @Get('admin')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  adminFindAll(@Query('page') page?: string) {
+    return this.complaintsService.adminFindAll(page ? parseInt(page, 10) : 1);
+  }
+}

--- a/api/src/complaints/complaints.module.ts
+++ b/api/src/complaints/complaints.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ComplaintsController } from './complaints.controller';
+import { ComplaintsService } from './complaints.service';
+
+@Module({
+  controllers: [ComplaintsController],
+  providers: [ComplaintsService],
+})
+export class ComplaintsModule {}

--- a/api/src/complaints/complaints.service.ts
+++ b/api/src/complaints/complaints.service.ts
@@ -1,0 +1,68 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateComplaintDto } from './dto/create-complaint.dto';
+
+const PAGE_SIZE = 20;
+
+@Injectable()
+export class ComplaintsService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(reporterId: string, dto: CreateComplaintDto) {
+    // Cannot report yourself
+    if (reporterId === dto.targetUserId) {
+      throw new BadRequestException('You cannot report yourself');
+    }
+
+    // Verify target user exists
+    const target = await this.prisma.user.findUnique({
+      where: { id: dto.targetUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      throw new NotFoundException('User not found');
+    }
+
+    return this.prisma.complaint.create({
+      data: {
+        reporterId,
+        targetUserId: dto.targetUserId,
+        reason: dto.reason,
+        description: dto.description ?? null,
+      },
+      select: {
+        id: true,
+        reason: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  async adminFindAll(page = 1) {
+    const skip = (page - 1) * PAGE_SIZE;
+    const [items, total] = await Promise.all([
+      this.prisma.complaint.findMany({
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: PAGE_SIZE,
+        include: {
+          reporter: { select: { id: true, email: true, username: true } },
+          target: {
+            select: {
+              id: true,
+              email: true,
+              username: true,
+              specialistProfile: { select: { nick: true, displayName: true } },
+            },
+          },
+        },
+      }),
+      this.prisma.complaint.count(),
+    ]);
+    return { items, total, page, pageSize: PAGE_SIZE };
+  }
+}

--- a/api/src/complaints/dto/create-complaint.dto.ts
+++ b/api/src/complaints/dto/create-complaint.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsString, IsOptional, MaxLength } from 'class-validator';
+import { ComplaintReason } from '@prisma/client';
+
+export class CreateComplaintDto {
+  @IsString()
+  targetUserId!: string;
+
+  @IsEnum(ComplaintReason)
+  reason!: ComplaintReason;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(2000)
+  description?: string;
+}

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -98,6 +98,12 @@ export default function SpecialistProfileScreen() {
   const [reviewComment, setReviewComment] = useState('');
   const [submitLoading, setSubmitLoading] = useState(false);
 
+  // Complaint form state
+  const [showComplaintForm, setShowComplaintForm] = useState(false);
+  const [complaintReason, setComplaintReason] = useState<'spam' | 'fraud' | 'inappropriate' | 'other'>('spam');
+  const [complaintDescription, setComplaintDescription] = useState('');
+  const [complaintLoading, setComplaintLoading] = useState(false);
+
   useEffect(() => {
     if (!nick) return;
     let cancelled = false;
@@ -216,6 +222,27 @@ export default function SpecialistProfileScreen() {
       } catch {
         // user cancelled or share unavailable — ignore silently
       }
+    }
+  }
+
+  async function handleSubmitComplaint() {
+    if (!profile || complaintLoading) return;
+    setComplaintLoading(true);
+    try {
+      await api.post('/complaints', {
+        targetUserId: profile.userId,
+        reason: complaintReason,
+        description: complaintDescription.trim() || undefined,
+      });
+      setShowComplaintForm(false);
+      setComplaintDescription('');
+      setComplaintReason('spam');
+      Alert.alert('Жалоба отправлена', 'Мы рассмотрим её в течение 24 часов.');
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось отправить жалобу';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setComplaintLoading(false);
     }
   }
 
@@ -352,6 +379,65 @@ export default function SpecialistProfileScreen() {
         <View style={styles.copyToast}>
           <Text style={styles.copyToastText}>Ссылка скопирована</Text>
         </View>
+      )}
+
+      {/* Report button — only for authenticated users viewing someone else's profile */}
+      {user && profile && user.userId !== profile.userId && (
+        <>
+          <TouchableOpacity
+            onPress={() => setShowComplaintForm(!showComplaintForm)}
+            style={styles.reportBtn}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.reportBtnText}>Пожаловаться</Text>
+          </TouchableOpacity>
+
+          {/* Complaint form */}
+          {showComplaintForm && (
+            <View style={styles.complaintForm}>
+              <Text style={styles.complaintFormTitle}>Причина жалобы</Text>
+              {(['spam', 'fraud', 'inappropriate', 'other'] as const).map((r) => (
+                <TouchableOpacity
+                  key={r}
+                  onPress={() => setComplaintReason(r)}
+                  style={[styles.reasonOption, complaintReason === r && styles.reasonOptionActive]}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.reasonOptionText, complaintReason === r && styles.reasonOptionTextActive]}>
+                    {r === 'spam' ? 'Спам' : r === 'fraud' ? 'Мошенничество' : r === 'inappropriate' ? 'Неприемлемый контент' : 'Другое'}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+              <TextInput
+                style={styles.complaintInput}
+                value={complaintDescription}
+                onChangeText={setComplaintDescription}
+                placeholder="Подробности (необязательно)"
+                placeholderTextColor={Colors.textMuted}
+                multiline
+                numberOfLines={3}
+              />
+              <View style={styles.complaintFormActions}>
+                <TouchableOpacity
+                  onPress={() => { setShowComplaintForm(false); setComplaintDescription(''); setComplaintReason('spam'); }}
+                  style={styles.cancelBtn}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.cancelBtnText}>Отмена</Text>
+                </TouchableOpacity>
+                <Button
+                  onPress={handleSubmitComplaint}
+                  variant="primary"
+                  loading={complaintLoading}
+                  disabled={complaintLoading}
+                  style={styles.submitBtn}
+                >
+                  Отправить
+                </Button>
+              </View>
+            </View>
+          )}
+        </>
       )}
     </View>
   );
@@ -1053,5 +1139,70 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: '#1A5BA8',
     fontWeight: '600',
+  },
+
+  // Report / Complaint
+  reportBtn: {
+    paddingVertical: 8,
+    alignItems: 'center',
+    width: '100%',
+  },
+  reportBtnText: {
+    fontSize: 12,
+    color: '#8A9BB0',
+    textDecorationLine: 'underline',
+  },
+  complaintForm: {
+    gap: 8,
+    padding: 14,
+    backgroundColor: '#FFF5F5',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#FECACA',
+  },
+  complaintFormTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#0F2447',
+    marginBottom: 4,
+  },
+  reasonOption: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#C0D0EA',
+    backgroundColor: '#FFFFFF',
+  },
+  reasonOptionActive: {
+    borderColor: '#C0322D',
+    backgroundColor: '#FFF5F5',
+  },
+  reasonOptionText: {
+    fontSize: 13,
+    color: '#4A6B88',
+  },
+  reasonOptionTextActive: {
+    color: '#C0322D',
+    fontWeight: '600',
+  },
+  complaintInput: {
+    borderWidth: 1,
+    borderColor: '#C0D0EA',
+    borderRadius: 8,
+    padding: 10,
+    color: '#0F2447',
+    fontSize: 13,
+    backgroundColor: '#FFFFFF',
+    minHeight: 60,
+    textAlignVertical: 'top',
+    marginTop: 4,
+  },
+  complaintFormActions: {
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    marginTop: 4,
   },
 });


### PR DESCRIPTION
## Summary
- `POST /api/complaints` — submit a complaint against a specialist (any authenticated user); validates self-report, validates target user exists
- `GET /api/complaints/admin` — paginated list of all complaints with reporter/target info (admin only)
- Prisma model `Complaint` with `ComplaintReason` enum: spam / fraud / inappropriate / other
- Migration `20260406000000_add_complaint` manually applied to remote DB
- Button "Пожаловаться" added to specialist profile sidebar — shown only when `user.userId !== profile.userId` and user is authenticated
- Inline form: reason selector (4 options) + optional description textarea
- On success: `Alert("Жалоба отправлена. Мы рассмотрим её в течение 24 часов.")`

## Test plan
- [ ] `POST /api/complaints` with valid auth → returns `{ id, reason, createdAt }`
- [ ] `POST /api/complaints` targeting self → 400 BadRequest
- [ ] `POST /api/complaints` unauthenticated → 401 Unauthorized
- [ ] `GET /api/complaints/admin` with admin JWT → returns `{ items, total, page, pageSize }`
- [ ] `GET /api/complaints/admin` with non-admin JWT → 403 Forbidden
- [ ] Open specialist profile as logged-in user → "Пожаловаться" button visible
- [ ] Open own specialist profile → button NOT visible
- [ ] Open profile as guest → button NOT visible
- [ ] Submit complaint → Alert with success message

🤖 Generated with [Claude Code](https://claude.com/claude-code)