### PR TITLE
fix: validate request body in PATCH /requests/:id (#168)

### DIFF
--- a/api/src/requests/dto/patch-request.dto.ts
+++ b/api/src/requests/dto/patch-request.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsNotEmpty, MaxLength, IsOptional, IsInt, Min, IsEnum } from 'class-validator';
+import { RequestStatus } from '@prisma/client';
+
+export class PatchRequestDto {
+  @IsOptional()
+  @IsEnum(RequestStatus)
+  status?: RequestStatus;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  city?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  budget?: number | null;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  category?: string;
+}

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -12,8 +12,7 @@ import {
 import { RequestsService } from './requests.service';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { RespondRequestDto } from './dto/respond-request.dto';
-import { UpdateRequestStatusDto } from './dto/update-request-status.dto';
-import { UpdateRequestDto } from './dto/update-request.dto';
+import { PatchRequestDto } from './dto/patch-request.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -96,7 +95,7 @@ export class RequestsController {
   update(
     @Request() req: any,
     @Param('id') id: string,
-    @Body() dto: any,
+    @Body() dto: PatchRequestDto,
   ) {
     // If body contains status field, use status-update logic
     if (dto.status) {


### PR DESCRIPTION
Replaces untyped `any` body with proper `PatchRequestDto` enabling ValidationPipe validation.

## Changes
- New `PatchRequestDto` in `api/src/requests/dto/patch-request.dto.ts` — combines status update and field update in one DTO (all fields optional, `status` validated with `@IsEnum(RequestStatus)`)
- `requests.controller.ts`: `update()` method now uses `PatchRequestDto` instead of `any`
- Removed unused imports of `UpdateRequestStatusDto` and `UpdateRequestDto` from controller