### PR TITLE
fix: log landing section API errors, no silent catch (#122)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -256,9 +256,9 @@ export default function LandingScreen() {
   const [popularCities, setPopularCities] = useState<any[]>([]);
 
   useEffect(() => {
-    api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch(() => {});
-    api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch(() => {});
-    api.get<any[]>('/specialists/cities/popular?limit=10').then(setPopularCities).catch(() => {});
+    api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err));
+    api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err));
+    api.get<any[]>('/specialists/cities/popular?limit=10').then(setPopularCities).catch((err) => console.warn('Landing section failed (popular cities):', err));
   }, []);
 
   const isWide = !isMobile;


### PR DESCRIPTION
Fixes #122

Replaces silent `.catch(() => {})` on landing page API calls with `.catch((err) => console.warn(...))`.

Errors are now visible in the dev console without breaking the UI — sections simply show empty state when data is unavailable.

Changed:
- `/specialists/featured` — warns with "Landing section failed (featured specialists)"
- `/requests/recent` — warns with "Landing section failed (recent requests)"
- `/specialists/cities/popular` — warns with "Landing section failed (popular cities)"