### PR TITLE
fix: promotions idempotency key + transaction (UC-11 security)

### DIFF
--- a/api/prisma/migrations/20260406000000_add_idempotency_key_to_promotions/migration.sql
+++ b/api/prisma/migrations/20260406000000_add_idempotency_key_to_promotions/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "promotions" ADD COLUMN "idempotencyKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "promotions_idempotencyKey_key" ON "promotions"("idempotencyKey");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -155,8 +155,9 @@ model Promotion {
   city         String
   tier         PromotionTier
   expiresAt    DateTime
-  reminderSent Boolean       @default(false)
-  createdAt    DateTime      @default(now())
+  reminderSent   Boolean       @default(false)
+  idempotencyKey String?       @unique
+  createdAt      DateTime      @default(now())
 
   @@index([city, tier, expiresAt])
   @@index([specialistId])

--- a/api/src/promotions/dto/purchase-promotion.dto.ts
+++ b/api/src/promotions/dto/purchase-promotion.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEnum, IsOptional, IsIn } from 'class-validator';
+import { IsString, IsEnum, IsOptional, IsIn, IsUUID } from 'class-validator';
 import { PromotionTier } from '@prisma/client';
 
 export class PurchasePromotionDto {
@@ -13,4 +13,9 @@ export class PurchasePromotionDto {
   @IsOptional()
   @IsIn([1, 3, 6])
   periodMonths?: 1 | 3 | 6 = 1;
+
+  // Client-generated idempotency key to prevent duplicate purchases on retry
+  @IsOptional()
+  @IsUUID()
+  idempotencyKey?: string;
 }

--- a/api/src/promotions/promotions.service.ts
+++ b/api/src/promotions/promotions.service.ts
@@ -28,72 +28,94 @@ export class PromotionsService {
    * Currently uses mock payment (no Stripe key configured).
    */
   async purchase(userId: string, dto: PurchasePromotionDto) {
-    // Verify user has a specialist profile
-    const profile = await this.prisma.specialistProfile.findUnique({
-      where: { userId },
-    });
-    if (!profile) {
-      throw new NotFoundException('Specialist profile not found. Create a profile first.');
+    // Idempotency: if the client sent a key and a promotion with that key already exists, return it
+    if (dto.idempotencyKey) {
+      const idempotent = await this.prisma.promotion.findUnique({
+        where: { idempotencyKey: dto.idempotencyKey },
+      });
+      if (idempotent) {
+        return {
+          promotion: idempotent,
+          payment: {
+            status: 'mock_paid',
+            amount: 0,
+            currency: 'RUB',
+            note: 'Duplicate request — returning existing promotion.',
+          },
+        };
+      }
     }
 
-    // Check specialist operates in the requested city
-    if (!profile.cities.includes(dto.city)) {
-      throw new BadRequestException(
-        `You don't have city "${dto.city}" in your profile. Add it first.`,
+    // Wrap the entire purchase in a transaction to prevent TOCTOU race conditions
+    return this.prisma.$transaction(async (tx) => {
+      // Verify user has a specialist profile
+      const profile = await tx.specialistProfile.findUnique({
+        where: { userId },
+      });
+      if (!profile) {
+        throw new NotFoundException('Specialist profile not found. Create a profile first.');
+      }
+
+      // Check specialist operates in the requested city
+      if (!profile.cities.includes(dto.city)) {
+        throw new BadRequestException(
+          `You don't have city "${dto.city}" in your profile. Add it first.`,
+        );
+      }
+
+      // Check for existing active promotion in same city+tier
+      const existing = await tx.promotion.findFirst({
+        where: {
+          specialistId: userId,
+          city: dto.city,
+          tier: dto.tier,
+          expiresAt: { gt: new Date() },
+        },
+      });
+      if (existing) {
+        throw new BadRequestException(
+          `You already have an active ${dto.tier} promotion in ${dto.city} until ${existing.expiresAt.toISOString()}`,
+        );
+      }
+
+      const months = dto.periodMonths ?? 1;
+      const basePrice = await this.getPrice(dto.city, dto.tier);
+
+      // Apply multi-month discount: 3 months = -10%, 6 months = -20%
+      const DISCOUNT: Record<number, number> = { 1: 0, 3: 0.1, 6: 0.2 };
+      const discount = DISCOUNT[months] ?? 0;
+      const price = Math.round(basePrice * months * (1 - discount));
+
+      // TODO: Integrate Stripe when STRIPE_SECRET_KEY is added to Doppler
+      // For now, mock payment: log and proceed
+      this.logger.log(
+        `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} months=${months} amount=${price} RUB`,
       );
-    }
 
-    // Check for existing active promotion in same city+tier
-    const existing = await this.prisma.promotion.findFirst({
-      where: {
-        specialistId: userId,
-        city: dto.city,
-        tier: dto.tier,
-        expiresAt: { gt: new Date() },
-      },
-    });
-    if (existing) {
-      throw new BadRequestException(
-        `You already have an active ${dto.tier} promotion in ${dto.city} until ${existing.expiresAt.toISOString()}`,
-      );
-    }
+      // Set expiry based on requested period (calendar months from now)
+      const expiresAt = new Date();
+      expiresAt.setMonth(expiresAt.getMonth() + months);
 
-    const months = dto.periodMonths ?? 1;
-    const basePrice = await this.getPrice(dto.city, dto.tier);
+      const promotion = await tx.promotion.create({
+        data: {
+          specialistId: userId,
+          city: dto.city,
+          tier: dto.tier,
+          expiresAt,
+          ...(dto.idempotencyKey ? { idempotencyKey: dto.idempotencyKey } : {}),
+        },
+      });
 
-    // Apply multi-month discount: 3 months = -10%, 6 months = -20%
-    const DISCOUNT: Record<number, number> = { 1: 0, 3: 0.1, 6: 0.2 };
-    const discount = DISCOUNT[months] ?? 0;
-    const price = Math.round(basePrice * months * (1 - discount));
-
-    // TODO: Integrate Stripe when STRIPE_SECRET_KEY is added to Doppler
-    // For now, mock payment: log and proceed
-    this.logger.log(
-      `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} months=${months} amount=${price} RUB`,
-    );
-
-    // Set expiry based on requested period (calendar months from now)
-    const expiresAt = new Date();
-    expiresAt.setMonth(expiresAt.getMonth() + months);
-
-    const promotion = await this.prisma.promotion.create({
-      data: {
-        specialistId: userId,
-        city: dto.city,
-        tier: dto.tier,
-        expiresAt,
-      },
-    });
-
-    return {
-      promotion,
-      payment: {
-        status: 'mock_paid',
-        amount: price,
-        currency: 'RUB',
-        note: 'Stripe integration pending. Payment simulated.',
-      },
-    };
+      return {
+        promotion,
+        payment: {
+          status: 'mock_paid',
+          amount: price,
+          currency: 'RUB',
+          note: 'Stripe integration pending. Payment simulated.',
+        },
+      };
+    }, { timeout: 10000 });
   }
 
   /** Get promotions for the authenticated user */


### PR DESCRIPTION
## Summary
- Added `idempotencyKey` (optional, unique) field to Promotion model
- Wrapped `purchase()` in `$transaction` to prevent TOCTOU race conditions
- Added `@IsUUID()` validation for idempotency key in DTO
- HMAC skipped (mock payment, no webhook)

## Test plan
- [ ] Purchase promotion without idempotencyKey — works as before
- [ ] Purchase with idempotencyKey — returns promotion
- [ ] Retry same idempotencyKey — returns existing promotion (no duplicate)
- [ ] Concurrent purchases for same city+tier — only one succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)