### PR TITLE
fix(api): wire up missing query filters for specialists and requests

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -39,8 +39,13 @@ export class RequestsController {
 
   // GET /requests — public feed (specialists browse)
   @Get()
-  getFeed(@Query('city') city?: string, @Query('page') page?: string) {
-    return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1);
+  getFeed(
+    @Query('city') city?: string,
+    @Query('page') page?: string,
+    @Query('status') status?: string,
+    @Query('search') search?: string,
+  ) {
+    return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1, status, search);
   }
 
   // POST /requests/:id/respond — specialist responds to a request

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -26,9 +26,18 @@ export class RequestsService {
     });
   }
 
-  async findFeed(city?: string, page = 1) {
-    const where: any = { status: RequestStatus.OPEN };
+  async findFeed(city?: string, page = 1, status?: string, search?: string) {
+    // Default to OPEN if no status provided; validate against known statuses
+    const allowedStatuses = Object.values(RequestStatus);
+    const resolvedStatus =
+      status && allowedStatuses.includes(status as RequestStatus)
+        ? (status as RequestStatus)
+        : RequestStatus.OPEN;
+    const where: any = { status: resolvedStatus };
     if (city) where.city = city;
+    if (search && search.trim()) {
+      where.description = { contains: search.trim(), mode: 'insensitive' };
+    }
 
     const skip = (page - 1) * PAGE_SIZE;
 

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -37,8 +37,9 @@ export class SpecialistsController {
     @Query('city') city?: string,
     @Query('badge') badge?: string,
     @Query('sort') sort?: string,
+    @Query('services') services?: string,
   ) {
-    return this.specialistsService.getCatalog(city, badge, sort);
+    return this.specialistsService.getCatalog(city, badge, sort, services);
   }
 
   @Get(':nick')

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -61,11 +61,14 @@ export class SpecialistsService {
     return { ...profile, activity };
   }
 
-  async getCatalog(city?: string, badge?: string, sort?: string) {
+  async getCatalog(city?: string, badge?: string, sort?: string, services?: string) {
     const now = new Date();
     const where: any = {};
     if (city) where.cities = { has: city };
     if (badge) where.badges = { has: badge };
+    if (services && services.trim()) {
+      where.services = { has: services.trim() };
+    }
 
     const profiles = await this.prisma.specialistProfile.findMany({
       where,


### PR DESCRIPTION
## Summary

- **#221** `GET /specialists?services=...` was silently ignored — controller did not read the `services` query param and service did not apply it to the Prisma WHERE clause. Fixed: added `@Query('services')` and `where.services = { has: value }`.
- **#222** `GET /requests?status=...&search=...` were silently ignored — controller only passed `city` and `page`. Fixed: added `status` and `search` params; service now filters `status` (defaults to `OPEN` for unknown values) and `description` via case-insensitive ILIKE.

## Root cause

Both endpoints had the same pattern: query params were declared in the controller but never forwarded to the service, and the service never applied them to the Prisma WHERE clause.

## Test plan

- [ ] `GET /api/specialists?services=Декларации 3-НДФЛ` returns only specialists whose `services` array contains that exact value (was returning all 10)
- [ ] `GET /api/requests?status=CLOSED` returns only CLOSED requests
- [ ] `GET /api/requests?search=налог` returns only requests whose description contains "налог" (case-insensitive)
- [ ] `GET /api/requests` (no status param) still defaults to OPEN
- [ ] `npx tsc --noEmit` passes with zero errors

Closes #221, Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)