### PR TITLE
fix(specialists): increase take limits for getPopularCities and getAvailableCities

### DIFF
--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -136,7 +136,7 @@ export class SpecialistsController {
 
   @Get('cities/popular')
   getPopularCities(@Query('limit') limit?: string) {
-    return this.specialistsService.getPopularCities(parseInt(limit ?? '10') || 10);
+    return this.specialistsService.getPopularCities(parseInt(limit ?? '50') || 50);
   }
 
   @Patch(':id/badges')

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -84,7 +84,7 @@ export class SpecialistsService {
   async getAvailableCities(): Promise<string[]> {
     const profiles = await this.prisma.specialistProfile.findMany({
       select: { cities: true },
-      take: 500,
+      take: 5000,
     });
     const citySet = new Set<string>();
     for (const profile of profiles) {
@@ -326,10 +326,10 @@ export class SpecialistsService {
     return profiles;
   }
 
-  async getPopularCities(limit = 10) {
+  async getPopularCities(limit = 50) {
     const profiles = await this.prisma.specialistProfile.findMany({
       select: { cities: true },
-      take: 1000,
+      take: 5000,
     });
     const cityCount = new Map<string, number>();
     for (const profile of profiles) {


### PR DESCRIPTION
Fixes #189

- `getAvailableCities`: `take` raised from 500 → 5000
- `getPopularCities`: `take` raised from 1000 → 5000, default `limit` raised from 10 → 50
- Controller default for `cities/popular` endpoint updated from 10 → 50