### PR TITLE
feat: add breadcrumbs to nested screens #421

### DIFF
--- a/app/(dashboard)/messages/[threadId].tsx
+++ b/app/(dashboard)/messages/[threadId].tsx
@@ -480,7 +480,7 @@ export default function ThreadScreen() {
 
   return (
     <SafeAreaView style={styles.safe}>
-      <Header title={otherName || 'Диалог'} showBack />
+      <Header title={otherName || 'Диалог'} showBack breadcrumbs={[{ label: 'Сообщения', route: '/(dashboard)/messages' }, { label: otherName || 'Диалог' }]} />
 
       <KeyboardAvoidingView
         style={styles.flex}

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -129,7 +129,7 @@ export default function MyRequestDetailScreen() {
   if (loading) {
     return (
       <SafeAreaView style={styles.safe}>
-        <Header title="Запрос" showBack />
+        <Header title="Запрос" showBack breadcrumbs={[{ label: 'Мои запросы', route: '/(dashboard)/my-requests' }, { label: 'Запрос' }]} />
         <View style={styles.loadingBox}>
           <ActivityIndicator size="large" color={Colors.brandPrimary} />
         </View>
@@ -140,7 +140,7 @@ export default function MyRequestDetailScreen() {
   if (error || !request) {
     return (
       <SafeAreaView style={styles.safe}>
-        <Header title="Запрос" showBack />
+        <Header title="Запрос" showBack breadcrumbs={[{ label: 'Мои запросы', route: '/(dashboard)/my-requests' }, { label: 'Запрос' }]} />
         <EmptyState
           icon="alert-circle-outline"
           title="Ошибка"
@@ -154,7 +154,7 @@ export default function MyRequestDetailScreen() {
 
   return (
     <SafeAreaView style={styles.safe}>
-      <Header title="Запрос" showBack />
+      <Header title="Запрос" showBack breadcrumbs={[{ label: 'Мои запросы', route: '/(dashboard)/my-requests' }, { label: 'Запрос' }]} />
       <ScrollView
         contentContainerStyle={styles.scroll}
         showsVerticalScrollIndicator={false}

--- a/app/(dashboard)/my-requests/edit/[id].tsx
+++ b/app/(dashboard)/my-requests/edit/[id].tsx
@@ -115,7 +115,7 @@ export default function EditRequestScreen() {
   if (loading) {
     return (
       <SafeAreaView style={styles.safe}>
-        <Header title="Редактирование" showBack />
+        <Header title="Редактирование" showBack breadcrumbs={[{ label: 'Мои запросы', route: '/(dashboard)/my-requests' }, { label: 'Редактирование' }]} />
         <View style={styles.loadingBox}>
           <ActivityIndicator size="large" color={Colors.brandPrimary} />
         </View>

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -92,7 +92,7 @@ export default function CreateRequestScreen() {
 
   return (
     <SafeAreaView style={styles.safe}>
-      <Header title="Новый запрос" showBack />
+      <Header title="Новый запрос" showBack breadcrumbs={[{ label: 'Мои запросы', route: '/(dashboard)/my-requests' }, { label: 'Новый запрос' }]} />
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}


### PR DESCRIPTION
Adds breadcrumb navigation to nested dashboard screens:
- messages/[threadId] — Сообщения / Диалог
- my-requests/[id] — Мои запросы / Запрос
- my-requests/new — Мои запросы / Новый запрос
- my-requests/edit/[id] — Мои запросы / Редактирование

Completes item #6 from task #421 (breadcrumbs in Header for nested screens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)