### PR TITLE
security: check isBlocked on WebSocket connection (#175)

### DIFF
--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -46,6 +46,16 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
         secret: process.env.JWT_SECRET!,
       });
 
+      const user = await this.prisma.user.findUnique({
+        where: { id: payload.sub },
+        select: { isBlocked: true },
+      });
+      if (!user || user.isBlocked) {
+        client.emit('error', { message: 'Account blocked' });
+        client.disconnect();
+        return;
+      }
+
       client.data.userId = payload.sub;
       client.data.email = payload.email;
       client.data.role = payload.role;


### PR DESCRIPTION
## Summary
- Add `isBlocked` check in `ChatGateway.handleConnection()` after JWT verify
- If user is not found or is blocked: emit error event and disconnect immediately
- Check runs BEFORE `client.data.userId` is set, preventing any further WS interaction

## Files
- `api/src/chat/chat.gateway.ts`

Closes #175