### PR TITLE
fix(otp): fixed 50px box width, reliable layout on web

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -343,13 +343,12 @@ const styles = StyleSheet.create({
   },
   otpRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignSelf: 'stretch',
+    gap: 10,
+    justifyContent: 'center',
   },
   otpBox: {
-    flex: 1,
-    maxWidth: 56,
-    height: 56,
+    width: 50,
+    height: 58,
     borderRadius: BorderRadius.md,
     backgroundColor: Colors.bgCard,
     borderWidth: 1.5,


### PR DESCRIPTION
flex:1 + alignSelf:stretch causes boxes to overflow on web (stretches to viewport, not container). Fixed width 50px + gap 10px + justifyContent:center is reliable across all screen sizes.