### PR TITLE
feat: chat file/image attachments — S3 upload + inline preview

### DIFF
--- a/api/prisma/migrations/20260407000000_add_message_attachments/migration.sql
+++ b/api/prisma/migrations/20260407000000_add_message_attachments/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "messages" ADD COLUMN "attachmentUrl" TEXT,
+                        ADD COLUMN "attachmentType" TEXT,
+                        ADD COLUMN "attachmentName" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -135,14 +135,17 @@ model Thread {
 }
 
 model Message {
-  id        String    @id @default(cuid())
-  threadId  String
-  thread    Thread    @relation(fields: [threadId], references: [id])
-  senderId  String
-  sender    User      @relation(fields: [senderId], references: [id])
-  content   String
-  readAt    DateTime?
-  createdAt DateTime  @default(now())
+  id             String    @id @default(cuid())
+  threadId       String
+  thread         Thread    @relation(fields: [threadId], references: [id])
+  senderId       String
+  sender         User      @relation(fields: [senderId], references: [id])
+  content        String
+  readAt         DateTime?
+  createdAt      DateTime  @default(now())
+  attachmentUrl  String?
+  attachmentType String?   // "IMAGE" | "DOCUMENT"
+  attachmentName String?
 
   @@index([threadId])
   @@map("messages")

--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -7,15 +7,33 @@ import {
   Query,
   Body,
   UseGuards,
+  UseInterceptors,
+  UploadedFile,
   Request,
   ForbiddenException,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { randomUUID } from 'crypto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { StorageService } from '../storage/storage.service';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
 import { StartThreadDto } from './dto/start-thread.dto';
 import { SendMessageDto } from './dto/send-message.dto';
+
+const ALLOWED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+const IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
 @Controller('threads')
 @UseGuards(JwtAuthGuard)
@@ -23,6 +41,7 @@ export class ChatController {
   constructor(
     private readonly chatService: ChatService,
     private readonly chatGateway: ChatGateway,
+    private readonly storageService: StorageService,
   ) {}
 
   @Get()
@@ -48,6 +67,50 @@ export class ChatController {
     return this.chatService.getMessages(req.user.id, threadId, parseInt(page ?? '1', 10) || 1);
   }
 
+  // POST /threads/:id/upload — upload a file attachment for a thread message
+  @Post(':id/upload')
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: 20 * 1024 * 1024 }, // 20 MB max
+      fileFilter: (_req, file, cb) => {
+        if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new BadRequestException(`File type not allowed: ${file.mimetype}`), false);
+        }
+      },
+    }),
+  )
+  async uploadChatFile(
+    @Request() req: { user: { id: string } },
+    @Param('id') threadId: string,
+    @UploadedFile() file: Express.Multer.File | undefined,
+  ): Promise<{ url: string; type: string; name: string }> {
+    if (!file) {
+      throw new BadRequestException('No file uploaded');
+    }
+
+    // Image limit: 10 MB
+    if (IMAGE_MIME_TYPES.has(file.mimetype) && file.size > 10 * 1024 * 1024) {
+      throw new BadRequestException('Image files must be under 10 MB');
+    }
+
+    // Verify caller is a thread participant
+    const thread = await this.chatService.verifyParticipant(req.user.id, threadId);
+    if (!thread) {
+      throw new NotFoundException('Thread not found or access denied');
+    }
+
+    const ext = file.originalname.split('.').pop()?.toLowerCase() || 'bin';
+    const fileId = randomUUID();
+    const key = `chat/${threadId}/${fileId}.${ext}`;
+
+    const url = await this.storageService.uploadBuffer(key, file.buffer, file.mimetype);
+    const type = IMAGE_MIME_TYPES.has(file.mimetype) ? 'IMAGE' : 'DOCUMENT';
+
+    return { url, type, name: file.originalname };
+  }
+
   // POST /threads/:id/messages — send a message via REST (fallback when WebSocket unavailable)
   @Post(':id/messages')
   async sendMessage(
@@ -60,7 +123,17 @@ export class ChatController {
       throw new NotFoundException('Thread not found or access denied');
     }
 
-    const message = await this.chatService.createMessage(threadId, req.user.id, dto.content.trim());
+    const attachment =
+      dto.attachmentUrl && dto.attachmentType && dto.attachmentName
+        ? { url: dto.attachmentUrl, type: dto.attachmentType, name: dto.attachmentName }
+        : undefined;
+
+    const message = await this.chatService.createMessage(
+      threadId,
+      req.user.id,
+      dto.content.trim(),
+      attachment,
+    );
 
     const room = `thread:${threadId}`;
 

--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -85,14 +85,22 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('send_message')
   async handleSendMessage(
     @ConnectedSocket() client: AuthenticatedSocket,
-    @MessageBody() data: { threadId: string; content: string },
+    @MessageBody() data: {
+      threadId: string;
+      content: string;
+      attachmentUrl?: string;
+      attachmentType?: string;
+      attachmentName?: string;
+    },
   ) {
     if (!client.data?.userId) {
       throw new WsException('Not authenticated');
     }
 
-    if (!data.content?.trim()) {
-      client.emit('error', { message: 'Content is required' });
+    // Allow empty content if attachment is present
+    const hasAttachment = !!(data.attachmentUrl && data.attachmentType && data.attachmentName);
+    if (!data.content?.trim() && !hasAttachment) {
+      client.emit('error', { message: 'Content or attachment is required' });
       return;
     }
 
@@ -102,10 +110,15 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return;
     }
 
+    const attachment = hasAttachment
+      ? { url: data.attachmentUrl!, type: data.attachmentType!, name: data.attachmentName! }
+      : undefined;
+
     const message = await this.chatService.createMessage(
       data.threadId,
       client.data.userId,
-      data.content.trim(),
+      data.content?.trim() ?? '',
+      attachment,
     );
 
     const room = `thread:${data.threadId}`;

--- a/api/src/chat/chat.service.ts
+++ b/api/src/chat/chat.service.ts
@@ -83,6 +83,9 @@ export class ChatService {
           content: true,
           readAt: true,
           createdAt: true,
+          attachmentUrl: true,
+          attachmentType: true,
+          attachmentName: true,
         },
       }),
       this.prisma.message.count({ where: { threadId } }),
