### PR TITLE
feat: delete avatar — backend endpoint + UI button (#134)

### DIFF
--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards, Request, UseInterceptors, UploadedFile, BadRequestException } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Param, Body, Query, UseGuards, Request, UseInterceptors, UploadedFile, BadRequestException } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { extname, join } from 'path';
@@ -71,6 +71,13 @@ export class SpecialistsController {
     const avatarUrl = `/api/uploads/avatars/${file.filename}`;
     await this.specialistsService.updateAvatarUrl(req.user.id, avatarUrl);
     return { avatarUrl };
+  }
+
+  @Delete('me/avatar')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  deleteAvatar(@Request() req: any) {
+    return this.specialistsService.deleteAvatar(req.user.id);
   }
 
   @Get('cities')

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import { unlink } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateSpecialistProfileDto } from './dto/create-specialist-profile.dto';
 import { UpdateSpecialistProfileDto } from './dto/update-specialist-profile.dto';
@@ -240,6 +243,33 @@ export class SpecialistsService {
       where: { userId },
       data: { avatarUrl },
     });
+  }
+
+  async deleteAvatar(userId: string) {
+    const profile = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+    if (!profile) throw new NotFoundException('Profile not found');
+
+    // If no avatar, nothing to do
+    if (!profile.avatarUrl) return { message: 'No avatar to delete' };
+
+    // Derive absolute file path from avatarUrl like "/api/uploads/avatars/filename.jpg"
+    // File lives at <project>/api/uploads/avatars/filename.jpg
+    const filename = profile.avatarUrl.split('/').pop();
+    if (filename) {
+      const filePath = join(__dirname, '..', '..', 'uploads', 'avatars', filename);
+      if (existsSync(filePath)) {
+        await unlink(filePath).catch(() => {
+          // Ignore errors if file already gone — still clear DB
+        });
+      }
+    }
+
+    await this.prisma.specialistProfile.update({
+      where: { userId },
+      data: { avatarUrl: null },
+    });
+
+    return { message: 'Avatar deleted' };
   }
 
   async adminUpdateBadges(specialistId: string, badges: string[]) {

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -54,6 +54,7 @@ export default function MySpecialistProfileScreen() {
   const [fnsSearch, setFnsSearch] = useState('');
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
+  const [deletingAvatar, setDeletingAvatar] = useState(false);
 
   const fetchProfile = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
@@ -159,6 +160,33 @@ export default function MySpecialistProfileScreen() {
     }
   }
 
+  async function handleDeleteAvatar() {
+    if (!avatarUrl) return;
+    Alert.alert(
+      'Удалить фото',
+      'Вы уверены, что хотите удалить аватар?',
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: 'Удалить',
+          style: 'destructive',
+          onPress: async () => {
+            setDeletingAvatar(true);
+            try {
+              await api.del('/specialists/me/avatar');
+              setAvatarUrl(null);
+              Alert.alert('Готово', 'Аватар удалён');
+            } catch (err) {
+              Alert.alert('Ошибка', err instanceof ApiError ? err.message : 'Не удалось удалить фото');
+            } finally {
+              setDeletingAvatar(false);
+            }
+          },
+        },
+      ],
+    );
+  }
+
   async function handleSave() {
     setSaving(true);
     try {
@@ -233,7 +261,7 @@ export default function MySpecialistProfileScreen() {
         <View style={styles.container}>
           {/* Avatar */}
           <View style={[styles.section, styles.avatarSection]}>
-            <TouchableOpacity onPress={pickAvatar} disabled={uploadingAvatar} style={styles.avatarWrap}>
+            <TouchableOpacity onPress={pickAvatar} disabled={uploadingAvatar || deletingAvatar} style={styles.avatarWrap}>
               {avatarUrl ? (
                 <Image source={{ uri: avatarUrl }} style={styles.avatar} />
               ) : (
@@ -249,6 +277,19 @@ export default function MySpecialistProfileScreen() {
                 <Text style={styles.changeAvatarText}>Изменить фото</Text>
               )}
             </TouchableOpacity>
+            {avatarUrl && (
+              <TouchableOpacity
+                onPress={handleDeleteAvatar}
+                disabled={deletingAvatar || uploadingAvatar}
+                style={styles.deleteAvatarBtn}
+              >
+                {deletingAvatar ? (
+                  <ActivityIndicator size="small" color={Colors.statusError} />
+                ) : (
+                  <Text style={styles.deleteAvatarText}>Удалить фото</Text>
+                )}
+              </TouchableOpacity>
+            )}
           </View>
 
           {/* Nick */}
@@ -617,6 +658,16 @@ const styles = StyleSheet.create({
   changeAvatarText: {
     fontSize: Typography.fontSize.sm,
     color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  deleteAvatarBtn: {
+    marginTop: Spacing.xs,
+    paddingVertical: 4,
+    paddingHorizontal: Spacing.md,
+  },
+  deleteAvatarText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
     fontWeight: Typography.fontWeight.medium,
   },
   readonlyField: {


### PR DESCRIPTION
Fixes #134 (partial — avatar delete only, resize deferred)

## Changes

**Backend** — DELETE /specialists/me/avatar:
- Finds specialist by userId, reads avatarUrl
- Derives absolute file path from URL, deletes file from disk (silent if already gone)
- Clears avatarUrl in DB (sets to null)
- No-op if avatarUrl is already null

**Frontend** — app/(dashboard)/profile.tsx:
- Adds deletingAvatar state
- Adds handleDeleteAvatar() function with Alert.alert confirmation
- Shows "Удалить фото" button below avatar only when avatarUrl exists
- Disables both avatar buttons during delete operation
- Clears local avatarUrl state after successful deletion