### PR TITLE
feat(email): switch from nodemailer to Brevo SDK

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1025.0",
         "@aws-sdk/s3-request-presigner": "^3.1025.0",
+        "@getbrevo/brevo": "^5.0.3",
         "@nestjs/common": "^10.4.15",
         "@nestjs/core": "^10.4.15",
         "@nestjs/jwt": "^10.2.0",
@@ -28,7 +29,6 @@
         "ioredis": "^5.10.1",
         "minio": "^8.0.7",
         "multer": "^2.1.1",
-        "nodemailer": "^8.0.4",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
@@ -38,7 +38,6 @@
       "devDependencies": {
         "@types/multer": "^2.1.0",
         "@types/node": "^22.13.0",
-        "@types/nodemailer": "^7.0.11",
         "@types/passport-jwt": "^4.0.1",
         "prisma": "^6.19.3",
         "ts-node-dev": "^2.0.0",
@@ -951,6 +950,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@getbrevo/brevo": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-5.0.3.tgz",
+      "integrity": "sha512-AIAFXiUkk5fpl8cVttGWZfxt84PFPS7DnB0+fRqd70kFsbwPvNfdYhrnD0tXL5jLmGrSeLv2pfACkzFD7gYeeA==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -2352,16 +2359,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/nodemailer": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
-      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
@@ -4214,15 +4211,6 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
-      }
-    },
-    "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/api/package.json
+++ b/api/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1025.0",
     "@aws-sdk/s3-request-presigner": "^3.1025.0",
+    "@getbrevo/brevo": "^5.0.3",
     "@nestjs/common": "^10.4.15",
     "@nestjs/core": "^10.4.15",
     "@nestjs/jwt": "^10.2.0",
@@ -33,7 +34,6 @@
     "ioredis": "^5.10.1",
     "minio": "^8.0.7",
     "multer": "^2.1.1",
-    "nodemailer": "^8.0.4",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@types/multer": "^2.1.0",
     "@types/node": "^22.13.0",
-    "@types/nodemailer": "^7.0.11",
     "@types/passport-jwt": "^4.0.1",
     "prisma": "^6.19.3",
     "ts-node-dev": "^2.0.0",

--- a/api/src/notifications/email.service.ts
+++ b/api/src/notifications/email.service.ts
@@ -1,30 +1,27 @@
 import { Injectable, Logger } from '@nestjs/common';
