### PR TITLE
feat: maxLength 500 on response message per UC-022 (#132)

### DIFF
--- a/api/src/requests/dto/respond-request.dto.ts
+++ b/api/src/requests/dto/respond-request.dto.ts
@@ -3,6 +3,6 @@ import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
 export class RespondRequestDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(2000)
+  @MaxLength(500)
   message!: string;
 }

--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -535,9 +535,11 @@ export default function CityRequestsScreen() {
               placeholderTextColor={Colors.textMuted}
               multiline
               numberOfLines={4}
+              maxLength={500}
               style={styles.messageInput}
               autoFocus
             />
+            <Text style={styles.charCounter}>{message.length}/500</Text>
             <View style={styles.modalBtns}>
               <Button onPress={closeModal} variant="ghost" style={styles.modalBtn}>
                 Отмена
@@ -775,6 +777,12 @@ const styles = StyleSheet.create({
     color: Colors.textPrimary,
     minHeight: 100,
     textAlignVertical: 'top',
+  },
+  charCounter: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'right',
+    marginTop: -Spacing.xs,
   },
   modalBtns: {
     flexDirection: 'row',


### PR DESCRIPTION
Fixes #132

Adds maxLength validation to specialist response message:
- Frontend: `maxLength={500}` on TextInput + character counter "N/500"
- Backend DTO: `@MaxLength(500)` in RespondRequestDto (was 2000)