### PR TITLE
fix: allow users to set role via updateRole (#169)

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -24,12 +24,16 @@ export class UsersService {
 
   /**
    * Set role for a new user (onboarding step 1).
-   * Only allowed when role is null (user has not yet picked a role).
+   * Allowed when user's role is still CLIENT (schema default = "not yet chosen").
+   * Blocked only when user already completed specialist onboarding (role = SPECIALIST).
    */
   async updateRole(userId: string, role: string): Promise<{ id: string; email: string; role: string }> {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found');
-    if (user.role !== null) {
+    // The Prisma schema sets role = CLIENT by default (not null), so checking !== null
+    // would always block. Instead, block only when role was explicitly set to SPECIALIST
+    // (i.e., the user completed specialist onboarding).
+    if (user.role === Role.SPECIALIST) {
       throw new BadRequestException('Role already assigned. Cannot change role via this endpoint.');
     }
 


### PR DESCRIPTION
## Problem

`UsersService.updateRole()` checked `if (user.role !== null)` but the Prisma schema has `role Role @default(CLIENT)`, meaning `role` is NEVER null. The guard always threw `BadRequestException('Role already assigned')`, so users could never select their role during onboarding.

## Fix

Changed guard from `user.role !== null` to `user.role === Role.SPECIALIST`.

**Logic:**
- `CLIENT` = schema default = "user has not yet chosen a role" → allow role selection
- `SPECIALIST` = explicitly set via `setupSpecialistProfile` onboarding → block to prevent downgrade

This preserves the privilege escalation guard in `setupSpecialistProfile` which independently checks `user.role === Role.CLIENT` to block re-entry.

## Files Changed

- `api/src/users/users.service.ts` — `updateRole()` guard condition + updated JSDoc comment

## Verification

- `npx tsc --noEmit` — no new errors (3 pre-existing errors in chat.service.ts remain unchanged)
- Logic: new CLIENT user can now call `PATCH /users/me` with `{role: 'CLIENT'}` or `{role: 'SPECIALIST'}` successfully
- Logic: a SPECIALIST user calling `PATCH /users/me` still gets 400 BadRequest

Fixes #169