-import * as nodemailer from 'nodemailer';
+import { BrevoClient } from '@getbrevo/brevo';
 
 @Injectable()
 export class EmailService {
   private readonly logger = new Logger(EmailService.name);
-  private transporter: nodemailer.Transporter | null = null;
+  private client: BrevoClient | null = null;
+  private senderEmail = 'no-reply@nalogovic.ru';
+  private senderName = 'Налоговик';
 
   constructor() {
-    if (process.env.SMTP_HOST) {
-      this.transporter = nodemailer.createTransport({
-        host: process.env.SMTP_HOST,
-        port: parseInt(process.env.SMTP_PORT ?? '587', 10),
-        secure: process.env.SMTP_PORT === '465',
-        auth: {
-          user: process.env.SMTP_USER,
-          pass: process.env.SMTP_PASS,
-        },
-      });
+    const apiKey = process.env.BREVO_API_KEY;
+    if (apiKey) {
+      this.client = new BrevoClient({ apiKey });
+      this.senderEmail = process.env.BREVO_SENDER_EMAIL || this.senderEmail;
+      this.senderName = process.env.BREVO_SENDER_NAME || this.senderName;
     } else {
-      this.logger.warn('SMTP_HOST not set — running in dev mode, emails will be logged only');
+      this.logger.warn('BREVO_API_KEY not set — running in dev mode, emails will be logged only');
     }
   }
 
   /** Notify client that a specialist responded to their request */
   notifyNewResponse(clientEmail: string, requestId: string, specialistId: string): void {
-    if (!process.env.SMTP_HOST) {
+    if (!this.client) {
       this.logger.log(
         `DEV EMAIL [notifyNewResponse]: to=${clientEmail} requestId=${requestId} specialistId=${specialistId}`,
       );
@@ -42,7 +39,7 @@ export class EmailService {
 
   /** Notify recipient that they have a new chat message */
   notifyNewMessage(recipientEmail: string, senderEmail: string, threadId: string): void {
-    if (!process.env.SMTP_HOST) {
+    if (!this.client) {
       this.logger.log(
         `DEV EMAIL [notifyNewMessage]: to=${recipientEmail} from=${senderEmail} threadId=${threadId}`,
       );
@@ -66,7 +63,7 @@ export class EmailService {
   ): void {
     if (specialistEmails.length === 0) return;
 
-    if (!process.env.SMTP_HOST) {
+    if (!this.client) {
       this.logger.log(
         `DEV EMAIL [notifyNewRequestInCity]: to=[${specialistEmails.join(', ')}] city=${requestCity}`,
       );
@@ -91,7 +88,7 @@ export class EmailService {
 
   /** Notify specialist that their promotion expires in 3 days */
   async notifyPromotionExpiringSoon(specialistEmail: string, city: string): Promise<void> {
-    if (!process.env.SMTP_HOST) {
+    if (!this.client) {
       this.logger.log(`[DEV] Promotion expiry reminder → ${specialistEmail} for city ${city}`);
       return;
     }
@@ -104,31 +101,33 @@ export class EmailService {
 
   /** Send a one-time password to the user */
   async sendOtp(email: string, code: string): Promise<void> {
-    if (!this.transporter) {
-      this.logger.log(`[DEV] OTP for ${email}: ${code} (SMTP not configured, email not sent)`);
+    if (!this.client) {
+      this.logger.log(`[DEV] OTP for ${email}: ${code} (Brevo not configured, email not sent)`);
       return;
     }
 
     try {
-      await this.send({
-        to: email,
+      await this.client.transactionalEmails.sendTransacEmail({
+        sender: { email: this.senderEmail, name: this.senderName },
+        to: [{ email }],
         subject: 'Ваш код для входа — Налоговик',
-        text: `Ваш код для входа: ${code}\n\nКод действителен 10 минут. Если вы не запрашивали код, проигнорируйте это письмо.`,
+        textContent: `Ваш код для входа: ${code}\n\nКод действителен 10 минут. Если вы не запрашивали код, проигнорируйте это письмо.`,
+        htmlContent: `<p>Ваш код для входа в <b>Налоговик</b>:</p><h2 style="letter-spacing:4px">${code}</h2><p>Код действителен 10 минут.</p>`,
       });
-      this.logger.log(`OTP email sent to ${email}`);
+      this.logger.log(`OTP email sent via Brevo to ${email}`);
     } catch (err) {
       this.logger.error(`[sendOtp] Failed to send OTP email to ${email}`, err);
     }
   }
 
   private async send(opts: { to: string; subject: string; text: string }): Promise<void> {
-    if (!this.transporter) return;
+    if (!this.client) return;
 
-    await this.transporter.sendMail({
-      from: process.env.SMTP_USER,
-      to: opts.to,
+    await this.client.transactionalEmails.sendTransacEmail({
+      sender: { email: this.senderEmail, name: this.senderName },
+      to: [{ email: opts.to }],
       subject: opts.subject,
-      text: opts.text,
+      textContent: opts.text,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Replace nodemailer (unconfigured SMTP) with `@getbrevo/brevo` SDK v5
- Reads `BREVO_API_KEY`, `BREVO_SENDER_EMAIL`, `BREVO_SENDER_NAME` from env
- `sendOtp` now sends real emails via Brevo transactional API with HTML template
- Graceful dev-mode fallback when `BREVO_API_KEY` not set

## Test
- [x] Manual curl test confirmed email arrives to serter2069@gmail.com via Brevo API
- [x] Doppler: BREVO_SENDER_EMAIL=serter20692@gmail.com, BREVO_SENDER_NAME=Налоговик

Closes #388