### PR TITLE
refactor: rename duplicate component names with My/Public prefix (#140)

### DIFF
--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -35,7 +35,7 @@ interface SpecialistProfile {
   fnsOffices: string[];
 }
 
-export default function SpecialistProfileScreen() {
+export default function MySpecialistProfileScreen() {
   const router = useRouter();
   const [profile, setProfile] = useState<SpecialistProfile | null>(null);
   const [loading, setLoading] = useState(true);

--- a/app/(dashboard)/requests/[id].tsx
+++ b/app/(dashboard)/requests/[id].tsx
@@ -48,7 +48,7 @@ interface RequestDetail {
   responses: ResponseItem[];
 }
 
-export default function RequestDetailScreen() {
+export default function MyRequestDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { user } = useAuth();

--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -42,7 +42,7 @@ function formatDate(iso: string) {
   });
 }
 
-export default function RequestDetailScreen() {
+export default function PublicRequestDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { user } = useAuth();

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -71,7 +71,7 @@ function getReviewerInitials(review: ReviewItem): string {
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
 
-export default function SpecialistProfileScreen() {
+export default function PublicSpecialistProfileScreen() {
   const { nick } = useLocalSearchParams<{ nick: string }>();
   const router = useRouter();
   const { user } = useAuth();


### PR DESCRIPTION
Fixes #140

Renames duplicate component names to be unambiguous:
- RequestDetailScreen → MyRequestDetailScreen (dashboard) / PublicRequestDetailScreen (public)
- SpecialistProfileScreen → MySpecialistProfileScreen (dashboard) / PublicSpecialistProfileScreen (public)

Improves error trace readability and React DevTools clarity.