### PR TITLE
feat(api): add PATCH /users/me/profile endpoint for basic profile fields

### DIFF
--- a/api/prisma/migrations/20260407000000_add_user_profile_fields/migration.sql
+++ b/api/prisma/migrations/20260407000000_add_user_profile_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "displayName" TEXT;
+ALTER TABLE "users" ADD COLUMN "city" TEXT;
+ALTER TABLE "users" ADD COLUMN "phone" TEXT;
+ALTER TABLE "users" ADD COLUMN "bio" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -28,6 +28,10 @@ model User {
   id          String    @id @default(cuid())
   email       String    @unique
   role        Role      @default(CLIENT)
+  displayName String?
+  city        String?
+  phone       String?
+  bio         String?
   createdAt   DateTime  @default(now())
   lastLoginAt DateTime?
 

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { ChatModule } from './chat/chat.module';
 import { SpecialistsModule } from './specialists/specialists.module';
 import { RequestsModule } from './requests/requests.module';
 import { PromotionsModule } from './promotions/promotions.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { PromotionsModule } from './promotions/promotions.module';
     SpecialistsModule,
     RequestsModule,
     PromotionsModule,
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/api/src/users/dto/update-profile.dto.ts
+++ b/api/src/users/dto/update-profile.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  displayName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  phone?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  bio?: string;
+}

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Patch, Body, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UsersService } from './users.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Controller('users')
+@UseGuards(JwtAuthGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  /** PATCH /users/me/profile — update basic profile fields (any authenticated user) */
+  @Patch('me/profile')
+  updateProfile(
+    @Request() req: { user: { id: string } },
+    @Body() dto: UpdateProfileDto,
+  ) {
+    return this.usersService.updateProfile(req.user.id, dto);
+  }
+}

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async updateProfile(
+    userId: string,
+    dto: UpdateProfileDto,
+  ): Promise<{ id: string; displayName: string | null; city: string | null; phone: string | null; bio: string | null }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const updated = await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...(dto.displayName !== undefined && { displayName: dto.displayName }),
+        ...(dto.city !== undefined && { city: dto.city }),
+        ...(dto.phone !== undefined && { phone: dto.phone }),
+        ...(dto.bio !== undefined && { bio: dto.bio }),
+      },
+    });
+
+    return {
+      id: updated.id,
+      displayName: updated.displayName,
+      city: updated.city,
+      phone: updated.phone,
+      bio: updated.bio,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `displayName`, `city`, `phone`, `bio` optional fields to the `User` Prisma model
- Creates Prisma migration `20260407000000_add_user_profile_fields` with the 4 ALTER TABLE columns
- Creates new `UsersModule` with `PATCH /api/users/me/profile` endpoint available to any authenticated user
- All fields are optional (`PATCH` semantics — only provided fields are updated)

## Files changed

- `api/prisma/schema.prisma` — 4 new nullable fields on `User` model
- `api/prisma/migrations/20260407000000_add_user_profile_fields/migration.sql` — migration SQL
- `api/src/users/dto/update-profile.dto.ts` — DTO with validation (MaxLength guards)
- `api/src/users/users.service.ts` — `updateProfile` service method
- `api/src/users/users.controller.ts` — `PATCH /users/me/profile` route
- `api/src/users/users.module.ts` — NestJS module
- `api/src/app.module.ts` — `UsersModule` registered

## Test plan

- [ ] `PATCH /api/users/me/profile` with JWT returns `{ id, displayName, city, phone, bio }`
- [ ] Partial body (e.g. only `displayName`) only updates that field, leaves others unchanged
- [ ] Unauthenticated request returns 401
- [ ] Body with field exceeding MaxLength returns 400
- [ ] `npx tsc --noEmit` passes (verified locally)

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)