### PR TITLE
feat: service categories DB + admin CRUD

### DIFF
--- a/api/src/categories/categories.controller.ts
+++ b/api/src/categories/categories.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Body, Param, UseGuards } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AdminGuard } from '../auth/admin.guard';
 
 @Controller('categories')
 export class CategoriesController {
@@ -8,5 +10,32 @@ export class CategoriesController {
   @Get()
   findAll() {
     return this.categoriesService.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Get('admin/all')
+  findAllAdmin() {
+    return this.categoriesService.findAllAdmin();
+  }
+
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Post()
+  create(@Body() body: { name: string; slug?: string; icon?: string; sortOrder?: number }) {
+    return this.categoriesService.create(body);
+  }
+
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() body: { name?: string; slug?: string; icon?: string; sortOrder?: number; isActive?: boolean },
+  ) {
+    return this.categoriesService.update(id, body);
+  }
+
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.categoriesService.remove(id);
   }
 }

--- a/api/src/categories/categories.service.ts
+++ b/api/src/categories/categories.service.ts
@@ -11,4 +11,30 @@ export class CategoriesService {
       orderBy: { sortOrder: 'asc' },
     });
   }
+
+  findAllAdmin() {
+    return this.prisma.serviceCategory.findMany({
+      orderBy: { sortOrder: 'asc' },
+    });
+  }
+
+  create(data: { name: string; slug?: string; icon?: string; sortOrder?: number }) {
+    const slug = data.slug || data.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+    return this.prisma.serviceCategory.create({
+      data: {
+        name: data.name,
+        slug,
+        icon: data.icon,
+        sortOrder: data.sortOrder ?? 0,
+      },
+    });
+  }
+
+  update(id: string, data: { name?: string; slug?: string; icon?: string; sortOrder?: number; isActive?: boolean }) {
+    return this.prisma.serviceCategory.update({ where: { id }, data });
+  }
+
+  remove(id: string) {
+    return this.prisma.serviceCategory.delete({ where: { id } });
+  }
 }

