### PR TITLE
fix: add loading state to onboarding buttons (#121)

### DIFF
--- a/app/(onboarding)/cities.tsx
+++ b/app/(onboarding)/cities.tsx
@@ -16,6 +16,7 @@ import { RUSSIAN_CITIES } from '../../constants/Cities';
 export default function CitiesScreen() {
   const router = useRouter();
   const [selected, setSelected] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
   function toggleCity(city: string) {
     setSelected((prev) =>
@@ -24,12 +25,17 @@ export default function CitiesScreen() {
   }
 
   async function handleContinue() {
-    // Save cities to AsyncStorage so they survive refresh/deep links
-    await AsyncStorage.setItem('onboarding_cities', JSON.stringify(selected));
-    router.push({
-      pathname: '/(onboarding)/fns',
-      params: { cities: JSON.stringify(selected) },
-    });
+    setIsLoading(true);
+    try {
+      // Save cities to AsyncStorage so they survive refresh/deep links
+      await AsyncStorage.setItem('onboarding_cities', JSON.stringify(selected));
+      router.push({
+        pathname: '/(onboarding)/fns',
+        params: { cities: JSON.stringify(selected) },
+      });
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   return (
@@ -92,6 +98,7 @@ export default function CitiesScreen() {
           <Button
             onPress={handleContinue}
             disabled={selected.length === 0}
+            loading={isLoading}
             style={styles.btn}
           >
             Продолжить

--- a/app/(onboarding)/fns.tsx
+++ b/app/(onboarding)/fns.tsx
@@ -20,6 +20,7 @@ export default function FNSScreen() {
   const [selected, setSelected] = useState<FNSOffice[]>([]);
   const [search, setSearch] = useState('');
   const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
   const selectedNames = new Set(selected.map((o) => o.name));
 
@@ -47,18 +48,23 @@ export default function FNSScreen() {
       setError('Выберите хотя бы одну ИФНС');
       return;
     }
-    const cities = [...new Set(selected.map((o) => o.city))];
-    const fnsNames = selected.map((o) => o.name);
-    // Persist to AsyncStorage for refresh/deep-link resilience
-    await AsyncStorage.setItem('onboarding_cities', JSON.stringify(cities));
-    await AsyncStorage.setItem('onboarding_fns', JSON.stringify(fnsNames));
-    router.push({
-      pathname: '/(onboarding)/services',
-      params: {
-        cities: JSON.stringify(cities),
-        fnsOffices: JSON.stringify(fnsNames),
-      },
-    });
+    setIsLoading(true);
+    try {
+      const cities = [...new Set(selected.map((o) => o.city))];
+      const fnsNames = selected.map((o) => o.name);
+      // Persist to AsyncStorage for refresh/deep-link resilience
+      await AsyncStorage.setItem('onboarding_cities', JSON.stringify(cities));
+      await AsyncStorage.setItem('onboarding_fns', JSON.stringify(fnsNames));
+      router.push({
+        pathname: '/(onboarding)/services',
+        params: {
+          cities: JSON.stringify(cities),
+          fnsOffices: JSON.stringify(fnsNames),
+        },
+      });
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   // Progress: step 3 of 4 (username → cities → fns → services)
@@ -155,6 +161,7 @@ export default function FNSScreen() {
             <Button
               onPress={handleContinue}
               disabled={selected.length === 0}
+              loading={isLoading}
               style={styles.continueBtn}
             >
               Далее


### PR DESCRIPTION
Fixes #121

Adds `isLoading` state to `fns.tsx` and `cities.tsx` onboarding screens. Button now shows spinner and is disabled during submit to prevent double-tap.

## Changes
- `app/(onboarding)/fns.tsx`: added `isLoading` state, wrapped `handleContinue` in `try/finally`, added `loading={isLoading}` to Button
- `app/(onboarding)/cities.tsx`: same pattern applied to `handleContinue`

## How to verify
Tap "Продолжить" on `/onboarding/cities` and `/onboarding/fns` → button shows ActivityIndicator spinner and is disabled until navigation completes.