### PR TITLE
fix: UI batch 2 — hero simplification, badge icons

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -293,27 +293,18 @@ export default function LandingScreen() {
                 {'\u042E\u0440\u0438\u0441\u0442\u044B \u0438 \u043D\u0430\u043B\u043E\u0433\u043E\u0432\u044B\u0435 \u043A\u043E\u043D\u0441\u0443\u043B\u044C\u0442\u0430\u043D\u0442\u044B \u0432 \u0432\u0430\u0448\u0435\u043C \u0433\u043E\u0440\u043E\u0434\u0435. \u041E\u043F\u0443\u0431\u043B\u0438\u043A\u0443\u0439\u0442\u0065 \u0437\u0430\u043F\u0440\u043E\u0441 \u0431\u0435\u0441\u043F\u043B\u0430\u0442\u043D\u043E \u2014 \u043F\u043E\u043B\u0443\u0447\u0438\u0442\u0435 \u043F\u0440\u0435\u0434\u043B\u043E\u0436\u0435\u043D\u0438\u044F \u043E\u0442 \u043F\u0440\u043E\u0432\u0435\u0440\u0435\u043D\u043D\u044B\u0445 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u043E\u0432'}
               </Text>
 
-              <QuickRequestForm />
-
-              {isWide && (
-                <View style={[styles.heroCtas, styles.heroCtasWide]}>
-                  <Button
-                    onPress={() => router.push('/specialists')}
-                    variant="primary"
-                    style={{ minWidth: 220 }}
-                  >{'\u041D\u0430\u0439\u0442\u0438 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u0430'}</Button>
-                  <Button
-                    onPress={() => router.push('/(auth)/email?redirectTo=%2F(dashboard)%2Fmy-requests%2Fnew')}
-                    variant="outline"
-                    style={{ minWidth: 200 }}
-                  >{'\u0420\u0430\u0437\u043C\u0435\u0441\u0442\u0438\u0442\u044C \u0437\u0430\u043F\u0440\u043E\u0441'}</Button>
-                  <Button
-                    onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
-                    variant="outline"
-                    style={{ minWidth: 200 }}
-                  >{'\u042F \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442'}</Button>
-                </View>
-              )}
+              <View style={[styles.heroCtas, isWide && styles.heroCtasWide]}>
+                <Button
+                  onPress={() => router.push('/specialists')}
+                  variant="primary"
+                  style={{ minWidth: 220 }}
+                >{'\u041D\u0430\u0439\u0442\u0438 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u0430'}</Button>
+                <Button
+                  onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
+                  variant="outline"
+                  style={{ minWidth: 200 }}
+                >{'\u042F \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442'}</Button>
+              </View>
             </View>
 
             {isWide ? (

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -21,6 +21,7 @@ import { Button } from '../../components/Button';
 import { LandingHeader } from '../../components/LandingHeader';
 import { EmptyState } from '../../components/EmptyState';
 import { Stars } from '../../components/Stars';
+import { Ionicons } from '@expo/vector-icons';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
 
 // Brand tokens
@@ -330,16 +331,19 @@ export default function PublicSpecialistProfileScreen() {
       <View style={styles.badgesRow}>
         {isVerified && (
           <View style={[styles.badge, styles.badgeSuccess]}>
-            <Text style={styles.badgeSuccessText}>✓ Проверен</Text>
+            <Ionicons name="shield-checkmark" size={14} color={B.success} />
+            <Text style={styles.badgeSuccessText}>Проверен</Text>
           </View>
         )}
         {profile.experience != null && (
           <View style={[styles.badge, styles.badgeAction]}>
-            <Text style={styles.badgeActionText}>⏱ {profile.experience} {profile.experience === 1 ? 'год' : profile.experience >= 2 && profile.experience <= 4 ? 'года' : 'лет'} опыта</Text>
+            <Ionicons name="briefcase-outline" size={14} color={B.action} />
+            <Text style={styles.badgeActionText}>{profile.experience} {profile.experience === 1 ? 'год' : profile.experience >= 2 && profile.experience <= 4 ? 'года' : 'лет'} опыта</Text>
           </View>
         )}
         <View style={[styles.badge, styles.badgeNeutral]}>
-          <Text style={styles.badgeNeutralText}>🗓 С {sinceYear} года</Text>
+          <Ionicons name="calendar-outline" size={14} color={B.muted} />
+          <Text style={styles.badgeNeutralText}>С {sinceYear} года</Text>
         </View>
       </View>
 
@@ -702,7 +706,7 @@ const styles = StyleSheet.create({
 
   // Badges
   badgesRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
-  badge: { paddingVertical: 3, paddingHorizontal: 9, borderRadius: 3 },
+  badge: { flexDirection: 'row', alignItems: 'center', gap: 4, paddingVertical: 4, paddingHorizontal: 10, borderRadius: 12 },
   badgeSuccess: { backgroundColor: B.bgSuccess },
   badgeSuccessText: { fontSize: 11, fontWeight: '600', color: B.success },
   badgeAction: { backgroundColor: B.bgAction },

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
+import { Ionicons } from '@expo/vector-icons';
 
 const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 import { api, ApiError } from '../../lib/api';
@@ -172,6 +173,7 @@ export default function SpecialistsCatalogScreen() {
                 </Text>
                 {isVerified && (
                   <View style={styles.verifiedBadge}>
+                    <Ionicons name="shield-checkmark" size={12} color="#1A7848" />
                     <Text style={styles.verifiedText}>Проверен</Text>
                   </View>
                 )}
@@ -597,10 +599,13 @@ const styles = StyleSheet.create({
     color: Colors.textSecondary,
   },
   verifiedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
     backgroundColor: '#E8F5ED',
-    paddingVertical: 1,
+    paddingVertical: 2,
     paddingHorizontal: 6,
-    borderRadius: BorderRadius.sm,
+    borderRadius: 10,
   },
   verifiedText: {
     fontSize: 10,


### PR DESCRIPTION
## Summary
- #317: Remove QuickRequestForm from hero, keep 2 main CTA buttons
- #318: Show 'Найти специалиста' button on mobile in hero (was desktop-only)
- #332: Add shield icon to verified badge, briefcase icon to experience badge on specialist pages

Note: Tasks #319, #320, #321, #324, #326, #327, #328, #329 were already implemented in previous commits on development.

Fixes #317 #318 #332