### PR TITLE
fix(ci): run prisma generate before tsc to fix TS2353 attachmentUrl errors (#213)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
         working-directory: ./api
         run: npm ci
 
+      - name: Generate Prisma client
+        working-directory: ./api
+        run: npx prisma generate
+
       - name: Build API (type check)
         working-directory: ./api
         run: npm run build
@@ -45,13 +49,13 @@ jobs:
         working-directory: ./api
         run: npm ci
 
-      - name: Build API
-        working-directory: ./api
-        run: npm run build
-
       - name: Generate Prisma client
         working-directory: ./api
         run: npx prisma generate
+
+      - name: Build API
+        working-directory: ./api
+        run: npm run build
 
       - name: Run DB migrations
         working-directory: ./api


### PR DESCRIPTION
## Root cause
`attachmentUrl`, `attachmentType`, `attachmentName` fields are defined in `prisma/schema.prisma` (Message model), but the Prisma client was never regenerated before the TypeScript compilation step in CI. This caused 3 `TS2353` errors in `chat.service.ts` selects that reference those fields.

## Fix
- `validate` job: add `Generate Prisma client` step **before** `Build API (type check)`
- `deploy` job: move `Generate Prisma client` step **before** `Build API`

## Verification
Locally after `npx prisma generate`: `npx tsc --noEmit` exits with 0 errors (was 3 errors).

Closes #213