### PR TITLE
feat(api): DELETE /requests/:id + PATCH /admin/specialists/:id

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Patch, Param, Body, UseGuards } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AdminUpdateSpecialistDto } from './dto/update-specialist.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Patch('specialists/:id')
+  updateSpecialist(@Param('id') id: string, @Body() dto: AdminUpdateSpecialistDto) {
+    return this.adminService.updateSpecialist(id, dto);
+  }
+}

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+@Module({
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AdminUpdateSpecialistDto } from './dto/update-specialist.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(private prisma: PrismaService) {}
+
+  async updateSpecialist(specialistId: string, dto: AdminUpdateSpecialistDto) {
+    const profile = await this.prisma.specialistProfile.findUnique({ where: { userId: specialistId } });
+    if (!profile) throw new NotFoundException('Specialist profile not found');
+    return this.prisma.specialistProfile.update({
+      where: { userId: specialistId },
+      data: dto,
+    });
+  }
+}

--- a/api/src/admin/dto/update-specialist.dto.ts
+++ b/api/src/admin/dto/update-specialist.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsString, IsArray, MaxLength } from 'class-validator';
+
+export class AdminUpdateSpecialistDto {
+  @IsOptional() @IsString() @MaxLength(500) bio?: string;
+  @IsOptional() @IsArray() @IsString({ each: true }) services?: string[];
+  @IsOptional() @IsArray() @IsString({ each: true }) cities?: string[];
+  @IsOptional() @IsArray() @IsString({ each: true }) badges?: string[];
+  @IsOptional() @IsString() @MaxLength(500) contacts?: string;
+}

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { SpecialistsModule } from './specialists/specialists.module';
 import { RequestsModule } from './requests/requests.module';
 import { PromotionsModule } from './promotions/promotions.module';
 import { UsersModule } from './users/users.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { UsersModule } from './users/users.module';
     RequestsModule,
     PromotionsModule,
     UsersModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -3,6 +3,8 @@ import {
   Get,
   Post,
   Patch,
+  Delete,
+  HttpCode,
   Param,
   Body,
   Query,
@@ -81,5 +83,13 @@ export class RequestsController {
     @Body() dto: UpdateRequestStatusDto,
   ) {
     return this.requestsService.updateStatus(req.user.id, id, dto.status);
+  }
+
+  // DELETE /requests/:id — client deletes own OPEN request
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(204)
+  deleteRequest(@Request() req: any, @Param('id') id: string) {
+    return this.requestsService.deleteRequest(req.user.id, id);
   }
 }

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -151,4 +151,12 @@ export class RequestsService {
       data: { status },
     });
   }
+
+  async deleteRequest(userId: string, requestId: string) {
+    const req = await this.prisma.request.findUnique({ where: { id: requestId } });
+    if (!req) throw new NotFoundException('Request not found');
+    if (req.clientId !== userId) throw new ForbiddenException('Not your request');
+    if (req.status !== RequestStatus.OPEN) throw new BadRequestException('Cannot delete a request that has been responded to');
+    await this.prisma.request.delete({ where: { id: requestId } });
+  }
 }


### PR DESCRIPTION
## Summary

- DELETE /requests/:id: owner-only, OPEN-only, returns 204 (fixes #229)
- PATCH /admin/specialists/:id: admin can update specialist profile fields (fixes #229, #230)
- Created full AdminModule (controller, service, DTO) — module was absent before

## Changes

- `requests.controller.ts`: added DELETE /:id endpoint
- `requests.service.ts`: added deleteRequest() method with ownership + status checks
- `admin/`: new module with PATCH specialists/:id endpoint
- `app.module.ts`: registered AdminModule

## Test plan

- [ ] DELETE /api/requests/:id as owner with OPEN request → 204
- [ ] DELETE /api/requests/:id as non-owner → 403
- [ ] DELETE /api/requests/:id that is not OPEN → 400
- [ ] DELETE /api/requests/:id that doesn't exist → 404
- [ ] PATCH /api/admin/specialists/:id with valid fields → updated profile
- [ ] PATCH /api/admin/specialists/:id with invalid specialist id → 404

🤖 Generated with Claude Code