### PR TITLE
feat(landing): pricing block, skeletons, empty states, form recovery, auth progress, CTA hierarchy

### DIFF
--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -16,6 +16,7 @@ import { Input } from '../../components/Input';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { api, ApiError } from '../../lib/api';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
+import { AuthProgress } from '../../components/AuthProgress';
 
 function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim());
@@ -72,6 +73,8 @@ export default function EmailScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={[styles.container, !isMobile && styles.containerWide]}>
+            <AuthProgress step={1} />
+
             {/* Back */}
             <TouchableOpacity onPress={() => router.canGoBack() ? router.back() : router.replace('/')} style={styles.back} accessibilityRole="button" accessibilityLabel="Назад">
               <Text style={styles.backText}>← Назад</Text>

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -17,6 +17,7 @@ import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Color
 import { api, ApiError, setRefreshToken } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 import { secureStorage } from '../../stores/storage';
+import { AuthProgress } from '../../components/AuthProgress';
 
 const CODE_LENGTH = 6;
 const RESEND_SECONDS = 60;
@@ -205,6 +206,8 @@ export default function OtpScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={styles.container}>
+            <AuthProgress step={2} />
+
             {/* Back */}
             <TouchableOpacity onPress={() => router.back()} style={styles.back} accessibilityRole="button" accessibilityLabel="Назад">
               <Text style={styles.backText}>← Назад</Text>

--- a/app/(auth)/role.tsx
+++ b/app/(auth)/role.tsx
@@ -13,6 +13,7 @@ import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Color
 import { api, ApiError } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 import { secureStorage } from '../../stores/storage';