@@ -123,9 +126,23 @@ export class ChatService {
   }
 
   /** Save a message to DB */
-  async createMessage(threadId: string, senderId: string, content: string) {
+  async createMessage(
+    threadId: string,
+    senderId: string,
+    content: string,
+    attachment?: { url: string; type: string; name: string },
+  ) {
     return this.prisma.message.create({
-      data: { threadId, senderId, content },
+      data: {
+        threadId,
+        senderId,
+        content,
+        ...(attachment && {
+          attachmentUrl: attachment.url,
+          attachmentType: attachment.type,
+          attachmentName: attachment.name,
+        }),
+      },
       select: {
         id: true,
         threadId: true,
@@ -133,6 +150,9 @@ export class ChatService {
         content: true,
         readAt: true,
         createdAt: true,
+        attachmentUrl: true,
+        attachmentType: true,
+        attachmentName: true,
       },
     });
   }
@@ -160,6 +180,9 @@ export class ChatService {
         content: true,
         readAt: true,
         createdAt: true,
+        attachmentUrl: true,
+        attachmentType: true,
+        attachmentName: true,
       },
     });
   }

--- a/api/src/chat/dto/send-message.dto.ts
+++ b/api/src/chat/dto/send-message.dto.ts
@@ -1,8 +1,22 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsOptional, MaxLength, IsIn, IsUrl } from 'class-validator';
 
 export class SendMessageDto {
   @IsString()
-  @IsNotEmpty()
   @MaxLength(2000)
   content!: string;
+
+  @IsOptional()
+  @IsString()
+  @IsUrl()
+  attachmentUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['IMAGE', 'DOCUMENT'])
+  attachmentType?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  attachmentName?: string;
 }

--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -10,8 +10,12 @@ import {
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
+  Image,
+  Alert,
 } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../../../stores/authStore';
 import { api } from '../../../lib/api';
 import { getSocket, disconnectSocket } from '../../../lib/socket';
@@ -20,6 +24,12 @@ import { EmptyState } from '../../../components/EmptyState';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import type { Socket } from 'socket.io-client';
 
