### PR TITLE
fix: UC-040 specialists catalog pagination — prevent OOM

### DIFF
--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -120,7 +120,7 @@ export class SpecialistsController {
       fns,
       category,
       parseInt(page ?? '1') || 1,
-      parseInt(limit ?? '9') || 9,
+      Math.min(parseInt(limit ?? '20') || 20, 50),
     );
   }
 

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -95,7 +95,10 @@ export class SpecialistsService {
     return Array.from(citySet).sort((a, b) => a.localeCompare(b, 'ru'));
   }
 
-  async getCatalog(city?: string, badge?: string, sort?: string, search?: string, fns?: string, category?: string, page: number = 1, limit: number = 9) {
+  async getCatalog(city?: string, badge?: string, sort?: string, search?: string, fns?: string, category?: string, page: number = 1, limit: number = 20) {
+    // Cap limit to prevent abuse
+    if (limit > 50) limit = 50;
+    if (limit < 1) limit = 1;
     const now = new Date();
     const profileWhere: any = { displayName: { not: null } };
     if (city) {

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -96,7 +96,7 @@ export default function SpecialistsCatalogScreen() {
 
   const fnsFilterParam = selectedFns.map((o) => o.name).join(',');
 
-  const PAGE_SIZE = 9;
+  const PAGE_SIZE = 20;
 
   const fetchSpecialists = useCallback(async (pageNum: number, append = false) => {
     if (append) {


### PR DESCRIPTION
Closes #270

- Default page size: 9 → 20
- Server-side limit cap: max 50 (controller + service double-guard)
- Frontend PAGE_SIZE updated to 20

Note: PASS 1 lightweight query (userId, experience, createdAt only) already mitigates OOM for the sort phase. Full profile data is fetched only for the current page (PASS 2).

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>