### PR TITLE
security: add message length validation in WebSocket gateway (#187)

### DIFF
--- a/api/src/chat/chat.gateway.ts
+++ b/api/src/chat/chat.gateway.ts
@@ -107,6 +107,20 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       throw new WsException('Not authenticated');
     }
 
+    // Validate content length to prevent oversized payload attacks
+    const MAX_CONTENT_LENGTH = 10000;
+    if (data.content && data.content.length > MAX_CONTENT_LENGTH) {
+      client.emit('error', { message: 'Message too long' });
+      return;
+    }
+
+    // Validate attachment URL length
+    const MAX_URL_LENGTH = 2048;
+    if (data.attachmentUrl && data.attachmentUrl.length > MAX_URL_LENGTH) {
+      client.emit('error', { message: 'Attachment URL too long' });
+      return;
+    }
+
     // Allow empty content if attachment is present
     const hasAttachment = !!(data.attachmentUrl && data.attachmentType && data.attachmentName);
     if (!data.content?.trim() && !hasAttachment) {


### PR DESCRIPTION
## Summary
- Added `MAX_CONTENT_LENGTH = 10000` check in `handleSendMessage` — emits error and returns early if exceeded
- Added `MAX_URL_LENGTH = 2048` check for `attachmentUrl` — emits error and returns early if exceeded
- Prevents malicious oversized payload attacks on the WebSocket chat server

Fixes #187