### PR TITLE
feat: payment stub (YuKassa placeholder)

### DIFF
--- a/api/prisma/migrations/20260409000000_add_payment_record/migration.sql
+++ b/api/prisma/migrations/20260409000000_add_payment_record/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "payment_records" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'RUB',
+    "status" "PaymentStatus" NOT NULL DEFAULT 'PENDING',
+    "provider" TEXT NOT NULL DEFAULT 'stub',
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "payment_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "payment_records_userId_idx" ON "payment_records"("userId");
+
+-- AddForeignKey
+ALTER TABLE "payment_records" ADD CONSTRAINT "payment_records_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   refreshTokens       RefreshToken[]
   complaintsGiven     Complaint[]       @relation("ComplaintReporter")
   complaintsReceived  Complaint[]       @relation("ComplaintTarget")
+  paymentRecords      PaymentRecord[]
 
   @@map("users")
 }
@@ -262,6 +263,28 @@ model ContactMethod {
 
   @@index([specialistId])
   @@map("contact_methods")
+}
+
+enum PaymentStatus {
+  PENDING
+  COMPLETED
+  FAILED
+}
+
+model PaymentRecord {
+  id        String        @id @default(cuid())
+  userId    String
+  user      User          @relation(fields: [userId], references: [id])
+  amount    Int           // in kopecks
+  currency  String        @default("RUB")
+  status    PaymentStatus @default(PENDING)
+  provider  String        @default("stub") // TODO: replace with "yukassa"
+  metadata  Json?
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  @@index([userId])
+  @@map("payment_records")
 }
 
 enum ComplaintReason {

--- a/api/src/promotions/promotions.service.ts
+++ b/api/src/promotions/promotions.service.ts
@@ -9,7 +9,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../notifications/email.service';
 import { PurchasePromotionDto } from './dto/purchase-promotion.dto';
 import { UpdatePricesDto } from './dto/update-prices.dto';
-import { PromotionTier } from '@prisma/client';
+import { PromotionTier, PaymentStatus } from '@prisma/client';
 
 // Hardcoded fallback prices (rubles) used when no DB override exists.
 const DEFAULT_PRICES: Record<PromotionTier, number> = {
@@ -41,7 +41,8 @@ export class PromotionsService {
         return {
           promotion: idempotent,
           payment: {
-            status: 'mock_paid',
+            id: null,
+            status: 'COMPLETED',
             amount: 0,
             currency: 'RUB',
             note: 'Duplicate request — returning existing promotion.',
@@ -90,13 +91,31 @@ export class PromotionsService {
       const discount = DISCOUNT[months] ?? 0;
       const price = Math.round(basePrice * months * (1 - discount));
 
-      // TODO: Integrate Stripe when STRIPE_SECRET_KEY is added to Doppler
-      // For now, mock payment: log and proceed
+      // Create payment record (PENDING)
+      const amountKopecks = price * 100;
+      const payment = await tx.paymentRecord.create({
+        data: {
+          userId,
+          amount: amountKopecks,
+          currency: 'RUB',
+          status: PaymentStatus.PENDING,
+          provider: 'stub',
+          metadata: { city: dto.city, tier: dto.tier, months },
+        },
+      });
+
+      // TODO: Replace stub with YuKassa integration
+      // Stub: immediately mark as COMPLETED (real provider: wait for webhook)
+      const completedPayment = await tx.paymentRecord.update({
+        where: { id: payment.id },
+        data: { status: PaymentStatus.COMPLETED },
+      });
+
       this.logger.log(
-        `MOCK PAYMENT: user=${userId} city=${dto.city} tier=${dto.tier} months=${months} amount=${price} RUB`,
+        `STUB PAYMENT: paymentId=${payment.id} user=${userId} city=${dto.city} tier=${dto.tier} months=${months} amount=${price} RUB`,
       );
 
-      // Set expiry based on requested period (calendar months from now)
+      // Create promotion only after successful payment
       const expiresAt = new Date();
       expiresAt.setMonth(expiresAt.getMonth() + months);
 
@@ -113,10 +132,11 @@ export class PromotionsService {
       return {
         promotion,
         payment: {
-          status: 'mock_paid',
+          id: completedPayment.id,
+          status: completedPayment.status,
           amount: price,
           currency: 'RUB',
-          note: 'Stripe integration pending. Payment simulated.',
+          note: 'Payment stub — YuKassa integration pending.',
         },
       };
     }, { timeout: 10000 });

--- a/app/(dashboard)/promotion.tsx
+++ b/app/(dashboard)/promotion.tsx
@@ -40,11 +40,23 @@ const TIER_COLORS: Record<string, string> = {
   TOP: '#D97706',
 };
 
+const TIER_PRICES_NUM: Record<Tier, number> = {
+  BASIC: 500,
+  FEATURED: 1500,
+  TOP: 3000,
+};
+
 const TIER_PRICES: Record<Tier, string> = {
   BASIC: '500\u20BD/мес',
   FEATURED: '1500\u20BD/мес',
   TOP: '3000\u20BD/мес',
 };
+
+const DISCOUNT: Record<PeriodMonths, number> = { 1: 0, 3: 0.1, 6: 0.2 };
+
+function calcTotal(tier: Tier, period: PeriodMonths): number {
+  return Math.round(TIER_PRICES_NUM[tier] * period * (1 - DISCOUNT[period]));
+}
 
 const PERIOD_OPTIONS: { value: PeriodMonths; label: string }[] = [
   { value: 1, label: '1 мес' },
@@ -76,6 +88,7 @@ export default function PromotionScreen() {
   const [selectedCity, setSelectedCity] = useState('');
   const [selectedPeriod, setSelectedPeriod] = useState<PeriodMonths>(1);
   const [purchasing, setPurchasing] = useState(false);
+  const [purchaseSuccess, setPurchaseSuccess] = useState(false);
   const [purchaseError, setPurchaseError] = useState('');
   const [profileCities, setProfileCities] = useState<string[]>([]);
 
@@ -117,6 +130,7 @@ export default function PromotionScreen() {
 
   function handlePurchase() {
     setPurchaseError('');
+    setPurchaseSuccess(false);
     setSelectedTier('BASIC');
     setSelectedPeriod(1);
     if (profileCities.length > 0) setSelectedCity(profileCities[0]);
@@ -126,6 +140,7 @@ export default function PromotionScreen() {
   async function handleConfirmPurchase() {
     setPurchasing(true);
     setPurchaseError('');
+    setPurchaseSuccess(false);
     try {
       const idempotencyKey = Math.random().toString(36).slice(2) + Date.now();
       await api.post<{ promotion: unknown; payment: unknown }>('/promotions/purchase', {
@@ -134,11 +149,16 @@ export default function PromotionScreen() {
         periodMonths: selectedPeriod,
         idempotencyKey,
       });
-      setModalVisible(false);
+      setPurchaseSuccess(true);
       fetchPromotions();
-      Alert.alert('Продвижение подключено!');
+      setTimeout(() => {
+        setModalVisible(false);
+        setPurchaseSuccess(false);
+      }, 1500);
     } catch (err) {
-      setPurchaseError(err instanceof ApiError ? err.message : 'Ошибка при покупке');
+      setPurchaseError(
+        err instanceof ApiError ? err.message : 'Ошибка оплаты. Попробуйте снова.',
+      );
     } finally {
       setPurchasing(false);
     }
@@ -308,17 +328,32 @@ export default function PromotionScreen() {
             {/* Error */}
             {purchaseError ? <Text style={styles.modalError}>{purchaseError}</Text> : null}
 
+            {/* Success */}
+            {purchaseSuccess ? (
+              <View style={styles.successBanner}>
+                <Text style={styles.successText}>Активировано</Text>
+              </View>
+            ) : null}
+
             {/* CTA */}
             <TouchableOpacity
-              style={[styles.modalCta, purchasing && styles.modalCtaDisabled]}
+              style={[
+                styles.modalCta,
+                (purchasing || purchaseSuccess) && styles.modalCtaDisabled,
+                purchaseSuccess && styles.modalCtaSuccess,
+              ]}
               onPress={handleConfirmPurchase}
               activeOpacity={0.85}
-              disabled={purchasing}
+              disabled={purchasing || purchaseSuccess}
             >
               {purchasing ? (
                 <ActivityIndicator size="small" color="#FFFFFF" />
+              ) : purchaseSuccess ? (
+                <Text style={styles.modalCtaText}>Активировано</Text>
               ) : (
-                <Text style={styles.modalCtaText}>Подключить (бесплатно)</Text>
+                <Text style={styles.modalCtaText}>
+                  Оплатить {calcTotal(selectedTier, selectedPeriod)} \u20BD
+                </Text>
               )}
             </TouchableOpacity>
 
@@ -578,6 +613,17 @@ const styles = StyleSheet.create({
     color: Colors.statusError,
     textAlign: 'center',
   },
+  successBanner: {
+    backgroundColor: Colors.statusBg.success,
+    borderRadius: BorderRadius.md,
+    padding: Spacing.sm,
+    alignItems: 'center',
+  },
+  successText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.statusSuccess,
+  },
   modalCta: {
     height: 48,
     backgroundColor: Colors.brandPrimary,
@@ -588,6 +634,10 @@ const styles = StyleSheet.create({
   },
   modalCtaDisabled: {
     opacity: 0.7,
+  },
+  modalCtaSuccess: {
+    backgroundColor: Colors.statusSuccess,
+    opacity: 1,
   },
   modalCtaText: {
     fontSize: Typography.fontSize.base,


### PR DESCRIPTION
## Summary
- Add `PaymentRecord` model with `PaymentStatus` enum (PENDING/COMPLETED/FAILED) + Prisma migration
- Replace mock `console.log` payment with real `PaymentRecord` flow: PENDING → COMPLETED (stub)
- Promotion created only after successful payment record
- Frontend: "Оплатить X ₽" button with calculated price, loading spinner, success banner, error state

## TODO
- Replace stub provider with YuKassa webhook flow