### PR TITLE
fix: config & auth improvements

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -8,3 +8,12 @@ JWT_SECRET=
 # Local dev example: http://localhost:8081,http://localhost:19006,https://p2ptax.smartlaunchhub.com
 # Staging/prod: https://p2ptax.smartlaunchhub.com
 ALLOWED_ORIGINS=
+HETZNER_S3_ENDPOINT=https://your-bucket.s3.hetzner.com
+HETZNER_S3_BUCKET=p2ptax
+HETZNER_S3_ACCESS_KEY=your-access-key
+HETZNER_S3_SECRET_KEY=your-secret-key
+ADMIN_EMAILS=admin@example.com,admin2@example.com
+BREVO_API_KEY=your-brevo-api-key
+BREVO_SENDER_EMAIL=noreply@example.com
+BREVO_SENDER_NAME=P2PTax
+REFRESH_TOKEN_SECRET=your-refresh-token-secret-min-32-chars

--- a/api/package.json
+++ b/api/package.json
@@ -32,7 +32,6 @@
     "dotenv": "^16.6.1",
     "helmet": "^8.1.0",
     "ioredis": "^5.10.1",
-    "minio": "^8.0.7",
     "multer": "^2.1.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -57,7 +57,7 @@ export class AuthService {
     const refreshToken = this.jwt.sign(
       { sub: user.id },
       {
-        secret: process.env.JWT_SECRET! + '-refresh',
+        secret: process.env.REFRESH_TOKEN_SECRET!,
         expiresIn: '30d',
       },
     );
@@ -195,7 +195,7 @@ export class AuthService {
     let payload: { sub: string };
     try {
       payload = this.jwt.verify(refreshToken, {
-        secret: process.env.JWT_SECRET! + '-refresh',
+        secret: process.env.REFRESH_TOKEN_SECRET!,
       }) as { sub: string };
     } catch {
       throw new UnauthorizedException('Invalid or expired refresh token');


### PR DESCRIPTION
- Complete .env.example with all required variables (S3, Brevo, admin emails, REFRESH_TOKEN_SECRET)
- Separate REFRESH_TOKEN_SECRET from JWT_SECRET (was JWT_SECRET+'-refresh')
- Remove unused minio dependency (replaced by @aws-sdk)
- OTP cleanup cron already existed in cleanup.service.ts — no new file needed