### PR TITLE
fix: OTP constants — UC-01/02/03 compliance

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -4,7 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../notifications/email.service';
 import { Role } from '@prisma/client';
 
-const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const OTP_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const DEV_OTP = '000000';
 
 function generateOtp(): string {
@@ -85,7 +85,7 @@ export class AuthService {
         email: normalizedEmail,
         usedAt: null,
         expiresAt: { gt: new Date() },
-        attempts: { gte: 3 },
+        attempts: { gte: 5 },
       },
     });
     if (lockedOtp) {
@@ -131,7 +131,7 @@ export class AuthService {
     }
 
     // Check attempt counter BEFORE verifying the code
-    if (otpRecord.attempts >= 3) {
+    if (otpRecord.attempts >= 5) {
       throw new HttpException('Too many OTP attempts', HttpStatus.TOO_MANY_REQUESTS);
     }
 


### PR DESCRIPTION
## Summary
- OTP TTL: 10min → 15min (matches UC-01 spec)
- Max OTP attempts: 3 → 5 (matches UC-02/03 spec)
- Throttle window derived from OTP_TTL_MS, so also corrected automatically

## Changed files
- `api/src/auth/auth.service.ts` — 3 constant changes (lines 7, 88, 134)

## Test plan
- [ ] Request OTP, wait >10min but <15min — code should still be valid
- [ ] Enter wrong OTP 4 times — should still allow 5th attempt
- [ ] Enter wrong OTP 5 times — should get 429 Too Many Requests