--- a/app/(admin)/categories.tsx
+++ b/app/(admin)/categories.tsx
@@ -1,0 +1,375 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+  TextInput,
+  Alert,
+} from 'react-native';
+import { api } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+interface ServiceCategory {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string | null;
+  sortOrder: number;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export default function AdminCategories() {
+  const [categories, setCategories] = useState<ServiceCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const [newName, setNewName] = useState('');
+  const [newIcon, setNewIcon] = useState('');
+  const [newSortOrder, setNewSortOrder] = useState('');
+
+  const fetchCategories = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError(null);
+    try {
+      const data = await api.get<ServiceCategory[]>('/categories/admin/all');
+      setCategories(data);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load categories');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchCategories(); }, [fetchCategories]);
+
+  const handleRefresh = () => { setRefreshing(true); fetchCategories(true); };
+
+  const handleToggleActive = async (cat: ServiceCategory) => {
+    try {
+      await api.patch(`/categories/${cat.id}`, { isActive: !cat.isActive });
+      setCategories(prev => prev.map(c => c.id === cat.id ? { ...c, isActive: !c.isActive } : c));
+    } catch (e: any) {
+      Alert.alert('Ошибка', e?.message ?? 'Failed to update');
+    }
+  };
+
+  const handleDelete = (cat: ServiceCategory) => {
+    Alert.alert(
+      'Удалить категорию',
+      `Удалить "${cat.name}"?`,
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: 'Удалить',
+          style: 'destructive',
+          onPress: async () => {
+            setDeletingId(cat.id);
+            try {
+              await api.del(`/categories/${cat.id}`);
+              setCategories(prev => prev.filter(c => c.id !== cat.id));
+            } catch (e: any) {
+              Alert.alert('Ошибка', e?.message ?? 'Failed to delete');
+            } finally {
+              setDeletingId(null);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    setSaving(true);
+    try {
+      const sortOrder = newSortOrder.trim() ? parseInt(newSortOrder.trim(), 10) : 0;
+      const created = await api.post<ServiceCategory>('/categories', {
+        name: newName.trim(),
+        icon: newIcon.trim() || undefined,
+        sortOrder,
+      });
+      setCategories(prev => [...prev, created].sort((a, b) => a.sortOrder - b.sortOrder));
+      setNewName('');
+      setNewIcon('');
+      setNewSortOrder('');
+    } catch (e: any) {
+      Alert.alert('Ошибка', e?.message ?? 'Failed to create');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Категории услуг" showBack />
+      <ScrollView
+        contentContainerStyle={styles.scroll}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+        }
+      >
+        <View style={styles.container}>
+          {/* Add new category form */}
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Добавить категорию</Text>
+            <TextInput
+              style={styles.input}
+              value={newName}
+              onChangeText={setNewName}
+              placeholder="Название"
+              placeholderTextColor={Colors.textMuted}
+            />
+            <TextInput
+              style={styles.input}
+              value={newIcon}
+              onChangeText={setNewIcon}
+              placeholder="Иконка (emoji, необязательно)"
+              placeholderTextColor={Colors.textMuted}
+            />
+            <TextInput
+              style={styles.input}
+              value={newSortOrder}
+              onChangeText={setNewSortOrder}
+              placeholder="Порядок сортировки (число, необязательно)"
+              placeholderTextColor={Colors.textMuted}
+              keyboardType="numeric"
+            />
+            <TouchableOpacity
+              style={[styles.createBtn, (saving || !newName.trim()) && styles.createBtnDisabled]}
+              onPress={handleCreate}
+              disabled={saving || !newName.trim()}
+              activeOpacity={0.75}
+            >
+              {saving ? (
+                <ActivityIndicator size="small" color={Colors.white} />
+              ) : (
+                <Text style={styles.createBtnText}>Добавить</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+
+          {/* Categories list */}
+          <Text style={styles.sectionTitle}>Список категорий</Text>
+
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
+          ) : error ? (
+            <Text style={styles.errorText}>{error}</Text>
+          ) : categories.length === 0 ? (
+            <Text style={styles.emptyText}>Нет категорий</Text>
+          ) : (
+            <View style={styles.list}>
+              {categories.map(cat => (
+                <View key={cat.id} style={styles.catRow}>
+                  <View style={styles.catInfo}>
+                    <Text style={styles.catIcon}>{cat.icon || '•'}</Text>
+                    <View style={styles.catTextBlock}>
+                      <Text style={[styles.catName, !cat.isActive && styles.catNameInactive]}>
+                        {cat.name}
+                      </Text>
+                      <Text style={styles.catMeta}>
+                        #{cat.sortOrder}{' '}
+                        {cat.isActive ? (
+                          <Text style={styles.activeLabel}>активна</Text>
+                        ) : (
+                          <Text style={styles.inactiveLabel}>скрыта</Text>
+                        )}
+                      </Text>
+                    </View>
+                  </View>
+                  <View style={styles.catActions}>
+                    <TouchableOpacity
+                      style={styles.toggleBtn}
+                      onPress={() => handleToggleActive(cat)}
+                      activeOpacity={0.7}
+                    >
+                      <Text style={styles.toggleBtnText}>
+                        {cat.isActive ? 'Скрыть' : 'Показать'}
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.deleteBtn}
+                      onPress={() => handleDelete(cat)}
+                      disabled={deletingId === cat.id}
+                      activeOpacity={0.7}
+                    >
+                      {deletingId === cat.id ? (
+                        <ActivityIndicator size="small" color={Colors.statusError} />
+                      ) : (
+                        <Text style={styles.deleteBtnText}>Удалить</Text>
+                      )}
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: Spacing['2xl'],
+  },
+  container: {
+    width: '100%',
+    maxWidth: 430,
+    paddingHorizontal: Spacing.xl,
+    gap: Spacing.lg,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+    marginTop: Spacing.md,
+    marginBottom: Spacing.sm,
+  },
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    ...Shadows.sm,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+    backgroundColor: Colors.bgPrimary,
+  },
+  createBtn: {
+    backgroundColor: Colors.brandPrimary,
+    borderRadius: BorderRadius.md,
+    paddingVertical: Spacing.md,
+    alignItems: 'center',
+    marginTop: Spacing.xs,
+  },
+  createBtnDisabled: {
+    opacity: 0.5,
+  },
+  createBtnText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.white,
+  },
+  loader: {
+    marginVertical: Spacing['2xl'],
+  },
+  errorText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    paddingVertical: Spacing.lg,
+  },
+  list: {
+    gap: Spacing.sm,
+  },
+  catRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    ...Shadows.sm,
+  },
+  catInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  catIcon: {
+    fontSize: 20,
+    width: 28,
+    textAlign: 'center',
+  },
+  catTextBlock: {
+    flex: 1,
+  },
+  catName: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+  },
+  catNameInactive: {
+    color: Colors.textMuted,
+  },
+  catMeta: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    marginTop: 2,
+  },
+  activeLabel: {
+    color: '#1A7848',
+  },
+  inactiveLabel: {
+    color: Colors.textMuted,
+  },
+  catActions: {
+    flexDirection: 'row',
+    gap: Spacing.xs,
+  },
+  toggleBtn: {
+    paddingVertical: 4,
+    paddingHorizontal: Spacing.sm,
+    borderRadius: BorderRadius.sm,
+    borderWidth: 1,
+    borderColor: Colors.brandPrimary,
+  },
+  toggleBtnText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  deleteBtn: {
+    paddingVertical: 4,
+    paddingHorizontal: Spacing.sm,
+    borderRadius: BorderRadius.sm,
+    borderWidth: 1,
+    borderColor: Colors.statusError,
+    minWidth: 60,
+    alignItems: 'center',
+  },
+  deleteBtnText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.medium,
+  },
+});

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -78,6 +78,7 @@ export default function AdminDashboard() {
     { label: 'Продвижения', route: '/(admin)/promotions' as const, icon: 'P' },
     { label: 'Запросы', route: '/(admin)/requests' as const, icon: 'R' },
     { label: 'Отзывы', route: '/(admin)/reviews' as const, icon: 'О' },
+    { label: 'Категории услуг', route: '/(admin)/categories' as const, icon: 'К' },
   ];
 
   return (

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -44,16 +44,19 @@ interface SpecialistItem {
   activity: { responseCount: number; avgRating: number | null; reviewCount: number };
 }
 
-const SERVICE_CATEGORIES = [
-  { label: 'Выездная проверка', value: 'Выездная проверка' },
-  { label: 'Камеральная проверка', value: 'Камеральная проверка' },
-  { label: 'Оперативный контроль', value: 'Отдел оперативного контроля' },
-];
+interface ServiceCategory {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string | null;
+  sortOrder: number;
+}
 
 export default function SpecialistsCatalogScreen() {
   const router = useRouter();
   const { isMobile, contentMaxWidth } = useBreakpoints();
 
+  const [serviceCategories, setServiceCategories] = useState<ServiceCategory[]>([]);
   const [items, setItems] = useState<SpecialistItem[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
@@ -64,6 +67,12 @@ export default function SpecialistsCatalogScreen() {
 
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedFns, setSelectedFns] = useState<FNSOffice[]>([]);
+
+  useEffect(() => {
+    api.get<ServiceCategory[]>('/categories')
+      .then(data => setServiceCategories(data))
+      .catch(() => {});
+  }, []);
   const [fnsQuery, setFnsQuery] = useState('');
   const [fnsDropdown, setFnsDropdown] = useState<FNSOffice[]>([]);
 
@@ -258,17 +267,17 @@ export default function SpecialistsCatalogScreen() {
                     Все
                   </Text>
                 </TouchableOpacity>
-                {SERVICE_CATEGORIES.map((cat) => {
-                  const isActive = cat.value === selectedCategory;
+                {serviceCategories.map((cat) => {
+                  const isActive = cat.name === selectedCategory;
                   return (
                     <TouchableOpacity
-                      key={cat.value}
-                      onPress={() => setSelectedCategory(cat.value)}
+                      key={cat.id}
+                      onPress={() => setSelectedCategory(cat.name)}
                       style={[styles.chip, isActive && styles.chipActive]}
                       activeOpacity={0.7}
                     >
                       <Text style={[styles.chipText, isActive && styles.chipTextActive]}>
-                        {cat.label}
+                        {cat.name}
                       </Text>
                     </TouchableOpacity>
                   );


### PR DESCRIPTION
## Changes

- `CategoriesController`: added POST/PATCH/DELETE admin endpoints protected by JwtAuthGuard + AdminGuard
- `CategoriesService`: added `findAllAdmin()` (returns all including inactive), `create()` with auto slug, `update()`, `remove()`
- Frontend `app/specialists/index.tsx`: loads categories from `/categories` API instead of hardcoded array
- New `app/(admin)/categories.tsx`: list all categories, toggle active/inactive, delete, add new category form
- Admin dashboard nav: added "Категории услуг" link

## Endpoints

- `GET /categories` — public, active only (existing)
- `GET /categories/admin/all` — admin only, all including inactive
- `POST /categories` — admin only, create
- `PATCH /categories/:id` — admin only, update
- `DELETE /categories/:id` — admin only, delete