### PR TITLE
feat: onboarding step 5 + specialist CTA fix + client welcome screen

### DIFF
--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -209,6 +209,53 @@ export default function DashboardHub() {
     </View>
   );
 
+  const welcomeSection = isClient && recentRequests.length === 0 && !loading && !loadError ? (
+    <View style={styles.welcomeCard}>
+      <Text style={styles.welcomeTitle}>Добро пожаловать!</Text>
+      <Text style={styles.welcomeSubtitle}>Вот как это работает:</Text>
+
+      <View style={styles.welcomeSteps}>
+        <View style={styles.welcomeStep}>
+          <View style={styles.stepBadge}>
+            <Text style={styles.stepBadgeText}>1</Text>
+          </View>
+          <View style={styles.stepContent}>
+            <Text style={styles.stepTitle}>Опишите проблему</Text>
+            <Text style={styles.stepDesc}>Расскажите о своей налоговой ситуации</Text>
+          </View>
+        </View>
+
+        <View style={styles.welcomeStep}>
+          <View style={styles.stepBadge}>
+            <Text style={styles.stepBadgeText}>2</Text>
+          </View>
+          <View style={styles.stepContent}>
+            <Text style={styles.stepTitle}>Получите ответы</Text>
+            <Text style={styles.stepDesc}>Специалисты из вашего города предложат решения</Text>
+          </View>
+        </View>
+
+        <View style={styles.welcomeStep}>
+          <View style={styles.stepBadge}>
+            <Text style={styles.stepBadgeText}>3</Text>
+          </View>
+          <View style={styles.stepContent}>
+            <Text style={styles.stepTitle}>Выберите подходящего</Text>
+            <Text style={styles.stepDesc}>Сравните и выберите специалиста</Text>
+          </View>
+        </View>
+      </View>
+
+      <Button
+        onPress={() => router.push('/(dashboard)/my-requests/new')}
+        variant="primary"
+        style={styles.welcomeBtn}
+      >
+        Создать первый запрос
+      </Button>
+    </View>
+  ) : null;
+
   const recentSection = isClient ? (
     <View style={styles.section}>
       <Text style={styles.sectionTitle}>Последние запросы</Text>
@@ -278,6 +325,7 @@ export default function DashboardHub() {
               <>
                 {statsSection}
                 {!loading && quickActions}
+                {!loading && welcomeSection}
                 {!loading && recentSection}
               </>
             )}
@@ -676,5 +724,66 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize['2xl'],
     fontWeight: Typography.fontWeight.bold,
     color: Colors.textPrimary,
+  },
+  // Welcome card (empty state for clients)
+  welcomeCard: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: Spacing['2xl'],
+    gap: Spacing.lg,
+    ...Shadows.sm,
+  },
+  welcomeTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  welcomeSubtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    marginTop: -Spacing.sm,
+  },
+  welcomeSteps: {
+    gap: Spacing.lg,
+  },
+  welcomeStep: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Spacing.md,
+  },
+  stepBadge: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: Colors.brandPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    marginTop: 2,
+  },
+  stepBadgeText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.bold,
+    color: '#FFFFFF',
+  },
+  stepContent: {
+    flex: 1,
+    gap: 2,
+  },
+  stepTitle: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  stepDesc: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+  },
+  welcomeBtn: {
+    width: '100%',
+    marginTop: Spacing.sm,
   },
 });