+interface Attachment {
+  url: string;
+  type: string;   // "IMAGE" | "DOCUMENT"
+  name: string;
+}
+
 interface Message {
   id: string;
   threadId: string;
@@ -27,6 +37,9 @@ interface Message {
   content: string;
   readAt: string | null;
   createdAt: string;
+  attachmentUrl?: string | null;
+  attachmentType?: string | null;
+  attachmentName?: string | null;
 }
 
 interface MessagesResponse {
@@ -78,6 +91,8 @@ export default function ThreadScreen() {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [pendingAttachment, setPendingAttachment] = useState<Attachment | null>(null);
+  const [uploadingFile, setUploadingFile] = useState(false);
 
   const flatListRef = useRef<FlatList<Message>>(null);
   const socketRef = useRef<Socket | null>(null);
@@ -226,14 +241,116 @@ export default function ThreadScreen() {
     }
   }
 
+  /** Upload a file (web: File object, native: { uri, name, mimeType }) */
+  async function uploadAttachment(fileData: { uri: string; name: string; mimeType: string }) {
+    if (!threadId) return;
+    setUploadingFile(true);
+    try {
+      const formData = new FormData();
+
+      if (Platform.OS === 'web') {
+        // On web, uri is a blob: URL — fetch it and append as Blob
+        const response = await fetch(fileData.uri);
+        const blob = await response.blob();
+        formData.append('file', blob, fileData.name);
+      } else {
+        // On native, use the RN FormData file append format
+        formData.append('file', {
+          uri: fileData.uri,
+          name: fileData.name,
+          type: fileData.mimeType,
+        } as unknown as Blob);
+      }
+
+      const result = await api.upload<Attachment>(`/threads/${threadId}/upload`, formData);
+      setPendingAttachment(result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Ошибка загрузки файла';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setUploadingFile(false);
+    }
+  }
+
+  async function handleAttachPress() {
+    if (Platform.OS === 'web') {
+      // Web: use file input element
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'image/jpeg,image/png,image/gif,image/webp,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      input.onchange = async (e) => {
+        const file = (e.target as HTMLInputElement).files?.[0];
+        if (!file) return;
+        const uri = URL.createObjectURL(file);
+        await uploadAttachment({ uri, name: file.name, mimeType: file.type });
+      };
+      input.click();
+      return;
+    }
+
+    // Native: show action sheet style
+    Alert.alert('Прикрепить файл', 'Выберите тип', [
+      {
+        text: 'Фото из галереи',
+        onPress: async () => {
+          const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Нет доступа', 'Разрешите доступ к галерее в настройках');
+            return;
+          }
+          const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ['images'],
+            quality: 0.85,
+          });
+          if (!result.canceled && result.assets[0]) {
+            const asset = result.assets[0];
+            const name = asset.fileName ?? `photo_${Date.now()}.jpg`;
+            const mimeType = asset.mimeType ?? 'image/jpeg';
+            await uploadAttachment({ uri: asset.uri, name, mimeType });
+          }
+        },
+      },
+      {
+        text: 'Камера',
+        onPress: async () => {
+          const perm = await ImagePicker.requestCameraPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Нет доступа', 'Разрешите доступ к камере в настройках');
+            return;
+          }
+          const result = await ImagePicker.launchCameraAsync({
+            mediaTypes: ['images'],
+            quality: 0.85,
+          });
+          if (!result.canceled && result.assets[0]) {
+            const asset = result.assets[0];
+            const name = asset.fileName ?? `photo_${Date.now()}.jpg`;
+            const mimeType = asset.mimeType ?? 'image/jpeg';
+            await uploadAttachment({ uri: asset.uri, name, mimeType });
+          }
+        },
+      },
+      { text: 'Отмена', style: 'cancel' },
+    ]);
+  }
+
+  function clearAttachment() {
+    setPendingAttachment(null);
+  }
+
   async function handleSend() {
     const content = input.trim();
-    if (!content || !threadId || sending) return;
+    const hasAttachment = !!pendingAttachment;
+
+    if (!content && !hasAttachment) return;
+    if (!threadId || sending) return;
 
     setInput('');
+    const attachmentToSend = pendingAttachment;
+    setPendingAttachment(null);
     setSending(true);
 
-    // Optimistic update: add message to local state immediately
+    // Optimistic update
     const optimisticMsg: Message = {
       id: `optimistic-${Date.now()}`,
       threadId: threadId!,
@@ -241,30 +358,78 @@ export default function ThreadScreen() {
       content,
       readAt: null,
       createdAt: new Date().toISOString(),
+      attachmentUrl: attachmentToSend?.url ?? null,
+      attachmentType: attachmentToSend?.type ?? null,
+      attachmentName: attachmentToSend?.name ?? null,
     };
     setMessages((prev) => [...prev, optimisticMsg]);
 
     try {
       if (socketRef.current?.connected) {
-        // Primary path: send via WebSocket — gateway broadcasts message_received to room
-        socketRef.current.emit('send_message', { threadId, content });
+        // Primary path: WebSocket
+        socketRef.current.emit('send_message', {
+          threadId,
+          content,
+          ...(attachmentToSend && {
+            attachmentUrl: attachmentToSend.url,
+            attachmentType: attachmentToSend.type,
+            attachmentName: attachmentToSend.name,
+          }),
+        });
       } else {
-        // Fallback: WebSocket unavailable — send via REST, which also emits to WS room
-        const message = await api.post<Message>(`/threads/${threadId}/messages`, { content });
-        // Append locally so sender sees the message immediately without waiting for WS event
+        // Fallback: REST
+        const message = await api.post<Message>(`/threads/${threadId}/messages`, {
+          content,
+          ...(attachmentToSend && {
+            attachmentUrl: attachmentToSend.url,
+            attachmentType: attachmentToSend.type,
+            attachmentName: attachmentToSend.name,
+          }),
+        });
         setMessages((prev) => {
           if (prev.some((m) => m.id === message.id)) return prev;
           return [...prev, message];
         });
       }
     } catch {
-      // Restore input on failure so user can retry
+      // Restore on failure
       setInput(content);
-      // Remove optimistic message on error
+      if (attachmentToSend) setPendingAttachment(attachmentToSend);
       setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id));
     } finally {
       setSending(false);
     }
