### PR TITLE
feat: ServiceCategory model and GET /api/categories endpoint

### DIFF
--- a/api/prisma/migrations/20260409100000_add_service_categories/migration.sql
+++ b/api/prisma/migrations/20260409100000_add_service_categories/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "service_categories" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "icon" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "service_categories_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "service_categories_name_key" ON "service_categories"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "service_categories_slug_key" ON "service_categories"("slug");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -287,6 +287,18 @@ model PaymentRecord {
   @@map("payment_records")
 }
 
+model ServiceCategory {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  slug      String   @unique
+  icon      String?  // emoji or SVG code
+  isActive  Boolean  @default(true)
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+
+  @@map("service_categories")
+}
+
 enum ComplaintReason {
   spam
   fraud

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -373,6 +373,28 @@ async function findOrCreateThread(userId1: string, userId2: string) {
 }
 
 async function main() {
+  // --- Seed service categories ---
+  console.log('Seeding service categories...');
+  const categories = [
+    { name: 'Выездная проверка', slug: 'vyezdnaya-proverka', icon: '🔍', sortOrder: 1 },
+    { name: 'Камеральная проверка', slug: 'kameralnaya-proverka', icon: '📋', sortOrder: 2 },
+    { name: 'Отдел оперативного контроля', slug: 'operativny-kontrol', icon: '⚡', sortOrder: 3 },
+    { name: 'Декларация 3-НДФЛ', slug: 'deklaraciya-3ndfl', icon: '📄', sortOrder: 4 },
+    { name: 'Налоговые вычеты', slug: 'nalogovye-vychety', icon: '💰', sortOrder: 5 },
+    { name: 'Споры с ФНС', slug: 'spory-s-fns', icon: '⚖️', sortOrder: 6 },
+    { name: 'Регистрация бизнеса', slug: 'registraciya-biznesa', icon: '🏢', sortOrder: 7 },
+    { name: 'Оптимизация налогов', slug: 'optimizaciya-nalogov', icon: '📊', sortOrder: 8 },
+    { name: 'Другое', slug: 'drugoe', icon: '💬', sortOrder: 9 },
+  ];
+  for (const cat of categories) {
+    await prisma.serviceCategory.upsert({
+      where: { slug: cat.slug },
+      update: {},
+      create: cat,
+    });
+  }
+  console.log(`  Seeded ${categories.length} categories`);
+
   console.log('Seeding specialists...');
 
   for (const spec of specialists) {

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { ComplaintsModule } from './complaints/complaints.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { StorageModule } from './storage/storage.module';
 import { IfnsModule } from './ifns/ifns.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
@@ -37,6 +38,7 @@ import { IfnsModule } from './ifns/ifns.module';
     ReviewsModule,
     ComplaintsModule,
     IfnsModule,
+    CategoriesModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/categories/categories.controller.ts
+++ b/api/src/categories/categories.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  findAll() {
+    return this.categoriesService.findAll();
+  }
+}

--- a/api/src/categories/categories.module.ts
+++ b/api/src/categories/categories.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [CategoriesController],
+  providers: [CategoriesService],
+  exports: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/api/src/categories/categories.service.ts
+++ b/api/src/categories/categories.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll() {
+    return this.prisma.serviceCategory.findMany({
+      where: { isActive: true },
+      orderBy: { sortOrder: 'asc' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Added `ServiceCategory` Prisma model (id, name, slug, icon, isActive, sortOrder)
- Migration `20260409100000_add_service_categories`
- Seed: 9 tax service categories (upsert by slug, idempotent)
- NestJS `CategoriesModule` with public `GET /api/categories` endpoint (no auth guard, sorted by sortOrder, only active)

## Test plan
- [x] `curl http://localhost:3812/api/categories` returns 9 categories in correct order
- [x] Seed is idempotent (upsert by slug)
- [x] Endpoint is public (no JWT required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)