### PR TITLE
feat: replace fake stats with real API data

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { StorageModule } from './storage/storage.module';
 import { IfnsModule } from './ifns/ifns.module';
 import { CategoriesModule } from './categories/categories.module';
+import { StatsModule } from './stats/stats.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { CategoriesModule } from './categories/categories.module';
     ComplaintsModule,
     IfnsModule,
     CategoriesModule,
+    StatsModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/stats/stats.controller.ts
+++ b/api/src/stats/stats.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { StatsService } from './stats.service';
+
+@Controller('stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get('landing')
+  getLandingStats() {
+    return this.statsService.getLandingStats();
+  }
+}

--- a/api/src/stats/stats.module.ts
+++ b/api/src/stats/stats.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { StatsController } from './stats.controller';
+import { StatsService } from './stats.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [StatsController],
+  providers: [StatsService],
+})
+export class StatsModule {}

--- a/api/src/stats/stats.service.ts
+++ b/api/src/stats/stats.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class StatsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getLandingStats() {
+    const [specialistsCount, ifnsCount, requestsCount] = await Promise.all([
+      this.prisma.specialistProfile.count({
+        where: { displayName: { not: null } },
+      }),
+      this.prisma.ifns.count(),
+      this.prisma.request.count(),
+    ]);
+
+    return { specialistsCount, ifnsCount, requestsCount };
+  }
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -328,6 +328,7 @@ export default function LandingScreen() {
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const [isLoadingSpecialists, setIsLoadingSpecialists] = useState(true);
   const [isLoadingRequests, setIsLoadingRequests] = useState(true);
+  const [landingStats, setLandingStats] = useState<{ specialistsCount: number; ifnsCount: number; requestsCount: number } | null>(null);
   const [reviews, setReviews] = useState<Array<{
     id: string;
     rating: number;
@@ -342,6 +343,7 @@ export default function LandingScreen() {
     api.get<any[]>('/specialists/featured?limit=50').then(setFeaturedSpecialists).catch((err) => console.warn('Landing section failed (featured specialists):', err)).finally(() => setIsLoadingSpecialists(false));
     api.get<any[]>('/requests/recent?limit=5').then(setRecentRequests).catch((err) => console.warn('Landing section failed (recent requests):', err)).finally(() => setIsLoadingRequests(false));
     api.get<any[]>('/reviews/public?limit=6').then(setReviews).catch((err) => console.warn('Landing section failed (reviews):', err));
+    api.get<{ specialistsCount: number; ifnsCount: number; requestsCount: number }>('/stats/landing').then(setLandingStats).catch((err) => console.warn('Landing section failed (stats):', err));
   }, []);
 
   const isWide = !isMobile;
@@ -431,26 +433,27 @@ export default function LandingScreen() {
         </View>
 
         {/* ===== Stats Bar ===== */}
-        <View style={styles.statsSection}>
-          <View style={[styles.statsInner, innerStyle]}>
-            <View style={[isMobile ? styles.statsRowMobile : styles.statsRow]}>
-              {[
-                { number: '200+', label: 'ИФНС в базе' },
-                { number: '500+', label: 'Специалистов' },
-                { number: '1-2 часа', label: 'Время первого отклика' },
-                { number: 'Бесплатно', label: 'Размещение запроса' },
-              ].map((stat, idx, arr) => (
-                <React.Fragment key={stat.label}>
-                  <View style={[styles.statItem, isMobile && styles.statItemMobile]}>
-                    <Text style={styles.statNumber}>{stat.number}</Text>
-                    <Text style={styles.statLabel}>{stat.label}</Text>
-                  </View>
-                  {!isMobile && idx < arr.length - 1 && <View style={styles.statDivider} />}
-                </React.Fragment>
-              ))}
+        {landingStats && (
+          <View style={styles.statsSection}>
+            <View style={[styles.statsInner, innerStyle]}>
+              <View style={[isMobile ? styles.statsRowMobile : styles.statsRow]}>
+                {[
+                  { number: String(landingStats.specialistsCount), label: 'Специалистов' },
+                  { number: String(landingStats.ifnsCount), label: 'ИФНС в базе' },
+                  { number: String(landingStats.requestsCount), label: 'Решённых запросов' },
+                ].map((stat, idx, arr) => (
+                  <React.Fragment key={stat.label}>
+                    <View style={[styles.statItem, isMobile && styles.statItemMobile]}>
+                      <Text style={styles.statNumber}>{stat.number}</Text>
+                      <Text style={styles.statLabel}>{stat.label}</Text>
+                    </View>
+                    {!isMobile && idx < arr.length - 1 && <View style={styles.statDivider} />}
+                  </React.Fragment>
+                ))}
+              </View>
             </View>
           </View>
-        </View>
+        )}
 
         {/* ===== SECTION 2b: Featured Specialists ===== */}
         {isLoadingSpecialists && (


### PR DESCRIPTION
## Summary
- Add `GET /api/stats/landing` endpoint (no auth) returning real counts from DB
- Frontend fetches real specialistsCount, ifnsCount, requestsCount
- Stats bar hidden until data loads (no skeleton, just absent)
- Removed fake "500+ Специалистов", "200+ ИФНС", "Бесплатно" items

## Test plan
- [ ] `curl /api/stats/landing` returns valid JSON with counts
- [ ] Landing page shows real numbers in stats bar
- [ ] Stats bar not visible during loading (no flash of fake data)

Generated with [Claude Code](https://claude.com/claude-code)