### PR TITLE
feat: UC-26/29 compliance — settings + city-requests

### DIFF
--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   SafeAreaView,
   FlatList,
+  ScrollView,
   ActivityIndicator,
   RefreshControl,
   TouchableOpacity,
@@ -30,6 +31,7 @@ interface RequestItem {
   id: string;
   description: string;
   city: string;
+  category: string | null;
   status: string;
   createdAt: string;
   client: { id: string };
@@ -57,6 +59,8 @@ export default function CityRequestsScreen() {
   const [respondedIds, setRespondedIds] = useState<Set<string>>(new Set());
   // Track seen request IDs (persisted in AsyncStorage)
   const [seenIds, setSeenIds] = useState<Set<string>>(new Set());
+  // Category filter (client-side)
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   // Pagination state per city
   const [cityPages, setCityPages] = useState<Record<string, number>>({});
   const [cityHasMore, setCityHasMore] = useState<Record<string, boolean>>({});
@@ -184,6 +188,13 @@ export default function CityRequestsScreen() {
     // Load seen IDs in parallel with data fetch so first render has correct state
     loadSeenIds();
     fetchData();
+
+    // Poll for new requests every 30 seconds
+    const intervalId = setInterval(() => {
+      fetchData(true);
+    }, 30_000);
+
+    return () => clearInterval(intervalId);
   }, [fetchData, loadSeenIds]);
 
   function handleRefresh() {
@@ -288,6 +299,11 @@ export default function CityRequestsScreen() {
               <View style={styles.cityChip}>
                 <Text style={styles.cityText}>{item.city}</Text>
               </View>
+              {item.category ? (
+                <View style={styles.categoryChip}>
+                  <Text style={styles.categoryText}>{item.category}</Text>
+                </View>
+              ) : null}
               {isNew && (
                 <View style={styles.newBadge}>
                   <Text style={styles.newBadgeText}>Новый</Text>
@@ -297,7 +313,9 @@ export default function CityRequestsScreen() {
             <Text style={styles.dateText}>{formatDate(item.createdAt)}</Text>
           </View>
           <Text style={styles.description} numberOfLines={4}>
-            {item.description}
+            {item.description.length > 200
+              ? item.description.slice(0, 200) + '...'
+              : item.description}
           </Text>
           <View style={styles.footer}>
             <Text style={styles.responsesText}>Откликов: {item._count.responses}</Text>
@@ -374,6 +392,21 @@ export default function CityRequestsScreen() {
     return null;
   };
 
+  // Unique categories from loaded requests (client-side filter)
+  const uniqueCategories = React.useMemo(() => {
+    const cats = new Set<string>();
+    for (const r of requests) {
+      if (r.category) cats.add(r.category);
+    }
+    return Array.from(cats).sort();
+  }, [requests]);
+
+  // Filtered requests by selected category
+  const filteredRequests = React.useMemo(() => {
+    if (!selectedCategory) return requests;
+    return requests.filter((r) => r.category === selectedCategory);
+  }, [requests, selectedCategory]);
+
   const content = renderContent();
 
   return (
@@ -393,11 +426,58 @@ export default function CityRequestsScreen() {
         </View>
       )}
 
+      {/* Category filter chips */}
+      {uniqueCategories.length > 0 && !loading && !error && (
+        <View style={styles.categoryBar}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.categoryScroll}
+          >
+            <TouchableOpacity
+              style={[
+                styles.categoryFilterChip,
+                !selectedCategory && styles.categoryFilterChipActive,
+              ]}
+              onPress={() => setSelectedCategory(null)}
+            >
+              <Text
+                style={[
+                  styles.categoryFilterText,
+                  !selectedCategory && styles.categoryFilterTextActive,
+                ]}
+              >
+                Все
+              </Text>
+            </TouchableOpacity>
+            {uniqueCategories.map((cat) => (
+              <TouchableOpacity
+                key={cat}
+                style={[
+                  styles.categoryFilterChip,
+                  selectedCategory === cat && styles.categoryFilterChipActive,
+                ]}
+                onPress={() => setSelectedCategory(selectedCategory === cat ? null : cat)}
+              >
+                <Text
+                  style={[
+                    styles.categoryFilterText,
+                    selectedCategory === cat && styles.categoryFilterTextActive,
+                  ]}
+                >
+                  {cat}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      )}
+
       {content ? (
         <View style={styles.contentFlex}>{content}</View>
       ) : (
         <FlatList
-          data={requests}
+          data={filteredRequests}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
           contentContainerStyle={styles.listContent}
@@ -549,6 +629,49 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.xs,
     color: Colors.statusInfo,
     fontWeight: Typography.fontWeight.semibold,
+  },
+  categoryBar: {
+    paddingVertical: Spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    backgroundColor: Colors.bgPrimary,
+  },
+  categoryScroll: {
+    paddingHorizontal: Spacing.lg,
+    gap: Spacing.xs,
+  },
+  categoryFilterChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: 6,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  categoryFilterChipActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  categoryFilterText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  categoryFilterTextActive: {
+    color: '#fff',
+  },
+  categoryChip: {
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  categoryText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
   },
   cityChip: {
     backgroundColor: Colors.bgSecondary,

--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -9,7 +9,6 @@ import {
   Switch,
   Alert,
   ActivityIndicator,
-  TextInput,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
@@ -20,8 +19,6 @@ import { api, ApiError } from '../../lib/api';
 import { isAdmin } from '../../lib/adminEmails';
 import { Header } from '../../components/Header';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
-
-type EmailChangeStep = 'viewing' | 'enterEmail' | 'enterOtp';
 
 interface MyReview {
   id: string;
@@ -39,20 +36,13 @@ const NOTIF_KEY = '@p2ptax_email_notif';
 
 export default function SettingsScreen() {
   const router = useRouter();
-  const { user, logout, updateEmail } = useAuth();
+  const { user, logout } = useAuth();
 
   const [emailNotif, setEmailNotif] = useState(true);
   const [notifLoading, setNotifLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [myReviews, setMyReviews] = useState<MyReview[]>([]);
   const [reviewsLoading, setReviewsLoading] = useState(false);
-
-  // Email change state machine
-  const [emailChangeStep, setEmailChangeStep] = useState<EmailChangeStep>('viewing');
-  const [newEmailInput, setNewEmailInput] = useState('');
-  const [otpInput, setOtpInput] = useState('');
-  const [emailChangeLoading, setEmailChangeLoading] = useState(false);
-  const [emailChangeError, setEmailChangeError] = useState<string | null>(null);
 
   // Load my reviews for CLIENT role
   useEffect(() => {
@@ -91,66 +81,6 @@ export default function SettingsScreen() {
     } catch {
       // Revert on failure
       setEmailNotif(!value);
-    }
-  }
-
-  function handleStartEmailChange() {
-    setNewEmailInput('');
-    setOtpInput('');
-    setEmailChangeError(null);
-    setEmailChangeStep('enterEmail');
-  }
-
-  function handleCancelEmailChange() {
-    setEmailChangeStep('viewing');
-    setNewEmailInput('');
-    setOtpInput('');
-    setEmailChangeError(null);
-  }
-
-  async function handleRequestOtp() {
-    const trimmed = newEmailInput.trim().toLowerCase();
-    if (!trimmed || !trimmed.includes('@')) {
-      setEmailChangeError('Введите корректный email');
-      return;
-    }
-    setEmailChangeError(null);
-    setEmailChangeLoading(true);
-    try {
-      await api.post('/users/me/change-email/request', { newEmail: trimmed });
-      setEmailChangeStep('enterOtp');
-    } catch (err) {
-      const msg = err instanceof ApiError ? err.message : 'Не удалось отправить код. Попробуйте позже.';
-      setEmailChangeError(msg);
-    } finally {
-      setEmailChangeLoading(false);
-    }
-  }
-
-  async function handleConfirmOtp() {
-    const trimmedEmail = newEmailInput.trim().toLowerCase();
-    const trimmedCode = otpInput.trim();
-    if (trimmedCode.length !== 6) {
-      setEmailChangeError('Введите 6-значный код');
-      return;
-    }
-    setEmailChangeError(null);
-    setEmailChangeLoading(true);
-    try {
-      const result = await api.post<{ accessToken: string; refreshToken: string; email: string }>(
-        '/users/me/change-email/confirm',
-        { newEmail: trimmedEmail, code: trimmedCode },
-      );
-      await updateEmail(result.email, result.accessToken, result.refreshToken);
-      setEmailChangeStep('viewing');
-      setNewEmailInput('');
-      setOtpInput('');
-      Alert.alert('Готово', 'Email успешно изменён');
-    } catch (err) {
-      const msg = err instanceof ApiError ? err.message : 'Неверный код или истёк срок действия.';
-      setEmailChangeError(msg);
-    } finally {
-      setEmailChangeLoading(false);
     }
   }
 
@@ -217,103 +147,25 @@ export default function SettingsScreen() {
           {/* Account section */}
           <Text style={styles.sectionTitle}>Аккаунт</Text>
           <View style={styles.card}>
-            {/* Email row — collapses into edit form when changing */}
-            {emailChangeStep === 'viewing' && (
+            {/* Email row — readonly display */}
+            <View style={styles.row}>
+              <View style={styles.rowTextBlock}>
+                <Text style={styles.rowLabel}>Email</Text>
+                <Text style={styles.rowHint} numberOfLines={1}>{user?.email ?? '—'}</Text>
+              </View>
+            </View>
+            <View style={styles.emailChangeBtnRow}>
               <TouchableOpacity
-                style={styles.row}
-                onPress={handleStartEmailChange}
-                activeOpacity={0.7}
+                style={[styles.emailChangeDisabledBtn]}
+                disabled
+                activeOpacity={1}
               >
-                <View style={styles.rowTextBlock}>
-                  <Text style={styles.rowLabel}>Email</Text>
-                  <Text style={styles.rowHint} numberOfLines={1}>{user?.email ?? '—'}</Text>
-                </View>
-                <Text style={styles.changeLink}>Изменить</Text>
+                <Text style={styles.emailChangeDisabledText}>Изменить email</Text>
               </TouchableOpacity>
-            )}
-
-            {emailChangeStep === 'enterEmail' && (
-              <View style={styles.emailChangeBlock}>
-                <Text style={styles.emailChangeTitle}>Новый email</Text>
-                <TextInput
-                  style={styles.emailInput}
-                  value={newEmailInput}
-                  onChangeText={setNewEmailInput}
-                  placeholder="new@example.com"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  autoFocus
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text style={styles.emailChangeError}>{emailChangeError}</Text>
-                ) : null}
-                <View style={styles.emailChangeActions}>
-                  <TouchableOpacity
-                    style={[styles.emailChangeBtn, styles.emailChangeBtnSecondary]}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    <Text style={styles.emailChangeBtnSecondaryText}>Отмена</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.emailChangeBtn, styles.emailChangeBtnPrimary, emailChangeLoading && styles.emailChangeBtnDisabled]}
-                    onPress={handleRequestOtp}
-                    disabled={emailChangeLoading}
-                  >
-                    {emailChangeLoading
-                      ? <ActivityIndicator size="small" color="#fff" />
-                      : <Text style={styles.emailChangeBtnPrimaryText}>Отправить код</Text>
-                    }
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-
-            {emailChangeStep === 'enterOtp' && (
-              <View style={styles.emailChangeBlock}>
-                <Text style={styles.emailChangeTitle}>Код из письма</Text>
-                <Text style={styles.emailChangeHint}>
-                  Код отправлен на {newEmailInput.trim().toLowerCase()}
-                </Text>
-                <TextInput
-                  style={styles.emailInput}
-                  value={otpInput}
-                  onChangeText={setOtpInput}
-                  placeholder="000000"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="number-pad"
-                  maxLength={6}
-                  autoFocus
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text style={styles.emailChangeError}>{emailChangeError}</Text>
-                ) : null}
-                <View style={styles.emailChangeActions}>
-                  <TouchableOpacity
-                    style={[styles.emailChangeBtn, styles.emailChangeBtnSecondary]}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    <Text style={styles.emailChangeBtnSecondaryText}>Отмена</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.emailChangeBtn, styles.emailChangeBtnPrimary, emailChangeLoading && styles.emailChangeBtnDisabled]}
-                    onPress={handleConfirmOtp}
-                    disabled={emailChangeLoading}
-                  >
-                    {emailChangeLoading
-                      ? <ActivityIndicator size="small" color="#fff" />
-                      : <Text style={styles.emailChangeBtnPrimaryText}>Подтвердить</Text>
-                    }
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-
+              <Text style={styles.emailChangeCaption}>
+                Будет доступно в следующей версии
+              </Text>
+            </View>
             <View style={styles.divider} />
             <View style={styles.row}>
               <Text style={styles.rowLabel}>Роль</Text>
@@ -330,7 +182,9 @@ export default function SettingsScreen() {
               <View style={styles.rowTextBlock}>
                 <Text style={styles.rowLabel}>Email-уведомления</Text>
                 <Text style={styles.rowHint}>
-                  Получать уведомления о новых сообщениях
+                  {user?.role === 'SPECIALIST'
+                    ? 'Новые запросы в ваших городах и сообщения'
+                    : 'Отклики специалистов и сообщения'}
                 </Text>
               </View>
               {notifLoading ? (
@@ -566,72 +420,28 @@ const styles = StyleSheet.create({
     color: Colors.textMuted,
     marginTop: 2,
   },
-  changeLink: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-    marginLeft: Spacing.sm,
-  },
-  emailChangeBlock: {
+  emailChangeBtnRow: {
     paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.lg,
-    gap: Spacing.sm,
+    paddingBottom: Spacing.lg,
+    gap: 4,
   },
-  emailChangeTitle: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
+  emailChangeDisabledBtn: {
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.sm,
+    alignItems: 'center',
+    opacity: 0.5,
   },
-  emailChangeHint: {
+  emailChangeDisabledText: {
     fontSize: Typography.fontSize.sm,
     color: Colors.textMuted,
-  },
-  emailInput: {
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    backgroundColor: Colors.bgPrimary,
-  },
-  emailChangeError: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-  },
-  emailChangeActions: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.xs,
-  },
-  emailChangeBtn: {
-    flex: 1,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 40,
-  },
-  emailChangeBtnPrimary: {
-    backgroundColor: Colors.brandPrimary,
-  },
-  emailChangeBtnPrimaryText: {
-    color: '#fff',
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  emailChangeBtnSecondary: {
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  emailChangeBtnSecondaryText: {
-    color: Colors.textSecondary,
-    fontSize: Typography.fontSize.sm,
     fontWeight: Typography.fontWeight.medium,
   },
-  emailChangeBtnDisabled: {
-    opacity: 0.6,
+  emailChangeCaption: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
## Summary
- **settings.tsx**: Email shown as readonly text with disabled "Изменить email" button + "Будет доступно в следующей версии" caption. Role-specific notification toggle descriptions (specialist vs client).
- **city-requests.tsx**: 30s auto-polling with proper cleanup, client-side category filter chips, description truncated to 200 chars, category chip in request cards.

## Test plan
- [ ] Open settings — verify email is readonly, disabled button shown
- [ ] Check notification toggle label differs for CLIENT vs SPECIALIST
- [ ] Open city-requests — verify category filter chips appear when requests have categories
- [ ] Wait 30s — verify new requests appear without manual refresh
- [ ] Verify description truncation at 200 chars