### PR TITLE
feat: specialists catalog redesign

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -8,6 +8,7 @@ interface SpecialistSeedData {
   displayName: string;
   avatarUrl: string;
   bio: string;
+  headline: string;
   experience: number;
   cities: string[];
   fnsOffices?: string[];
@@ -24,10 +25,11 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Иван Петров',
     avatarUrl: 'https://images.unsplash.com/photo-1560250097-0b93528c311a?w=200&h=200&fit=crop&crop=face',
     bio: 'Специализируюсь на разрешении налоговых споров с ФНС. Успешно представлял клиентов в арбитражных судах по делам о доначислениях, штрафах и пенях. Помогаю минимизировать налоговые риски для бизнеса.',
+    headline: 'Представительство в ФНС — быстро и с результатом',
     experience: 12,
     cities: ['Москва'],
     fnsOffices: ['Инспекция ФНС России № 1 по г.Москве', 'Инспекция ФНС России № 9 по г.Москве', 'Инспекция ФНС России № 15 по г. Москве'],
-    services: ['Налоговые споры', 'Представительство в суде', 'Досудебное обжалование', 'Налоговый аудит'],
+    services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'],
     badges: ['verified'],
     contacts: 'Telegram: @ivan_petrov_tax',
     reviews: [
@@ -44,10 +46,11 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Елена Соколова',
     avatarUrl: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=200&h=200&fit=crop&crop=face',
     bio: 'Помогаю физическим лицам с декларациями 3-НДФЛ: налоговые вычеты при покупке жилья, лечении, обучении. Заполню и подам декларацию за вас, проконтролирую получение возврата.',
+    headline: 'Решу вопрос с камеральной проверкой',
     experience: 8,
     cities: ['Санкт-Петербург'],
     fnsOffices: ['Межрайонная ИФНС России № 16 по Санкт-Петербургу', 'Межрайонная ИФНС России № 20 по Санкт-Петербургу'],
-    services: ['Декларации 3-НДФЛ', 'Имущественный вычет', 'Социальный вычет', 'Возврат налога'],
+    services: ['Камеральная проверка', 'Выездная проверка'],
     badges: ['verified'],
     contacts: 'WhatsApp: +7 (921) 555-00-01',
     reviews: [
@@ -63,10 +66,11 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Дмитрий Волков',
     avatarUrl: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=200&h=200&fit=crop&crop=face',
     bio: 'Налоговый консультант для бизнеса. 15 лет опыта в оптимизации налогообложения для ООО и ИП. Помогаю выбрать оптимальную систему налогообложения и легально снизить налоговую нагрузку.',
+    headline: '15 лет работы с выездными проверками',
     experience: 15,
     cities: ['Екатеринбург'],
     fnsOffices: ['Межрайонная ИФНС России № 25 по Свердловской области', 'Межрайонная ИФНС России № 32 по Свердловской области'],
-    services: ['Оптимизация налогов', 'Выбор системы налогообложения', 'Налоговое планирование', 'Консультации для бизнеса'],
+    services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'],
     badges: ['verified'],
     contacts: 'Email: volkov.tax@mail.ru',
     reviews: [
@@ -83,9 +87,10 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Мария Новикова',
     avatarUrl: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=200&h=200&fit=crop&crop=face',
     bio: 'Помогу зарегистрировать ИП или ООО под ключ: подготовка документов, подача в ФНС, выбор ОКВЭД и системы налогообложения. Также консультирую по реорганизации и ликвидации.',
+    headline: 'Сопровождение в отделе оперативного контроля ФНС',
     experience: 5,
     cities: ['Казань'],
-    services: ['Регистрация ИП', 'Регистрация ООО', 'Выбор ОКВЭД', 'Ликвидация бизнеса'],
+    services: ['Отдел оперативного контроля', 'Камеральная проверка'],
     badges: ['verified'],
     contacts: 'Telegram: @maria_novikova_biz',
     reviews: [
@@ -100,10 +105,11 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Алексей Кузнецов',
     avatarUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop&crop=face',
     bio: 'Эксперт по налоговым вычетам для физических лиц. Помогу вернуть НДФЛ за покупку жилья, лечение, обучение, инвестиции (ИИС). Работаю дистанционно по всей России.',
+    headline: 'Камеральные проверки без доначислений — мой результат',
     experience: 10,
     cities: ['Москва'],
     fnsOffices: ['Инспекция ФНС России № 20 по г.Москве', 'Инспекция ФНС России № 21 по г.Москве', 'Инспекция ФНС России № 22 по г. Москве'],
-    services: ['Налоговые вычеты', 'Инвестиционный вычет ИИС', 'Возврат НДФЛ', 'Консультации по налогам'],
+    services: ['Камеральная проверка', 'Выездная проверка', 'Отдел оперативного контроля'],
     badges: ['verified'],
     contacts: 'Email: kuznetsov.tax@gmail.com',
     reviews: [
@@ -119,9 +125,10 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Ольга Морозова',
     avatarUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face',
     bio: 'Юрист-налоговик с опытом работы в ФНС. Знаю систему изнутри и помогаю клиентам защищать свои права при проверках и доначислениях. Специализируюсь на спорах с налоговой.',
+    headline: 'Бывший сотрудник ФНС — знаю систему изнутри',
     experience: 7,
     cities: ['Новосибирск'],
-    services: ['Споры с ФНС', 'Сопровождение проверок', 'Обжалование решений ФНС', 'Налоговые консультации'],
+    services: ['Выездная проверка', 'Камеральная проверка'],
     badges: [],
     contacts: 'Telegram: @morozova_tax',
     reviews: [
@@ -136,9 +143,10 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Сергей Лебедев',
     avatarUrl: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=200&h=200&fit=crop&crop=face',
     bio: 'Бухгалтер-консультант с фокусом на НДС. Помогаю компаниям правильно вести учёт НДС, готовить декларации и проходить камеральные проверки без доначислений.',
+    headline: 'Камеральные проверки по НДС — прохожу без замечаний',
     experience: 9,
     cities: ['Краснодар'],
-    services: ['НДС', 'Бухучёт', 'Камеральные проверки', 'Декларации по НДС'],
+    services: ['Камеральная проверка', 'Выездная проверка'],
     badges: ['verified'],
     contacts: 'WhatsApp: +7 (861) 200-00-01',
     reviews: [
@@ -154,9 +162,10 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Анна Козлова',
     avatarUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&h=200&fit=crop&crop=face',
     bio: 'Консультирую самозанятых по налогам и регистрации. Помогу разобраться с приложением "Мой налог", оптимизировать доход и избежать ошибок при работе с платформами.',
+    headline: 'Оперативный контроль и самозанятость без штрафов',
     experience: 4,
     cities: ['Санкт-Петербург'],
-    services: ['Налоги для самозанятых', 'Регистрация самозанятости', 'Приложение "Мой налог"', 'Консультации'],
+    services: ['Отдел оперативного контроля', 'Камеральная проверка'],
     badges: ['verified'],
     contacts: 'Telegram: @anna_samozanyatye',
     reviews: [
@@ -173,9 +182,10 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Виктор Смирнов',
     avatarUrl: 'https://images.unsplash.com/photo-1463453091185-61582044d556?w=200&h=200&fit=crop&crop=face',
     bio: 'Специалист по международному налогообложению. Консультирую по вопросам ВЭД, двойного налогообложения, валютного контроля и работы с иностранными контрагентами.',
+    headline: 'Выездные проверки при ВЭД — защищу интересы бизнеса',
     experience: 11,
     cities: ['Ростов-на-Дону'],
-    services: ['Международное налогообложение', 'ВЭД', 'Валютный контроль', 'Двойное налогообложение'],
+    services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'],
     badges: ['verified'],
     contacts: 'Email: smirnov.international@tax.ru',
     reviews: [
@@ -191,10 +201,11 @@ const specialists: SpecialistSeedData[] = [
     displayName: 'Татьяна Иванова',
     avatarUrl: 'https://images.unsplash.com/photo-1551836022-d5d88e9218df?w=200&h=200&fit=crop&crop=face',
     bio: 'Аудитор с 14-летним стажем. Провожу налоговый аудит для компаний любого масштаба: от ИП до крупного бизнеса. Выявляю риски до того, как их найдёт налоговая.',
+    headline: 'Подготовлю к выездной проверке — без сюрпризов',
     experience: 14,
     cities: ['Москва'],
     fnsOffices: ['Инспекция ФНС России № 28 по г. Москве', 'Инспекция ФНС России № 29 по г. Москве', 'Инспекция ФНС России № 30 по г. Москве'],
-    services: ['Налоговый аудит', 'Due diligence', 'Оценка налоговых рисков', 'Подготовка к проверкам'],
+    services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'],
     badges: ['verified'],
     contacts: 'Telegram: @ivanova_audit',
     reviews: [
@@ -394,6 +405,7 @@ async function main() {
         nick: spec.nick,
         displayName: spec.displayName,
         bio: spec.bio,
+        headline: spec.headline,
         experience: spec.experience,
         cities: spec.cities,
         fnsOffices: spec.fnsOffices ?? [],
@@ -407,6 +419,7 @@ async function main() {
         nick: spec.nick,
         displayName: spec.displayName,
         bio: spec.bio,
+        headline: spec.headline,
         experience: spec.experience,
         cities: spec.cities,
         fnsOffices: spec.fnsOffices ?? [],

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -34,7 +34,7 @@ async function bootstrap() {
   app.use(helmet({ contentSecurityPolicy: false }));
 
   const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || ['https://p2ptax.smartlaunchhub.com'];
-  app.enableCors({ origin: allowedOrigins });
+  app.enableCors({ origin: allowedOrigins, credentials: true });
 
   const port = process.env.PORT ?? 3812;
   await app.listen(port);

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -10,8 +10,6 @@ import {
   ActivityIndicator,
   RefreshControl,
   TextInput,
-  Share,
-  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter, Stack } from 'expo-router';
@@ -25,8 +23,10 @@ import { Header } from '../../components/Header';
 import { LandingHeader } from '../../components/LandingHeader';
 import { Stars } from '../../components/Stars';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
+import { FNS_OFFICES, FNSOffice } from '../../constants/FNS';
 
 const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
+// APP_URL used in Head meta tags
 
 interface SpecialistItem {
   nick: string;
@@ -44,34 +44,15 @@ interface SpecialistItem {
   activity: { responseCount: number; avgRating: number | null; reviewCount: number };
 }
 
-const SORT_OPTIONS: { label: string; value: string }[] = [
-  { label: 'По рейтингу', value: 'rating' },
-  { label: 'По новизне', value: 'newest' },
-  { label: 'По опыту', value: 'experience' },
-  { label: 'По откликам', value: 'responses' },
-];
-
-interface FnsResult {
-  id: string;
-  code: string;
-  name: string;
-  city: { name: string };
-}
-
-const SPECIALIZATION_FILTERS = [
-  { label: 'Все', value: '' },
-  { label: 'Декларации', value: 'Декларации' },
-  { label: 'Споры с ФНС', value: 'Споры' },
-  { label: 'Оптимизация', value: 'Оптимизация' },
-  { label: 'Вычеты', value: 'Вычеты' },
-  { label: 'Регистрация бизнеса', value: 'Регистрация' },
-  { label: 'НДС', value: 'НДС' },
-  { label: 'Аудит', value: 'Аудит' },
+const SERVICE_CATEGORIES = [
+  { label: 'Выездная проверка', value: 'Выездная проверка' },
+  { label: 'Камеральная проверка', value: 'Камеральная проверка' },
+  { label: 'Оперативный контроль', value: 'Отдел оперативного контроля' },
 ];
 
 export default function SpecialistsCatalogScreen() {
   const router = useRouter();
-  const { isMobile, numColumns, contentMaxWidth } = useBreakpoints();
+  const { isMobile, contentMaxWidth } = useBreakpoints();
 
   const [items, setItems] = useState<SpecialistItem[]>([]);
   const [page, setPage] = useState(1);
@@ -81,36 +62,24 @@ export default function SpecialistsCatalogScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
 
-  const [searchText, setSearchText] = useState('');
-  const [searchDebounced, setSearchDebounced] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');
-  const [selectedFns, setSelectedFns] = useState<FnsResult[]>([]);
-  const [sort, setSort] = useState('rating');
-  const [fnsDropdownResults, setFnsDropdownResults] = useState<FnsResult[]>([]);
+  const [selectedFns, setSelectedFns] = useState<FNSOffice[]>([]);
+  const [fnsQuery, setFnsQuery] = useState('');
+  const [fnsDropdown, setFnsDropdown] = useState<FNSOffice[]>([]);
 
-  // Debounce search input
+  // Local FNS dropdown filtering
   useEffect(() => {
-    const timer = setTimeout(() => setSearchDebounced(searchText), 400);
-    return () => clearTimeout(timer);
-  }, [searchText]);
-
-  // Fetch FNS results from API when search text changes
-  useEffect(() => {
-    if (!searchText.trim()) {
-      setFnsDropdownResults([]);
+    if (fnsQuery.trim().length < 2) {
+      setFnsDropdown([]);
       return;
     }
-    const timer = setTimeout(async () => {
-      try {
-        const results = await api.get<FnsResult[]>(`/ifns/search?q=${encodeURIComponent(searchText.trim())}`);
-        const selectedCodes = new Set(selectedFns.map((o) => o.code));
-        setFnsDropdownResults(results.filter((r) => !selectedCodes.has(r.code)).slice(0, 6));
-      } catch {
-        setFnsDropdownResults([]);
-      }
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchText, selectedFns]);
+    const q = fnsQuery.trim().toLowerCase();
+    const selectedCodes = new Set(selectedFns.map((o) => o.code));
+    const results = FNS_OFFICES.filter(
+      (o) => !selectedCodes.has(o.code) && (o.name.toLowerCase().includes(q) || o.city.toLowerCase().includes(q))
+    ).slice(0, 8);
+    setFnsDropdown(results);
+  }, [fnsQuery, selectedFns]);
 
   const fnsFilterParam = selectedFns.map((o) => o.name).join(',');
 
@@ -126,8 +95,6 @@ export default function SpecialistsCatalogScreen() {
     try {
       const params = new URLSearchParams();
       if (fnsFilterParam) params.set('fns', fnsFilterParam);
-      if (sort) params.set('sort', sort);
-      if (searchDebounced.trim()) params.set('search', searchDebounced.trim());
       if (selectedCategory) params.set('category', selectedCategory);
       params.set('page', String(pageNum));
       params.set('limit', String(PAGE_SIZE));
@@ -149,12 +116,12 @@ export default function SpecialistsCatalogScreen() {
       setLoadingMore(false);
       setRefreshing(false);
     }
-  }, [fnsFilterParam, sort, searchDebounced, selectedCategory]);
+  }, [fnsFilterParam, selectedCategory]);
 
   useEffect(() => {
     fetchSpecialists(1, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fnsFilterParam, sort, searchDebounced, selectedCategory]);
+  }, [fnsFilterParam, selectedCategory]);
 
   function handleRefresh() {
     setRefreshing(true);
@@ -169,19 +136,6 @@ export default function SpecialistsCatalogScreen() {
 
   const specialists = items;
 
-  async function handleShare(nick: string, displayName: string) {
-    const url = `${APP_URL}/specialists/${nick}`;
-    try {
-      if (Platform.OS === 'web' && typeof navigator !== 'undefined' && navigator.share) {
-        await navigator.share({ title: displayName, url });
-      } else {
-        await Share.share({ message: `${displayName} - ${url}`, url });
-      }
-    } catch {
-      // user cancelled
-    }
-  }
-
   function renderSpecialist({ item }: { item: SpecialistItem }) {
     const isVerified = item.badges.includes('verified');
     const displayName = item.displayName || `@${item.nick}`;
@@ -190,10 +144,10 @@ export default function SpecialistsCatalogScreen() {
       <TouchableOpacity
         onPress={() => router.push(`/specialists/${item.nick}`)}
         activeOpacity={0.8}
-        style={styles.cardWrapperMobile}
+        style={isMobile ? styles.cardWrapperMobile : styles.cardWrapperGrid}
       >
         <View style={[styles.card, isMobile && styles.cardMobile]}>
-          {/* Top row: avatar + name/spec/city */}
+          {/* Top row: avatar + name/headline/city */}
           <View style={styles.cardHeader}>
             <Avatar name={displayName} imageUri={item.avatarUrl || undefined} size="lg" />
             <View style={styles.cardInfo}>
@@ -209,7 +163,7 @@ export default function SpecialistsCatalogScreen() {
                 )}
               </View>
               {item.headline && (
-                <Text style={styles.headline} numberOfLines={1}>
+                <Text style={styles.headline} numberOfLines={2}>
                   {item.headline}
                 </Text>
               )}
@@ -219,18 +173,6 @@ export default function SpecialistsCatalogScreen() {
                 {item.memberSince ? `на сайте с ${item.memberSince}` : ''}
               </Text>
             </View>
-            {/* Share button */}
-            <TouchableOpacity
-              onPress={(e) => {
-                e.stopPropagation?.();
-                handleShare(item.nick, displayName);
-              }}
-              hitSlop={8}
-              style={styles.shareBtn}
-              activeOpacity={0.6}
-            >
-              <Ionicons name="share-outline" size={18} color={Colors.textMuted} />
-            </TouchableOpacity>
           </View>
 
           {/* Rating */}
@@ -283,7 +225,9 @@ export default function SpecialistsCatalogScreen() {
         data={specialists}
         keyExtractor={(item) => item.nick}
         renderItem={renderSpecialist}
-        numColumns={1}
+        numColumns={isMobile ? 1 : 2}
+        key={isMobile ? 'single' : 'double'}
+        columnWrapperStyle={isMobile ? undefined : { gap: 16 }}
         contentContainerStyle={[
           styles.listContent,
           !isMobile && styles.listContentWide,
@@ -298,26 +242,60 @@ export default function SpecialistsCatalogScreen() {
         }
         ListHeaderComponent={
           <View style={[styles.filters, { maxWidth: filtersMaxWidth }]}>
-            {/* Unified search — finds specialists, ИФНС offices, or services */}
+            {/* Service category chips */}
+            <View>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.chipsRow}
+              >
+                <TouchableOpacity
+                  onPress={() => setSelectedCategory('')}
+                  style={[styles.chip, selectedCategory === '' && styles.chipActive]}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.chipText, selectedCategory === '' && styles.chipTextActive]}>
+                    Все
+                  </Text>
+                </TouchableOpacity>
+                {SERVICE_CATEGORIES.map((cat) => {
+                  const isActive = cat.value === selectedCategory;
+                  return (
+                    <TouchableOpacity
+                      key={cat.value}
+                      onPress={() => setSelectedCategory(cat.value)}
+                      style={[styles.chip, isActive && styles.chipActive]}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
+                        {cat.label}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </ScrollView>
+            </View>
+
+            {/* FNS search */}
             <View style={styles.searchSection}>
               <TextInput
                 style={styles.searchInput}
-                value={searchText}
-                onChangeText={setSearchText}
-                placeholder="Найти специалиста, ИФНС или услугу..."
+                value={fnsQuery}
+                onChangeText={setFnsQuery}
+                placeholder="Ваша ИФНС..."
                 placeholderTextColor={Colors.textMuted}
                 autoCorrect={false}
               />
-              {fnsDropdownResults.length > 0 && (
+              {fnsDropdown.length > 0 && (
                 <View style={styles.fnsDropdown}>
                   <Text style={styles.fnsDropdownHeader}>Инспекции ФНС</Text>
-                  {fnsDropdownResults.map((office) => (
+                  {fnsDropdown.map((office) => (
                     <TouchableOpacity
                       key={office.code}
                       onPress={() => {
                         setSelectedFns((prev) => [...prev, office]);
-                        setSearchText('');
-                        setFnsDropdownResults([]);
+                        setFnsQuery('');
+                        setFnsDropdown([]);
                       }}
                       style={styles.fnsDropdownItem}
                       activeOpacity={0.7}
@@ -325,7 +303,7 @@ export default function SpecialistsCatalogScreen() {
                       <Text style={styles.fnsDropdownName} numberOfLines={2}>
                         {office.name}
                       </Text>
-                      <Text style={styles.fnsDropdownCity}>{office.city.name}</Text>
+                      <Text style={styles.fnsDropdownCity}>{office.city}</Text>
                     </TouchableOpacity>
                   ))}
                 </View>
@@ -345,55 +323,13 @@ export default function SpecialistsCatalogScreen() {
                     activeOpacity={0.7}
                   >
                     <Text style={styles.fnsChipText} numberOfLines={1}>
-                      {office.name} ({office.city.name})
+                      {office.name} ({office.city})
                     </Text>
                     <Text style={styles.fnsChipRemove}>x</Text>
                   </TouchableOpacity>
                 ))}
               </View>
             )}
-
-            {/* Specialization filter chips */}
-            <View>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={true}
-                contentContainerStyle={styles.chipsRow}
-              >
-                {SPECIALIZATION_FILTERS.map((spec) => {
-                  const isActive = spec.value === selectedCategory;
-                  return (
-                    <TouchableOpacity
-                      key={spec.value || '__all_spec__'}
-                      onPress={() => setSelectedCategory(spec.value)}
-                      style={[styles.chip, isActive && styles.chipActive]}
-                      activeOpacity={0.7}
-                    >
-                      <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
-                        {spec.label}
-                      </Text>
-                    </TouchableOpacity>
-                  );
-                })}
-              </ScrollView>
-            </View>
-
-            {/* Sort */}
-            <View style={styles.sortRow}>
-              <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ flexDirection: 'row', gap: 12 }}>
-                {SORT_OPTIONS.map((opt) => (
-                  <TouchableOpacity
-                    key={opt.value}
-                    onPress={() => setSort(opt.value)}
-                    activeOpacity={0.7}
-                  >
-                    <Text style={[styles.sortOption, sort === opt.value && styles.sortOptionActive]}>
-                      {opt.label}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </ScrollView>
-            </View>
           </View>
         }
         ListEmptyComponent={
@@ -571,23 +507,6 @@ const styles = StyleSheet.create({
     color: Colors.textAccent,
     lineHeight: 16,
   },
-  sortRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  sortLabel: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  sortOption: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  sortOptionActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.semibold,
-  },
   // Card styles
   cardWrapperMobile: {
     width: '100%',
@@ -596,6 +515,7 @@ const styles = StyleSheet.create({
   },
   cardWrapperGrid: {
     flex: 1,
+    marginBottom: Spacing.sm,
   },
   card: {
     backgroundColor: Colors.bgCard,
@@ -672,10 +592,6 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: Colors.brandPrimary,
     fontWeight: Typography.fontWeight.medium,
-  },
-  shareBtn: {
-    padding: Spacing.xs,
-    marginLeft: 'auto',
   },
   servicesRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Responsive 2-column layout on desktop, 1-column on mobile (FlatList numColumns + key switching)
- Replaced 7 specialization filters with 3 fixed service categories: Выездная проверка / Камеральная проверка / Оперативный контроль
- FNS filter: local searchable input using FNS_OFFICES from constants/FNS.ts (300+ offices, no API call, ≥2 chars triggers dropdown, max 8 results)
- Removed share button from catalog cards (remains on specialist profile page)
- headline field shown under specialist name (numberOfLines=2, textSecondary style)
- Seed data updated: all 10 specialists have headline + services from new 3 categories

## Test plan
- [ ] Desktop: 2 columns visible side by side
- [ ] Mobile: single column
- [ ] Category chips filter works (Все / 3 categories)
- [ ] FNS input: type 2+ chars → dropdown with offices appears → select → chip shown → filters API call
- [ ] No share button in catalog cards
- [ ] Specialist headline visible under name in card