### PR TITLE
fix: RolesGuard explicit 401/403 responses (#180)

### DIFF
--- a/api/src/auth/roles.guard.ts
+++ b/api/src/auth/roles.guard.ts
@@ -1,4 +1,10 @@
-import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Role } from '@prisma/client';
 import { ROLES_KEY } from './roles.decorator';
@@ -19,6 +25,17 @@ export class RolesGuard implements CanActivate {
     }
 
     const { user } = context.switchToHttp().getRequest();
-    return requiredRoles.includes(user?.role);
+
+    // No user at all — not authenticated (401)
+    if (!user) {
+      throw new UnauthorizedException('Authentication required');
+    }
+
+    // Authenticated but wrong role (403)
+    if (!requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('Insufficient permissions');
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
## Problem

`RolesGuard.canActivate()` silently returned `false` when `user` was undefined (unauthenticated request). NestJS converts `false` into a generic 403 Forbidden in both cases:
- Unauthenticated request (no JWT) → got 403, should be **401**
- Authenticated but wrong role → got 403, correct

This breaks frontend routing logic that needs to distinguish between "not logged in" (redirect to login) and "no permission" (show 403 page).

## Fix

Added explicit exception throwing:
- `user` is undefined → throw `UnauthorizedException` (401)
- `user` exists but role not in `requiredRoles` → throw `ForbiddenException` (403)

## Files changed

- `api/src/auth/roles.guard.ts`

## Verification

- `npx tsc --noEmit` passes with no errors
- Logic: unauthenticated requests to `@Roles()`-decorated routes now return 401, authenticated users with wrong role return 403