### PR TITLE
fix: add pagination to admin list endpoints (#177)

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -23,11 +23,15 @@ export class AdminController {
     return this.adminService.getStats();
   }
 
-  /** GET /admin/users — all users, optional ?role=CLIENT|SPECIALIST */
+  /** GET /admin/users — all users, optional ?role=CLIENT|SPECIALIST&page=1&limit=50 */
   @Get('users')
   @UseGuards(JwtAuthGuard, AdminGuard)
-  getUsers(@Query('role') role?: string) {
-    return this.adminService.getUsers(role);
+  getUsers(
+    @Query('role') role?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.adminService.getUsers(role, page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
   }
 
   /** PATCH /admin/users/:id — block or unblock a user */
@@ -37,17 +41,23 @@ export class AdminController {
     return this.adminService.blockUser(id, dto.isBlocked);
   }
 
-  /** GET /admin/specialists — all specialist profiles */
+  /** GET /admin/specialists — all specialist profiles, optional ?page=1&limit=50 */
   @Get('specialists')
   @UseGuards(JwtAuthGuard, AdminGuard)
-  getSpecialists() {
-    return this.adminService.getSpecialists();
+  getSpecialists(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.adminService.getSpecialists(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
   }
 
-  /** GET /admin/requests — all platform requests */
+  /** GET /admin/requests — all platform requests, optional ?page=1&limit=50 */
   @Get('requests')
   @UseGuards(JwtAuthGuard, AdminGuard)
-  getAllRequests() {
-    return this.adminService.getAllRequests();
+  getAllRequests(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.adminService.getAllRequests(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
   }
 }

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -30,38 +30,58 @@ export class AdminService {
     };
   }
 
-  async getUsers(role?: string) {
+  async getUsers(role?: string, page = 1, limit = 50) {
     const where: any = {};
     if (role === 'CLIENT' || role === 'SPECIALIST') {
       where.role = role;
     }
 
-    return this.prisma.user.findMany({
-      where,
-      orderBy: { createdAt: 'desc' },
-      select: {
-        id: true,
-        email: true,
-        role: true,
-        isBlocked: true,
-        createdAt: true,
-        lastLoginAt: true,
-        specialistProfile: {
-          select: { nick: true, cities: true, services: true },
+    const take = Math.min(limit, 200);
+    const skip = (page - 1) * take;
+
+    const [items, total] = await Promise.all([
+      this.prisma.user.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take,
+        skip,
+        select: {
+          id: true,
+          email: true,
+          role: true,
+          isBlocked: true,
+          createdAt: true,
+          lastLoginAt: true,
+          specialistProfile: {
+            select: { nick: true, cities: true, services: true },
+          },
         },
-      },
-    });
+      }),
+      this.prisma.user.count({ where }),
+    ]);
+
+    return { items, total, page, pages: Math.ceil(total / take) };
   }
 
-  async getSpecialists() {
-    return this.prisma.specialistProfile.findMany({
-      orderBy: { updatedAt: 'desc' },
-      include: {
-        user: {
-          select: { id: true, email: true, createdAt: true, lastLoginAt: true },
+  async getSpecialists(page = 1, limit = 50) {
+    const take = Math.min(limit, 200);
+    const skip = (page - 1) * take;
+
+    const [items, total] = await Promise.all([
+      this.prisma.specialistProfile.findMany({
+        orderBy: { updatedAt: 'desc' },
+        take,
+        skip,
+        include: {
+          user: {
+            select: { id: true, email: true, createdAt: true, lastLoginAt: true },
+          },
         },
-      },
-    });
+      }),
+      this.prisma.specialistProfile.count(),
+    ]);
+
+    return { items, total, page, pages: Math.ceil(total / take) };
   }
 
   async blockUser(id: string, isBlocked: boolean) {
@@ -77,13 +97,23 @@ export class AdminService {
     });
   }
 
-  async getAllRequests() {
-    return this.prisma.request.findMany({
-      orderBy: { createdAt: 'desc' },
-      include: {
-        client: { select: { id: true, email: true } },
-        _count: { select: { responses: true } },
-      },
-    });
+  async getAllRequests(page = 1, limit = 50) {
+    const take = Math.min(limit, 200);
+    const skip = (page - 1) * take;
+
+    const [items, total] = await Promise.all([
+      this.prisma.request.findMany({
+        orderBy: { createdAt: 'desc' },
+        take,
+        skip,
+        include: {
+          client: { select: { id: true, email: true } },
+          _count: { select: { responses: true } },
+        },
+      }),
+      this.prisma.request.count(),
+    ]);
+
+    return { items, total, page, pages: Math.ceil(total / take) };
   }
 }


### PR DESCRIPTION
## Summary
- `GET /admin/users`, `/admin/specialists`, `/admin/requests` now support `?page=1&limit=50`
- Default `take: 50`, max capped at `200` to prevent unbounded result sets
- Response shape changed to `{ items, total, page, pages }` for all three endpoints

## Files changed
- `api/src/admin/admin.service.ts`
- `api/src/admin/admin.controller.ts`

Closes #177