+  }
+
+  function renderAttachmentContent(item: Message, isMe: boolean) {
+    if (!item.attachmentUrl) return null;
+
+    if (item.attachmentType === 'IMAGE') {
+      return (
+        <Image
+          source={{ uri: item.attachmentUrl }}
+          style={styles.attachImage}
+          resizeMode="cover"
+        />
+      );
+    }
+
+    // DOCUMENT
+    return (
+      <View style={[styles.docRow, isMe ? styles.docRowMe : styles.docRowOther]}>
+        <Ionicons
+          name="document-outline"
+          size={20}
+          color={isMe ? 'rgba(255,255,255,0.9)' : Colors.textMuted}
+        />
+        <Text
+          style={[styles.docName, isMe ? styles.docNameMe : styles.docNameOther]}
+          numberOfLines={1}
+        >
+          {item.attachmentName ?? 'Файл'}
+        </Text>
+      </View>
+    );
   }
 
   function renderMessage({ item, index }: { item: Message; index: number }) {
@@ -289,9 +454,12 @@ export default function ThreadScreen() {
         )}
         <View style={[styles.msgRow, isMe ? styles.msgRowMe : styles.msgRowOther]}>
           <View style={[styles.bubble, isMe ? styles.bubbleMe : styles.bubbleOther]}>
-            <Text style={[styles.msgText, isMe ? styles.msgTextMe : styles.msgTextOther]}>
-              {item.content}
-            </Text>
+            {renderAttachmentContent(item, isMe)}
+            {!!item.content && (
+              <Text style={[styles.msgText, isMe ? styles.msgTextMe : styles.msgTextOther]}>
+                {item.content}
+              </Text>
+            )}
             <View style={styles.msgMeta}>
               <Text style={[styles.msgTime, isMe ? styles.msgTimeMe : styles.msgTimeOther]}>
                 {formatMsgTime(item.createdAt)}
@@ -307,6 +475,8 @@ export default function ThreadScreen() {
       </>
     );
   }
+
+  const canSend = !!(input.trim() || pendingAttachment);
 
   return (
     <SafeAreaView style={styles.safe}>
@@ -358,7 +528,41 @@ export default function ThreadScreen() {
           </View>
         )}
 
