### PR TITLE
fix: thread list 30s polling — new chats visible without manual refresh

### DIFF
--- a/app/(dashboard)/messages/index.tsx
+++ b/app/(dashboard)/messages/index.tsx
@@ -105,6 +105,8 @@ export default function MessagesScreen() {
 
   useEffect(() => {
     fetchThreads();
+    const intervalId = setInterval(fetchThreads, 30_000);
+    return () => clearInterval(intervalId);
   }, [fetchThreads]);
 
   function getOtherParticipant(thread: ThreadItem): ThreadParticipant {


### PR DESCRIPTION
Adds 30s polling to thread list. Matches city-requests.tsx pattern. Cleanup on unmount.

Closes #2294