### PR TITLE
fix(api): add budget range and category filters to GET /requests

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -44,8 +44,19 @@ export class RequestsController {
     @Query('page') page?: string,
     @Query('status') status?: string,
     @Query('search') search?: string,
+    @Query('category') category?: string,
+    @Query('budgetMin') budgetMin?: string,
+    @Query('budgetMax') budgetMax?: string,
   ) {
-    return this.requestsService.findFeed(city, page ? parseInt(page, 10) : 1, status, search);
+    return this.requestsService.findFeed(
+      city,
+      page ? parseInt(page, 10) : 1,
+      status,
+      search,
+      category,
+      budgetMin != null ? parseInt(budgetMin, 10) : undefined,
+      budgetMax != null ? parseInt(budgetMax, 10) : undefined,
+    );
   }
 
   // POST /requests/:id/respond — specialist responds to a request

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -26,7 +26,15 @@ export class RequestsService {
     });
   }
 
-  async findFeed(city?: string, page = 1, status?: string, search?: string) {
+  async findFeed(
+    city?: string,
+    page = 1,
+    status?: string,
+    search?: string,
+    category?: string,
+    budgetMin?: number,
+    budgetMax?: number,
+  ) {
     // Default to OPEN if no status provided; validate against known statuses
     const allowedStatuses = Object.values(RequestStatus);
     const resolvedStatus =
@@ -38,6 +46,9 @@ export class RequestsService {
     if (search && search.trim()) {
       where.description = { contains: search.trim(), mode: 'insensitive' };
     }
+    if (category) where.category = category;
+    if (budgetMin != null) where.budget = { ...(where.budget || {}), gte: budgetMin };
+    if (budgetMax != null) where.budget = { ...(where.budget || {}), lte: budgetMax };
 
     const skip = (page - 1) * PAGE_SIZE;
 


### PR DESCRIPTION
Closes #222

Adds missing budget range (`budgetMin`/`budgetMax`) and `category` filter to `GET /api/requests`. Status and search filters were already added in #223.

## Changes

- `requests.controller.ts` — added `@Query()` params for `category`, `budgetMin`, `budgetMax`
- `requests.service.ts` — extended `findFeed()` signature and wired params to Prisma `where` clause with proper `gte`/`lte` budget range merging; `budgetMin`/`budgetMax` parsed as integers

## Test plan

- [ ] `GET /api/requests?category=tax` returns only requests with that category
- [ ] `GET /api/requests?budgetMin=5000` returns only requests with budget >= 5000
- [ ] `GET /api/requests?budgetMax=20000` returns only requests with budget <= 20000
- [ ] `GET /api/requests?budgetMin=5000&budgetMax=20000` returns requests in range
- [ ] Existing filters (city, status, search, page) still work unchanged
- [ ] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)