### PR TITLE
fix(admin): add AdminGuard — restrict /admin/* endpoints to ADMIN_EMAILS

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -2,9 +2,10 @@ import { Controller, Patch, Param, Body, UseGuards } from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { AdminUpdateSpecialistDto } from './dto/update-specialist.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from './admin.guard';
 
 @Controller('admin')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, AdminGuard)
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 

--- a/api/src/admin/admin.guard.ts
+++ b/api/src/admin/admin.guard.ts
@@ -1,0 +1,32 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+
+/**
+ * Guard that restricts access to admin endpoints.
+ * Checks if the authenticated user's email is in the ADMIN_EMAILS env var
+ * (comma-separated list). Falls back to requiring no-match (deny-all)
+ * if the env var is not set.
+ *
+ * Must be used after JwtAuthGuard so req.user is populated.
+ */
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const user = req.user;
+
+    if (!user?.email) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    const adminEmails = (process.env.ADMIN_EMAILS ?? '')
+      .split(',')
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean);
+
+    if (!adminEmails.includes(user.email.toLowerCase())) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Problem

PR #234 added `PATCH /admin/specialists/:id` with only `JwtAuthGuard` — any authenticated user (CLIENT, SPECIALIST) could update specialist profiles.

## Fix

`AdminGuard` checks `req.user.email` against `ADMIN_EMAILS` env var (comma-separated list). Returns `403 Admin access required` if the user is not in the list.

**Usage (Doppler):**
```
ADMIN_EMAILS=admin@example.com,moderator@example.com
```

`AdminGuard` is applied at class level in `AdminController`, so all future admin routes are protected automatically.

## Test plan
- [ ] `PATCH /admin/specialists/:id` without token → 401
- [ ] With regular CLIENT token → 403 "Admin access required"
- [ ] With admin email token (in ADMIN_EMAILS) → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)