### PR TITLE
feat(frontend): UC-09/UC-19 profile settings — specialist edit link

### DIFF
--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -351,6 +351,19 @@ export default function SettingsScreen() {
                 {user?.role === 'SPECIALIST' ? 'Специалист' : 'Заказчик'}
               </Text>
             </View>
+            {user?.role === 'SPECIALIST' && (
+              <>
+                <View style={styles.divider} />
+                <TouchableOpacity
+                  style={styles.row}
+                  onPress={() => router.push('/(dashboard)/profile')}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.rowLabel}>Редактировать профиль</Text>
+                  <Text style={styles.rowArrow}>{'>'}</Text>
+                </TouchableOpacity>
+              </>
+            )}
           </View>
 
           {/* Notifications section */}


### PR DESCRIPTION
Closes #252

## Summary
- Settings screen (`/(dashboard)/settings`) already had: email display, role info, logout with confirm, email change, notifications, reviews, delete account
- Added: "Edit profile" link for SPECIALIST role that navigates to `/(dashboard)/profile`

## Test plan
- [ ] Open settings as CLIENT — no "Edit profile" link visible
- [ ] Open settings as SPECIALIST — "Edit profile" link visible, navigates to profile page
- [ ] Logout with confirm dialog works
- [ ] Email and role display correctly