### PR TITLE
fix(otp): OTP box layout - maxWidth 56px + space-between

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -343,11 +343,12 @@ const styles = StyleSheet.create({
   },
   otpRow: {
     flexDirection: 'row',
-    gap: Spacing.sm,
+    justifyContent: 'space-between',
     alignSelf: 'stretch',
   },
   otpBox: {
     flex: 1,
+    maxWidth: 56,
     height: 56,
     borderRadius: BorderRadius.md,
     backgroundColor: Colors.bgCard,


### PR DESCRIPTION
Boxes stretch evenly (flex:1) but capped at 56px. space-between prevents overflow.