### PR TITLE
feat(frontend): UC-024 promotion nav + UC-061 SEO

### DIFF
--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -455,6 +455,15 @@ export default function MySpecialistProfileScreen() {
           >
             Сохранить профиль
           </Button>
+
+          {/* Promotion navigation (UC-024) */}
+          <Button
+            onPress={() => router.push('/(dashboard)/promotion')}
+            variant="outline"
+            style={styles.promotionBtn}
+          >
+            Продвинуть профиль
+          </Button>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -626,6 +635,9 @@ const styles = StyleSheet.create({
   saveBtn: {
     width: '100%',
     marginTop: Spacing.md,
+  },
+  promotionBtn: {
+    width: '100%',
     marginBottom: Spacing['3xl'],
   },
   avatarSection: {


### PR DESCRIPTION
## Summary
- **#265 UC-024**: Added "Продвинуть профиль" outline button on specialist profile screen → navigates to /(dashboard)/promotion
- **#267 UC-061**: SEO meta tags (`<Head>` with title, description, og:title, og:description, og:url) already present on `specialists/[nick]` and `requests/[id]` pages — verified, no changes needed

Closes #265
Closes #267