### PR TITLE
feat: email notification for REST fallback messages (#138)

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -51,7 +51,7 @@ export class ChatController {
   // POST /threads/:id/messages — send a message via REST (fallback when WebSocket unavailable)
   @Post(':id/messages')
   async sendMessage(
-    @Request() req: { user: { id: string } },
+    @Request() req: { user: { id: string; email: string } },
     @Param('id') threadId: string,
     @Body() dto: SendMessageDto,
   ) {
@@ -62,11 +62,24 @@ export class ChatController {
 
     const message = await this.chatService.createMessage(threadId, req.user.id, dto.content.trim());
 
+    const room = `thread:${threadId}`;
+
     // Notify connected participants in real time via WebSocket (same as gateway)
     try {
-      this.chatGateway.server.to(`thread:${threadId}`).emit('message_received', message);
+      this.chatGateway.server.to(room).emit('message_received', message);
     } catch {
       // Non-blocking — WS emit failure must not fail the REST response
+    }
+
+    // Email notification for offline recipient — fire-and-forget (same logic as gateway)
+    const recipientId =
+      thread.participant1Id === req.user.id
+        ? thread.participant2Id
+        : thread.participant1Id;
+
+    const recipientOnline = this.chatGateway.isUserInRoom(recipientId, room);
+    if (!recipientOnline) {
+      this.chatGateway.notifyRecipientAsync(recipientId, req.user.email, threadId).catch(() => {});
     }
 
     return message;

--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -158,7 +158,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   /** Look up recipient email and send notification */
-  private async notifyRecipientAsync(
+  async notifyRecipientAsync(
     recipientId: string,
     senderEmail: string,
     threadId: string,
@@ -173,7 +173,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   /** Check if a user has any socket in a given room */
-  private isUserInRoom(userId: string, room: string): boolean {
+  isUserInRoom(userId: string, room: string): boolean {
     const adapter = this.server.adapter as any;
     const roomSockets: Set<string> | undefined = adapter.rooms?.get(room);
     if (!roomSockets) return false;


### PR DESCRIPTION
Fixes #138

## Summary
- Exposes `notifyRecipientAsync` and `isUserInRoom` as public methods on `ChatGateway` (previously private)
- REST fallback endpoint `POST /threads/:id/messages` now checks if recipient is offline and sends email notification — same logic as the WebSocket gateway
- No code duplication: controller reuses gateway methods directly

## How to verify
1. POST `/threads/:id/messages` with a valid JWT while recipient has no active WebSocket connection
2. Check API logs for: `DEV EMAIL [notifyNewMessage]: to=<recipient> from=<sender> threadId=<id>` (in dev mode without SMTP)
3. In production: recipient receives email "Новое сообщение — Налоговик"