### PR TITLE
fix: presigned URLs for private chat attachments

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -94,7 +94,7 @@ export class ChatController {
     @Request() req: { user: { id: string } },
     @Param('id') threadId: string,
     @UploadedFile() file: Express.Multer.File | undefined,
-  ): Promise<{ url: string; type: string; name: string }> {
+  ): Promise<{ url: string; signedUrl: string; type: string; name: string }> {
     if (!file) {
       throw new BadRequestException('No file uploaded');
     }
@@ -114,10 +114,13 @@ export class ChatController {
     const fileId = randomUUID();
     const key = `chat/${threadId}/${fileId}.${ext}`;
 
-    const url = await this.storageService.uploadBuffer(key, file.buffer, file.mimetype);
+    // Upload as private (no ACL) — access via presigned URL only
+    const s3Key = await this.storageService.uploadBuffer(key, file.buffer, file.mimetype);
+    const signedUrl = await this.storageService.getPresignedUrl(s3Key);
     const type = IMAGE_MIME_TYPES.has(file.mimetype) ? 'IMAGE' : 'DOCUMENT';
 
-    return { url, type, name: file.originalname };
+    // Store the S3 key in DB (not the signed URL) so we can regenerate signed URLs later
+    return { url: s3Key, signedUrl, type, name: file.originalname };
   }
 
   // POST /threads/:id/messages — send a message via REST (fallback when WebSocket unavailable)

--- a/api/src/chat/chat.service.ts
+++ b/api/src/chat/chat.service.ts
@@ -1,9 +1,13 @@
 import { Injectable, ForbiddenException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { StorageService } from '../storage/storage.service';
 
 @Injectable()
 export class ChatService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly storageService: StorageService,
+  ) {}
 
   /** List threads where user is participant, sorted by last message */
   async getThreads(userId: string) {
@@ -91,7 +95,20 @@ export class ChatService {
       this.prisma.message.count({ where: { threadId } }),
     ]);
 
-    return { messages, total, page, pages: Math.ceil(total / take) };
+    // Generate fresh signed URLs for attachments
+    // NOTE: existing attachmentUrl in DB are public URLs (pre-migration). After this change, only new uploads use signed URLs.
+    const enriched = await Promise.all(
+      messages.map(async (msg) => {
+        if (!msg.attachmentUrl) return msg;
+        // Legacy public URLs start with http — new uploads store only the S3 key
+        const isLegacyUrl = msg.attachmentUrl.startsWith('http');
+        if (isLegacyUrl) return msg; // keep legacy public URLs as-is
+        const signedUrl = await this.storageService.getPresignedUrl(msg.attachmentUrl);
+        return { ...msg, signedUrl };
+      }),
+    );
+
+    return { messages: enriched, total, page, pages: Math.ceil(total / take) };
   }
 
   /** Upsert thread between two users. Returns { threadId } */

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -75,7 +75,7 @@ export class SpecialistsController {
     if (this.storageService.isS3Enabled) {
       // Buffer is already in memory — upload directly to S3/MinIO without touching disk
       const s3Key = `avatars/${req.user.id}${ext}`;
-      avatarUrl = await this.storageService.uploadBuffer(s3Key, file.buffer, file.mimetype);
+      avatarUrl = await this.storageService.uploadBufferPublic(s3Key, file.buffer, file.mimetype);
     } else {
       // Local disk fallback — write buffer to disk once, serve via static assets
       const { writeFile } = await import('fs/promises');

--- a/api/src/storage/storage.service.ts
+++ b/api/src/storage/storage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { S3Client, DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, DeleteObjectCommand, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 @Injectable()
 export class StorageService {
@@ -34,7 +35,27 @@ export class StorageService {
     return !!this.s3;
   }
 
+  /**
+   * Upload a file as private (no ACL). Use getPresignedUrl() to generate temporary access URLs.
+   * Returns the S3 key (not a URL) — callers must use getPresignedUrl() for access.
+   */
   async uploadBuffer(key: string, buffer: Buffer, mimeType: string): Promise<string> {
+    if (!this.s3) throw new Error('S3 not configured');
+    await this.s3.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: mimeType,
+      }),
+    );
+    return key;
+  }
+
+  /**
+   * Upload a file with public-read ACL (for avatars and other intentionally public assets).
+   */
+  async uploadBufferPublic(key: string, buffer: Buffer, mimeType: string): Promise<string> {
     if (!this.s3) throw new Error('S3 not configured');
     await this.s3.send(
       new PutObjectCommand({
@@ -45,6 +66,25 @@ export class StorageService {
         ACL: 'public-read',
       }),
     );
+    return `${this.endpoint}/${this.bucket}/${key}`;
+  }
+
+  /**
+   * Generate a presigned URL for private S3 objects (e.g. chat attachments).
+   */
+  async getPresignedUrl(key: string, expiresIn = 3600): Promise<string> {
+    if (!this.s3) throw new Error('S3 not configured');
+    const command = new GetObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+    });
+    return getSignedUrl(this.s3, command, { expiresIn });
+  }
+
+  /**
+   * Get the public URL for a key (for objects uploaded with public-read ACL).
+   */
+  getPublicUrl(key: string): string {
     return `${this.endpoint}/${this.bucket}/${key}`;
   }
 


### PR DESCRIPTION
- Remove ACL: public-read from chat file uploads
- Add getPresignedUrl() method to StorageService (1 hour expiry)
- Add uploadBufferPublic() for specialist avatars (public data)
- Chat upload returns S3 key + signedUrl (key stored in DB, signedUrl for immediate use)
- Chat getMessages generates fresh signed URLs for attachments
- Legacy public URLs in DB are preserved as-is (backward compatible)
- Specialist avatars remain public (profile photos are public data)