### PR TITLE
feat: landing API endpoints (featured/recent/popular)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -47,6 +47,12 @@ export class RequestsController {
     return this.requestsService.findMyResponses(req.user.id);
   }
 
+  // GET /requests/recent — public, recent open requests for landing page
+  @Get('recent')
+  getRecent(@Query('limit') limit?: string) {
+    return this.requestsService.findRecent(parseInt(limit ?? '5') || 5);
+  }
+
   // GET /requests — public feed accessible without authentication
   @Get()
   @UseGuards(OptionalJwtAuthGuard)

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -23,6 +23,23 @@ export class RequestsService {
     private emailService: EmailService,
   ) {}
 
+  async findRecent(limit = 5) {
+    return this.prisma.request.findMany({
+      where: { status: RequestStatus.OPEN },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        description: true,
+        city: true,
+        category: true,
+        budget: true,
+        createdAt: true,
+        _count: { select: { responses: true } },
+      },
+    });
+  }
+
   async create(clientId: string, dto: CreateRequestDto) {
     const openCount = await this.prisma.request.count({
       where: { clientId, status: RequestStatus.OPEN },

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -100,6 +100,16 @@ export class SpecialistsController {
     );
   }
 
+  @Get('featured')
+  getFeatured(@Query('limit') limit?: string) {
+    return this.specialistsService.getFeatured(parseInt(limit ?? '8') || 8);
+  }
+
+  @Get('cities/popular')
+  getPopularCities(@Query('limit') limit?: string) {
+    return this.specialistsService.getPopularCities(parseInt(limit ?? '10') || 10);
+  }
+
   @Patch(':id/badges')
   @UseGuards(JwtAuthGuard, AdminGuard)
   updateBadges(@Param('id') id: string, @Body('badges') badges: string[]) {

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -242,6 +242,42 @@ export class SpecialistsService {
     });
   }
 
+  async getFeatured(limit = 8) {
+    const profiles = await this.prisma.specialistProfile.findMany({
+      where: { displayName: { not: null } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        nick: true,
+        displayName: true,
+        avatarUrl: true,
+        cities: true,
+        services: true,
+        badges: true,
+        experience: true,
+      },
+    });
+    return profiles;
+  }
+
+  async getPopularCities(limit = 10) {
+    const profiles = await this.prisma.specialistProfile.findMany({
+      select: { cities: true },
+      take: 1000,
+    });
+    const cityCount = new Map<string, number>();
+    for (const profile of profiles) {
+      for (const city of profile.cities) {
+        const trimmed = city?.trim();
+        if (trimmed) cityCount.set(trimmed, (cityCount.get(trimmed) ?? 0) + 1);
+      }
+    }
+    return Array.from(cityCount.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit)
+      .map(([city, count]) => ({ city, count }));
+  }
+
   private async computeActivity(userId: string) {
     const [responseCount, ratingAgg] = await Promise.all([
       this.prisma.response.count({ where: { specialistId: userId } }),

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -14,6 +14,7 @@ import { useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
 import { Typography, BorderRadius, Colors, Spacing } from '../constants/Colors';
 import { secureStorage } from '../stores/storage';
+import { api } from '../lib/api';
 
 const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 import { useBreakpoints } from '../hooks/useBreakpoints';
@@ -250,6 +251,15 @@ export default function LandingScreen() {
   const router = useRouter();
   const { isMobile, isTablet, isDesktop } = useBreakpoints();
   const [heroImageError, setHeroImageError] = React.useState(false);
+  const [featuredSpecialists, setFeaturedSpecialists] = useState<any[]>([]);
+  const [recentRequests, setRecentRequests] = useState<any[]>([]);
+  const [popularCities, setPopularCities] = useState<any[]>([]);
+
+  useEffect(() => {
+    api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch(() => {});
+    api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch(() => {});
+    api.get<any[]>('/specialists/cities/popular?limit=10').then(setPopularCities).catch(() => {});
+  }, []);
 
   const isWide = !isMobile;
   const sectionMaxWidth: number | '100%' = isDesktop ? 1200 : isTablet ? 900 : '100%';


### PR DESCRIPTION
## Summary
- Adds GET /specialists/featured — top 8 specialists for landing hero section
- Adds GET /requests/recent — 5 most recent OPEN requests for social proof
- Adds GET /specialists/cities/popular — top 10 cities by specialist count
- Wires all 3 endpoints into app/index.tsx via useEffect

## Test plan
- [ ] curl localhost:3812/api/specialists/featured
- [ ] curl localhost:3812/api/requests/recent
- [ ] curl localhost:3812/api/specialists/cities/popular
- [ ] Verify index.tsx loads data on mount (check network tab)