--- a/app/(onboarding)/cities.tsx
+++ b/app/(onboarding)/cities.tsx
@@ -50,11 +50,13 @@ export default function CitiesScreen() {
             <Text style={styles.backBtnText}>← Назад</Text>
           </TouchableOpacity>
 
-          {/* Progress indicator — 4 steps */}
+          {/* Progress indicator — 5 steps */}
           <View style={styles.progressRow}>
             <View style={[styles.progressDot, styles.progressDotDone]} />
             <View style={styles.progressLine} />
             <View style={[styles.progressDot, styles.progressDotActive]} />
+            <View style={styles.progressLine} />
+            <View style={styles.progressDot} />
             <View style={styles.progressLine} />
             <View style={styles.progressDot} />
             <View style={styles.progressLine} />
@@ -68,7 +70,7 @@ export default function CitiesScreen() {
 
           {/* Header */}
           <View style={styles.header}>
-            <Text style={styles.step}>Шаг 2 из 4</Text>
+            <Text style={styles.step}>Шаг 2 из 5</Text>
             <Text style={styles.title}>Выберите города</Text>
             <Text style={styles.subtitle}>
               В каких городах России вы оказываете услуги?

--- a/app/(onboarding)/fns.tsx
+++ b/app/(onboarding)/fns.tsx
@@ -117,7 +117,7 @@ export default function FNSScreen() {
         keyboardShouldPersistTaps="handled"
       >
         <View style={styles.container}>
-          {/* Progress — 4 steps */}
+          {/* Progress — 5 steps */}
           <View style={styles.progressRow}>
             <View style={[styles.progressDot, styles.progressDotDone]} />
             <View style={styles.progressLine} />
@@ -126,10 +126,12 @@ export default function FNSScreen() {
             <View style={[styles.progressDot, styles.progressDotActive]} />
             <View style={styles.progressLine} />
             <View style={styles.progressDot} />
+            <View style={styles.progressLine} />
+            <View style={styles.progressDot} />
           </View>
 
           <View style={styles.header}>
-            <Text style={styles.step}>Шаг 3 из 4</Text>
+            <Text style={styles.step}>Шаг 3 из 5</Text>
             <Text style={styles.title}>Выберите ИФНС</Text>
             <Text style={styles.subtitle}>
               Укажите инспекции ФНС, с которыми вы работаете

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -1,0 +1,376 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Button } from '../../components/Button';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { api, ApiError, tryRefreshTokens, getToken } from '../../lib/api';
+import { useAuth } from '../../stores/authStore';
+import { AuthUser } from '../../stores/authStore';
+
+export default function ProfileScreen() {
+  const router = useRouter();
+  const { completeOnboarding, login, user } = useAuth();
+
+  const [displayName, setDisplayName] = useState('');
+  const [headline, setHeadline] = useState('');
+  const [bio, setBio] = useState('');
+  const [contacts, setContacts] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [focusedField, setFocusedField] = useState<string | null>(null);
+
+  async function handleSubmit() {
+    setError('');
+    setLoading(true);
+    try {
+      // Read all previously saved onboarding data
+      const [citiesRaw, fnsRaw, fnsDataRaw, servicesRaw] = await Promise.all([
+        AsyncStorage.getItem('onboarding_cities'),
+        AsyncStorage.getItem('onboarding_fns'),
+        AsyncStorage.getItem('onboarding_fns_data'),
+        AsyncStorage.getItem('onboarding_services'),
+      ]);
+
+      const cities: string[] = citiesRaw ? JSON.parse(citiesRaw) : [];
+      const fnsOffices: string[] = fnsRaw ? JSON.parse(fnsRaw) : [];
+      const services: string[] = servicesRaw ? JSON.parse(servicesRaw) : [];
+
+      const patchBody: Record<string, unknown> = {
+        cities,
+        fnsOffices,
+        services,
+      };
+
+      const trimmedDisplayName = displayName.trim();
+      const trimmedHeadline = headline.trim();
+      const trimmedBio = bio.trim();
+      const trimmedContacts = contacts.trim();
+
+      if (trimmedDisplayName) patchBody.displayName = trimmedDisplayName;
+      if (trimmedHeadline) patchBody.headline = trimmedHeadline;
+      if (trimmedBio) patchBody.bio = trimmedBio;
+      if (trimmedContacts) patchBody.contacts = trimmedContacts;
+
+      await api.patch('/users/me/specialist-profile', patchBody);
+
+      // Refresh JWT so the new token carries SPECIALIST role (not CLIENT)
+      await tryRefreshTokens();
+      const freshToken = await getToken();
+      if (freshToken) {
+        // Fetch updated user profile (role is now SPECIALIST in DB)
+        const freshUser = await api.get<{ id: string; email: string; role: string; username: string | null }>('/users/me');
+        await login(freshToken, {
+          userId: freshUser.id,
+          email: freshUser.email,
+          role: freshUser.role,
+          username: freshUser.username,
+          isNewUser: false,
+        } as AuthUser);
+      }
+
+      // Mark onboarding complete — sets isNewUser=false in store + AsyncStorage
+      await completeOnboarding(user?.username ?? '');
+
+      // Clean up AsyncStorage onboarding keys
+      await Promise.all([
+        AsyncStorage.removeItem('onboarding_cities'),
+        AsyncStorage.removeItem('onboarding_fns'),
+        AsyncStorage.removeItem('onboarding_fns_data'),
+        AsyncStorage.removeItem('onboarding_services'),
+      ]);
+
+      router.replace('/');
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        setError('Профиль уже существует. Попробуйте войти снова.');
+      } else if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError('Не удалось сохранить профиль. Попробуйте снова.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <KeyboardAvoidingView
+        style={styles.kav}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.container}>
+            {/* Progress indicator — 5 steps */}
+            <View style={styles.progressRow}>
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotDone]} />
+              <View style={styles.progressLine} />
+              <View style={[styles.progressDot, styles.progressDotActive]} />
+            </View>
+
+            {/* Header */}
+            <View style={styles.header}>
+              <Text style={styles.step}>Шаг 5 из 5 — Расскажите о себе</Text>
+              <Text style={styles.title}>Ваш профиль</Text>
+              <Text style={styles.subtitle}>
+                Все поля необязательны. Заполните то, что хотите показать клиентам.
+              </Text>
+            </View>
+
+            {/* Form */}
+            <View style={styles.form}>
+              {/* displayName */}
+              <View style={styles.fieldWrapper}>
+                <Text style={styles.inputLabel}>Отображаемое имя</Text>
+                <TextInput
+                  value={displayName}
+                  onChangeText={setDisplayName}
+                  placeholder="Иван Петров"
+                  placeholderTextColor={Colors.textMuted}
+                  autoCapitalize="words"
+                  onFocus={() => setFocusedField('displayName')}
+                  onBlur={() => setFocusedField(null)}
+                  style={[
+                    styles.input,
+                    focusedField === 'displayName' && styles.inputFocused,
+                  ]}
+                />
+              </View>
+
+              {/* headline */}
+              <View style={styles.fieldWrapper}>
+                <Text style={styles.inputLabel}>Слоган / заголовок</Text>
+                <TextInput
+                  value={headline}
+                  onChangeText={setHeadline}
+                  placeholder="Решу ваш вопрос с ФНС быстро"
+                  placeholderTextColor={Colors.textMuted}
+                  autoCapitalize="sentences"
+                  maxLength={150}
+                  onFocus={() => setFocusedField('headline')}
+                  onBlur={() => setFocusedField(null)}
+                  style={[
+                    styles.input,
+                    focusedField === 'headline' && styles.inputFocused,
+                  ]}
+                />
+                <Text style={styles.charCount}>{headline.length}/150</Text>
+              </View>
+
+              {/* bio */}
+              <View style={styles.fieldWrapper}>
+                <Text style={styles.inputLabel}>О себе</Text>
+                <TextInput
+                  value={bio}
+                  onChangeText={setBio}
+                  placeholder="Опыт работы, специализация..."
+                  placeholderTextColor={Colors.textMuted}
+                  multiline
+                  numberOfLines={5}
+                  textAlignVertical="top"
+                  autoCapitalize="sentences"
+                  maxLength={1000}
+                  onFocus={() => setFocusedField('bio')}
+                  onBlur={() => setFocusedField(null)}
+                  style={[
+                    styles.textarea,
+                    focusedField === 'bio' && styles.inputFocused,
+                  ]}
+                />
+                <Text style={styles.charCount}>{bio.length}/1000</Text>
+              </View>
+
+              {/* contacts */}
+              <View style={styles.fieldWrapper}>
+                <Text style={styles.inputLabel}>Контакты / ссылки</Text>
+                <TextInput
+                  value={contacts}
+                  onChangeText={setContacts}
+                  placeholder="Telegram: @username"
+                  placeholderTextColor={Colors.textMuted}
+                  autoCapitalize="none"
+                  maxLength={200}
+                  onFocus={() => setFocusedField('contacts')}
+                  onBlur={() => setFocusedField(null)}
+                  style={[
+                    styles.input,
+                    focusedField === 'contacts' && styles.inputFocused,
+                  ]}
+                />
+                <Text style={styles.charCount}>{contacts.length}/200</Text>
+              </View>
+
+              {!!error && <Text style={styles.errorText}>{error}</Text>}
+
+              <Button
+                onPress={handleSubmit}
+                loading={loading}
+                disabled={loading}
+                style={styles.btn}
+              >
+                Завершить регистрацию
+              </Button>
+
+              <TouchableOpacity
+                onPress={handleSubmit}
+                disabled={loading}
+                style={styles.skipBtn}
+                activeOpacity={0.7}
+              >
+                <Text style={styles.skipBtnText}>Пропустить</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  kav: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+    justifyContent: 'center',
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing['2xl'],
+  },
+  progressRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 0,
+    marginTop: Spacing.xl,
+  },
+  progressDot: {
+    width: 10,
+    height: 10,
+    borderRadius: BorderRadius.sm,
+    backgroundColor: Colors.border,
+  },
+  progressDotDone: {
+    backgroundColor: Colors.brandSecondary,
+  },
+  progressDotActive: {
+    backgroundColor: Colors.brandPrimary,
+    width: 12,
+    height: 12,
+    borderRadius: BorderRadius.sm,
+  },
+  progressLine: {
+    width: 32,
+    height: 2,
+    backgroundColor: Colors.border,
+    marginHorizontal: Spacing.xs,
+  },
+  header: {
+    gap: Spacing.xs,
+  },
+  step: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  form: {
+    gap: Spacing.lg,
+  },
+  fieldWrapper: {
+    gap: Spacing.xs,
+  },
+  inputLabel: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textSecondary,
+    marginBottom: 2,
+  },
+  input: {
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  textarea: {
+    minHeight: 120,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  inputFocused: {
+    borderColor: Colors.brandPrimary,
+  },
+  charCount: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textAlign: 'right',
+    marginTop: 2,
+  },
+  errorText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusError,
+    marginTop: 2,
+  },
+  btn: {
+    width: '100%',
+    marginTop: Spacing.sm,
+  },
+  skipBtn: {
+    alignItems: 'center',
+    paddingVertical: Spacing.sm,
+  },
+  skipBtnText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+  },
+});

