### PR TITLE
fix: admin promotions endpoint + quick request testIDs (#287, #289)

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -70,4 +70,14 @@ export class AdminController {
   ) {
     return this.adminService.getAllRequests(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
   }
+
+  /** GET /admin/promotions — all promotions with user info, optional ?page=1&limit=50 */
+  @Get('promotions')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getPromotions(
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.adminService.getPromotions(page ? parseInt(page, 10) : 1, limit ? parseInt(limit, 10) : 50);
+  }
 }

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -110,6 +110,27 @@ export class AdminService {
     });
   }
 
+  async getPromotions(page = 1, limit = 50) {
+    const take = Math.min(limit, 200);
+    const skip = (page - 1) * take;
+
+    const [items, total] = await Promise.all([
+      this.prisma.promotion.findMany({
+        orderBy: { createdAt: 'desc' },
+        take,
+        skip,
+        include: {
+          specialist: {
+            select: { id: true, email: true, role: true },
+          },
+        },
+      }),
+      this.prisma.promotion.count(),
+    ]);
+
+    return { items, total, page, pages: Math.ceil(total / take) };
+  }
+
   async getAllRequests(page = 1, limit = 50) {
     const take = Math.min(limit, 200);
     const skip = (page - 1) * take;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -63,6 +63,7 @@ function QuickRequestForm() {
     <View style={qrf.container}>
       <Text style={qrf.title}>Опишите задачу</Text>
       <TextInput
+        testID="quick-request-description"
         style={qrf.input}
         placeholder="Нужна помощь с налоговой декларацией..."
         placeholderTextColor={Colors.textMuted}
@@ -84,7 +85,7 @@ function QuickRequestForm() {
         ))}
       </View>
       {error ? <Text style={qrf.error}>{error}</Text> : null}
-      <TouchableOpacity style={qrf.btn} onPress={handleSubmit} activeOpacity={0.85}>
+      <TouchableOpacity testID="quick-request-submit" style={qrf.btn} onPress={handleSubmit} activeOpacity={0.85}>
         <Text style={qrf.btnText}>Найти специалиста →</Text>
       </TouchableOpacity>
     </View>


### PR DESCRIPTION
## Summary
- **#287**: Added `GET /admin/promotions` endpoint with pagination and specialist user info (was returning 404)
- **#289**: Added `testID="quick-request-submit"` and `testID="quick-request-description"` to the landing quick request form so Playwright can locate the submit button

## Test plan
- [ ] `curl localhost:3812/api/admin/promotions` returns 200 with paginated list
- [ ] Playwright can find submit button via `[data-testid="quick-request-submit"]`
- [ ] `npx tsc --noEmit` passes for both API and frontend

Generated with Claude Code