+        {/* Attachment preview above input */}
+        {pendingAttachment && (
+          <View style={styles.attachPreview}>
+            {pendingAttachment.type === 'IMAGE' ? (
+              <Image source={{ uri: pendingAttachment.url }} style={styles.attachPreviewImg} />
+            ) : (
+              <View style={styles.attachPreviewDoc}>
+                <Ionicons name="document-outline" size={20} color={Colors.textMuted} />
+                <Text style={styles.attachPreviewName} numberOfLines={1}>
+                  {pendingAttachment.name}
+                </Text>
+              </View>
+            )}
+            <TouchableOpacity onPress={clearAttachment} style={styles.attachRemoveBtn} hitSlop={8}>
+              <Ionicons name="close-circle" size={20} color={Colors.textMuted} />
+            </TouchableOpacity>
+          </View>
+        )}
+
         <View style={styles.inputBar}>
+          {/* Attach button */}
+          <TouchableOpacity
+            style={styles.attachBtn}
+            onPress={handleAttachPress}
+            disabled={uploadingFile || sending}
+            activeOpacity={0.7}
+            hitSlop={6}
+          >
+            {uploadingFile ? (
+              <ActivityIndicator size="small" color={Colors.textMuted} />
+            ) : (
+              <Ionicons name="attach" size={22} color={Colors.textMuted} />
+            )}
+          </TouchableOpacity>
+
           <TextInput
             style={styles.textInput}
             value={input}
@@ -370,9 +574,9 @@ export default function ThreadScreen() {
             returnKeyType="default"
           />
           <TouchableOpacity
-            style={[styles.sendBtn, (!input.trim() || sending) && styles.sendBtnDisabled]}
+            style={[styles.sendBtn, (!canSend || sending) && styles.sendBtnDisabled]}
             onPress={handleSend}
-            disabled={!input.trim() || sending}
+            disabled={!canSend || sending}
             activeOpacity={0.7}
           >
             {sending ? (
@@ -480,6 +684,61 @@ const styles = StyleSheet.create({
   msgTimeOther: {
     color: Colors.textMuted,
   },
+  // Attachment inside message bubble
+  attachImage: {
+    width: 200,
+    height: 150,
+    borderRadius: BorderRadius.md,
+    marginBottom: 4,
+  },
+  docRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  docRowMe: {},
+  docRowOther: {},
+  docName: {
+    fontSize: Typography.fontSize.sm,
+    flex: 1,
+  },
+  docNameMe: {
+    color: 'rgba(255,255,255,0.9)',
+  },
+  docNameOther: {
+    color: Colors.textPrimary,
+  },
+  // Attachment preview above input
+  attachPreview: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs,
+    backgroundColor: Colors.bgSecondary,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    gap: Spacing.sm,
+  },
+  attachPreviewImg: {
+    width: 48,
+    height: 48,
+    borderRadius: BorderRadius.sm,
+  },
+  attachPreviewDoc: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: 6,
+  },
+  attachPreviewName: {
+    flex: 1,
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textPrimary,
+  },
+  attachRemoveBtn: {
+    padding: 2,
+  },
   typingWrap: {
     paddingHorizontal: Spacing.xl,
     paddingBottom: Spacing.xs,
@@ -498,6 +757,12 @@ const styles = StyleSheet.create({
     borderTopColor: Colors.border,
     backgroundColor: Colors.bgSecondary,
     gap: Spacing.sm,
+  },
+  attachBtn: {
+    width: 36,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   textInput: {
     flex: 1,


### PR DESCRIPTION
## Summary
- Adds `attachmentUrl`, `attachmentType`, `attachmentName` fields to `Message` model with Prisma migration
- New `POST /threads/:id/upload` endpoint — validates MIME type/size, uploads to S3 via StorageService, returns `{ url, type, name }`
- Updates WebSocket gateway and REST fallback to forward attachment data when saving messages
- Frontend: paperclip button → expo-image-picker (native) / file input (web) → upload → preview strip → send with message

## Test plan
- [ ] Upload image via chat → appears inline in message bubble
- [ ] Upload PDF → appears as filename + doc icon in bubble
- [ ] Text-only messages still work unchanged
- [ ] Attachment with empty text body sends correctly
- [ ] File > 10MB image rejected with error
- [ ] Unsupported MIME type rejected

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)