### PR TITLE
fix: align seed admin email with ADMIN_EMAILS env var

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -629,15 +629,15 @@ async function main() {
   // Email must match ADMIN_EMAILS env var used by AdminGuard
   console.log('Seeding admin user...');
   await prisma.user.upsert({
-    where: { email: 'dev@p2ptax.ru' },
+    where: { email: 'admin@p2ptax.ru' },
     update: {},
     create: {
-      email: 'dev@p2ptax.ru',
+      email: 'admin@p2ptax.ru',
       username: 'admin',
       role: Role.CLIENT,
     },
   });
-  console.log('  Created admin user: dev@p2ptax.ru (OTP 000000 in dev mode)');
+  console.log('  Created admin user: admin@p2ptax.ru (OTP 000000 in dev mode)');
 
   console.log('Seeding complete!');
 }

--- a/lib/adminEmails.ts
+++ b/lib/adminEmails.ts
@@ -1,7 +1,7 @@
 // Admin emails are loaded from EXPO_PUBLIC_ADMIN_EMAILS env var (comma-separated).
 // If the env var is not set (e.g. local dev without Doppler), falls back to dev email.
 // Never hardcode production emails here.
-const raw = process.env.EXPO_PUBLIC_ADMIN_EMAILS ?? 'dev@p2ptax.ru';
+const raw = process.env.EXPO_PUBLIC_ADMIN_EMAILS ?? 'admin@p2ptax.ru';
 
 export const ADMIN_EMAILS: string[] = raw
   .split(',')


### PR DESCRIPTION
Fixes #275

Seed was creating `dev@p2ptax.ru` but `ADMIN_EMAILS` env var in Doppler contains `admin@p2ptax.ru,ruslan@p2ptax.ru`. This mismatch caused 403 for the dev admin user.

## Changes
- `api/prisma/seed.ts`: changed admin seed email from `dev@p2ptax.ru` → `admin@p2ptax.ru`
- `lib/adminEmails.ts`: updated fallback (used when `EXPO_PUBLIC_ADMIN_EMAILS` is not set) from `dev@p2ptax.ru` → `admin@p2ptax.ru`