### PR TITLE
feat: unlock reviews section on landing page (#394)

### DIFF
--- a/api/src/reviews/reviews.controller.ts
+++ b/api/src/reviews/reviews.controller.ts
@@ -28,6 +28,12 @@ export class ReviewsController {
     return this.reviewsService.create(req.user.id, dto);
   }
 
+  /** GET /reviews/recent — public, recent reviews with comments for landing page */
+  @Get('recent')
+  getRecent(@Query('limit') limit?: string) {
+    return this.reviewsService.findRecent(limit ? parseInt(limit, 10) : 6);
+  }
+
   @Get('my')
   @UseGuards(JwtAuthGuard)
   getMyReviews(@Request() req: any) {

--- a/api/src/reviews/reviews.service.ts
+++ b/api/src/reviews/reviews.service.ts
@@ -15,6 +15,30 @@ const PAGE_SIZE = 20;
 export class ReviewsService {
   constructor(private prisma: PrismaService) {}
 
+  async findRecent(limit = 6) {
+    return this.prisma.review.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      where: { comment: { not: null } },
+      select: {
+        id: true,
+        rating: true,
+        comment: true,
+        createdAt: true,
+        specialist: {
+          select: {
+            specialistProfile: {
+              select: { displayName: true, cities: true },
+            },
+          },
+        },
+        client: {
+          select: { username: true },
+        },
+      },
+    });
+  }
+
   async create(clientId: string, dto: CreateReviewDto) {
     // Resolve specialist by nick
     const specialistProfile = await this.prisma.specialistProfile.findUnique({

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -322,12 +322,14 @@ export default function LandingScreen() {
   const [heroImageError, setHeroImageError] = React.useState(false);
   const [featuredSpecialists, setFeaturedSpecialists] = useState<any[]>([]);
   const [recentRequests, setRecentRequests] = useState<any[]>([]);
+  const [recentReviews, setRecentReviews] = useState<any[]>([]);
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const [isLoadingSpecialists, setIsLoadingSpecialists] = useState(true);
   const [isLoadingRequests, setIsLoadingRequests] = useState(true);
   useEffect(() => {
     api.get<any[]>('/specialists/featured?limit=8').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err)).finally(() => setIsLoadingSpecialists(false));
     api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err)).finally(() => setIsLoadingRequests(false));
+    api.get<any[]>('/reviews/recent?limit=6').then(setRecentReviews).catch((err) => console.warn('Landing section failed (recent reviews):', err));
   }, []);
 
   const isWide = !isMobile;
@@ -695,7 +697,31 @@ export default function LandingScreen() {
           </View>
         </View>
 
-        {/* ===== SECTION 7: Reviews — hidden until real API reviews available ===== */}
+        {/* ===== SECTION 7: Reviews ===== */}
+        {recentReviews.length > 0 && (
+          <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>
+            <View style={[styles.sectionInner, innerStyle]}>
+              <Text style={styles.sectionTitle} accessibilityRole="header" aria-level={2}>{'Отзывы клиентов'}</Text>
+              <View style={[styles.reviewsRow, isDesktop && styles.reviewsRowDesktop, isTablet && styles.reviewsRowTablet]}>
+                {recentReviews.slice(0, isDesktop ? 3 : isTablet ? 4 : 3).map((review: any) => {
+                  const profile = review.specialist?.specialistProfile;
+                  const displayName = profile?.displayName ?? 'Специалист';
+                  const city = profile?.cities?.[0] ?? null;
+                  const stars = '★'.repeat(review.rating) + '☆'.repeat(5 - review.rating);
+                  return (
+                    <View key={review.id} style={[styles.reviewCard, isTablet && !isDesktop && styles.reviewCardTablet]}>
+                      <Text style={styles.reviewQuote}>{'"'}</Text>
+                      <Text style={styles.reviewText} numberOfLines={5}>{review.comment}</Text>
+                      <Text style={styles.reviewStars}>{stars}</Text>
+                      <Text style={styles.reviewName}>{displayName}</Text>
+                      {city ? <Text style={styles.reviewCity}>{city}</Text> : null}
+                    </View>
+                  );
+                })}
+              </View>
+            </View>
+          </View>
+        )}
 
         {/* ===== SECTION 8: FAQ ===== */}
         <View style={[styles.section, { backgroundColor: Colors.bgPrimary }]}>


### PR DESCRIPTION
## Summary
- Add `GET /reviews/recent` public endpoint (no auth required) returning up to 6 recent reviews that have comments, with specialist displayName and cities
- Add `findRecent()` method to ReviewsService
- Connect reviews to landing page SECTION 7 (was a placeholder comment since reviews API wasn't ready)
- Render review cards with rating stars, specialist name, and city; section is hidden if no reviews

## Test plan
- [ ] Check `https://p2ptax.smartlaunchhub.com/api/reviews/recent?limit=6` returns review data
- [ ] Verify landing page shows "Отзывы клиентов" section with review cards
- [ ] Confirm section is hidden if 0 reviews returned
- [ ] TypeScript compiles clean (verified locally)

Closes #394