### PR TITLE
fix: add promotion screen to specialist sidebar (#118)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -23,6 +23,7 @@ const SPECIALIST_NAV_ITEMS: SidebarNavItem[] = [
   { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(dashboard)/messages', segment: 'messages' },
   { label: 'Запросы города', icon: 'location-outline', route: '/(dashboard)/city-requests', segment: 'city-requests' },
   { label: 'Лента запросов', icon: 'newspaper-outline', route: '/requests', segment: 'requests' },
+  { label: 'Продвижение', icon: 'rocket-outline', route: '/(dashboard)/promotion', segment: 'promotion' },
   { label: 'Настройки', icon: 'settings-outline', route: '/(dashboard)/settings', segment: 'settings' },
 ];
 


### PR DESCRIPTION
Fixes #118

Adds 'Продвижение' navigation link in specialist dashboard sidebar/layout. Screen was fully implemented (UC-024) but unreachable from UI.

- Added `{ label: 'Продвижение', icon: 'rocket-outline', route: '/(dashboard)/promotion', segment: 'promotion' }` to `SPECIALIST_NAV_ITEMS`
- Link only appears for SPECIALIST role users (CLIENT_NAV_ITEMS unchanged)
- Uses `rocket-outline` Ionicons icon, consistent with existing sidebar icon style
- TypeScript compiles clean before and after