### PR TITLE
feat: process pending quick request after auth (UC-079) (#137)

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -136,8 +136,8 @@ export default function OtpScreen() {
           try {
             await secureStorage.removeItem('p2ptax_pending_request'); // remove BEFORE post (race condition guard)
             const pendingData = JSON.parse(pendingRaw);
-            const created = await api.post('/requests', pendingData);
-            router.replace(`/(dashboard)/requests/${(created as any).data.id}` as any);
+            const created = await api.post<{ id: string }>('/requests', pendingData);
+            router.replace(`/(dashboard)/requests/${created.id}` as any);
             return;
           } catch {
             // POST failed — fall through to normal dashboard redirect

--- a/app/(auth)/role.tsx
+++ b/app/(auth)/role.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { api, ApiError } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
+import { secureStorage } from '../../stores/storage';
 
 export default function RoleScreen() {
   const router = useRouter();
@@ -28,6 +29,19 @@ export default function RoleScreen() {
       if (role === 'SPECIALIST') {
         router.replace('/(onboarding)/username');
       } else {
+        // Check for pending quick request saved from landing page before auth
+        const pendingRaw = await secureStorage.getItem('p2ptax_pending_request');
+        if (pendingRaw) {
+          try {
+            await secureStorage.removeItem('p2ptax_pending_request'); // remove BEFORE post (race condition guard)
+            const pendingData = JSON.parse(pendingRaw);
+            const created = await api.post<{ id: string }>('/requests', pendingData);
+            router.replace(`/(dashboard)/requests/${created.id}` as any);
+            return;
+          } catch {
+            // POST failed — fall through to normal dashboard redirect
+          }
+        }
         router.replace('/(dashboard)');
       }
     } catch {


### PR DESCRIPTION
Fixes #137

After successful OTP auth (or role selection for new users), checks AsyncStorage for 'p2ptax_pending_request'.

If found:
- POSTs to /requests with stored description/city/budget
- Clears storage key (removed BEFORE POST to prevent race conditions)
- Redirects to the newly created request

On failure: clears key silently, proceeds with normal navigation.

**Changes:**
- `app/(auth)/otp.tsx`: Fixed `.data.id` bug (API returns object directly, not `{ data: { id } }`). Now handles pending request for returning CLIENT users.
- `app/(auth)/role.tsx`: Added pending request logic for new CLIENT users after role selection.

**SPECIALIST users:** pending request is skipped (they can't create requests).