### PR TITLE
fix: responses endpoint + offset pagination (#284 #285)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -69,6 +69,13 @@ export class RequestsController {
     );
   }
 
+  // GET /requests/:id/responses — owner gets list of responses
+  @Get(':id/responses')
+  @UseGuards(JwtAuthGuard)
+  getResponses(@Request() req: any, @Param('id') id: string) {
+    return this.requestsService.findResponses(id, req.user.id);
+  }
+
   // GET /requests/:id — public, owner gets full data including responses
   @Get(':id')
   @UseGuards(OptionalJwtAuthGuard)

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -144,6 +144,28 @@ export class RequestsService {
     });
   }
 
+  async findResponses(requestId: string, userId: string) {
+    const request = await this.prisma.request.findUnique({
+      where: { id: requestId },
+      select: { clientId: true },
+    });
+    if (!request) throw new NotFoundException('Request not found');
+    if (request.clientId !== userId) throw new ForbiddenException('Only the request owner can view responses');
+
+    return this.prisma.response.findMany({
+      where: { requestId },
+      include: {
+        specialist: {
+          select: {
+            id: true, email: true,
+            specialistProfile: { select: { nick: true, displayName: true, avatarUrl: true } },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
   async findById(requestId: string, userId: string | null) {
     const request = await this.prisma.request.findUnique({
       where: { id: requestId },

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -111,7 +111,10 @@ export class SpecialistsController {
     @Query('category') category?: string,
     @Query('page') page?: string,
     @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
   ) {
+    const parsedLimit = Math.min(parseInt(limit ?? '20') || 20, 50);
+    const parsedOffset = offset !== undefined ? parseInt(offset, 10) : undefined;
     return this.specialistsService.getCatalog(
       city,
       badge,
@@ -120,7 +123,8 @@ export class SpecialistsController {
       fns,
       category,
       parseInt(page ?? '1') || 1,
-      Math.min(parseInt(limit ?? '20') || 20, 50),
+      parsedLimit,
+      parsedOffset !== undefined && !isNaN(parsedOffset) ? parsedOffset : undefined,
     );
   }
 

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -95,7 +95,7 @@ export class SpecialistsService {
     return Array.from(citySet).sort((a, b) => a.localeCompare(b, 'ru'));
   }
 
-  async getCatalog(city?: string, badge?: string, sort?: string, search?: string, fns?: string, category?: string, page: number = 1, limit: number = 20) {
+  async getCatalog(city?: string, badge?: string, sort?: string, search?: string, fns?: string, category?: string, page: number = 1, limit: number = 20, offset?: number) {
     // Cap limit to prevent abuse
     if (limit > 50) limit = 50;
     if (limit < 1) limit = 1;
@@ -226,7 +226,7 @@ export class SpecialistsService {
 
     const total = allProfiles.length;
     const pages = Math.ceil(total / limit);
-    const skip = (page - 1) * limit;
+    const skip = offset !== undefined ? offset : (page - 1) * limit;
     const pageUserIds = allProfiles.slice(skip, skip + limit).map((p) => p.userId);
 
     // PASS 2: Fetch full data only for the current page


### PR DESCRIPTION
## Summary
- **#285**: Added `GET /requests/:id/responses` endpoint — returns responses list for request owner (auth required, ownership check)
- **#284**: Added `?offset=` query param support to `GET /specialists` catalog. When offset is provided it overrides page-based skip. Existing `?page=` still works.

## Test plan
- [ ] `GET /api/requests/:id/responses` with owner token returns 200 + responses array
- [ ] `GET /api/requests/:id/responses` with non-owner token returns 403
- [ ] `GET /api/specialists?limit=3&offset=3` returns different results than offset=0
- [ ] `GET /api/specialists?page=2&limit=3` still works as before

Generated with Claude Code