### PR TITLE
fix: replace English tax doc photo in hero

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -399,7 +399,7 @@ export default function LandingScreen() {
                   <View style={[styles.heroImage, styles.heroImageWide, styles.heroImageFallback]} />
                 ) : (
                   <Image
-                    source={{ uri: 'https://images.unsplash.com/photo-1554224155-6726b3ff858f?w=600&q=80' }}
+                    source={{ uri: 'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?w=600&q=80' }}
                     style={[styles.heroImage, styles.heroImageWide]}
                     resizeMode="cover"
                     onError={() => setHeroImageError(true)}
@@ -413,7 +413,7 @@ export default function LandingScreen() {
                   <View style={[styles.heroImage, styles.heroImageFallback]} />
                 ) : (
                   <Image
-                    source={{ uri: 'https://images.unsplash.com/photo-1554224155-6726b3ff858f?w=600&q=80' }}
+                    source={{ uri: 'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?w=600&q=80' }}
                     style={styles.heroImage}
                     resizeMode="cover"
                     onError={() => setHeroImageError(true)}


### PR DESCRIPTION
Fixes #392

Replaces Unsplash photo showing English tax documents ("Tax Withholding and Estimated Tax" text visible) with a neutral business photo of a professional working with documents — appropriate for a Russian tax service audience.

**Changed:** `app/index.tsx` — both mobile and desktop hero image URLs updated from `photo-1554224155-6726b3ff858f` to `photo-1450101499163-c8848c66ca85`.