### PR TITLE
fix(otp): stretch OTP boxes to full container width

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -344,11 +344,11 @@ const styles = StyleSheet.create({
   otpRow: {
     flexDirection: 'row',
     gap: Spacing.sm,
-    justifyContent: 'center',
+    alignSelf: 'stretch',
   },
   otpBox: {
-    width: 44,
-    height: 52,
+    flex: 1,
+    height: 56,
     borderRadius: BorderRadius.md,
     backgroundColor: Colors.bgCard,
     borderWidth: 1.5,


### PR DESCRIPTION
Replace fixed width:44 with flex:1 + alignSelf:stretch so boxes fill the row evenly. Height 52→56px.