### PR TITLE
fix: budget 'rub.' -> 'руб.' on request pages (#131)

### DIFF
--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -151,7 +151,7 @@ export default function RequestDetailScreen() {
                 <View style={styles.metaItem}>
                   <Text style={styles.metaLabel}>Бюджет</Text>
                   <Text style={styles.metaValue}>
-                    {request.budget.toLocaleString('ru-RU')} rub.
+                    {request.budget.toLocaleString('ru-RU')} руб.
                   </Text>
                 </View>
               )}


### PR DESCRIPTION
Fixes #131

Fixes budget currency label from Latin 'rub.' to Cyrillic 'руб.' on public request detail page.

**Changed:** `app/requests/[id].tsx` line 154 — `rub.` → `руб.`