### PR TITLE
fix(auth): switch JwtModule to registerAsync to defer JWT_SECRET env read

### DIFF
--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -11,9 +11,13 @@ import { CleanupService } from './cleanup.service';
 @Module({
   imports: [
     PassportModule,
-    JwtModule.register({
-      // No global expiresIn — each jwt.sign call specifies its own expiry
-      secret: process.env.JWT_SECRET!,
+    JwtModule.registerAsync({
+      // useFactory defers env access until runtime (after Doppler/process.env is populated),
+      // avoiding the issue where process.env.JWT_SECRET is read at module-import time.
+      useFactory: () => ({
+        // No global expiresIn — each jwt.sign call specifies its own expiry
+        secret: process.env.JWT_SECRET,
+      }),
     }),
   ],
   controllers: [AuthController],


### PR DESCRIPTION
Fixes #188

`JwtModule.register` reads `process.env.JWT_SECRET` at module import time (before the runtime env is populated by Doppler). `registerAsync` with `useFactory` defers this read until NestJS DI initialises the module, ensuring the secret is always available.