### PR TITLE
security: remove client email from public reviews endpoint (#179)

### DIFF
--- a/api/src/reviews/reviews.service.ts
+++ b/api/src/reviews/reviews.service.ts
@@ -116,7 +116,7 @@ export class ReviewsService {
           rating: true,
           comment: true,
           createdAt: true,
-          client: { select: { id: true, username: true, email: true } },
+          client: { select: { id: true, username: true } },
         },
       }),
       this.prisma.review.count({ where: { specialistId } }),


### PR DESCRIPTION
Removes email from GET /reviews/specialist/:nick response — privacy fix.