### PR TITLE
feat: SEO meta tags for specialist and request pages (#135)

### DIFF
--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -8,7 +8,8 @@ import {
   ActivityIndicator,
   TouchableOpacity,
 } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
@@ -41,6 +42,8 @@ function formatDate(iso: string) {
     minute: '2-digit',
   });
 }
+
+const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 
 export default function PublicRequestDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -106,8 +109,24 @@ export default function PublicRequestDetailScreen() {
 
   const isOpen = request.status === 'OPEN';
 
+  const pageTitle = request.category
+    ? `${request.category} — запрос в ${request.city} | Налоговик`
+    : `Налоговый запрос в ${request.city} | Налоговик`;
+  const pageDescription = request.description.slice(0, 160);
+  const pageUrl = `${APP_URL}/requests/${id}`;
+
   return (
     <SafeAreaView style={styles.safe}>
+      <Stack.Screen options={{ title: pageTitle }} />
+      {/* TODO: add og:image when CDN/static image is available */}
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:type" content="article" />
+      </Head>
       <LandingHeader />
       <Header title="Детали запроса" />
 

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -13,6 +13,7 @@ import {
   Share,
 } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';
 import { formatExperience } from '../../lib/format';
 import { useAuth } from '../../stores/authStore';
@@ -70,6 +71,8 @@ function getReviewerInitials(review: ReviewItem): string {
   if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
   return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 }
+
+const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 
 export default function PublicSpecialistProfileScreen() {
   const { nick } = useLocalSearchParams<{ nick: string }>();
@@ -650,9 +653,26 @@ export default function PublicSpecialistProfileScreen() {
     </View>
   );
 
+  const pageTitle = `${displayName} — налоговый консультант`;
+  const pageDescription = profile.bio
+    ? profile.bio.slice(0, 160)
+    : profile.cities.length > 0
+    ? `Налоговый консультант в ${profile.cities.join(', ')}. Опишите задачу бесплатно и получите предложение.`
+    : 'Налоговый консультант на платформе Налоговик. Опишите задачу бесплатно.';
+  const pageUrl = `${APP_URL}/specialists/${nick}`;
+
   return (
     <SafeAreaView style={styles.safe}>
-      <Stack.Screen options={{ title: `${displayName} — Налоговик` }} />
+      <Stack.Screen options={{ title: pageTitle }} />
+      {/* TODO: add og:image when CDN/static image is available */}
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:type" content="profile" />
+      </Head>
       <LandingHeader />
       <ScrollView
         contentContainerStyle={styles.scroll}


### PR DESCRIPTION
Fixes #135 (partial)

Adds og:title, og:description, og:url meta tags to:
- /specialists/[nick] — og:type: profile, title uses specialist name, description from bio or cities
- /requests/[id] — og:type: article, title includes category + city, description from request text

Note: og:image deferred (requires CDN setup). JSON-LD and canonical deferred as separate tasks.