### PR TITLE
fix: allow empty content when attachment is present in SendMessageDto (#186)

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -128,10 +128,15 @@ export class ChatController {
         ? { url: dto.attachmentUrl, type: dto.attachmentType, name: dto.attachmentName }
         : undefined;
 
+    // Validate: must have content or attachment
+    if (!dto.content?.trim() && !attachment) {
+      throw new BadRequestException('Content or attachment is required');
+    }
+
     const message = await this.chatService.createMessage(
       threadId,
       req.user.id,
-      dto.content.trim(),
+      dto.content?.trim() ?? '',
       attachment,
     );
 

--- a/api/src/chat/dto/send-message.dto.ts
+++ b/api/src/chat/dto/send-message.dto.ts
@@ -1,9 +1,10 @@
 import { IsString, IsOptional, MaxLength, IsIn, IsUrl } from 'class-validator';
 
 export class SendMessageDto {
+  @IsOptional()
   @IsString()
   @MaxLength(2000)
-  content!: string;
+  content?: string;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Summary
- Changes `content` in `SendMessageDto` from required `@IsString()` to optional `@IsOptional() @IsString()`
- Adds manual validation in `chat.controller.ts` REST endpoint: throws `BadRequestException` if both `content` and `attachment` are absent
- Gateway already had this logic; controller now matches it

## Test plan
- [ ] Message with only attachment (no content) is accepted by both gateway and REST endpoint
- [ ] Message with empty content AND no attachment is rejected with proper error
- [ ] Message with both content and attachment still works
- [ ] TypeScript compiles without errors

Fixes #186