--- a/app/(onboarding)/services.tsx
+++ b/app/(onboarding)/services.tsx
@@ -14,14 +14,10 @@ import { useRouter, useLocalSearchParams } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Button } from '../../components/Button';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
-import { api, ApiError, tryRefreshTokens, getToken } from '../../lib/api';
-import { useAuth } from '../../stores/authStore';
-import { AuthUser } from '../../stores/authStore';
 
 export default function ServicesScreen() {
   const router = useRouter();
   const { cities: citiesParam, fnsOffices: fnsParam } = useLocalSearchParams<{ cities: string; fnsOffices: string }>();
-  const { completeOnboarding, login, user } = useAuth();
 
   let citiesFromParams: string[] = [];
   let fnsFromParams: string[] = [];
@@ -73,6 +69,7 @@ export default function ServicesScreen() {
   const [error, setError] = useState('');
   const [focused, setFocused] = useState(false);
 
+
   function handleChipToggle(chip: string) {
     setSelectedChips((prev) =>
       prev.includes(chip) ? prev.filter((c) => c !== chip) : [...prev, chip],
@@ -100,36 +97,11 @@ export default function ServicesScreen() {
     setError('');
     setLoading(true);
     try {
-      await api.patch('/users/me/specialist-profile', {
-        cities,
-        fnsOffices,
-        services: combined,
-      });
-      // Refresh JWT so the new token carries SPECIALIST role (not CLIENT)
-      await tryRefreshTokens();
-      const freshToken = await getToken();
-      if (freshToken) {
-        // Fetch updated user profile (role is now SPECIALIST in DB)
-        const freshUser = await api.get<{ id: string; email: string; role: string; username: string | null }>('/users/me');
-        await login(freshToken, {
-          userId: freshUser.id,
-          email: freshUser.email,
-          role: freshUser.role,
-          username: freshUser.username,
-          isNewUser: false,
-        } as AuthUser);
-      }
-      // Mark onboarding complete — sets isNewUser=false in store + AsyncStorage
-      await completeOnboarding(user?.username ?? '');
-      router.replace('/');
+      // Save services to AsyncStorage and proceed to step 5 (profile)
+      await AsyncStorage.setItem('onboarding_services', JSON.stringify(combined));
+      router.push('/(onboarding)/profile');
     } catch (err) {
-      if (err instanceof ApiError && err.status === 409) {
-        setError('Профиль уже существует. Попробуйте войти снова.');
-      } else if (err instanceof ApiError) {
-        setError(err.message);
-      } else {
-        setError('Не удалось сохранить профиль. Попробуйте снова.');
-      }
+      setError('Не удалось сохранить данные. Попробуйте снова.');
     } finally {
       setLoading(false);
     }
@@ -147,7 +119,7 @@ export default function ServicesScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={styles.container}>
-            {/* Progress indicator — 4 steps */}
+            {/* Progress indicator — 5 steps */}
             <View style={styles.progressRow}>
               <View style={[styles.progressDot, styles.progressDotDone]} />
               <View style={styles.progressLine} />
@@ -156,11 +128,13 @@ export default function ServicesScreen() {
               <View style={[styles.progressDot, styles.progressDotDone]} />
               <View style={styles.progressLine} />
               <View style={[styles.progressDot, styles.progressDotActive]} />
+              <View style={styles.progressLine} />
+              <View style={styles.progressDot} />
             </View>
 
             {/* Header */}
             <View style={styles.header}>
-              <Text style={styles.step}>Шаг 4 из 4</Text>
+              <Text style={styles.step}>Шаг 4 из 5</Text>
               <Text style={styles.title}>Ваши услуги</Text>
               <Text style={styles.subtitle}>
                 Расскажите, что вы умеете делать. Клиенты увидят это в вашем профиле.
@@ -227,7 +201,7 @@ export default function ServicesScreen() {
                 disabled={loading || (services.trim().length === 0 && selectedChips.length === 0)}
                 style={styles.btn}
               >
-                Завершить настройку
+                Продолжить
               </Button>
             </View>
           </View>

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -74,9 +74,11 @@ export default function UsernameScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={styles.container}>
-            {/* Progress — 4 steps */}
+            {/* Progress — 5 steps */}
             <View style={styles.progressRow}>
               <View style={[styles.progressDot, styles.progressDotActive]} />
+              <View style={styles.progressLine} />
+              <View style={styles.progressDot} />
               <View style={styles.progressLine} />
               <View style={styles.progressDot} />
               <View style={styles.progressLine} />
@@ -87,7 +89,7 @@ export default function UsernameScreen() {
 
             {/* Header */}
             <View style={styles.header}>
-              <Text style={styles.step}>Шаг 1 из 4</Text>
+              <Text style={styles.step}>Шаг 1 из 5</Text>
               <Text style={styles.title}>Придумайте ник</Text>
               <Text style={styles.subtitle}>
                 Это ваш публичный псевдоним на платформе. Можно изменить позже.

--- a/app/specialist/dashboard.tsx
+++ b/app/specialist/dashboard.tsx
@@ -197,7 +197,7 @@ export default function SpecialistDashboard() {
       </Text>
       <TouchableOpacity
         style={styles.noProfileCtaBtn}
-        onPress={() => router.push('/specialist/onboarding')}
+        onPress={() => router.push('/(onboarding)/username')}
         activeOpacity={0.8}
       >
         <Text style={styles.noProfileCtaBtnText}>Создать профиль</Text>


### PR DESCRIPTION
## Summary

- **Onboarding step 5**: `services.tsx` now saves services to AsyncStorage and routes to new `profile.tsx` instead of submitting API immediately. `profile.tsx` is a new step 5 with optional `displayName`, `headline` (150 chars), `bio` (1000 chars), `contacts` (200 chars) fields — submits full PATCH to `/users/me/specialist-profile` with all collected data on complete or skip.
- **Progress indicators** in `username`, `cities`, `fns`, `services` updated from "X из 4" to "X из 5" with extra dot in progress row.
- **Specialist dashboard CTA**: "Создать профиль" button now routes to `/(onboarding)/username` (express flow) instead of `/specialist/onboarding` (old manual wizard).
- **Client welcome screen**: when `recentRequests.length === 0 && !loading && !loadError`, a welcome card is shown above the empty recent list, explaining the 3-step flow with numbered badges and a primary "Создать первый запрос" button.

## Test plan

- [ ] New specialist registers, goes through steps 1-5, profile screen appears with optional fields, submitting creates specialist profile correctly
- [ ] "Пропустить" on step 5 still completes onboarding and redirects to /
- [ ] Specialist with no profile sees "Создать профиль" → goes to username step (step 1 of 5)
- [ ] New client with no requests sees the welcome card with 3 steps and CTA button
- [ ] Client with existing requests sees the normal recent requests list (no welcome card)
- [ ] Progress dots show 5 steps across all onboarding screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)