+import { AuthProgress } from '../../components/AuthProgress';
 
 export default function RoleScreen() {
   const router = useRouter();
@@ -57,6 +58,8 @@ export default function RoleScreen() {
   return (
     <SafeAreaView style={styles.safe}>
       <View style={styles.container}>
+        <AuthProgress step={3} />
+
         <View style={styles.header}>
           <Text style={styles.title}>Кто вы?</Text>
           <Text style={styles.subtitle}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -633,16 +633,23 @@ export default function LandingScreen() {
                 { num: '1', title: '\u041E\u043F\u0438\u0448\u0438\u0442\u0435 \u0437\u0430\u0434\u0430\u0447\u0443', desc: '\u0427\u0442\u043E \u043D\u0443\u0436\u043D\u043E \u0441\u0434\u0435\u043B\u0430\u0442\u044C, \u0441\u0440\u043E\u043A, \u0431\u044E\u0434\u0436\u0435\u0442' },
                 { num: '2', title: '\u041F\u043E\u043B\u0443\u0447\u0438\u0442\u0435 \u043E\u0442\u043A\u043B\u0438\u043A\u0438', desc: '\u0421\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u044B \u0438\u0437 \u0432\u0430\u0448\u0435\u0433\u043E \u0433\u043E\u0440\u043E\u0434\u0430 \u043F\u0440\u0438\u0448\u043B\u044E\u0442 \u043F\u0440\u0435\u0434\u043B\u043E\u0436\u0435\u043D\u0438\u044F' },
                 { num: '3', title: '\u0412\u044B\u0431\u0435\u0440\u0438\u0442\u0435 \u0438 \u043F\u043B\u0430\u0442\u0438\u0442\u0435', desc: '\u0411\u0435\u0437\u043E\u043F\u0430\u0441\u043D\u0430\u044F \u0441\u0434\u0435\u043B\u043A\u0430, \u0434\u0435\u043D\u044C\u0433\u0438 \u043F\u0435\u0440\u0435\u0445\u043E\u0434\u044F\u0442 \u043F\u043E\u0441\u043B\u0435 \u0432\u044B\u043F\u043E\u043B\u043D\u0435\u043D\u0438\u044F' },
-              ].map((step) => (
-                <View key={step.num} style={[styles.stepItem, isWide && styles.stepItemWide]}>
-                  <View style={styles.stepNumberCircle}>
-                    <Text style={styles.stepNumberText}>{step.num}</Text>
+              ].map((step, idx, arr) => (
+                <React.Fragment key={step.num}>
+                  {idx > 0 && isWide && (
+                    <View style={{ justifyContent: 'center', paddingBottom: 24 }}>
+                      <Ionicons name="arrow-forward" size={24} color={Colors.border} />
+                    </View>
+                  )}
+                  <View style={[styles.stepItem, isWide && styles.stepItemWide]}>
+                    <View style={styles.stepNumberCircle}>
+                      <Text style={styles.stepNumberText}>{step.num}</Text>
+                    </View>
+                    <View style={styles.stepTextBlock}>
+                      <Text style={[styles.stepTitle, !isWide && { textAlign: 'center' as const }]}>{step.title}</Text>
+                      <Text style={[styles.stepDesc, !isWide && { textAlign: 'center' as const }]}>{step.desc}</Text>
+                    </View>
                   </View>
-                  <View style={styles.stepTextBlock}>
-                    <Text style={[styles.stepTitle, !isWide && { textAlign: 'center' as const }]}>{step.title}</Text>
-                    <Text style={[styles.stepDesc, !isWide && { textAlign: 'center' as const }]}>{step.desc}</Text>
-                  </View>
-                </View>
+                </React.Fragment>
               ))}
             </View>
           </View>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -418,12 +418,12 @@ export default function LandingScreen() {
                 <Button
                   onPress={() => router.push('/specialists')}
                   variant="primary"
-                  style={{ minWidth: 220, maxWidth: 260 }}
+                  style={!isWide ? { width: '100%', minHeight: 52 } : { minWidth: 220, maxWidth: 260 }}
                 >{'\u041D\u0430\u0439\u0442\u0438 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u0430'}</Button>
                 <Button
                   onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
                   variant="outline"
-                  style={{ minWidth: 200, maxWidth: 260 }}
+                  style={!isWide ? { alignSelf: 'center' } : { minWidth: 200, maxWidth: 260 }}
                 >{'\u042F \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442'}</Button>
               </View>
             </View>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -694,6 +694,51 @@ export default function LandingScreen() {
           </View>
         </View>
 
+        {/* ===== SECTION 8b: Transparent Pricing ===== */}
+        <View style={[styles.section, { backgroundColor: Colors.bgCard }]}>
+          <View style={[styles.sectionInner, innerStyle]}>
+            <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>
+              {'\u041F\u0440\u043E\u0437\u0440\u0430\u0447\u043D\u043E\u0435 \u0446\u0435\u043D\u043E\u043E\u0431\u0440\u0430\u0437\u043E\u0432\u0430\u043D\u0438\u0435'}
+            </Text>
+
+            <View style={[styles.forWhomRow, isWide && styles.forWhomRowWide]}>
+              {/* For clients */}
+              <View style={pricingStyles.card}>
+                <Text style={pricingStyles.cardTitle}>{'\u0414\u043B\u044F \u043A\u043B\u0438\u0435\u043D\u0442\u043E\u0432'}</Text>
+                {[
+                  '\u0420\u0430\u0437\u043C\u0435\u0441\u0442\u0438\u0442\u044C \u0437\u0430\u043F\u0440\u043E\u0441 \u2014 \u0431\u0435\u0441\u043F\u043B\u0430\u0442\u043D\u043E',
+                  '\u041E\u043F\u0438\u0441\u0430\u0442\u044C \u0437\u0430\u0434\u0430\u0447\u0443 \u2014 \u0431\u0435\u0441\u043F\u043B\u0430\u0442\u043D\u043E',
+                  '\u041F\u043B\u0430\u0442\u0438\u0442\u0435 \u0442\u043E\u043B\u044C\u043A\u043E \u0432\u044B\u0431\u0440\u0430\u043D\u043D\u043E\u043C\u0443 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u0443',
+                ].map((item) => (
+                  <View key={item} style={pricingStyles.row}>
+                    <Ionicons name="checkmark-circle" size={20} color={Colors.statusSuccess} />
+                    <Text style={pricingStyles.rowText}>{item}</Text>
+                  </View>
+                ))}
+              </View>
+
+              {/* For specialists */}
+              <View style={pricingStyles.card}>
+                <Text style={pricingStyles.cardTitle}>{'\u0414\u043B\u044F \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u043E\u0432'}</Text>
+                {[
+                  '\u0420\u0435\u0433\u0438\u0441\u0442\u0440\u0430\u0446\u0438\u044F \u2014 \u0431\u0435\u0441\u043F\u043B\u0430\u0442\u043D\u043E',
+                  '\u041F\u043E\u043B\u0443\u0447\u0435\u043D\u0438\u0435 \u043E\u0442\u043A\u043B\u0438\u043A\u043E\u0432 \u2014 \u0431\u0435\u0441\u043F\u043B\u0430\u0442\u043D\u043E',
+                  '\u041A\u043E\u043C\u0438\u0441\u0441\u0438\u044F \u043F\u043B\u0430\u0442\u0444\u043E\u0440\u043C\u044B \u2014 0%',
+                ].map((item) => (
+                  <View key={item} style={pricingStyles.row}>
+                    <Ionicons name="checkmark-circle" size={20} color={Colors.statusSuccess} />
+                    <Text style={pricingStyles.rowText}>{item}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+
+            <TouchableOpacity onPress={() => router.push('/pricing')} activeOpacity={0.7} style={{ marginTop: Spacing.md }}>
+              <Text style={dyn.seeAllText}>{'\u041F\u043E\u0434\u0440\u043E\u0431\u043D\u0435\u0435 \u043E \u0442\u0430\u0440\u0438\u0444\u0430\u0445 \u2192'}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+
         {/* ===== SECTION 9: Final CTA ===== */}
         <View style={styles.ctaSection}>
           <View style={[styles.ctaContent, innerStyle]}>
@@ -1446,6 +1491,35 @@ const dyn = StyleSheet.create({
     fontSize: Typography.fontSize.base,
     color: Colors.brandPrimary,
     fontWeight: Typography.fontWeight.semibold,
+  },
+});
+
+const pricingStyles = StyleSheet.create({
+  card: {
+    flex: 1,
+    backgroundColor: Colors.white,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: Spacing['2xl'],
+    gap: Spacing.md,
+  },
+  cardTitle: {
+    fontSize: Typography.fontSize.title,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginBottom: Spacing.xs,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  rowText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+    flex: 1,
   },
 });
 // dev-sync test Thu Apr  9 08:47:11 PDT 2026

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -68,6 +68,20 @@ function QuickRequestForm() {
   const [error, setError] = useState('');
   const [submitted, setSubmitted] = useState(false);
 
+  // Restore saved form data after auth redirect
+  useEffect(() => {
+    secureStorage.getItem('p2ptax_pending_request').then(saved => {
+      if (saved) {
+        try {
+          const { description: d, city: c, serviceType: s } = JSON.parse(saved);
+          if (d) setDescription(d);
+          if (c) setCity(c);
+          if (s) setServiceType(s);
+        } catch {}
+      }
+    });
+  }, []);
+
   const effectiveCity = city || customCity.trim();
 
   const handleSubmit = async () => {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -42,6 +42,14 @@ const SERVICE_TYPES = [
   'Другое',
 ];
 
+const DEFAULT_CITIES = [
+  '\u041C\u043E\u0441\u043A\u0432\u0430',
+  '\u0421\u0430\u043D\u043A\u0442-\u041F\u0435\u0442\u0435\u0440\u0431\u0443\u0440\u0433',
+  '\u0415\u043A\u0430\u0442\u0435\u0440\u0438\u043D\u0431\u0443\u0440\u0433',
+  '\u041D\u043E\u0432\u043E\u0441\u0438\u0431\u0438\u0440\u0441\u043A',
+  '\u041A\u0430\u0437\u0430\u043D\u044C',
+];
+
 const TASK_SERVICE_TYPE_MAP: Record<string, string> = {
   'Декларация 3-НДФЛ': 'declaration',
   'Спор с налоговой инспекцией': 'dispute',
@@ -552,6 +560,21 @@ export default function LandingScreen() {
             </View>
           </View>
         )}
+        {!isLoadingRequests && recentRequests.length === 0 && (
+          <View style={[styles.section, { backgroundColor: Colors.bgSecondary }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u0438\u0435 \u0437\u0430\u043F\u0440\u043E\u0441\u044B'}</Text>
+              <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textSecondary, textAlign: 'center', lineHeight: 22, maxWidth: 400 }}>
+                {'\u0411\u0443\u0434\u044C\u0442\u0435 \u043F\u0435\u0440\u0432\u044B\u043C! \u0420\u0430\u0437\u043C\u0435\u0441\u0442\u0438\u0442\u0435 \u0437\u0430\u043F\u0440\u043E\u0441 \u0438 \u043F\u043E\u043B\u0443\u0447\u0438\u0442\u0435 \u043E\u0442\u043A\u043B\u0438\u043A\u0438 \u043E\u0442 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u043E\u0432.'}
+              </Text>
+              <Button
+                onPress={() => router.push('/(auth)/email?redirectTo=%2F(dashboard)%2Fmy-requests%2Fnew')}
+                variant="primary"
+                style={{ marginTop: Spacing.sm }}
+              >{'\u0421\u043E\u0437\u0434\u0430\u0442\u044C \u0437\u0430\u043F\u0440\u043E\u0441'}</Button>
+            </View>
+          </View>
+        )}
 
         {/* ===== SECTION 2d: Popular Cities ===== */}
         {isLoadingCities && (
@@ -563,12 +586,12 @@ export default function LandingScreen() {
             </View>
           </View>
         )}
-        {!isLoadingCities && popularCities.length > 0 && (
+        {!isLoadingCities && (
           <View style={[styles.section, { backgroundColor: Colors.white }]}>
             <View style={[styles.sectionInner, innerStyle]}>
               <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041F\u043E\u043F\u0443\u043B\u044F\u0440\u043D\u044B\u0435 \u0433\u043E\u0440\u043E\u0434\u0430'}</Text>
               <View style={dyn.citiesRow}>
-                {popularCities.map((item: any) => {
+                {(popularCities.length > 0 ? popularCities : DEFAULT_CITIES).map((item: any) => {
                   const cityName = typeof item === 'string' ? item : (item.city || item.name || String(item));
                   return (
                     <TouchableOpacity

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -650,50 +650,7 @@ export default function LandingScreen() {
           </View>
         </View>
 
-        {/* ===== SECTION 7: Reviews ===== */}
-        <View style={[styles.section, { backgroundColor: Colors.bgCard }]}>
-          <View style={[styles.sectionInner, innerStyle]}>
-            <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041E\u0442\u0437\u044B\u0432\u044B \u043A\u043B\u0438\u0435\u043D\u0442\u043E\u0432'}</Text>
-
-            {(() => {
-              const reviews = [
-                {
-                  text: '\u041F\u043E\u043C\u043E\u0433\u043B\u0438 \u0440\u0430\u0437\u043E\u0431\u0440\u0430\u0442\u044C\u0441\u044F \u0441 \u043D\u0430\u043B\u043E\u0433\u043E\u0432\u044B\u043C \u0432\u044B\u0447\u0435\u0442\u043E\u043C, \u0431\u044B\u0441\u0442\u0440\u043E \u0438 \u043F\u043E\u043D\u044F\u0442\u043D\u043E. \u0412\u0435\u0440\u043D\u0443\u043B\u0438 260 \u0442\u044B\u0441\u044F\u0447 \u0437\u0430 \u043A\u0432\u0430\u0440\u0442\u0438\u0440\u0443!',
-                  name: '\u0410\u043D\u043D\u0430 \u041A.',
-                  city: '\u041C\u043E\u0441\u043A\u0432\u0430',
-                },
-                {
-                  text: '\u041D\u0430\u0448\u043B\u0438 \u0441\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u0430 \u0437\u0430 \u0447\u0430\u0441, \u0441\u043F\u043E\u0440 \u0441 \u0424\u041D\u0421 \u0440\u0435\u0448\u0438\u043B\u0438 \u0437\u0430 2 \u043C\u0435\u0441\u044F\u0446\u0430. \u0414\u043E\u043D\u0430\u0447\u0438\u0441\u043B\u0435\u043D\u0438\u0435 \u043E\u0442\u043C\u0435\u043D\u0435\u043D\u043E \u043F\u043E\u043B\u043D\u043E\u0441\u0442\u044C\u044E.',
-                  name: '\u0414\u043C\u0438\u0442\u0440\u0438\u0439 \u0412.',
-                  city: '\u0415\u043A\u0430\u0442\u0435\u0440\u0438\u043D\u0431\u0443\u0440\u0433',
-                },
-                {
-                  text: '\u041E\u0442\u043B\u0438\u0447\u043D\u044B\u0439 \u0441\u0435\u0440\u0432\u0438\u0441. \u0417\u0430\u0440\u0435\u0433\u0438\u0441\u0442\u0440\u0438\u0440\u043E\u0432\u0430\u043B\u0438 \u041E\u041E\u041E \u043F\u043E\u0434 \u043A\u043B\u044E\u0447 \u0437\u0430 3 \u0434\u043D\u044F, \u0432\u0441\u0451 \u043E\u0431\u044A\u044F\u0441\u043D\u0438\u043B\u0438 \u0438 \u043F\u043E\u043C\u043E\u0433\u043B\u0438 \u0441 \u0432\u044B\u0431\u043E\u0440\u043E\u043C \u043D\u0430\u043B\u043E\u0433\u043E\u0432\u043E\u0433\u043E \u0440\u0435\u0436\u0438\u043C\u0430.',
-                  name: '\u041C\u0430\u0440\u0438\u043D\u0430 \u0421.',
-                  city: '\u041A\u0430\u0437\u0430\u043D\u044C',
-                },
-              ];
-              const renderReviewCard = (review: typeof reviews[0]) => (
-                <View key={review.name} style={[styles.reviewCard, !isMobile && isTablet && styles.reviewCardTablet, isMobile && { width: 280, flex: undefined as any }]}>
-                  <Text style={styles.reviewQuote}>{'\u201C'}</Text>
-                  <Text style={styles.reviewText}>{review.text}</Text>
-                  <Text style={styles.reviewStars}>{'\u2605\u2605\u2605\u2605\u2605'}</Text>
-                  <Text style={styles.reviewName}>{review.name}</Text>
-                  <Text style={styles.reviewCity}>{review.city}</Text>
-                </View>
-              );
-              return isMobile ? (
-                <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 16, paddingVertical: 4 }}>
-                  {reviews.map(renderReviewCard)}
-                </ScrollView>
-              ) : (
-                <View style={[styles.reviewsRow, isDesktop && styles.reviewsRowDesktop, isTablet && styles.reviewsRowTablet]}>
-                  {reviews.map(renderReviewCard)}
-                </View>
-              );
-            })()}
-          </View>
-        </View>
+        {/* ===== SECTION 7: Reviews — hidden until real API reviews available ===== */}
 
         {/* ===== SECTION 8: FAQ ===== */}
         <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   TextInput,
   Platform,
   Image,
+  Animated,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, Stack } from 'expo-router';
@@ -289,6 +290,39 @@ const qrf = StyleSheet.create({
 });
 
 
+// ---- Skeleton Components ----
+
+function SkeletonPulse({ children }: { children: React.ReactNode }) {
+  const opacity = useRef(new Animated.Value(0.15)).current;
+  useEffect(() => {
+    const anim = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 0.35, duration: 800, useNativeDriver: true }),
+        Animated.timing(opacity, { toValue: 0.15, duration: 800, useNativeDriver: true }),
+      ]),
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [opacity]);
+  return <Animated.View style={{ opacity }}>{children}</Animated.View>;
+}
+
+function SkeletonCard({ width, height }: { width: number | string; height: number }) {
+  return (
+    <SkeletonPulse>
+      <View style={{ width: width as any, height, backgroundColor: Colors.textMuted, borderRadius: 8 }} />
+    </SkeletonPulse>
+  );
+}
+
+function SkeletonChip() {
+  return (
+    <SkeletonPulse>
+      <View style={{ width: 80, height: 32, backgroundColor: Colors.textMuted, borderRadius: 16 }} />
+    </SkeletonPulse>
+  );
+}
+
 // ---- Main ----
 
 export default function LandingScreen() {
@@ -299,11 +333,14 @@ export default function LandingScreen() {
   const [recentRequests, setRecentRequests] = useState<any[]>([]);
   const [popularCities, setPopularCities] = useState<any[]>([]);
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
+  const [isLoadingSpecialists, setIsLoadingSpecialists] = useState(true);
+  const [isLoadingRequests, setIsLoadingRequests] = useState(true);
+  const [isLoadingCities, setIsLoadingCities] = useState(true);
 
   useEffect(() => {
-    api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err));
-    api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err));
-    api.get<any[]>('/specialists/cities/popular?limit=10').then(setPopularCities).catch((err) => console.warn('Landing section failed (popular cities):', err));
+    api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err)).finally(() => setIsLoadingSpecialists(false));
+    api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err)).finally(() => setIsLoadingRequests(false));
+    api.get<any[]>('/specialists/cities/popular?limit=10').then(setPopularCities).catch((err) => console.warn('Landing section failed (popular cities):', err)).finally(() => setIsLoadingCities(false));
   }, []);
 
   const isWide = !isMobile;
@@ -427,7 +464,18 @@ export default function LandingScreen() {
         </View>
 
         {/* ===== SECTION 2b: Featured Specialists ===== */}
-        {featuredSpecialists.length > 0 && (
+        {isLoadingSpecialists && (
+          <View style={[styles.section, { backgroundColor: Colors.bgPrimary, paddingVertical: 40 }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 12, flexDirection: 'row' }}>
+                <SkeletonCard width={160} height={100} />
+                <SkeletonCard width={160} height={100} />
+                <SkeletonCard width={160} height={100} />
+              </ScrollView>
+            </View>
+          </View>
+        )}
+        {!isLoadingSpecialists && featuredSpecialists.length > 0 && (
           <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>
             <View style={[styles.sectionInner, innerStyle]}>
               <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u0421\u043F\u0435\u0446\u0438\u0430\u043B\u0438\u0441\u0442\u044B'}</Text>
@@ -466,7 +514,17 @@ export default function LandingScreen() {
         )}
 
         {/* ===== SECTION 2c: Recent Requests ===== */}
-        {recentRequests.length > 0 && (
+        {isLoadingRequests && (
+          <View style={[styles.section, { backgroundColor: Colors.bgSecondary, paddingVertical: 40 }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <View style={{ width: '100%', gap: 12 }}>
+                <SkeletonCard width="100%" height={60} />
+                <SkeletonCard width="100%" height={60} />
+              </View>
+            </View>
+          </View>
+        )}
+        {!isLoadingRequests && recentRequests.length > 0 && (
           <View style={[styles.section, { backgroundColor: Colors.bgSecondary }]}>
             <View style={[styles.sectionInner, innerStyle]}>
               <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041F\u043E\u0441\u043B\u0435\u0434\u043D\u0438\u0435 \u0437\u0430\u043F\u0440\u043E\u0441\u044B'}</Text>
@@ -496,7 +554,16 @@ export default function LandingScreen() {
         )}
 
         {/* ===== SECTION 2d: Popular Cities ===== */}
-        {popularCities.length > 0 && (
+        {isLoadingCities && (
+          <View style={[styles.section, { backgroundColor: Colors.white, paddingVertical: 40 }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, justifyContent: 'center' }}>
+                <SkeletonChip /><SkeletonChip /><SkeletonChip /><SkeletonChip /><SkeletonChip />
+              </View>
+            </View>
+          </View>
+        )}
+        {!isLoadingCities && popularCities.length > 0 && (
           <View style={[styles.section, { backgroundColor: Colors.white }]}>
             <View style={[styles.sectionInner, innerStyle]}>
               <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041F\u043E\u043F\u0443\u043B\u044F\u0440\u043D\u044B\u0435 \u0433\u043E\u0440\u043E\u0434\u0430'}</Text>

--- a/components/AuthProgress.tsx
+++ b/components/AuthProgress.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Typography, Spacing } from '../constants/Colors';
+
+interface AuthProgressProps {
+  step: 1 | 2 | 3;
+  total?: number;
+}
+
+const LABELS = ['Email', '\u041A\u043E\u0434', '\u041F\u0440\u043E\u0444\u0438\u043B\u044C'];
+
+export function AuthProgress({ step, total = 3 }: AuthProgressProps) {
+  return (
+    <View style={s.container}>
+      <View style={s.row}>
+        {Array.from({ length: total }, (_, i) => {
+          const idx = i + 1;
+          const isActive = idx <= step;
+          const isCurrent = idx === step;
+          return (
+            <React.Fragment key={idx}>
+              {i > 0 && (
+                <View style={[s.line, isActive && s.lineActive]} />
+              )}
+              <View style={[s.circle, isActive && s.circleActive, isCurrent && s.circleCurrent]}>
+                <Text style={[s.circleText, isActive && s.circleTextActive]}>{idx}</Text>
+              </View>
+            </React.Fragment>
+          );
+        })}
+      </View>
+      <View style={s.labelsRow}>
+        {LABELS.slice(0, total).map((label, i) => (
+          <Text
+            key={label}
+            style={[s.label, i + 1 <= step && s.labelActive]}
+          >
+            {label}
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    gap: Spacing.xs,
+    width: '100%',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  circle: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: Colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.bgPrimary,
+  },
+  circleActive: {
+    borderColor: Colors.brandPrimary,
+    backgroundColor: Colors.brandPrimary,
+  },
+  circleCurrent: {
+    borderColor: Colors.brandPrimary,
+    backgroundColor: Colors.brandPrimary,
+  },
+  circleText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textMuted,
+  },
+  circleTextActive: {
+    color: Colors.white,
+  },
+  line: {
+    width: 40,
+    height: 2,
+    backgroundColor: Colors.border,
+  },
+  lineActive: {
+    backgroundColor: Colors.brandPrimary,
+  },
+  labelsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: 32 * 3 + 40 * 2,
+  },
+  label: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    width: 32,
+  },
+  labelActive: {
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});


### PR DESCRIPTION
## Summary
- **Pricing section**: transparent pricing block between FAQ and CTA with checkmark icons
- **Skeleton loaders**: animated pulse skeletons for specialists, requests, cities while loading
- **Empty states**: "create request" CTA when no requests; default cities fallback
- **Form recovery**: restore QuickRequestForm fields after auth redirect
- **Auth progress**: 3-step progress indicator on email/otp/role screens
- **CTA hierarchy**: full-width primary CTA on mobile, outline secondary below
- **Step arrows**: arrow-forward icons between how-it-works steps on desktop
- **Reviews removed**: hardcoded fake reviews section hidden until real API

## Test plan
- [ ] Verify pricing section renders between FAQ and Final CTA
- [ ] Verify skeleton loaders appear briefly on landing load
- [ ] Verify empty requests show "create request" prompt
- [ ] Verify cities fallback to defaults when API returns empty
- [ ] Fill quick request form, navigate to auth, come back — fields restored
- [ ] Auth screens show step indicator (1/2/3)
- [ ] Mobile hero: primary CTA full-width, outline centered below
- [ ] Desktop how-it-works: arrows between steps
- [ ] Reviews section no longer visible