### PR TITLE
security: hide specialist contacts from unauthenticated users (#119)

### DIFF
--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -7,6 +7,7 @@ import { SpecialistsService } from './specialists.service';
 import { CreateSpecialistProfileDto } from './dto/create-specialist-profile.dto';
 import { UpdateSpecialistProfileDto } from './dto/update-specialist-profile.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
@@ -117,7 +118,8 @@ export class SpecialistsController {
   }
 
   @Get(':nick')
-  getProfile(@Param('nick') nick: string) {
-    return this.specialistsService.getProfile(nick);
+  @UseGuards(OptionalJwtAuthGuard)
+  getProfile(@Param('nick') nick: string, @Request() req: any) {
+    return this.specialistsService.getProfile(nick, req.user ?? null);
   }
 }

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -59,17 +59,18 @@ export class SpecialistsService {
     });
   }
 
-  async getProfile(nick: string) {
+  async getProfile(nick: string, requestingUser: { id: string } | null = null) {
     const profile = await this.prisma.specialistProfile.findUnique({
       where: { nick },
     });
     if (!profile) throw new NotFoundException('Specialist not found');
 
     const activity = await this.computeActivity(profile.userId);
-    // Strip internal IDs and contacts from public profile response
-    const { id: _id, userId: _userId, contacts: _contacts, ...publicProfile } = profile;
+    // Strip internal IDs from public profile response; contacts only for authenticated users
+    const { id: _id, userId: _userId, contacts, ...publicProfile } = profile;
     return {
       ...publicProfile,
+      ...(requestingUser ? { contacts } : {}),
       activity,
       rating: activity.avgRating,
       reviewCount: activity.reviewCount,


### PR DESCRIPTION
Fixes #119

Uses OptionalJwtAuthGuard on GET /specialists/:nick. When caller is not authenticated, contact fields are stripped from the response. Authenticated users (any role) receive contacts as before.

UC-040 compliance: contacts not exposed in public API.

## Changes
- `specialists.controller.ts`: added `@UseGuards(OptionalJwtAuthGuard)` to `GET /:nick`, passes `req.user` to service
- `specialists.service.ts`: `getProfile(nick, requestingUser)` — contacts included only when `requestingUser` is non-null

## How to verify
- `curl http://localhost:3812/specialists/<nick>` → no contacts field in response
- `curl -H "Authorization: Bearer <token>" http://localhost:3812/specialists/<nick>` → contacts field present