### PR TITLE
fix(auth): specialist registration — send lowercase role to verify-otp; add 404 screen

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -94,7 +94,7 @@ export default function OtpScreen() {
       const res = await api.post<VerifyOtpResponse>('/auth/verify-otp', {
         email,
         code,
-        role,
+        role: role.toLowerCase(),
       });
       await login(res.accessToken, {
         userId: res.user.userId,

--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View, Text, StyleSheet, SafeAreaView } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Button } from '../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
+
+export default function NotFoundScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <View style={styles.container}>
+        <Text style={styles.code}>404</Text>
+        <Text style={styles.title}>Страница не найдена</Text>
+        <Text style={styles.subtitle}>
+          Кажется, такой страницы не существует. Возможно, ссылка устарела.
+        </Text>
+        <Button onPress={() => router.replace('/')} style={styles.btn}>
+          На главную
+        </Button>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: Spacing['2xl'],
+    gap: Spacing.lg,
+    maxWidth: 430,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  code: {
+    fontSize: 72,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+    lineHeight: 80,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.md,
+  },
+});


### PR DESCRIPTION
## Summary

- **#231 fix**: `otp.tsx` was sending `role: 'SPECIALIST'` (uppercase) to `POST /auth/verify-otp`, but `auth.service.ts` checks `if (role === 'specialist')` (exact lowercase). Result: all specialist registrations via UI were silently falling through to CLIENT role. Fix: `role: role.toLowerCase()` before the API call.
- **#232 fix**: Added `app/+not-found.tsx` — expo-router catch-all 404 page with "На главную" button.

## Test plan
- [ ] Landing page → "Я специалист" → email input → OTP → login returns SPECIALIST role JWT
- [ ] Navigate to `/nonexistent-route` → shows 404 page, not blank screen
- [ ] "Войти как заказчик" flow still works (CLIENT role assigned correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)