### PR TITLE
feat(landing): unlock reviews section (#393)

### DIFF
--- a/api/src/reviews/reviews.controller.ts
+++ b/api/src/reviews/reviews.controller.ts
@@ -56,6 +56,12 @@ export class ReviewsController {
     return this.reviewsService.listBySpecialist(nick, page ? parseInt(page, 10) : 1);
   }
 
+  /** GET /reviews/public?limit=N — recent reviews for landing page (no auth) */
+  @Get('public')
+  listPublic(@Query('limit') limit?: string) {
+    return this.reviewsService.listPublic(limit ? parseInt(limit, 10) : 6);
+  }
+
   @Get('eligibility/:nick')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.CLIENT)

--- a/api/src/reviews/reviews.service.ts
+++ b/api/src/reviews/reviews.service.ts
@@ -157,6 +157,40 @@ export class ReviewsService {
     return { success: true };
   }
 
+  /** GET /reviews/public — last N reviews with specialist name, for landing page */
+  async listPublic(limit = 6) {
+    const items = await this.prisma.review.findMany({
+      where: { comment: { not: null } },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        rating: true,
+        comment: true,
+        createdAt: true,
+        client: { select: { username: true } },
+        specialist: {
+          select: {
+            specialistProfile: { select: { displayName: true, nick: true } },
+          },
+        },
+      },
+    });
+
+    return items.map((r) => ({
+      id: r.id,
+      rating: r.rating,
+      comment: r.comment,
+      createdAt: r.createdAt,
+      clientName: r.client?.username || 'Клиент',
+      specialistName:
+        r.specialist?.specialistProfile?.displayName ||
+        r.specialist?.specialistProfile?.nick ||
+        'Специалист',
+      specialistNick: r.specialist?.specialistProfile?.nick,
+    }));
+  }
+
   /**
    * Check if a client can review a specialist:
    * - has a CLOSED request that the specialist responded to

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -325,9 +325,18 @@ export default function LandingScreen() {
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const [isLoadingSpecialists, setIsLoadingSpecialists] = useState(true);
   const [isLoadingRequests, setIsLoadingRequests] = useState(true);
+  const [reviews, setReviews] = useState<Array<{
+    id: string;
+    rating: number;
+    comment: string | null;
+    clientName: string;
+    specialistName: string;
+    specialistNick?: string;
+  }>>([]);
   useEffect(() => {
     api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err)).finally(() => setIsLoadingSpecialists(false));
     api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err)).finally(() => setIsLoadingRequests(false));
+    api.get<any[]>('/reviews/public?limit=6').then(setReviews).catch((err) => console.warn('Landing section failed (reviews):', err));
   }, []);
 
   const isWide = !isMobile;
@@ -695,7 +704,39 @@ export default function LandingScreen() {
           </View>
         </View>
 
-        {/* ===== SECTION 7: Reviews — hidden until real API reviews available ===== */}
+        {/* ===== SECTION 7: Reviews ===== */}
+        {reviews.length > 0 && (
+          <View style={[styles.section, { backgroundColor: Colors.bgSecondary }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'\u041e\u0442\u0437\u044b\u0432\u044b \u043a\u043b\u0438\u0435\u043d\u0442\u043e\u0432'}</Text>
+              <Text style={styles.sectionSubtitle}>{'\u0420\u0435\u0430\u043b\u044c\u043d\u044b\u0435 \u043e\u0442\u0437\u044b\u0432\u044b \u043e\u0442 \u043f\u0440\u043e\u0432\u0435\u0440\u0435\u043d\u043d\u044b\u0445 \u043a\u043b\u0438\u0435\u043d\u0442\u043e\u0432'}</Text>
+
+              <View style={[
+                styles.reviewsRow,
+                isWide && styles.reviewsRowDesktop,
+                isTablet && !isWide && styles.reviewsRowTablet,
+              ]}>
+                {reviews.map((review) => (
+                  <View
+                    key={review.id}
+                    style={[
+                      styles.reviewCard,
+                      isTablet && !isWide && styles.reviewCardTablet,
+                    ]}
+                  >
+                    <Text style={styles.reviewQuote}>{'\u201c'}</Text>
+                    <Text style={styles.reviewText}>{review.comment}</Text>
+                    <Text style={styles.reviewStars}>
+                      {'\u2605'.repeat(review.rating)}{'\u2606'.repeat(5 - review.rating)}
+                    </Text>
+                    <Text style={styles.reviewName}>{review.clientName}</Text>
+                    <Text style={styles.reviewCity}>{'\u0421\u043f\u0435\u0446\u0438\u0430\u043b\u0438\u0441\u0442: '}{review.specialistName}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          </View>
+        )}
 
         {/* ===== SECTION 8: FAQ ===== */}
         <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>


### PR DESCRIPTION
## Summary
- Add `GET /reviews/public?limit=N` endpoint (no auth) returning last N reviews with comment, rating, client name, and specialist name
- Unlock Section 7 (Reviews) on the landing page — connects to real API, hidden if no reviews returned
- Frontend shows up to 6 review cards with stars, client name, specialist name

## Changes
- `api/src/reviews/reviews.service.ts` — new `listPublic()` method
- `api/src/reviews/reviews.controller.ts` — new `GET /reviews/public` route
- `app/index.tsx` — reviews state + useEffect + Section 7 JSX

## Test plan
- [ ] `GET /api/reviews/public` returns array of reviews (43 in DB from seed)
- [ ] Landing page Section 7 renders review cards
- [ ] Section hidden if API returns empty array
- [ ] Frontend tsc passes (`npx tsc --noEmit`)

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)