### PR TITLE
fix: request description maxLength 1000→2000 per UC-010 (#128)

### DIFF
--- a/app/(dashboard)/requests/edit/[id].tsx
+++ b/app/(dashboard)/requests/edit/[id].tsx
@@ -145,7 +145,7 @@ export default function EditRequestScreen() {
               <TextInput
                 value={description}
                 onChangeText={(t) => {
-                  if (t.length <= 1000) setDescription(t);
+                  if (t.length <= 2000) setDescription(t);
                   if (errors.description) setErrors((e) => ({ ...e, description: undefined }));
                 }}
                 placeholder="Опишите вашу задачу подробно..."
@@ -153,7 +153,7 @@ export default function EditRequestScreen() {
                 autoCapitalize="sentences"
                 multiline={true}
                 numberOfLines={4}
-                maxLength={1000}
+                maxLength={2000}
                 style={[
                   styles.descriptionInput,
                   errors.description ? styles.descriptionInputError : null,
@@ -164,7 +164,7 @@ export default function EditRequestScreen() {
                 {errors.description ? (
                   <Text style={styles.errorText}>{errors.description}</Text>
                 ) : <View />}
-                <Text style={styles.charCounter}>{description.length}/1000</Text>
+                <Text style={styles.charCounter}>{description.length}/2000</Text>
               </View>
             </View>
 

--- a/app/(dashboard)/requests/new.tsx
+++ b/app/(dashboard)/requests/new.tsx
@@ -104,7 +104,7 @@ export default function CreateRequestScreen() {
               <TextInput
                 value={description}
                 onChangeText={(t) => {
-                  if (t.length <= 1000) setDescription(t);
+                  if (t.length <= 2000) setDescription(t);
                   if (errors.description) setErrors((e) => ({ ...e, description: undefined }));
                 }}
                 placeholder="Опишите вашу задачу подробно..."
@@ -112,7 +112,7 @@ export default function CreateRequestScreen() {
                 autoCapitalize="sentences"
                 multiline={true}
                 numberOfLines={4}
-                maxLength={1000}
+                maxLength={2000}
                 style={[
                   styles.descriptionInput,
                   errors.description ? styles.descriptionInputError : null,
@@ -123,7 +123,7 @@ export default function CreateRequestScreen() {
                 {errors.description ? (
                   <Text style={styles.errorText}>{errors.description}</Text>
                 ) : <View />}
-                <Text style={styles.charCounter}>{description.length}/1000</Text>
+                <Text style={styles.charCounter}>{description.length}/2000</Text>
               </View>
             </View>
 


### PR DESCRIPTION
Fixes #128

Aligns frontend maxLength with backend @MaxLength(2000) and UC-010 spec. Also fixes character counter display.

## Changes
- `app/(dashboard)/requests/new.tsx`: maxLength 1000→2000, counter text "N/1000"→"N/2000", onChangeText guard 1000→2000
- `app/(dashboard)/requests/edit/[id].tsx`: same three changes