### PR TITLE
feat: add admin user to seed (#124)

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -625,6 +625,20 @@ async function main() {
     console.log(`  Response: ${r.specialistEmail} -> "${r.requestDescription.slice(0, 40)}..."`);
   }
 
+  // --- Seed admin user ---
+  // Email must match ADMIN_EMAILS env var used by AdminGuard
+  console.log('Seeding admin user...');
+  await prisma.user.upsert({
+    where: { email: 'dev@p2ptax.ru' },
+    update: {},
+    create: {
+      email: 'dev@p2ptax.ru',
+      username: 'admin',
+      role: Role.CLIENT,
+    },
+  });
+  console.log('  Created admin user: dev@p2ptax.ru (OTP 000000 in dev mode)');
+
   console.log('Seeding complete!');
 }
 


### PR DESCRIPTION
Fixes #124

Adds admin user to `prisma/seed.ts`. Email `dev@p2ptax.ru` matches the `ADMIN_EMAILS` env var used by `AdminGuard` in dev config. Enables testing admin panel without manual DB setup.

- Login: `dev@p2ptax.ru` with OTP `000000` in dev mode
- No specialist profile created (admin doesn't need one)
- Uses `upsert` pattern consistent with rest of seed