### PR TITLE
fix: add PATCH /api/admin/specialists/:id/badges endpoint (#286)

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -51,6 +51,16 @@ export class AdminController {
     return this.adminService.getSpecialists(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
   }
 
+  /** PATCH /admin/specialists/:id/badges — update specialist badges */
+  @Patch('specialists/:id/badges')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  updateSpecialistBadges(
+    @Param('id') id: string,
+    @Body('badges') badges: string[],
+  ) {
+    return this.adminService.updateSpecialistBadges(id, badges);
+  }
+
   /** GET /admin/requests — all platform requests, optional ?page=1&limit=50 */
   @Get('requests')
   @UseGuards(JwtAuthGuard, AdminGuard)

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -97,6 +97,19 @@ export class AdminService {
     });
   }
 
+  async updateSpecialistBadges(specialistProfileId: string, badges: string[]) {
+    const profile = await this.prisma.specialistProfile.findUnique({
+      where: { userId: specialistProfileId },
+    });
+    if (!profile) {
+      throw new NotFoundException(`Specialist profile ${specialistProfileId} not found`);
+    }
+    return this.prisma.specialistProfile.update({
+      where: { userId: specialistProfileId },
+      data: { badges },
+    });
+  }
+
   async getAllRequests(page = 1, limit = 50) {
     const take = Math.min(limit, 200);
     const skip = (page - 1) * take;


### PR DESCRIPTION
## Summary
- Admin panel calls `PATCH /api/admin/specialists/:id/badges` to assign badges, but the endpoint only existed at `/api/specialists/:id/badges` (specialists controller)
- Added `updateSpecialistBadges` method to `AdminService` and corresponding `PATCH specialists/:id/badges` route to `AdminController`
- tsc --noEmit passes clean

## Test plan
- [ ] `PATCH /api/admin/specialists/:id/badges` with admin token returns 200
- [ ] Badges are persisted in DB
- [ ] Non-admin gets 403

Fixes #286