### PR TITLE
fix: QuickRequestForm sends data to server

### DIFF
--- a/api/prisma/migrations/20260409150000_add_quick_requests/migration.sql
+++ b/api/prisma/migrations/20260409150000_add_quick_requests/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "quick_requests" (
+    "id" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "serviceType" TEXT NOT NULL,
+    "city" TEXT,
+    "ifnsId" TEXT,
+    "ifnsName" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quick_requests_pkey" PRIMARY KEY ("id")
+);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -302,6 +302,19 @@ model ServiceCategory {
   @@map("service_categories")
 }
 
+model QuickRequest {
+  id          String   @id @default(cuid())
+  description String
+  serviceType String
+  city        String?
+  ifnsId      String?
+  ifnsName    String?
+  status      String   @default("pending")
+  createdAt   DateTime @default(now())
+
+  @@map("quick_requests")
+}
+
 enum ComplaintReason {
   spam
   fraud

--- a/api/src/requests/dto/create-quick-request.dto.ts
+++ b/api/src/requests/dto/create-quick-request.dto.ts
@@ -1,0 +1,29 @@
+import { IsString, IsNotEmpty, MinLength, MaxLength, IsOptional } from 'class-validator';
+
+export class CreateQuickRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3)
+  @MaxLength(500)
+  description: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  serviceType: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  ifnsId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  ifnsName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+}

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { RequestsService } from './requests.service';
 import { CreateRequestDto } from './dto/create-request.dto';
+import { CreateQuickRequestDto } from './dto/create-quick-request.dto';
 import { RespondRequestDto } from './dto/respond-request.dto';
 import { PatchRequestDto } from './dto/patch-request.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -23,6 +24,12 @@ import { Role } from '@prisma/client';
 @Controller('requests')
 export class RequestsController {
   constructor(private readonly requestsService: RequestsService) {}
+
+  // POST /requests/quick — anonymous quick request from landing page
+  @Post('quick')
+  createQuick(@Body() dto: CreateQuickRequestDto) {
+    return this.requestsService.createQuick(dto);
+  }
 
   // POST /requests — client creates a request
   @Post()

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -9,6 +9,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../notifications/email.service';
 import { CreateRequestDto } from './dto/create-request.dto';
+import { CreateQuickRequestDto } from './dto/create-quick-request.dto';
 import { RespondRequestDto } from './dto/respond-request.dto';
 import { RequestStatus, Prisma } from '@prisma/client';
 
@@ -37,6 +38,19 @@ export class RequestsService {
         createdAt: true,
         _count: { select: { responses: true } },
       },
+    });
+  }
+
+  async createQuick(dto: CreateQuickRequestDto) {
+    return this.prisma.quickRequest.create({
+      data: {
+        description: dto.description.trim().slice(0, 500),
+        serviceType: dto.serviceType,
+        city: dto.city ?? null,
+        ifnsId: dto.ifnsId ?? null,
+        ifnsName: dto.ifnsName ?? null,
+      },
+      select: { id: true, status: true },
     });
   }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -56,6 +56,8 @@ function QuickRequestForm() {
     });
   }, []);
 
+  const [submitting, setSubmitting] = useState(false);
+
   const handleSubmit = async () => {
     if (!serviceType) {
       setError('Выберите тип услуги');
@@ -75,8 +77,19 @@ function QuickRequestForm() {
       pending.ifnsId = selectedIfns.id;
       pending.ifnsName = selectedIfns.name;
     }
+    // Save to localStorage as backup (for restore after auth redirect)
     await secureStorage.setItem('p2ptax_pending_request', JSON.stringify(pending));
-    setSubmitted(true);
+
+    // Send to server
+    setSubmitting(true);
+    try {
+      await api.post('/requests/quick', pending);
+      setSubmitted(true);
+    } catch (e: any) {
+      setError(e?.message || 'Не удалось отправить заявку. Попробуйте позже.');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   function handleNewRequest() {
@@ -145,8 +158,8 @@ function QuickRequestForm() {
       />
 
       {error ? <Text style={qrf.error}>{error}</Text> : null}
-      <TouchableOpacity testID="quick-request-submit" style={qrf.btn} onPress={handleSubmit} activeOpacity={0.85}>
-        <Text style={qrf.btnText}>Найти специалиста →</Text>
+      <TouchableOpacity testID="quick-request-submit" style={[qrf.btn, submitting && { opacity: 0.6 }]} onPress={handleSubmit} activeOpacity={0.85} disabled={submitting}>
+        <Text style={qrf.btnText}>{submitting ? 'Отправка...' : 'Найти специалиста →'}</Text>
       </TouchableOpacity>
     </View>
   );


### PR DESCRIPTION
## Summary
- Added `quick_requests` table for anonymous landing page submissions
- Added `POST /api/requests/quick` endpoint (no auth required) with validation
- Frontend `handleSubmit` now POSTs to server before showing success
- Loading state and error handling added to submit button
- localStorage save kept as backup for auth redirect restore

## Test plan
- [ ] Submit quick request form on landing page — verify row appears in `quick_requests` table
- [ ] Submit with empty description — verify validation error shown
- [ ] Submit without selecting service type — verify validation error shown
- [ ] Verify success message only shows after server 200

Generated with Claude Code