### PR TITLE
feat: /pricing page — promotion tiers (UC-30)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -74,7 +74,7 @@ function RootNavigator() {
     const inOnboardingGroup = segments[0] === '(onboarding)';
     // Public routes that guests can access freely
     const isPublicRoute =
-      segments[0] === 'specialists' || segments[0] === 'requests';
+      segments[0] === 'specialists' || segments[0] === 'requests' || segments[0] === 'pricing';
 
     // New user must complete onboarding before accessing anything else
     if (user && user.isNewUser && !inOnboardingGroup) {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -604,6 +604,10 @@ export default function LandingScreen() {
                 <Text style={styles.footerLink}>{'\u0417\u0430\u043F\u0440\u043E\u0441\u044B'}</Text>
               </TouchableOpacity>
               <Text style={styles.footerDot}>{'\u00B7'}</Text>
+              <TouchableOpacity onPress={() => router.push('/pricing')} activeOpacity={0.7}>
+                <Text style={styles.footerLink}>{'\u0422\u0430\u0440\u0438\u0444\u044B'}</Text>
+              </TouchableOpacity>
+              <Text style={styles.footerDot}>{'\u00B7'}</Text>
               <TouchableOpacity
                 onPress={() => {
                   if (Platform.OS === 'web') {

--- a/app/pricing.tsx
+++ b/app/pricing.tsx
@@ -1,0 +1,456 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  TouchableOpacity,
+  Platform,
+} from 'react-native';
+import { useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
+import { Typography, BorderRadius, Colors, Spacing } from '../constants/Colors';
+import { useBreakpoints } from '../hooks/useBreakpoints';
+import { LandingHeader } from '../components/LandingHeader';
+
+// ---- Pricing data ----
+
+type TierKey = 'BASIC' | 'FEATURED' | 'TOP';
+type CityKey = 'moscow' | 'spb' | 'other';
+
+const TIERS: { key: TierKey; name: string; features: string[] }[] = [
+  {
+    key: 'BASIC',
+    name: 'Basic',
+    features: [
+      'Профиль в каталоге',
+      'До 5 откликов в месяц',
+      'Базовая позиция в поиске',
+    ],
+  },
+  {
+    key: 'FEATURED',
+    name: 'Featured',
+    features: [
+      'Все из Basic',
+      'Безлимитные отклики',
+      'Выделение в поиске',
+      'Бейдж "Проверенный"',
+    ],
+  },
+  {
+    key: 'TOP',
+    name: 'Top',
+    features: [
+      'Все из Featured',
+      'Первая позиция в городе',
+      'Персональный менеджер',
+      'Приоритетная модерация',
+      'Баннер на главной',
+    ],
+  },
+];
+
+const CITIES: { key: CityKey; label: string }[] = [
+  { key: 'moscow', label: 'Москва' },
+  { key: 'spb', label: 'Санкт-Петербург' },
+  { key: 'other', label: 'Другие города' },
+];
+
+// Base monthly prices per city
+const PRICES: Record<CityKey, Record<TierKey, number>> = {
+  moscow: { BASIC: 1500, FEATURED: 3000, TOP: 5000 },
+  spb: { BASIC: 1200, FEATURED: 2500, TOP: 4000 },
+  other: { BASIC: 800, FEATURED: 1500, TOP: 2500 },
+};
+
+type PeriodKey = 1 | 3 | 6;
+
+const PERIODS: { months: PeriodKey; label: string; discount: number }[] = [
+  { months: 1, label: '1 месяц', discount: 0 },
+  { months: 3, label: '3 месяца', discount: 0.1 },
+  { months: 6, label: '6 месяцев', discount: 0.2 },
+];
+
+function formatPrice(price: number): string {
+  return price.toLocaleString('ru-RU');
+}
+
+// ---- Main ----
+
+export default function PricingScreen() {
+  const router = useRouter();
+  const { isMobile } = useBreakpoints();
+  const [selectedCity, setSelectedCity] = useState<CityKey>('moscow');
+  const [selectedPeriod, setSelectedPeriod] = useState<PeriodKey>(1);
+
+  const currentDiscount = PERIODS.find((p) => p.months === selectedPeriod)?.discount ?? 0;
+
+  function getPrice(tier: TierKey): number {
+    const base = PRICES[selectedCity][tier];
+    return Math.round(base * (1 - currentDiscount));
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Stack.Screen options={{ title: 'Тарифы продвижения — Налоговик' }} />
+      <Head>
+        <title>Тарифы продвижения — Налоговик</title>
+        <meta name="description" content="Тарифы продвижения для специалистов на платформе Налоговик. BASIC, Featured, Top — выберите подходящий тариф." />
+      </Head>
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+      >
+        <LandingHeader />
+
+        <View style={styles.content}>
+          {/* Title */}
+          <Text style={styles.title}>Тарифы продвижения</Text>
+          <Text style={styles.subtitle}>
+            Выберите тариф, чтобы получать больше клиентов в вашем городе
+          </Text>
+
+          {/* City selector */}
+          <View style={styles.selectorSection}>
+            <Text style={styles.selectorLabel}>Город</Text>
+            <View style={styles.chipRow}>
+              {CITIES.map((city) => (
+                <TouchableOpacity
+                  key={city.key}
+                  style={[styles.chip, selectedCity === city.key && styles.chipSelected]}
+                  onPress={() => setSelectedCity(city.key)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.chipText, selectedCity === city.key && styles.chipTextSelected]}>
+                    {city.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Period selector */}
+          <View style={styles.selectorSection}>
+            <Text style={styles.selectorLabel}>Период</Text>
+            <View style={styles.chipRow}>
+              {PERIODS.map((period) => (
+                <TouchableOpacity
+                  key={period.months}
+                  style={[styles.chip, selectedPeriod === period.months && styles.chipSelected]}
+                  onPress={() => setSelectedPeriod(period.months)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.chipText, selectedPeriod === period.months && styles.chipTextSelected]}>
+                    {period.label}
+                    {period.discount > 0 ? ` (-${period.discount * 100}%)` : ''}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Tier cards */}
+          <View style={[styles.tiersRow, !isMobile && styles.tiersRowWide]}>
+            {TIERS.map((tier, index) => {
+              const isFeatured = tier.key === 'FEATURED';
+              const price = getPrice(tier.key);
+
+              return (
+                <View
+                  key={tier.key}
+                  style={[
+                    styles.tierCard,
+                    isFeatured && styles.tierCardFeatured,
+                    !isMobile && styles.tierCardWide,
+                  ]}
+                >
+                  {isFeatured && (
+                    <View style={styles.popularBadge}>
+                      <Text style={styles.popularBadgeText}>Популярный</Text>
+                    </View>
+                  )}
+                  <Text style={[styles.tierName, isFeatured && styles.tierNameFeatured]}>
+                    {tier.name}
+                  </Text>
+                  <View style={styles.priceRow}>
+                    <Text style={[styles.priceAmount, isFeatured && styles.priceAmountFeatured]}>
+                      {formatPrice(price)}
+                    </Text>
+                    <Text style={[styles.pricePeriod, isFeatured && styles.pricePeriodFeatured]}>
+                      /мес
+                    </Text>
+                  </View>
+                  {currentDiscount > 0 && (
+                    <Text style={[styles.originalPrice, isFeatured && styles.originalPriceFeatured]}>
+                      {formatPrice(PRICES[selectedCity][tier.key])} /мес без скидки
+                    </Text>
+                  )}
+                  <View style={styles.featuresList}>
+                    {tier.features.map((feature) => (
+                      <View key={feature} style={styles.featureItem}>
+                        <Text style={[styles.featureCheck, isFeatured && styles.featureCheckFeatured]}>
+                          {'\u2713'}
+                        </Text>
+                        <Text style={[styles.featureText, isFeatured && styles.featureTextFeatured]}>
+                          {feature}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                  <TouchableOpacity
+                    style={[styles.tierBtn, isFeatured && styles.tierBtnFeatured]}
+                    onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+                    activeOpacity={0.8}
+                  >
+                    <Text style={[styles.tierBtnText, isFeatured && styles.tierBtnTextFeatured]}>
+                      Выбрать тариф
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              );
+            })}
+          </View>
+
+          {/* CTA */}
+          <View style={styles.ctaSection}>
+            <Text style={styles.ctaTitle}>Готовы начать?</Text>
+            <Text style={styles.ctaSubtitle}>
+              Зарегистрируйтесь как специалист и выберите подходящий тариф
+            </Text>
+            <TouchableOpacity
+              style={styles.ctaBtn}
+              onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+              activeOpacity={0.8}
+            >
+              <Text style={styles.ctaBtnText}>Зарегистрироваться как специалист</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ---- Styles ----
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+  },
+  content: {
+    width: '100%',
+    maxWidth: 430,
+    alignSelf: 'center',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing['3xl'],
+    gap: Spacing.xl,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+
+  // Selectors
+  selectorSection: {
+    gap: Spacing.sm,
+  },
+  selectorLabel: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.sm,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    backgroundColor: Colors.bgCard,
+  },
+  chipSelected: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  chipText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+  },
+  chipTextSelected: {
+    color: Colors.white,
+  },
+
+  // Tier cards
+  tiersRow: {
+    gap: Spacing.lg,
+  },
+  tiersRowWide: {
+    flexDirection: 'row',
+  },
+  tierCard: {
+    flex: 1,
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: Spacing.xl,
+    gap: Spacing.md,
+    alignItems: 'center',
+  },
+  tierCardFeatured: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  tierCardWide: {
+    flex: 1,
+  },
+  popularBadge: {
+    backgroundColor: Colors.statusBg.accent,
+    borderRadius: BorderRadius.full,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xxs,
+  },
+  popularBadgeText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.brandPrimary,
+  },
+  tierName: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  tierNameFeatured: {
+    color: Colors.white,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 4,
+  },
+  priceAmount: {
+    fontSize: Typography.fontSize['3xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  priceAmountFeatured: {
+    color: Colors.white,
+  },
+  pricePeriod: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+  },
+  pricePeriodFeatured: {
+    color: 'rgba(255,255,255,0.7)',
+  },
+  originalPrice: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textDecorationLine: 'line-through',
+  },
+  originalPriceFeatured: {
+    color: 'rgba(255,255,255,0.5)',
+  },
+  featuresList: {
+    width: '100%',
+    gap: Spacing.sm,
+    marginTop: Spacing.sm,
+  },
+  featureItem: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    alignItems: 'flex-start',
+  },
+  featureCheck: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.statusSuccess,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  featureCheckFeatured: {
+    color: Colors.white,
+  },
+  featureText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+    flex: 1,
+  },
+  featureTextFeatured: {
+    color: 'rgba(255,255,255,0.9)',
+  },
+  tierBtn: {
+    width: '100%',
+    height: 44,
+    borderRadius: BorderRadius.md,
+    borderWidth: 2,
+    borderColor: Colors.brandPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: Spacing.sm,
+  },
+  tierBtnFeatured: {
+    backgroundColor: Colors.white,
+    borderColor: Colors.white,
+  },
+  tierBtnText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.brandPrimary,
+  },
+  tierBtnTextFeatured: {
+    color: Colors.brandPrimary,
+  },
+
+  // CTA
+  ctaSection: {
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingVertical: Spacing['3xl'],
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  ctaTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  ctaSubtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  ctaBtn: {
+    backgroundColor: Colors.brandPrimary,
+    borderRadius: BorderRadius.md,
+    height: 52,
+    paddingHorizontal: Spacing['3xl'],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: Spacing.sm,
+  },
+  ctaBtnText: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.white,
+  },
+});

--- a/components/LandingHeader.tsx
+++ b/components/LandingHeader.tsx
@@ -47,6 +47,12 @@ export function LandingHeader() {
               <Text style={styles.navLink}>Лента запросов</Text>
             </TouchableOpacity>
             <TouchableOpacity
+              onPress={() => router.push('/pricing')}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.navLink}>Тарифы</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
               onPress={() => {
                 if (Platform.OS === 'web') {
                   document.getElementById('how-it-works')?.scrollIntoView({ behavior: 'smooth' });
@@ -125,6 +131,13 @@ export function LandingHeader() {
             style={styles.mobileMenuItem}
           >
             <Text style={styles.mobileMenuText}>Лента запросов</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => { setMenuOpen(false); router.push('/pricing'); }}
+            activeOpacity={0.7}
+            style={styles.mobileMenuItem}
+          >
+            <Text style={styles.mobileMenuText}>Тарифы</Text>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => {


### PR DESCRIPTION
## Summary
- Adds static `/pricing` page accessible to unauthenticated users
- Shows BASIC/FEATURED/TOP promotion tiers with city and period selectors
- Prices: Moscow (1500/3000/5000), SPb (1200/2500/4000), Other (800/1500/2500) per month
- Period discounts: 3 months (-10%), 6 months (-20%)
- CTA button redirects to specialist registration
- Added `pricing` to `isPublicRoute` in `_layout.tsx` so auth guard allows guest access
- Added "Тарифы" link to LandingHeader (desktop nav + mobile menu) and landing footer

## Test plan
- [ ] Open `/pricing` as unauthenticated user — page loads without redirect
- [ ] Switch cities — prices update correctly
- [ ] Switch periods — discounts apply correctly
- [ ] Click CTA — redirects to `/(auth)/email?role=SPECIALIST`
- [ ] Header "Тарифы" link works on desktop and mobile menu
- [ ] Footer "Тарифы" link works
- [ ] `npx tsc --noEmit` passes with 0 errors