### PR TITLE
fix: admin blockUser validation and IDOR prevention (#171)

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -10,6 +10,7 @@ import {
 import { AdminService } from './admin.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
+import { BlockUserDto } from './dto/block-user.dto';
 
 @Controller('admin')
 export class AdminController {
@@ -32,8 +33,8 @@ export class AdminController {
   /** PATCH /admin/users/:id — block or unblock a user */
   @Patch('users/:id')
   @UseGuards(JwtAuthGuard, AdminGuard)
-  blockUser(@Param('id') id: string, @Body('isBlocked') isBlocked: boolean) {
-    return this.adminService.blockUser(id, isBlocked);
+  blockUser(@Param('id') id: string, @Body() dto: BlockUserDto) {
+    return this.adminService.blockUser(id, dto.isBlocked);
   }
 
   /** GET /admin/specialists — all specialist profiles */

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -65,6 +65,11 @@ export class AdminService {
   }
 
   async blockUser(id: string, isBlocked: boolean) {
+    const user = await this.prisma.user.findUnique({ where: { id } });
+    if (!user) {
+      throw new NotFoundException(`User ${id} not found`);
+    }
+
     return this.prisma.user.update({
       where: { id },
       data: { isBlocked },

--- a/api/src/admin/dto/block-user.dto.ts
+++ b/api/src/admin/dto/block-user.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class BlockUserDto {
+  @IsBoolean()
+  isBlocked!: boolean;
+}


### PR DESCRIPTION
## Summary

- Added `BlockUserDto` with `@IsBoolean()` validation so non-boolean `isBlocked` values are rejected at controller level (400 Bad Request)
- Added `findUnique` guard in `AdminService.blockUser()` — throws `NotFoundException` (404) if target user does not exist, preventing blind Prisma `update` calls that would error with P2025
- Controller now uses `@Body() dto: BlockUserDto` instead of raw `@Body('isBlocked')`, ensuring ValidationPipe enforces the type

## Files changed

- `api/src/admin/dto/block-user.dto.ts` — new DTO
- `api/src/admin/admin.controller.ts` — use DTO
- `api/src/admin/admin.service.ts` — add existence check

## Test plan

- [ ] `PATCH /api/admin/users/:nonExistentId` → 404 Not Found
- [ ] `PATCH /api/admin/users/:validId` with `{ "isBlocked": "yes" }` → 400 Bad Request
- [ ] `PATCH /api/admin/users/:validId` with `{ "isBlocked": true }` → 200 OK, user blocked
- [ ] `npx tsc --noEmit` passes with 0 errors

Fixes #171