### PR TITLE
fix: add 5/day rate limit for complaints (#2289)

### DIFF
--- a/api/src/complaints/complaints.service.ts
+++ b/api/src/complaints/complaints.service.ts
@@ -18,6 +18,20 @@ export class ComplaintsService {
       throw new BadRequestException('You cannot report yourself');
     }
 
+    // Rate limit: max 5 complaints per reporter per 24 hours
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const recentCount = await this.prisma.complaint.count({
+      where: {
+        reporterId,
+        createdAt: { gte: since },
+      },
+    });
+    if (recentCount >= 5) {
+      throw new BadRequestException(
+        'Превышен лимит жалоб. Максимум 5 жалоб в сутки.',
+      );
+    }
+
     // Verify target user exists
     const target = await this.prisma.user.findUnique({
       where: { id: dto.targetUserId },


### PR DESCRIPTION
## Summary
- Added DB-based rate limit check in ComplaintsService.create()
- Count complaints by reporterId in last 24h, if >= 5 → 400 BadRequest
- No schema changes, no frontend changes

Trinity: #2289