### PR TITLE
fix: user deletion FK constraint order (#170)

### DIFF
--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -289,7 +289,14 @@ export class UsersService {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found');
 
+    // Capture email before transaction for OTP cleanup (keyed by email, not userId)
+    const userEmail = user.email;
+
     await this.prisma.$transaction([
+      // Complaints filed by or against this user
+      this.prisma.complaint.deleteMany({ where: { reporterId: userId } }),
+      this.prisma.complaint.deleteMany({ where: { targetUserId: userId } }),
+
       // Reviews given by user
       this.prisma.review.deleteMany({ where: { clientId: userId } }),
 
@@ -332,6 +339,12 @@ export class UsersService {
 
       // Specialist profile
       this.prisma.specialistProfile.deleteMany({ where: { userId } }),
+
+      // Refresh tokens
+      this.prisma.refreshToken.deleteMany({ where: { userId } }),
+
+      // OTP codes (keyed by email, no FK to User)
+      this.prisma.otpCode.deleteMany({ where: { email: userEmail } }),
 
       // Finally, the user
       this.prisma.user.delete({ where: { id: userId } }),


### PR DESCRIPTION
Reorders `deleteUser` \`\$transaction\` and adds missing deletions to prevent FK constraint violations.

**Changes:**
- Add `complaint.deleteMany` (both `reporterId` and `targetUserId`) at the start of the transaction
- Add `refreshToken.deleteMany` before the final `user.delete`
- Add `otpCode.deleteMany` by email (captured before transaction, since `OtpCode` has no FK to User)
- Complaints moved to front — they reference User directly and must be cleared before reviews/messages

**Deletion order (final):**
1. complaints (reporterId + targetUserId)
2. reviews (clientId + specialistId + on requests)
3. messages (senderId + thread participants)
4. threads
5. responses (specialistId + request.clientId)
6. requests (clientId)
7. promotions (specialistId)
8. specialistProfile (userId)
9. refreshTokens (userId)
10. otpCodes (email)
11. user.delete (id)

Fixes #170