### PR TITLE
fix: OTP request-otp rate limit — email bombing protection

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -16,7 +16,11 @@ import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
-    ThrottlerModule.forRoot([{ ttl: 60000, limit: 60 }]),
+    ThrottlerModule.forRoot([
+      { name: 'default', ttl: 60000, limit: 60 },
+      { name: 'email-otp', ttl: 900000, limit: 3 },
+      { name: 'ip-otp', ttl: 900000, limit: 10 },
+    ]),
     ScheduleModule.forRoot(),
     PrismaModule,
     NotificationsModule,

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -4,6 +4,7 @@ import { IsEmail, IsString, Length, IsOptional, IsIn } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { AuthService } from './auth.service';
 import { EmailThrottlerGuard } from './email-throttler.guard';
+import { IpThrottlerGuard } from './ip-throttler.guard';
 
 class RequestOtpDto {
   @IsEmail()
@@ -33,8 +34,11 @@ class RefreshDto {
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @UseGuards(EmailThrottlerGuard)
-  @Throttle({ default: { ttl: 300000, limit: 3 } })
+  @UseGuards(EmailThrottlerGuard, IpThrottlerGuard)
+  @Throttle({
+    'email-otp': { ttl: 900000, limit: 3 },
+    'ip-otp': { ttl: 900000, limit: 10 },
+  })
   @Post('request-otp')
   requestOtp(@Body() body: RequestOtpDto) {
     return this.authService.requestOtp(body.email);

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
 import { EmailThrottlerGuard } from './email-throttler.guard';
+import { IpThrottlerGuard } from './ip-throttler.guard';
 import { CleanupService } from './cleanup.service';
 
 @Module({
@@ -16,7 +17,7 @@ import { CleanupService } from './cleanup.service';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, EmailThrottlerGuard, CleanupService],
+  providers: [AuthService, JwtStrategy, EmailThrottlerGuard, IpThrottlerGuard, CleanupService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/api/src/auth/email-throttler.guard.ts
+++ b/api/src/auth/email-throttler.guard.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
-import { ExecutionContext } from '@nestjs/common';
 
 /**
- * #1897: Custom throttle guard for auth endpoints.
+ * #1897/#2253: Custom throttle guard for auth endpoints.
  * Uses the email from the request body as the rate-limit key instead of IP.
- * This prevents bypass via X-Forwarded-For spoofing — the key is tied to
- * the email address being authenticated, not the client IP.
+ * Targets the 'email-otp' named throttler (3 req/15min per email).
  */
 @Injectable()
 export class EmailThrottlerGuard extends ThrottlerGuard {

--- a/api/src/auth/ip-throttler.guard.ts
+++ b/api/src/auth/ip-throttler.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+/**
+ * #2253: IP-based throttle guard for auth endpoints.
+ * Uses client IP as the rate-limit key to prevent brute-force
+ * attacks from a single IP across multiple email addresses.
+ */
+@Injectable()
+export class IpThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, any>): Promise<string> {
+    return `ip:${req.ip}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Named throttlers in ThrottlerModule: `email-otp` (3 req/15min) and `ip-otp` (10 req/15min)
- New `IpThrottlerGuard` uses client IP as rate-limit key
- Both guards applied to `request-otp` endpoint to prevent email bombing and brute force

## Files changed
- `api/src/app.module.ts` — added named throttler configs
- `api/src/auth/ip-throttler.guard.ts` — NEW, IP-based throttle guard
- `api/src/auth/email-throttler.guard.ts` — updated comments
- `api/src/auth/auth.controller.ts` — dual guards + named throttle config
- `api/src/auth/auth.module.ts` — registered IpThrottlerGuard

Closes #2253