### PR TITLE
feat: prototyping system with 30 pages and 74 states

### DIFF
--- a/app/proto/_layout.tsx
+++ b/app/proto/_layout.tsx
@@ -1,0 +1,7 @@
+import { Stack } from 'expo-router';
+
+export default function ProtoLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }} />
+  );
+}

--- a/app/proto/index.tsx
+++ b/app/proto/index.tsx
@@ -1,0 +1,160 @@
+import React, { useState, useMemo } from 'react';
+import { View, Text, ScrollView, TextInput, StyleSheet, useWindowDimensions } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+import { protoRegistry, PROTO_GROUPS, getPagesByGroup } from '../../constants/protoRegistry';
+import { ProtoCard } from '../../components/proto/ProtoCard';
+
+const GROUP_LABELS: Record<string, string> = {
+  Auth: 'Авторизация',
+  Onboarding: 'Онбординг',
+  Dashboard: 'Кабинет клиента',
+  Specialist: 'Специалист',
+  Public: 'Публичные страницы',
+  Admin: 'Администрирование',
+};
+
+export default function ProtoIndex() {
+  const [search, setSearch] = useState('');
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 1024;
+  const isTablet = width >= 768 && !isDesktop;
+
+  const columns = isDesktop ? 3 : isTablet ? 2 : 1;
+  const totalStates = protoRegistry.reduce((s, p) => s + p.stateCount, 0);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return null;
+    const q = search.toLowerCase();
+    return protoRegistry.filter(
+      (p) => p.title.toLowerCase().includes(q) || p.id.toLowerCase().includes(q) || p.route.toLowerCase().includes(q)
+    );
+  }, [search]);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <View style={styles.header}>
+        <Text style={styles.title}>P2PTax — Прототипы</Text>
+        <Text style={styles.subtitle}>
+          {protoRegistry.length} страниц, {totalStates} состояний
+        </Text>
+      </View>
+
+      <View style={styles.searchWrap}>
+        <TextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Поиск по названию, роуту..."
+          placeholderTextColor={Colors.textMuted}
+          style={styles.searchInput}
+        />
+      </View>
+
+      {filtered ? (
+        <View style={styles.groupSection}>
+          <Text style={styles.groupTitle}>Результаты поиска ({filtered.length})</Text>
+          <View style={[styles.grid, { flexDirection: 'row', flexWrap: 'wrap' }]}>
+            {filtered.map((page) => (
+              <View key={page.id} style={{ width: columns === 1 ? '100%' : columns === 2 ? '50%' : '33.33%', padding: Spacing.xs }}>
+                <ProtoCard page={page} />
+              </View>
+            ))}
+          </View>
+          {filtered.length === 0 && (
+            <Text style={styles.emptyText}>Ничего не найдено</Text>
+          )}
+        </View>
+      ) : (
+        PROTO_GROUPS.map((group) => {
+          const pages = getPagesByGroup(group);
+          if (pages.length === 0) return null;
+          return (
+            <View key={group} style={styles.groupSection}>
+              <View style={styles.groupHeader}>
+                <Text style={styles.groupTitle}>{GROUP_LABELS[group] || group}</Text>
+                <Text style={styles.groupCount}>{pages.length}</Text>
+              </View>
+              <View style={[styles.grid, { flexDirection: 'row', flexWrap: 'wrap' }]}>
+                {pages.map((page) => (
+                  <View key={page.id} style={{ width: columns === 1 ? '100%' : columns === 2 ? '50%' : '33.33%', padding: Spacing.xs }}>
+                    <ProtoCard page={page} />
+                  </View>
+                ))}
+              </View>
+            </View>
+          );
+        })
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F0F2F5',
+  },
+  content: {
+    padding: Spacing.lg,
+    maxWidth: 1200,
+    alignSelf: 'center',
+    width: '100%',
+    paddingBottom: 64,
+  },
+  header: {
+    marginBottom: Spacing['2xl'],
+    gap: Spacing.xs,
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+  },
+  searchWrap: {
+    marginBottom: Spacing['2xl'],
+  },
+  searchInput: {
+    height: 44,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.lg,
+    fontSize: Typography.fontSize.base,
+    color: Colors.textPrimary,
+  },
+  groupSection: {
+    marginBottom: Spacing['3xl'],
+  },
+  groupHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+  },
+  groupTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  groupCount: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.full,
+    overflow: 'hidden',
+  },
+  grid: {},
+  emptyText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    marginTop: Spacing['2xl'],
+  },
+});

--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { ProtoLayout } from '../../../components/proto/ProtoLayout';
+import { getPageById } from '../../../constants/protoRegistry';
+import { Colors, Typography, Spacing } from '../../../constants/Colors';
+
+// State components
+import { AuthEmailStates } from '../../../components/proto/states/AuthEmailStates';
+import { AuthOtpStates } from '../../../components/proto/states/AuthOtpStates';
+import { OnboardingUsernameStates } from '../../../components/proto/states/OnboardingUsernameStates';
+import { OnboardingCitiesStates } from '../../../components/proto/states/OnboardingCitiesStates';
+import { OnboardingServicesStates } from '../../../components/proto/states/OnboardingServicesStates';
+import { OnboardingFnsStates } from '../../../components/proto/states/OnboardingFnsStates';
+import { OnboardingProfileStates } from '../../../components/proto/states/OnboardingProfileStates';
+import { DashboardStates } from '../../../components/proto/states/DashboardStates';
+import { MyRequestsStates } from '../../../components/proto/states/MyRequestsStates';
+import { MyRequestsNewStates } from '../../../components/proto/states/MyRequestsNewStates';
+import { MyRequestDetailStates } from '../../../components/proto/states/MyRequestDetailStates';
+import { ResponsesStates } from '../../../components/proto/states/ResponsesStates';
+import { MessagesStates } from '../../../components/proto/states/MessagesStates';
+import { MessageThreadStates } from '../../../components/proto/states/MessageThreadStates';
+import { ProfileStates } from '../../../components/proto/states/ProfileStates';
+import { SettingsStates } from '../../../components/proto/states/SettingsStates';
+import { SpecialistDashboardStates } from '../../../components/proto/states/SpecialistDashboardStates';
+import { SpecialistRespondStates } from '../../../components/proto/states/SpecialistRespondStates';
+import { SpecialistProfilePublicStates } from '../../../components/proto/states/SpecialistProfilePublicStates';
+import { LandingStates } from '../../../components/proto/states/LandingStates';
+import { PublicRequestsStates } from '../../../components/proto/states/PublicRequestsStates';
+import { PublicRequestDetailStates } from '../../../components/proto/states/PublicRequestDetailStates';
+import { SpecialistsCatalogStates } from '../../../components/proto/states/SpecialistsCatalogStates';
+import { PricingStates } from '../../../components/proto/states/PricingStates';
+import { AdminDashboardStates } from '../../../components/proto/states/AdminDashboardStates';
+import { AdminUsersStates } from '../../../components/proto/states/AdminUsersStates';
+import { AdminRequestsStates } from '../../../components/proto/states/AdminRequestsStates';
+import { AdminModerationStates } from '../../../components/proto/states/AdminModerationStates';
+import { AdminReviewsStates } from '../../../components/proto/states/AdminReviewsStates';
+import { AdminPromotionsStates } from '../../../components/proto/states/AdminPromotionsStates';
+
+const STATE_MAP: Record<string, React.ComponentType> = {
+  'auth-email': AuthEmailStates,
+  'auth-otp': AuthOtpStates,
+  'onboarding-username': OnboardingUsernameStates,
+  'onboarding-cities': OnboardingCitiesStates,
+  'onboarding-services': OnboardingServicesStates,
+  'onboarding-fns': OnboardingFnsStates,
+  'onboarding-profile': OnboardingProfileStates,
+  'dashboard': DashboardStates,
+  'my-requests': MyRequestsStates,
+  'my-requests-new': MyRequestsNewStates,
+  'my-request-detail': MyRequestDetailStates,
+  'responses': ResponsesStates,
+  'messages': MessagesStates,
+  'message-thread': MessageThreadStates,
+  'profile': ProfileStates,
+  'settings': SettingsStates,
+  'specialist-dashboard': SpecialistDashboardStates,
+  'specialist-respond': SpecialistRespondStates,
+  'specialist-profile-public': SpecialistProfilePublicStates,
+  'landing': LandingStates,
+  'public-requests': PublicRequestsStates,
+  'public-request-detail': PublicRequestDetailStates,
+  'specialists-catalog': SpecialistsCatalogStates,
+  'pricing': PricingStates,
+  'admin-dashboard': AdminDashboardStates,
+  'admin-users': AdminUsersStates,
+  'admin-requests': AdminRequestsStates,
+  'admin-moderation': AdminModerationStates,
+  'admin-reviews': AdminReviewsStates,
+  'admin-promotions': AdminPromotionsStates,
+};
+
+export default function ProtoStatesPage() {
+  const { page } = useLocalSearchParams<{ page: string }>();
+  const pageData = getPageById(page || '');
+  const StatesComponent = page ? STATE_MAP[page] : undefined;
+
+  if (!pageData || !StatesComponent) {
+    return (
+      <View style={styles.notFound}>
+        <Text style={styles.notFoundTitle}>Страница не найдена</Text>
+        <Text style={styles.notFoundText}>Proto page "{page}" не существует в реестре</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ProtoLayout title={pageData.title} route={pageData.route}>
+      <StatesComponent />
+    </ProtoLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  notFound: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing['3xl'],
+  },
+  notFoundTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginBottom: Spacing.sm,
+  },
+  notFoundText: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textMuted,
+  },
+});

--- a/app/proto/states/_layout.tsx
+++ b/app/proto/states/_layout.tsx
@@ -1,0 +1,7 @@
+import { Stack } from 'expo-router';
+
+export default function StatesLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }} />
+  );
+}

--- a/components/proto/ProtoCard.tsx
+++ b/components/proto/ProtoCard.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import type { ProtoPage } from '../../constants/protoRegistry';
+
+interface ProtoCardProps {
+  page: ProtoPage;
+}
+
+const GROUP_COLORS: Record<string, string> = {
+  Auth: '#6366F1',
+  Onboarding: '#8B5CF6',
+  Dashboard: '#1A5BA8',
+  Specialist: '#059669',
+  Public: '#D97706',
+  Admin: '#DC2626',
+};
+
+export function ProtoCard({ page }: ProtoCardProps) {
+  const [hovered, setHovered] = useState(false);
+  const groupColor = GROUP_COLORS[page.group] || Colors.brandPrimary;
+
+  const handlePress = () => {
+    if (Platform.OS === 'web') {
+      window.open(`/proto/states/${page.id}`, '_blank');
+    }
+  };
+
+  const webProps = Platform.OS === 'web'
+    ? { onMouseEnter: () => setHovered(true), onMouseLeave: () => setHovered(false) }
+    : {};
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      activeOpacity={0.7}
+      style={[
+        styles.card,
+        hovered && styles.cardHovered,
+      ]}
+      {...(webProps as any)}
+    >
+      <View style={[styles.accent, { backgroundColor: groupColor }]} />
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>{page.title}</Text>
+        <Text style={styles.route} numberOfLines={1}>{page.route}</Text>
+        <View style={styles.footer}>
+          <View style={styles.stateBadge}>
+            <Text style={styles.stateCount}>{page.stateCount}</Text>
+            <Text style={styles.stateLabel}>
+              {page.stateCount === 1 ? 'состояние' : page.stateCount < 5 ? 'состояния' : 'состояний'}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    overflow: 'hidden',
+    flexDirection: 'row',
+    ...Shadows.sm,
+  },
+  cardHovered: {
+    borderColor: Colors.brandPrimary,
+    ...Shadows.md,
+  },
+  accent: {
+    width: 4,
+  },
+  body: {
+    flex: 1,
+    padding: Spacing.lg,
+    gap: Spacing.xs,
+  },
+  title: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  route: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    fontFamily: Platform.OS === 'web' ? 'monospace' : undefined,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: Spacing.sm,
+  },
+  stateBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 2,
+    borderRadius: BorderRadius.full,
+    gap: 4,
+  },
+  stateCount: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+  },
+  stateLabel: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+});

--- a/components/proto/ProtoLayout.tsx
+++ b/components/proto/ProtoLayout.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, Platform } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+
+interface ProtoLayoutProps {
+  title: string;
+  route: string;
+  children: React.ReactNode;
+}
+
+export function ProtoLayout({ title, route, children }: ProtoLayoutProps) {
+  const handleBack = () => {
+    if (Platform.OS === 'web') {
+      window.open('/proto', '_self');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleBack} style={styles.backBtn}>
+          <Text style={styles.backIcon}>{'<'}</Text>
+          <Text style={styles.backLabel}>Индекс</Text>
+        </TouchableOpacity>
+        <View style={styles.headerCenter}>
+          <Text style={styles.title} numberOfLines={1}>{title}</Text>
+          <Text style={styles.route}>{route}</Text>
+        </View>
+        <View style={styles.headerRight} />
+      </View>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {children}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F0F2F5',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 56,
+    paddingHorizontal: Spacing.lg,
+    backgroundColor: Colors.bgCard,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  backBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Spacing.sm,
+    paddingRight: Spacing.md,
+    gap: 4,
+  },
+  backIcon: {
+    fontSize: Typography.fontSize.lg,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.bold,
+  },
+  backLabel: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.brandPrimary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  headerCenter: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  route: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    marginTop: 1,
+  },
+  headerRight: {
+    width: 80,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: Spacing.lg,
+    gap: Spacing['3xl'],
+    paddingBottom: 64,
+  },
+});

--- a/components/proto/StateSection.tsx
+++ b/components/proto/StateSection.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
+
+interface StateSectionProps {
+  title: string;
+  children: React.ReactNode;
+  maxWidth?: number;
+}
+
+export function StateSection({ title, children, maxWidth = 430 }: StateSectionProps) {
+  return (
+    <View style={styles.section}>
+      <View style={styles.labelRow}>
+        <View style={styles.labelBadge}>
+          <Text style={styles.labelText}>{title}</Text>
+        </View>
+        <View style={styles.line} />
+      </View>
+      <View style={[styles.content, { maxWidth }]}>
+        <View style={styles.phone}>
+          {children}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    gap: Spacing.md,
+  },
+  labelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  labelBadge: {
+    backgroundColor: Colors.brandPrimary,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.sm,
+  },
+  labelText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.bold,
+    color: '#FFFFFF',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  line: {
+    flex: 1,
+    height: 1,
+    backgroundColor: Colors.border,
+  },
+  content: {
+    alignSelf: 'center',
+    width: '100%',
+  },
+  phone: {
+    backgroundColor: Colors.bgPrimary,
+    borderRadius: BorderRadius.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    overflow: 'hidden',
+    minHeight: 200,
+  },
+});

--- a/components/proto/states/AdminDashboardStates.tsx
+++ b/components/proto/states/AdminDashboardStates.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { MOCK_ADMIN_STATS } from '../../../constants/protoMockData';
+
+function StatCard({ label, value, color, trend }: { label: string; value: string | number; color: string; trend?: string }) {
+  return (
+    <View style={s.statCard}>
+      <Text style={s.statLabel}>{label}</Text>
+      <Text style={[s.statValue, { color }]}>{value}</Text>
+      {trend && <Text style={s.statTrend}>{trend}</Text>}
+    </View>
+  );
+}
+
+function ChartPlaceholder({ title }: { title: string }) {
+  return (
+    <View style={s.chartCard}>
+      <Text style={s.chartTitle}>{title}</Text>
+      <View style={s.chartArea}>
+        <View style={s.chartBars}>
+          {[40, 65, 45, 80, 55, 70, 90].map((h, i) => (
+            <View key={i} style={[s.chartBar, { height: h, backgroundColor: i === 6 ? Colors.brandPrimary : Colors.bgSecondary }]} />
+          ))}
+        </View>
+        <View style={s.chartLabels}>
+          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map((d) => (
+            <Text key={d} style={s.chartLabel}>{d}</Text>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function AdminDashboardStates() {
+  const st = MOCK_ADMIN_STATS;
+  return (
+    <StateSection title="STATS" maxWidth={800}>
+      <View style={s.container}>
+        <Text style={s.pageTitle}>Панель администратора</Text>
+
+        <View style={s.statsGrid}>
+          <StatCard label="Всего пользователей" value={st.totalUsers} color={Colors.textPrimary} trend="+23 сегодня" />
+          <StatCard label="Специалистов" value={st.totalSpecialists} color={Colors.brandPrimary} />
+          <StatCard label="Всего заявок" value={st.totalRequests} color={Colors.textPrimary} trend="+15 сегодня" />
+          <StatCard label="Активные заявки" value={st.activeRequests} color={Colors.statusSuccess} />
+          <StatCard label="На модерации" value={st.pendingModeration} color="#D97706" />
+          <StatCard label="Средний рейтинг" value={st.avgRating} color={Colors.brandPrimary} />
+        </View>
+
+        <View style={s.revenue}>
+          <Text style={s.revenueLabel}>Общий доход</Text>
+          <Text style={s.revenueValue}>{st.revenue}</Text>
+        </View>
+
+        <ChartPlaceholder title="Регистрации за неделю" />
+        <ChartPlaceholder title="Заявки за неделю" />
+
+        <View style={s.recentSection}>
+          <Text style={s.sectionTitle}>Последние действия</Text>
+          {[
+            { action: 'Регистрация', detail: 'Новый пользователь: Сергей К.', time: '5 мин назад' },
+            { action: 'Заявка', detail: 'Новая заявка: Декларация 3-НДФЛ', time: '12 мин назад' },
+            { action: 'Модерация', detail: 'Специалист ожидает проверки', time: '30 мин назад' },
+            { action: 'Отзыв', detail: 'Новый отзыв от Елены В.', time: '1 час назад' },
+          ].map((item, i) => (
+            <View key={i} style={s.activityRow}>
+              <View style={s.activityDot} />
+              <View style={s.activityContent}>
+                <Text style={s.activityAction}>{item.action}: <Text style={s.activityDetail}>{item.detail}</Text></Text>
+                <Text style={s.activityTime}>{item.time}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      </View>
+    </StateSection>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  pageTitle: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  statsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm },
+  statCard: {
+    width: '48%', backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    padding: Spacing.md, borderWidth: 1, borderColor: Colors.border, gap: 2, ...Shadows.sm,
+  },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold },
+  statTrend: { fontSize: Typography.fontSize.xs, color: Colors.statusSuccess },
+  revenue: {
+    backgroundColor: '#0F2447', borderRadius: BorderRadius.md, padding: Spacing.lg, alignItems: 'center', gap: Spacing.xs,
+  },
+  revenueLabel: { fontSize: Typography.fontSize.sm, color: 'rgba(255,255,255,0.7)' },
+  revenueValue: { fontSize: 28, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  chartCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  chartTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  chartArea: { gap: Spacing.sm },
+  chartBars: { flexDirection: 'row', alignItems: 'flex-end', gap: Spacing.sm, height: 100 },
+  chartBar: { flex: 1, borderRadius: BorderRadius.sm },
+  chartLabels: { flexDirection: 'row', gap: Spacing.sm },
+  chartLabel: { flex: 1, fontSize: Typography.fontSize.xs, color: Colors.textMuted, textAlign: 'center' },
+  recentSection: { gap: Spacing.md },
+  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  activityRow: { flexDirection: 'row', gap: Spacing.md, alignItems: 'flex-start' },
+  activityDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: Colors.brandPrimary, marginTop: 6 },
+  activityContent: { flex: 1, gap: 1 },
+  activityAction: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  activityDetail: { fontWeight: Typography.fontWeight.regular, color: Colors.textSecondary },
+  activityTime: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+});

--- a/components/proto/states/AdminModerationStates.tsx
+++ b/components/proto/states/AdminModerationStates.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function ModerationCard({ name, type, date }: { name: string; type: string; date: string }) {
+  return (
+    <View style={s.card}>
+      <View style={s.cardTop}>
+        <View style={s.avatar}><Text style={s.avatarText}>{name[0]}</Text></View>
+        <View style={s.cardInfo}>
+          <Text style={s.cardName}>{name}</Text>
+          <Text style={s.cardType}>{type}</Text>
+          <Text style={s.cardDate}>{date}</Text>
+        </View>
+        <View style={s.pendingBadge}><Text style={s.pendingText}>Ожидает</Text></View>
+      </View>
+      <View style={s.cardActions}>
+        <View style={s.btnView}><Text style={s.btnViewText}>Просмотр</Text></View>
+        <View style={s.btnApprove}><Text style={s.btnApproveText}>{'✓'}</Text></View>
+        <View style={s.btnReject}><Text style={s.btnRejectText}>{'✕'}</Text></View>
+      </View>
+    </View>
+  );
+}
+
+function ApprovePopup() {
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <Text style={s.popupIcon}>{'✓'}</Text>
+        <Text style={s.popupTitle}>Одобрить профиль?</Text>
+        <Text style={s.popupText}>Профиль специалиста Ольга Смирнова будет опубликован и виден клиентам</Text>
+        <View style={s.popupActions}>
+          <View style={s.popupBtnApprove}><Text style={s.popupBtnText}>Одобрить</Text></View>
+          <View style={s.popupBtnCancel}><Text style={s.popupBtnCancelText}>Отмена</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function RejectPopup() {
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <Text style={s.popupIcon}>{'✕'}</Text>
+        <Text style={s.popupTitle}>Отклонить профиль?</Text>
+        <View style={s.field}>
+          <Text style={s.fieldLabel}>Причина отклонения</Text>
+          <TextInput
+            value="Неполная информация о квалификации"
+            editable={false}
+            multiline
+            style={s.textarea}
+          />
+        </View>
+        <View style={s.popupActions}>
+          <View style={s.popupBtnReject}><Text style={s.popupBtnText}>Отклонить</Text></View>
+          <View style={s.popupBtnCancel}><Text style={s.popupBtnCancelText}>Отмена</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const QUEUE_ITEMS = [
+  { name: 'Ольга Смирнова', type: 'Верификация специалиста', date: '08.04.2026' },
+  { name: 'Игорь Новиков', type: 'Верификация специалиста', date: '07.04.2026' },
+  { name: 'Марина Соколова', type: 'Верификация специалиста', date: '07.04.2026' },
+  { name: 'Дмитрий Козлов', type: 'Жалоба на специалиста', date: '06.04.2026' },
+  { name: 'Анна Морозова', type: 'Обновление профиля', date: '05.04.2026' },
+];
+
+export function AdminModerationStates() {
+  return (
+    <>
+      <StateSection title="QUEUE" maxWidth={800}>
+        <View style={s.container}>
+          <View style={s.header}>
+            <Text style={s.pageTitle}>Модерация</Text>
+            <View style={s.countBadge}><Text style={s.countText}>{QUEUE_ITEMS.length}</Text></View>
+          </View>
+          {QUEUE_ITEMS.map((item, i) => (
+            <ModerationCard key={i} name={item.name} type={item.type} date={item.date} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="APPROVE_POPUP" maxWidth={800}>
+        <View style={[s.container, { minHeight: 400 }]}>
+          <Text style={s.pageTitle}>Модерация</Text>
+          <ModerationCard name="Ольга Смирнова" type="Верификация специалиста" date="08.04.2026" />
+          <ApprovePopup />
+        </View>
+      </StateSection>
+      <StateSection title="REJECT_POPUP" maxWidth={800}>
+        <View style={[s.container, { minHeight: 400 }]}>
+          <Text style={s.pageTitle}>Модерация</Text>
+          <ModerationCard name="Ольга Смирнова" type="Верификация специалиста" date="08.04.2026" />
+          <RejectPopup />
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md, position: 'relative' },
+  header: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  countBadge: {
+    backgroundColor: '#D97706', minWidth: 24, height: 24, borderRadius: 12,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6,
+  },
+  countText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  cardTop: { flexDirection: 'row', alignItems: 'center', gap: Spacing.md },
+  avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  cardInfo: { flex: 1 },
+  cardName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  cardType: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  cardDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  pendingBadge: { backgroundColor: '#fef3cd', paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  pendingText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: '#D97706' },
+  cardActions: { flexDirection: 'row', gap: Spacing.sm },
+  btnView: {
+    flex: 1, height: 36, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  btnViewText: { fontSize: Typography.fontSize.sm, color: Colors.textPrimary },
+  btnApprove: {
+    width: 36, height: 36, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: '#e6f4ed',
+  },
+  btnApproveText: { fontSize: 16, color: Colors.statusSuccess },
+  btnReject: {
+    width: 36, height: 36, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: '#fde8e8',
+  },
+  btnRejectText: { fontSize: 16, color: Colors.statusError },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing['2xl'],
+    alignItems: 'center', gap: Spacing.md, width: '100%', maxWidth: 360,
+  },
+  popupIcon: { fontSize: 40, color: Colors.statusSuccess },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  field: { width: '100%', gap: Spacing.xs },
+  fieldLabel: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  textarea: {
+    minHeight: 64, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md,
+    padding: Spacing.md, fontSize: Typography.fontSize.sm, color: Colors.textPrimary, textAlignVertical: 'top',
+  },
+  popupActions: { width: '100%', gap: Spacing.sm },
+  popupBtnApprove: {
+    height: 44, backgroundColor: Colors.statusSuccess, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  popupBtnReject: {
+    height: 44, backgroundColor: Colors.statusError, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  popupBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  popupBtnCancel: {
+    height: 44, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  popupBtnCancelText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+});

--- a/components/proto/states/AdminPromotionsStates.tsx
+++ b/components/proto/states/AdminPromotionsStates.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+const PROMO_DATA = [
+  { id: '1', code: 'WELCOME30', discount: '30%', type: 'Скидка на тариф', usages: 45, maxUsages: 100, active: true, expiry: '30.06.2026' },
+  { id: '2', code: 'NEWYEAR', discount: '50%', type: 'Новогодняя акция', usages: 100, maxUsages: 100, active: false, expiry: '31.01.2026' },
+  { id: '3', code: 'FRIEND10', discount: '10%', type: 'Реферальная программа', usages: 23, maxUsages: 500, active: true, expiry: '31.12.2026' },
+  { id: '4', code: 'LAUNCH', discount: '100%', type: 'Бесплатный месяц', usages: 189, maxUsages: 200, active: true, expiry: '01.05.2026' },
+];
+
+function PromoCard({ code, discount, type, usages, maxUsages, active, expiry }: {
+  code: string; discount: string; type: string; usages: number; maxUsages: number; active: boolean; expiry: string;
+}) {
+  const pct = Math.round((usages / maxUsages) * 100);
+  return (
+    <View style={s.card}>
+      <View style={s.cardTop}>
+        <View>
+          <View style={s.codeRow}>
+            <Text style={s.code}>{code}</Text>
+            <View style={[s.statusDot, { backgroundColor: active ? Colors.statusSuccess : Colors.textMuted }]} />
+          </View>
+          <Text style={s.type}>{type}</Text>
+        </View>
+        <View style={s.discountBadge}>
+          <Text style={s.discountText}>{discount}</Text>
+        </View>
+      </View>
+      <View style={s.progressRow}>
+        <View style={s.progressBar}>
+          <View style={[s.progressFill, { width: `${pct}%` }]} />
+        </View>
+        <Text style={s.usageText}>{usages}/{maxUsages}</Text>
+      </View>
+      <View style={s.cardBottom}>
+        <Text style={s.expiry}>До {expiry}</Text>
+        <View style={s.cardActions}>
+          <View style={s.btnEdit}><Text style={s.btnEditText}>Изменить</Text></View>
+          <View style={s.btnToggle}>
+            <Text style={s.btnToggleText}>{active ? 'Деактивировать' : 'Активировать'}</Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function AdminPromotionsStates() {
+  return (
+    <StateSection title="LIST" maxWidth={800}>
+      <View style={s.container}>
+        <View style={s.header}>
+          <Text style={s.pageTitle}>Промо-коды</Text>
+          <View style={s.addBtn}><Text style={s.addBtnText}>+ Создать</Text></View>
+        </View>
+        <View style={s.statsRow}>
+          <View style={s.stat}>
+            <Text style={s.statValue}>4</Text>
+            <Text style={s.statLabel}>Всего</Text>
+          </View>
+          <View style={s.stat}>
+            <Text style={[s.statValue, { color: Colors.statusSuccess }]}>3</Text>
+            <Text style={s.statLabel}>Активные</Text>
+          </View>
+          <View style={s.stat}>
+            <Text style={s.statValue}>357</Text>
+            <Text style={s.statLabel}>Использований</Text>
+          </View>
+        </View>
+        {PROMO_DATA.map((p) => (
+          <PromoCard key={p.id} {...p} />
+        ))}
+      </View>
+    </StateSection>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md },
+  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  addBtn: {
+    backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+  },
+  addBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  statsRow: { flexDirection: 'row', gap: Spacing.sm },
+  stat: {
+    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    padding: Spacing.md, alignItems: 'center', borderWidth: 1, borderColor: Colors.border,
+  },
+  statValue: { fontSize: 20, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  cardTop: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  codeRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  code: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary, fontFamily: 'monospace' },
+  statusDot: { width: 8, height: 8, borderRadius: 4 },
+  type: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  discountBadge: {
+    backgroundColor: Colors.brandPrimary + '15', paddingHorizontal: Spacing.md, paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.full,
+  },
+  discountText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  progressRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  progressBar: { flex: 1, height: 6, backgroundColor: Colors.bgSecondary, borderRadius: 3 },
+  progressFill: { height: 6, backgroundColor: Colors.brandPrimary, borderRadius: 3 },
+  usageText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, minWidth: 50, textAlign: 'right' },
+  cardBottom: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  expiry: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  cardActions: { flexDirection: 'row', gap: Spacing.sm },
+  btnEdit: {
+    paddingHorizontal: Spacing.sm, paddingVertical: Spacing.xs, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  btnEditText: { fontSize: Typography.fontSize.xs, color: Colors.textPrimary },
+  btnToggle: {
+    paddingHorizontal: Spacing.sm, paddingVertical: Spacing.xs, borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgSecondary,
+  },
+  btnToggleText: { fontSize: Typography.fontSize.xs, color: Colors.brandPrimary },
+});

--- a/components/proto/states/AdminRequestsStates.tsx
+++ b/components/proto/states/AdminRequestsStates.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_REQUESTS } from '../../../constants/protoMockData';
+
+const STATUS_MAP: Record<string, { label: string; color: string }> = {
+  NEW: { label: 'Новая', color: Colors.brandPrimary },
+  ACTIVE: { label: 'Активная', color: Colors.statusSuccess },
+  IN_PROGRESS: { label: 'В работе', color: '#D97706' },
+  COMPLETED: { label: 'Завершена', color: Colors.textMuted },
+  CANCELLED: { label: 'Отменена', color: Colors.statusError },
+};
+
+function RequestRow({ title, client, status, date, city }: {
+  title: string; client: string; status: string; date: string; city: string;
+}) {
+  const st = STATUS_MAP[status] || STATUS_MAP.NEW;
+  return (
+    <View style={s.row}>
+      <View style={s.rowMain}>
+        <Text style={s.rowTitle} numberOfLines={1}>{title}</Text>
+        <View style={s.rowMeta}>
+          <Text style={s.rowClient}>{client}</Text>
+          <Text style={s.dot}>{'·'}</Text>
+          <Text style={s.rowCity}>{city}</Text>
+          <Text style={s.dot}>{'·'}</Text>
+          <Text style={s.rowDate}>{date}</Text>
+        </View>
+      </View>
+      <View style={[s.badge, { backgroundColor: st.color + '20' }]}>
+        <Text style={[s.badgeText, { color: st.color }]}>{st.label}</Text>
+      </View>
+    </View>
+  );
+}
+
+function ModerationPopup() {
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <Text style={s.popupTitle}>Модерация заявки</Text>
+        <View style={s.popupCard}>
+          <Text style={s.popupCardTitle}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+          <Text style={s.popupCardDesc}>Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета...</Text>
+          <View style={s.popupCardMeta}>
+            <Text style={s.popupMetaText}>Елена Васильева</Text>
+            <Text style={s.popupMetaText}>Москва</Text>
+            <Text style={s.popupMetaText}>3 000 — 5 000 ₽</Text>
+          </View>
+        </View>
+        <View style={s.popupActions}>
+          <View style={s.popupBtnApprove}><Text style={s.popupBtnText}>Одобрить</Text></View>
+          <View style={s.popupBtnReject}><Text style={s.popupBtnRejectText}>Отклонить</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function AdminRequestsStates() {
+  return (
+    <>
+      <StateSection title="LIST" maxWidth={800}>
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Заявки (3 456)</Text>
+          <View style={s.filters}>
+            <View style={[s.filterChip, s.filterActive]}><Text style={s.filterActiveText}>Все</Text></View>
+            <View style={s.filterChip}><Text style={s.filterText}>Новые</Text></View>
+            <View style={s.filterChip}><Text style={s.filterText}>Активные</Text></View>
+            <View style={s.filterChip}><Text style={s.filterText}>Завершены</Text></View>
+          </View>
+          {MOCK_REQUESTS.map((r) => (
+            <RequestRow key={r.id} title={r.title} client={r.clientName} status={r.status} date={r.createdAt} city={r.city} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="MODERATION_POPUP" maxWidth={800}>
+        <View style={[s.container, { minHeight: 450 }]}>
+          <Text style={s.pageTitle}>Заявки</Text>
+          {MOCK_REQUESTS.slice(0, 2).map((r) => (
+            <RequestRow key={r.id} title={r.title} client={r.clientName} status={r.status} date={r.createdAt} city={r.city} />
+          ))}
+          <ModerationPopup />
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md, position: 'relative' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  filters: { flexDirection: 'row', gap: Spacing.sm, flexWrap: 'wrap' },
+  filterChip: {
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.full,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  filterActive: { backgroundColor: Colors.brandPrimary, borderColor: Colors.brandPrimary },
+  filterText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  filterActiveText: { fontSize: Typography.fontSize.xs, color: '#FFF', fontWeight: Typography.fontWeight.semibold },
+  row: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, gap: Spacing.sm,
+  },
+  rowMain: { flex: 1 },
+  rowTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  rowMeta: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, marginTop: 2 },
+  rowClient: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  dot: { fontSize: Typography.fontSize.xs, color: Colors.border },
+  rowCity: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  rowDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  badge: { paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  badgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing.lg,
+    width: '100%', maxWidth: 400, gap: Spacing.md,
+  },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupCard: {
+    backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md, padding: Spacing.md, gap: Spacing.sm,
+  },
+  popupCardTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  popupCardDesc: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  popupCardMeta: { flexDirection: 'row', gap: Spacing.sm },
+  popupMetaText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  popupActions: { flexDirection: 'row', gap: Spacing.sm },
+  popupBtnApprove: {
+    flex: 1, height: 40, backgroundColor: Colors.statusSuccess, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  popupBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  popupBtnReject: {
+    flex: 1, height: 40, backgroundColor: '#fde8e8', borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  popupBtnRejectText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.statusError },
+});

--- a/components/proto/states/AdminReviewsStates.tsx
+++ b/components/proto/states/AdminReviewsStates.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_REVIEWS } from '../../../constants/protoMockData';
+
+function ReviewRow({ author, rating, text, date, specialistName }: {
+  author: string; rating: number; text: string; date: string; specialistName: string;
+}) {
+  const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating);
+  return (
+    <View style={s.reviewCard}>
+      <View style={s.reviewHeader}>
+        <View style={s.reviewLeft}>
+          <Text style={s.reviewAuthor}>{author}</Text>
+          <Text style={s.reviewStars}>{stars}</Text>
+        </View>
+        <View style={s.reviewRight}>
+          <Text style={s.reviewSpecialist}>О: {specialistName}</Text>
+          <Text style={s.reviewDate}>{date}</Text>
+        </View>
+      </View>
+      <Text style={s.reviewText}>{text}</Text>
+      <View style={s.reviewActions}>
+        <View style={s.btnView}><Text style={s.btnViewText}>Подробнее</Text></View>
+        <View style={s.btnDelete}><Text style={s.btnDeleteText}>Удалить</Text></View>
+      </View>
+    </View>
+  );
+}
+
+export function AdminReviewsStates() {
+  return (
+    <StateSection title="LIST" maxWidth={800}>
+      <View style={s.container}>
+        <View style={s.header}>
+          <Text style={s.pageTitle}>Отзывы</Text>
+          <Text style={s.subtitle}>Средний рейтинг: 4.7</Text>
+        </View>
+        <View style={s.stats}>
+          {[
+            { stars: 5, count: 28, pct: 56 },
+            { stars: 4, count: 12, pct: 24 },
+            { stars: 3, count: 6, pct: 12 },
+            { stars: 2, count: 2, pct: 4 },
+            { stars: 1, count: 2, pct: 4 },
+          ].map((row) => (
+            <View key={row.stars} style={s.statRow}>
+              <Text style={s.statStars}>{row.stars}{'★'}</Text>
+              <View style={s.statBar}><View style={[s.statBarFill, { width: `${row.pct}%` }]} /></View>
+              <Text style={s.statCount}>{row.count}</Text>
+            </View>
+          ))}
+        </View>
+        {MOCK_REVIEWS.map((r) => (
+          <ReviewRow key={r.id} author={r.author} rating={r.rating} text={r.text} date={r.date} specialistName={r.specialistName} />
+        ))}
+      </View>
+    </StateSection>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md },
+  header: { gap: Spacing.xs },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  stats: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  statRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  statStars: { width: 30, fontSize: Typography.fontSize.xs, color: Colors.textMuted, textAlign: 'right' },
+  statBar: { flex: 1, height: 8, backgroundColor: Colors.bgSecondary, borderRadius: 4 },
+  statBarFill: { height: 8, backgroundColor: Colors.brandPrimary, borderRadius: 4 },
+  statCount: { width: 24, fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  reviewCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  reviewHeader: { flexDirection: 'row', justifyContent: 'space-between' },
+  reviewLeft: { gap: 2 },
+  reviewRight: { alignItems: 'flex-end', gap: 2 },
+  reviewAuthor: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  reviewStars: { fontSize: 12, color: Colors.brandPrimary },
+  reviewSpecialist: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  reviewDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  reviewText: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  reviewActions: { flexDirection: 'row', gap: Spacing.sm },
+  btnView: {
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.xs, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  btnViewText: { fontSize: Typography.fontSize.xs, color: Colors.textPrimary },
+  btnDelete: {
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.xs, borderRadius: BorderRadius.md,
+    backgroundColor: '#fde8e8',
+  },
+  btnDeleteText: { fontSize: Typography.fontSize.xs, color: Colors.statusError },
+});

--- a/components/proto/states/AdminUsersStates.tsx
+++ b/components/proto/states/AdminUsersStates.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_USERS } from '../../../constants/protoMockData';
+
+function UserRow({ name, email, role, city }: { name: string; email: string; role: string; city: string }) {
+  return (
+    <View style={s.userRow}>
+      <View style={s.avatar}><Text style={s.avatarText}>{name.split(' ').map(n => n[0]).join('')}</Text></View>
+      <View style={s.userInfo}>
+        <Text style={s.userName}>{name}</Text>
+        <Text style={s.userEmail}>{email}</Text>
+      </View>
+      <View style={s.userMeta}>
+        <View style={[s.roleBadge, { backgroundColor: role === 'SPECIALIST' ? '#e6f4ed' : Colors.bgSecondary }]}>
+          <Text style={[s.roleText, { color: role === 'SPECIALIST' ? Colors.statusSuccess : Colors.brandPrimary }]}>
+            {role === 'SPECIALIST' ? 'Специалист' : 'Клиент'}
+          </Text>
+        </View>
+        <Text style={s.userCity}>{city}</Text>
+      </View>
+    </View>
+  );
+}
+
+function UserPopup() {
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <View style={s.popupHeader}>
+          <Text style={s.popupTitle}>Алексей Петров</Text>
+          <Text style={s.popupClose}>{'x'}</Text>
+        </View>
+        <View style={s.popupBody}>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Email</Text><Text style={s.popupValue}>apetrov@yandex.ru</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Роль</Text><Text style={s.popupValue}>Специалист</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Город</Text><Text style={s.popupValue}>Санкт-Петербург</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Регистрация</Text><Text style={s.popupValue}>10.01.2026</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Заявки</Text><Text style={s.popupValue}>215 завершено</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Рейтинг</Text><Text style={s.popupValue}>4.8 (42 отзыва)</Text></View>
+          <View style={s.popupRow}><Text style={s.popupLabel}>Статус</Text><Text style={[s.popupValue, { color: Colors.statusSuccess }]}>Активен</Text></View>
+        </View>
+        <View style={s.popupActions}>
+          <View style={s.popupBtn}><Text style={s.popupBtnText}>Заблокировать</Text></View>
+          <View style={s.popupBtnDanger}><Text style={s.popupBtnDangerText}>Удалить</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function AdminUsersStates() {
+  return (
+    <>
+      <StateSection title="LIST" maxWidth={800}>
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Пользователи (1 247)</Text>
+          <TextInput
+            value=""
+            editable={false}
+            placeholder="Поиск по имени, email..."
+            placeholderTextColor={Colors.textMuted}
+            style={s.searchInput}
+          />
+          <View style={s.filters}>
+            <View style={[s.filterChip, s.filterActive]}><Text style={s.filterActiveText}>Все</Text></View>
+            <View style={s.filterChip}><Text style={s.filterText}>Клиенты</Text></View>
+            <View style={s.filterChip}><Text style={s.filterText}>Специалисты</Text></View>
+          </View>
+          {MOCK_USERS.map((u) => (
+            <UserRow key={u.id} name={u.name} email={u.email} role={u.role} city={u.city} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="DETAIL_POPUP" maxWidth={800}>
+        <View style={[s.container, { minHeight: 500 }]}>
+          <Text style={s.pageTitle}>Пользователи</Text>
+          {MOCK_USERS.slice(0, 3).map((u) => (
+            <UserRow key={u.id} name={u.name} email={u.email} role={u.role} city={u.city} />
+          ))}
+          <UserPopup />
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md, position: 'relative' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  searchInput: {
+    height: 40, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.md, fontSize: Typography.fontSize.sm, color: Colors.textPrimary,
+  },
+  filters: { flexDirection: 'row', gap: Spacing.sm },
+  filterChip: {
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.full,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  filterActive: { backgroundColor: Colors.brandPrimary, borderColor: Colors.brandPrimary },
+  filterText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  filterActiveText: { fontSize: Typography.fontSize.xs, color: '#FFF', fontWeight: Typography.fontWeight.semibold },
+  userRow: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
+    paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary,
+  },
+  avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  userInfo: { flex: 1 },
+  userName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  userEmail: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  userMeta: { alignItems: 'flex-end', gap: 2 },
+  roleBadge: { paddingHorizontal: Spacing.sm, paddingVertical: 1, borderRadius: BorderRadius.full },
+  roleText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
+  userCity: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing.lg,
+    width: '100%', maxWidth: 380, gap: Spacing.md,
+  },
+  popupHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupClose: { fontSize: Typography.fontSize.lg, color: Colors.textMuted, padding: Spacing.xs },
+  popupBody: { gap: Spacing.sm },
+  popupRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  popupLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  popupValue: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  popupActions: { gap: Spacing.sm, marginTop: Spacing.sm },
+  popupBtn: {
+    height: 40, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  popupBtnText: { fontSize: Typography.fontSize.sm, color: Colors.textPrimary },
+  popupBtnDanger: {
+    height: 40, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: '#fde8e8',
+  },
+  popupBtnDangerText: { fontSize: Typography.fontSize.sm, color: Colors.statusError, fontWeight: Typography.fontWeight.medium },
+});

--- a/components/proto/states/AuthEmailStates.tsx
+++ b/components/proto/states/AuthEmailStates.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { View, Text, TextInput, ActivityIndicator, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function AuthScreen({ email, error, loading }: { email: string; error?: string; loading?: boolean }) {
+  return (
+    <View style={s.container}>
+      <View style={s.logoWrap}>
+        <Text style={s.logo}>Налоговик</Text>
+        <Text style={s.tagline}>Найдите налогового специалиста</Text>
+      </View>
+      <View style={s.form}>
+        <Text style={s.label}>Email</Text>
+        <TextInput
+          value={email}
+          editable={false}
+          placeholder="your@email.com"
+          placeholderTextColor={Colors.textMuted}
+          style={[s.input, error ? s.inputError : null]}
+        />
+        {error ? <Text style={s.error}>{error}</Text> : null}
+        <View style={[s.btn, loading ? s.btnDisabled : null]}>
+          {loading ? (
+            <ActivityIndicator size="small" color="#FFF" />
+          ) : (
+            <Text style={s.btnText}>Получить код</Text>
+          )}
+        </View>
+      </View>
+      <Text style={s.footer}>Нажимая кнопку, вы соглашаетесь с условиями использования</Text>
+    </View>
+  );
+}
+
+export function AuthEmailStates() {
+  return (
+    <>
+      <StateSection title="DEFAULT">
+        <AuthScreen email="" />
+      </StateSection>
+      <StateSection title="ERROR">
+        <AuthScreen email="invalid-email" error="Введите корректный email адрес" />
+      </StateSection>
+      <StateSection title="LOADING">
+        <AuthScreen email="elena@mail.ru" loading />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing['2xl'], alignItems: 'center' },
+  logoWrap: { alignItems: 'center', gap: Spacing.xs, marginTop: Spacing['3xl'] },
+  logo: { fontSize: 28, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  tagline: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
+  form: { width: '100%', maxWidth: 360, gap: Spacing.md },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  inputError: { borderColor: Colors.statusError },
+  error: { fontSize: Typography.fontSize.xs, color: Colors.statusError },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', marginTop: Spacing.sm,
+  },
+  btnDisabled: { opacity: 0.7 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  footer: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textAlign: 'center', marginTop: Spacing.lg },
+});

--- a/components/proto/states/AuthOtpStates.tsx
+++ b/components/proto/states/AuthOtpStates.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Text, TextInput, ActivityIndicator, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function OtpScreen({ code, error, resendTimer, loading }: { code: string; error?: string; resendTimer?: number; loading?: boolean }) {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Text style={s.title}>Введите код</Text>
+        <Text style={s.subtitle}>Код отправлен на elena@mail.ru</Text>
+      </View>
+      <View style={s.codeRow}>
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <View key={i} style={[s.codeBox, error ? s.codeBoxError : null, code[i] ? s.codeBoxFilled : null]}>
+            <Text style={[s.codeChar, error ? s.codeCharError : null]}>{code[i] || ''}</Text>
+          </View>
+        ))}
+      </View>
+      {error ? <Text style={s.error}>{error}</Text> : null}
+      <View style={[s.btn, loading ? s.btnDisabled : null]}>
+        {loading ? (
+          <ActivityIndicator size="small" color="#FFF" />
+        ) : (
+          <Text style={s.btnText}>Подтвердить</Text>
+        )}
+      </View>
+      {resendTimer !== undefined ? (
+        resendTimer > 0 ? (
+          <Text style={s.resend}>Отправить код повторно через {resendTimer} сек</Text>
+        ) : (
+          <Text style={s.resendActive}>Отправить код повторно</Text>
+        )
+      ) : (
+        <Text style={s.resendActive}>Отправить код повторно</Text>
+      )}
+    </View>
+  );
+}
+
+export function AuthOtpStates() {
+  return (
+    <>
+      <StateSection title="DEFAULT">
+        <OtpScreen code="" />
+      </StateSection>
+      <StateSection title="ERROR">
+        <OtpScreen code="123456" error="Неверный код. Попробуйте ещё раз." />
+      </StateSection>
+      <StateSection title="RESEND">
+        <OtpScreen code="" resendTimer={42} />
+      </StateSection>
+      <StateSection title="LOADING">
+        <OtpScreen code="000000" loading />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing['2xl'], alignItems: 'center' },
+  header: { alignItems: 'center', gap: Spacing.xs, marginTop: Spacing['2xl'] },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  codeRow: { flexDirection: 'row', gap: Spacing.sm, justifyContent: 'center' },
+  codeBox: {
+    width: 44, height: 52, borderWidth: 1.5, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.bgCard,
+  },
+  codeBoxError: { borderColor: Colors.statusError },
+  codeBoxFilled: { borderColor: Colors.brandPrimary },
+  codeChar: { fontSize: 22, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  codeCharError: { color: Colors.statusError },
+  error: { fontSize: Typography.fontSize.xs, color: Colors.statusError, textAlign: 'center' },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', width: '100%', maxWidth: 300,
+  },
+  btnDisabled: { opacity: 0.7 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  resend: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  resendActive: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium },
+});

--- a/components/proto/states/DashboardStates.tsx
+++ b/components/proto/states/DashboardStates.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+
+function StatCard({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <View style={s.statCard}>
+      <Text style={[s.statValue, { color }]}>{value}</Text>
+      <Text style={s.statLabel}>{label}</Text>
+    </View>
+  );
+}
+
+function RequestRow({ title, status, date, statusColor }: { title: string; status: string; date: string; statusColor: string }) {
+  return (
+    <View style={s.row}>
+      <View style={s.rowLeft}>
+        <Text style={s.rowTitle} numberOfLines={1}>{title}</Text>
+        <Text style={s.rowDate}>{date}</Text>
+      </View>
+      <View style={[s.badge, { backgroundColor: statusColor + '20' }]}>
+        <Text style={[s.badgeText, { color: statusColor }]}>{status}</Text>
+      </View>
+    </View>
+  );
+}
+
+function EmptyDashboard() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Text style={s.greeting}>Добрый день, Елена!</Text>
+        <Text style={s.subGreeting}>Добро пожаловать в Налоговик</Text>
+      </View>
+      <View style={s.emptyBlock}>
+        <Text style={s.emptyIcon}>{'📋'}</Text>
+        <Text style={s.emptyTitle}>Пока нет заявок</Text>
+        <Text style={s.emptyText}>Создайте первую заявку, чтобы найти налогового специалиста</Text>
+        <View style={s.btn}><Text style={s.btnText}>Создать заявку</Text></View>
+      </View>
+    </View>
+  );
+}
+
+function WithDataDashboard() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Text style={s.greeting}>Добрый день, Елена!</Text>
+      </View>
+      <View style={s.statsRow}>
+        <StatCard label="Активные" value="3" color={Colors.brandPrimary} />
+        <StatCard label="Отклики" value="8" color={Colors.statusSuccess} />
+        <StatCard label="Завершены" value="12" color={Colors.textMuted} />
+      </View>
+      <View style={s.section}>
+        <Text style={s.sectionTitle}>Активные заявки</Text>
+        <View style={s.list}>
+          <RequestRow title="Декларация 3-НДФЛ за 2025" status="Новая" date="08.04.2026" statusColor={Colors.brandPrimary} />
+          <RequestRow title="Регистрация ИП на УСН" status="3 отклика" date="07.04.2026" statusColor={Colors.statusSuccess} />
+          <RequestRow title="Оптимизация налогов ООО" status="В работе" date="05.04.2026" statusColor="#D97706" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function LoadingDashboard() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Text style={s.greeting}>Добрый день!</Text>
+      </View>
+      <View style={s.loadingWrap}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        <Text style={s.loadingText}>Загрузка данных...</Text>
+      </View>
+    </View>
+  );
+}
+
+export function DashboardStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <EmptyDashboard />
+      </StateSection>
+      <StateSection title="WITH_DATA">
+        <WithDataDashboard />
+      </StateSection>
+      <StateSection title="LOADING">
+        <LoadingDashboard />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  header: { gap: Spacing.xs, paddingTop: Spacing.sm },
+  greeting: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subGreeting: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  statsRow: { flexDirection: 'row', gap: Spacing.sm },
+  statCard: {
+    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    padding: Spacing.md, alignItems: 'center', borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
+  },
+  statValue: { fontSize: 24, fontWeight: Typography.fontWeight.bold },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  section: { gap: Spacing.sm },
+  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  list: { gap: Spacing.sm },
+  row: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    backgroundColor: Colors.bgCard, padding: Spacing.md, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  rowLeft: { flex: 1, marginRight: Spacing.sm },
+  rowTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  rowDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  badge: { paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  badgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
+  emptyBlock: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.md },
+  emptyIcon: { fontSize: 48 },
+  emptyTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  btn: {
+    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: Spacing['2xl'], marginTop: Spacing.sm,
+  },
+  btnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  loadingWrap: { alignItems: 'center', padding: Spacing['4xl'], gap: Spacing.md },
+  loadingText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+});

--- a/components/proto/states/LandingStates.tsx
+++ b/components/proto/states/LandingStates.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function Hero() {
+  return (
+    <View style={s.hero}>
+      <View style={s.heroNav}>
+        <Text style={s.logoText}>Налоговик</Text>
+        <View style={s.navLinks}>
+          <Text style={s.navLink}>Специалисты</Text>
+          <Text style={s.navLink}>Тарифы</Text>
+          <View style={s.loginBtn}><Text style={s.loginBtnText}>Войти</Text></View>
+        </View>
+      </View>
+      <View style={s.heroContent}>
+        <Text style={s.heroTitle}>Найдите налогового{'\n'}специалиста</Text>
+        <Text style={s.heroSubtitle}>
+          Сервис для поиска квалифицированных налоговых консультантов, бухгалтеров и юристов в вашем городе
+        </Text>
+        <View style={s.heroCta}>
+          <View style={s.heroBtn}><Text style={s.heroBtnText}>Найти специалиста</Text></View>
+          <View style={s.heroBtnSecondary}><Text style={s.heroBtnSecondaryText}>Я специалист</Text></View>
+        </View>
+        <View style={s.heroStats}>
+          <View style={s.heroStat}><Text style={s.heroStatValue}>189</Text><Text style={s.heroStatLabel}>Специалистов</Text></View>
+          <View style={s.heroStat}><Text style={s.heroStatValue}>3 400+</Text><Text style={s.heroStatLabel}>Заявок</Text></View>
+          <View style={s.heroStat}><Text style={s.heroStatValue}>4.7</Text><Text style={s.heroStatLabel}>Средняя оценка</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Features() {
+  const items = [
+    { icon: '🔍', title: 'Поиск', desc: 'Найдите специалиста по городу, услуге и бюджету' },
+    { icon: '✓', title: 'Верификация', desc: 'Все специалисты проверены через ФНС' },
+    { icon: '💬', title: 'Связь', desc: 'Безопасный чат прямо на платформе' },
+    { icon: '⭐', title: 'Отзывы', desc: 'Реальные отзывы от клиентов' },
+  ];
+  return (
+    <View style={s.features}>
+      <Text style={s.sectionTitle}>Почему Налоговик?</Text>
+      <View style={s.featureGrid}>
+        {items.map((item) => (
+          <View key={item.title} style={s.featureCard}>
+            <Text style={s.featureIcon}>{item.icon}</Text>
+            <Text style={s.featureTitle}>{item.title}</Text>
+            <Text style={s.featureDesc}>{item.desc}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function HowItWorks() {
+  const steps = [
+    { num: '1', title: 'Создайте заявку', desc: 'Опишите задачу, укажите город и бюджет' },
+    { num: '2', title: 'Получите отклики', desc: 'Специалисты предложат свои услуги' },
+    { num: '3', title: 'Выберите лучшего', desc: 'Сравните цены, отзывы и опыт' },
+  ];
+  return (
+    <View style={s.howItWorks}>
+      <Text style={s.sectionTitle}>Как это работает</Text>
+      <View style={s.stepsRow}>
+        {steps.map((step) => (
+          <View key={step.num} style={s.step}>
+            <View style={s.stepNum}><Text style={s.stepNumText}>{step.num}</Text></View>
+            <Text style={s.stepTitle}>{step.title}</Text>
+            <Text style={s.stepDesc}>{step.desc}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function PricingBlock() {
+  return (
+    <View style={s.pricingBlock}>
+      <Text style={s.sectionTitle}>Начните бесплатно</Text>
+      <Text style={s.pricingSubtitle}>Для клиентов — всегда бесплатно. Для специалистов — от 0 ₽/мес.</Text>
+      <View style={s.pricingCta}>
+        <View style={s.heroBtn}><Text style={s.heroBtnText}>Попробовать бесплатно</Text></View>
+      </View>
+    </View>
+  );
+}
+
+export function LandingStates() {
+  return (
+    <>
+      <StateSection title="HERO" maxWidth={800}>
+        <Hero />
+      </StateSection>
+      <StateSection title="FEATURES" maxWidth={800}>
+        <Features />
+      </StateSection>
+      <StateSection title="HOW_IT_WORKS" maxWidth={800}>
+        <HowItWorks />
+      </StateSection>
+      <StateSection title="PRICING_BLOCK" maxWidth={800}>
+        <PricingBlock />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  hero: { backgroundColor: '#0F2447' },
+  heroNav: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md,
+  },
+  logoText: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  navLinks: { flexDirection: 'row', alignItems: 'center', gap: Spacing.lg },
+  navLink: { fontSize: Typography.fontSize.sm, color: 'rgba(255,255,255,0.7)' },
+  loginBtn: {
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.sm, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: 'rgba(255,255,255,0.3)',
+  },
+  loginBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: '#FFF' },
+  heroContent: { padding: Spacing['2xl'], paddingTop: Spacing['3xl'], paddingBottom: Spacing['4xl'], gap: Spacing.lg },
+  heroTitle: { fontSize: 28, fontWeight: Typography.fontWeight.bold, color: '#FFF', lineHeight: 36 },
+  heroSubtitle: { fontSize: Typography.fontSize.base, color: 'rgba(255,255,255,0.75)', lineHeight: 24 },
+  heroCta: { flexDirection: 'row', gap: Spacing.md, marginTop: Spacing.sm },
+  heroBtn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: Spacing['2xl'],
+  },
+  heroBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  heroBtnSecondary: {
+    height: 48, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    paddingHorizontal: Spacing['2xl'], borderWidth: 1, borderColor: 'rgba(255,255,255,0.3)',
+  },
+  heroBtnSecondaryText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.medium, color: '#FFF' },
+  heroStats: { flexDirection: 'row', gap: Spacing.lg, marginTop: Spacing.lg },
+  heroStat: { alignItems: 'center' },
+  heroStatValue: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  heroStatLabel: { fontSize: Typography.fontSize.xs, color: 'rgba(255,255,255,0.6)', marginTop: 2 },
+  features: { padding: Spacing['2xl'], gap: Spacing.lg, backgroundColor: Colors.bgPrimary },
+  sectionTitle: { fontSize: 22, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary, textAlign: 'center' },
+  featureGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.md },
+  featureCard: {
+    width: '47%', backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  featureIcon: { fontSize: 28 },
+  featureTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  featureDesc: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, lineHeight: 20 },
+  howItWorks: { padding: Spacing['2xl'], gap: Spacing.lg, backgroundColor: Colors.bgSecondary },
+  stepsRow: { gap: Spacing.lg },
+  step: { flexDirection: 'column', alignItems: 'center', gap: Spacing.sm },
+  stepNum: {
+    width: 36, height: 36, borderRadius: 18, backgroundColor: Colors.brandPrimary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  stepNumText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  stepTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  stepDesc: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  pricingBlock: {
+    padding: Spacing['2xl'], gap: Spacing.md, backgroundColor: Colors.bgPrimary, alignItems: 'center',
+  },
+  pricingSubtitle: { fontSize: Typography.fontSize.base, color: Colors.textMuted, textAlign: 'center' },
+  pricingCta: { marginTop: Spacing.sm },
+});

--- a/components/proto/states/MessageThreadStates.tsx
+++ b/components/proto/states/MessageThreadStates.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_MESSAGES } from '../../../constants/protoMockData';
+
+function ChatHeader() {
+  return (
+    <View style={s.chatHeader}>
+      <Text style={s.backArrow}>{'<'}</Text>
+      <View style={s.chatAvatar}><Text style={s.chatAvatarText}>А</Text></View>
+      <View>
+        <Text style={s.chatName}>Алексей Петров</Text>
+        <Text style={s.chatStatus}>Онлайн</Text>
+      </View>
+    </View>
+  );
+}
+
+function MessageBubble({ text, fromMe, time }: { text: string; fromMe: boolean; time: string }) {
+  return (
+    <View style={[s.bubbleWrap, fromMe ? s.bubbleRight : s.bubbleLeft]}>
+      <View style={[s.bubble, fromMe ? s.bubbleMine : s.bubbleTheirs]}>
+        <Text style={[s.bubbleText, fromMe ? s.bubbleTextMine : null]}>{text}</Text>
+        <Text style={[s.bubbleTime, fromMe ? s.bubbleTimeMine : null]}>{time}</Text>
+      </View>
+    </View>
+  );
+}
+
+function InputBar({ typing }: { typing?: boolean }) {
+  return (
+    <View style={s.inputBar}>
+      {typing && <Text style={s.typingIndicator}>Алексей печатает...</Text>}
+      <View style={s.inputRow}>
+        <TextInput
+          value=""
+          editable={false}
+          placeholder="Введите сообщение..."
+          placeholderTextColor={Colors.textMuted}
+          style={s.chatInput}
+        />
+        <View style={s.sendBtn}><Text style={s.sendText}>{'>'}</Text></View>
+      </View>
+    </View>
+  );
+}
+
+export function MessageThreadStates() {
+  return (
+    <>
+      <StateSection title="CHAT">
+        <View style={s.container}>
+          <ChatHeader />
+          <View style={s.messages}>
+            {MOCK_MESSAGES.map((m) => (
+              <MessageBubble key={m.id} text={m.text} fromMe={m.fromMe} time={m.time} />
+            ))}
+          </View>
+          <InputBar />
+        </View>
+      </StateSection>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <ChatHeader />
+          <View style={s.emptyChat}>
+            <Text style={s.emptyChatText}>Начните диалог с Алексеем Петровым</Text>
+          </View>
+          <InputBar />
+        </View>
+      </StateSection>
+      <StateSection title="TYPING_INDICATOR">
+        <View style={s.container}>
+          <ChatHeader />
+          <View style={s.messages}>
+            {MOCK_MESSAGES.slice(0, 3).map((m) => (
+              <MessageBubble key={m.id} text={m.text} fromMe={m.fromMe} time={m.time} />
+            ))}
+          </View>
+          <InputBar typing />
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1 },
+  chatHeader: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md,
+    borderBottomWidth: 1, borderBottomColor: Colors.border, backgroundColor: Colors.bgCard,
+  },
+  backArrow: { fontSize: Typography.fontSize.lg, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.bold },
+  chatAvatar: { width: 36, height: 36, borderRadius: 18, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  chatAvatarText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  chatName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  chatStatus: { fontSize: Typography.fontSize.xs, color: Colors.statusSuccess },
+  messages: { padding: Spacing.md, gap: Spacing.sm },
+  bubbleWrap: { flexDirection: 'row' },
+  bubbleRight: { justifyContent: 'flex-end' },
+  bubbleLeft: { justifyContent: 'flex-start' },
+  bubble: { maxWidth: '80%', padding: Spacing.md, borderRadius: BorderRadius.lg },
+  bubbleMine: { backgroundColor: Colors.brandPrimary, borderBottomRightRadius: BorderRadius.sm },
+  bubbleTheirs: { backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderBottomLeftRadius: BorderRadius.sm },
+  bubbleText: { fontSize: Typography.fontSize.sm, color: Colors.textPrimary, lineHeight: 20 },
+  bubbleTextMine: { color: '#FFF' },
+  bubbleTime: { fontSize: 10, color: Colors.textMuted, marginTop: 4, alignSelf: 'flex-end' },
+  bubbleTimeMine: { color: 'rgba(255,255,255,0.7)' },
+  inputBar: { padding: Spacing.md, borderTopWidth: 1, borderTopColor: Colors.border, backgroundColor: Colors.bgCard },
+  inputRow: { flexDirection: 'row', gap: Spacing.sm, alignItems: 'center' },
+  chatInput: {
+    flex: 1, height: 40, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.full,
+    paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.sm, color: Colors.textPrimary,
+  },
+  sendBtn: {
+    width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.brandPrimary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  sendText: { fontSize: Typography.fontSize.md, color: '#FFF', fontWeight: Typography.fontWeight.bold },
+  typingIndicator: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginBottom: Spacing.xs, fontStyle: 'italic' },
+  emptyChat: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing['3xl'] },
+  emptyChatText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/components/proto/states/MessagesStates.tsx
+++ b/components/proto/states/MessagesStates.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_THREADS } from '../../../constants/protoMockData';
+
+function ThreadItem({ name, lastMessage, time, unread }: {
+  name: string; lastMessage: string; time: string; unread: number;
+}) {
+  return (
+    <View style={s.thread}>
+      <View style={s.avatar}><Text style={s.avatarText}>{name[0]}</Text></View>
+      <View style={s.threadBody}>
+        <View style={s.threadTop}>
+          <Text style={[s.threadName, unread > 0 ? s.threadNameBold : null]}>{name}</Text>
+          <Text style={s.threadTime}>{time}</Text>
+        </View>
+        <View style={s.threadBottom}>
+          <Text style={[s.threadMsg, unread > 0 ? s.threadMsgBold : null]} numberOfLines={1}>{lastMessage}</Text>
+          {unread > 0 && (
+            <View style={s.unreadBadge}><Text style={s.unreadText}>{unread}</Text></View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function MessagesStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Сообщения</Text>
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Нет сообщений</Text>
+            <Text style={s.emptyText}>Сообщения появятся после принятия отклика специалиста</Text>
+          </View>
+        </View>
+      </StateSection>
+      <StateSection title="THREAD_LIST">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Сообщения</Text>
+          {MOCK_THREADS.map((t) => (
+            <ThreadItem key={t.id} name={t.name} lastMessage={t.lastMessage} time={t.time} unread={t.unread} />
+          ))}
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.sm },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary, marginBottom: Spacing.sm },
+  thread: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
+    paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary,
+  },
+  avatar: { width: 44, height: 44, borderRadius: 22, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  threadBody: { flex: 1, gap: 2 },
+  threadTop: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  threadName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  threadNameBold: { fontWeight: Typography.fontWeight.bold },
+  threadTime: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  threadBottom: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  threadMsg: { flex: 1, fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  threadMsgBold: { color: Colors.textPrimary, fontWeight: Typography.fontWeight.medium },
+  unreadBadge: {
+    backgroundColor: Colors.brandPrimary, minWidth: 20, height: 20, borderRadius: 10,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5,
+  },
+  unreadText: { fontSize: 11, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  emptyWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/components/proto/states/MyRequestDetailStates.tsx
+++ b/components/proto/states/MyRequestDetailStates.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_RESPONSES } from '../../../constants/protoMockData';
+
+function ResponseCard({ name, city, rating, reviews, price, message }: {
+  name: string; city: string; rating: number; reviews: number; price: string; message: string;
+}) {
+  const stars = '★'.repeat(Math.round(rating)) + '☆'.repeat(5 - Math.round(rating));
+  return (
+    <View style={s.respCard}>
+      <View style={s.respHeader}>
+        <View style={s.respAvatar}><Text style={s.respAvatarText}>{name[0]}</Text></View>
+        <View style={s.respInfo}>
+          <Text style={s.respName}>{name}</Text>
+          <Text style={s.respCity}>{city}</Text>
+        </View>
+        <Text style={s.respPrice}>{price}</Text>
+      </View>
+      <View style={s.respRating}>
+        <Text style={s.stars}>{stars}</Text>
+        <Text style={s.ratingText}>{rating} ({reviews})</Text>
+      </View>
+      <Text style={s.respMessage} numberOfLines={2}>{message}</Text>
+      <View style={s.respActions}>
+        <View style={s.respBtnPrimary}><Text style={s.respBtnPrimaryText}>Принять</Text></View>
+        <View style={s.respBtnSecondary}><Text style={s.respBtnSecondaryText}>Написать</Text></View>
+      </View>
+    </View>
+  );
+}
+
+function DetailScreen({ mode }: { mode: 'responses' | 'no_responses' | 'closed' }) {
+  return (
+    <View style={s.container}>
+      <View style={s.detailCard}>
+        <View style={s.detailHeader}>
+          <Text style={s.detailTitle}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+          <View style={[s.badge, { backgroundColor: mode === 'closed' ? Colors.textMuted + '20' : Colors.brandPrimary + '20' }]}>
+            <Text style={[s.badgeText, { color: mode === 'closed' ? Colors.textMuted : Colors.brandPrimary }]}>
+              {mode === 'closed' ? 'Закрыта' : 'Активная'}
+            </Text>
+          </View>
+        </View>
+        <Text style={s.detailDesc}>
+          Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры.
+        </Text>
+        <View style={s.detailMeta}>
+          <View style={s.metaItem}><Text style={s.metaLabel}>Город</Text><Text style={s.metaValue}>Москва</Text></View>
+          <View style={s.metaItem}><Text style={s.metaLabel}>Услуга</Text><Text style={s.metaValue}>Декларация 3-НДФЛ</Text></View>
+          <View style={s.metaItem}><Text style={s.metaLabel}>Бюджет</Text><Text style={s.metaValue}>3 000 — 5 000 ₽</Text></View>
+          <View style={s.metaItem}><Text style={s.metaLabel}>Дата</Text><Text style={s.metaValue}>08.04.2026</Text></View>
+        </View>
+      </View>
+
+      <Text style={s.sectionTitle}>
+        Отклики {mode === 'responses' ? `(${MOCK_RESPONSES.length})` : '(0)'}
+      </Text>
+
+      {mode === 'responses' ? (
+        MOCK_RESPONSES.map((r) => (
+          <ResponseCard
+            key={r.id} name={r.specialistName} city={r.specialistCity}
+            rating={r.rating} reviews={r.reviewCount} price={r.price} message={r.message}
+          />
+        ))
+      ) : mode === 'no_responses' ? (
+        <View style={s.emptyWrap}>
+          <Text style={s.emptyTitle}>Пока нет откликов</Text>
+          <Text style={s.emptyText}>Специалисты увидят вашу заявку и смогут предложить свои услуги</Text>
+        </View>
+      ) : (
+        <View style={s.emptyWrap}>
+          <Text style={s.emptyTitle}>Заявка закрыта</Text>
+          <Text style={s.emptyText}>Эта заявка была завершена или отменена</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+export function MyRequestDetailStates() {
+  return (
+    <>
+      <StateSection title="WITH_RESPONSES">
+        <DetailScreen mode="responses" />
+      </StateSection>
+      <StateSection title="NO_RESPONSES">
+        <DetailScreen mode="no_responses" />
+      </StateSection>
+      <StateSection title="CLOSED">
+        <DetailScreen mode="closed" />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  detailCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  detailHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm },
+  detailTitle: { flex: 1, fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  badge: { paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  badgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
+  detailDesc: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  detailMeta: { gap: Spacing.sm },
+  metaItem: { flexDirection: 'row', justifyContent: 'space-between' },
+  metaLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  metaValue: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  respCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  respHeader: { flexDirection: 'row', alignItems: 'center', gap: Spacing.md },
+  respAvatar: {
+    width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSecondary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  respAvatarText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  respInfo: { flex: 1 },
+  respName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  respCity: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  respPrice: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  respRating: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
+  stars: { fontSize: 14, color: Colors.brandPrimary },
+  ratingText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  respMessage: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  respActions: { flexDirection: 'row', gap: Spacing.sm, marginTop: Spacing.xs },
+  respBtnPrimary: {
+    flex: 1, height: 38, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  respBtnPrimaryText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  respBtnSecondary: {
+    flex: 1, height: 38, backgroundColor: 'transparent', borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border,
+  },
+  respBtnSecondaryText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  emptyWrap: { alignItems: 'center', padding: Spacing['2xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/components/proto/states/MyRequestsNewStates.tsx
+++ b/components/proto/states/MyRequestsNewStates.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { View, Text, TextInput, ActivityIndicator, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function FormScreen({ errors, loading, success }: { errors?: Record<string, string>; loading?: boolean; success?: boolean }) {
+  return (
+    <View style={s.container}>
+      {success && (
+        <View style={s.overlay}>
+          <View style={s.popup}>
+            <Text style={s.popupIcon}>{'✓'}</Text>
+            <Text style={s.popupTitle}>Заявка создана!</Text>
+            <Text style={s.popupText}>Специалисты получат уведомление и смогут откликнуться</Text>
+            <View style={s.popupBtn}><Text style={s.popupBtnText}>К моим заявкам</Text></View>
+          </View>
+        </View>
+      )}
+      <Text style={s.pageTitle}>Новая заявка</Text>
+      <View style={s.form}>
+        <View style={s.field}>
+          <Text style={s.label}>Заголовок *</Text>
+          <TextInput
+            value={errors ? 'Де' : ''}
+            editable={false}
+            placeholder="Кратко опишите задачу"
+            placeholderTextColor={Colors.textMuted}
+            style={[s.input, errors?.title ? s.inputError : null]}
+          />
+          {errors?.title && <Text style={s.error}>{errors.title}</Text>}
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Описание *</Text>
+          <TextInput
+            value=""
+            editable={false}
+            placeholder="Подробно опишите, что нужно сделать..."
+            placeholderTextColor={Colors.textMuted}
+            multiline
+            style={[s.textarea, errors?.description ? s.inputError : null]}
+          />
+          {errors?.description && <Text style={s.error}>{errors.description}</Text>}
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Город *</Text>
+          <View style={[s.select, errors?.city ? s.inputError : null]}>
+            <Text style={s.selectText}>Выберите город</Text>
+            <Text style={s.selectArrow}>{'>'}</Text>
+          </View>
+          {errors?.city && <Text style={s.error}>{errors.city}</Text>}
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Услуга *</Text>
+          <View style={s.select}>
+            <Text style={s.selectText}>Выберите услугу</Text>
+            <Text style={s.selectArrow}>{'>'}</Text>
+          </View>
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Бюджет</Text>
+          <TextInput
+            value=""
+            editable={false}
+            placeholder="Например: 5 000 — 10 000 ₽"
+            placeholderTextColor={Colors.textMuted}
+            style={s.input}
+          />
+        </View>
+      </View>
+      <View style={[s.btn, loading ? s.btnLoading : null]}>
+        {loading ? (
+          <ActivityIndicator size="small" color="#FFF" />
+        ) : (
+          <Text style={s.btnText}>Создать заявку</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+export function MyRequestsNewStates() {
+  return (
+    <>
+      <StateSection title="FORM">
+        <FormScreen />
+      </StateSection>
+      <StateSection title="VALIDATION_ERROR">
+        <FormScreen errors={{
+          title: 'Заголовок должен содержать минимум 5 символов',
+          description: 'Обязательное поле',
+          city: 'Выберите город',
+        }} />
+      </StateSection>
+      <StateSection title="LOADING">
+        <FormScreen loading />
+      </StateSection>
+      <StateSection title="SUCCESS_POPUP">
+        <FormScreen success />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg, position: 'relative' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  form: { gap: Spacing.lg },
+  field: { gap: Spacing.xs },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  textarea: {
+    minHeight: 96, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, padding: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+    textAlignVertical: 'top',
+  },
+  inputError: { borderColor: Colors.statusError },
+  error: { fontSize: Typography.fontSize.xs, color: Colors.statusError },
+  select: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, flexDirection: 'row',
+    alignItems: 'center', justifyContent: 'space-between',
+  },
+  selectText: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
+  selectArrow: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnLoading: { opacity: 0.7 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing['2xl'],
+    alignItems: 'center', gap: Spacing.md, width: '100%', maxWidth: 340,
+  },
+  popupIcon: { fontSize: 48, color: Colors.statusSuccess },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  popupBtn: {
+    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: Spacing['2xl'], marginTop: Spacing.sm,
+  },
+  popupBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/MyRequestsStates.tsx
+++ b/components/proto/states/MyRequestsStates.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_REQUESTS } from '../../../constants/protoMockData';
+
+const STATUS_MAP: Record<string, { label: string; color: string }> = {
+  NEW: { label: 'Новая', color: Colors.brandPrimary },
+  ACTIVE: { label: 'Активная', color: Colors.statusSuccess },
+  IN_PROGRESS: { label: 'В работе', color: '#D97706' },
+  COMPLETED: { label: 'Завершена', color: Colors.textMuted },
+  CANCELLED: { label: 'Отменена', color: Colors.statusError },
+};
+
+function RequestCard({ title, service, city, status, date, responses }: {
+  title: string; service: string; city: string; status: string; date: string; responses: number;
+}) {
+  const st = STATUS_MAP[status] || STATUS_MAP.NEW;
+  return (
+    <View style={s.card}>
+      <View style={s.cardHeader}>
+        <Text style={s.cardTitle} numberOfLines={2}>{title}</Text>
+        <View style={[s.badge, { backgroundColor: st.color + '20' }]}>
+          <Text style={[s.badgeText, { color: st.color }]}>{st.label}</Text>
+        </View>
+      </View>
+      <View style={s.meta}>
+        <Text style={s.metaItem}>{service}</Text>
+        <Text style={s.metaDot}>{'·'}</Text>
+        <Text style={s.metaItem}>{city}</Text>
+      </View>
+      <View style={s.cardFooter}>
+        <Text style={s.date}>{date}</Text>
+        {responses > 0 && <Text style={s.responses}>{responses} откликов</Text>}
+      </View>
+    </View>
+  );
+}
+
+export function MyRequestsStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Мои заявки</Text>
+            <View style={s.addBtn}><Text style={s.addBtnText}>+ Новая</Text></View>
+          </View>
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Нет заявок</Text>
+            <Text style={s.emptyText}>Создайте заявку, чтобы получить предложения от специалистов</Text>
+          </View>
+        </View>
+      </StateSection>
+      <StateSection title="LIST">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Мои заявки</Text>
+            <View style={s.addBtn}><Text style={s.addBtnText}>+ Новая</Text></View>
+          </View>
+          {MOCK_REQUESTS.map((r) => (
+            <RequestCard
+              key={r.id} title={r.title} service={r.service}
+              city={r.city} status={r.status} date={r.createdAt} responses={r.responseCount}
+            />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="LOADING">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Мои заявки</Text>
+          </View>
+          <View style={s.loadingWrap}>
+            <ActivityIndicator size="large" color={Colors.brandPrimary} />
+          </View>
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md },
+  topBar: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  addBtn: {
+    backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+  },
+  addBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm },
+  cardTitle: { flex: 1, fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  badge: { paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  badgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
+  meta: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
+  metaItem: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  metaDot: { fontSize: Typography.fontSize.xs, color: Colors.border },
+  cardFooter: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  date: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  responses: { fontSize: Typography.fontSize.xs, color: Colors.statusSuccess, fontWeight: Typography.fontWeight.medium },
+  emptyWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  loadingWrap: { alignItems: 'center', padding: Spacing['4xl'] },
+});

--- a/components/proto/states/OnboardingCitiesStates.tsx
+++ b/components/proto/states/OnboardingCitiesStates.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function ProgressBar() {
+  return (
+    <View style={s.progress}><View style={[s.progressBar, { width: '40%' }]} /></View>
+  );
+}
+
+function CityChip({ name, removable }: { name: string; removable?: boolean }) {
+  return (
+    <View style={s.chip}>
+      <Text style={s.chipText}>{name}</Text>
+      {removable && <Text style={s.chipRemove}>x</Text>}
+    </View>
+  );
+}
+
+function SearchResult({ name }: { name: string }) {
+  return (
+    <TouchableOpacity style={s.searchItem}>
+      <Text style={s.searchText}>{name}</Text>
+      <Text style={s.searchAdd}>+</Text>
+    </TouchableOpacity>
+  );
+}
+
+function Screen({ search, selectedCities, showResults }: { search: string; selectedCities: string[]; showResults?: boolean }) {
+  const results = ['Москва', 'Московская область', 'Мытищи'];
+  return (
+    <View style={s.container}>
+      <ProgressBar />
+      <Text style={s.step}>Шаг 2 из 5</Text>
+      <Text style={s.title}>В каких городах вы работаете?</Text>
+      <Text style={s.subtitle}>Выберите города, где вы можете оказывать услуги</Text>
+      {selectedCities.length > 0 && (
+        <View style={s.chipRow}>
+          {selectedCities.map((c) => <CityChip key={c} name={c} removable />)}
+        </View>
+      )}
+      <TextInput
+        value={search}
+        editable={false}
+        placeholder="Введите название города..."
+        placeholderTextColor={Colors.textMuted}
+        style={s.input}
+      />
+      {showResults && (
+        <View style={s.results}>
+          {results.map((r) => <SearchResult key={r} name={r} />)}
+        </View>
+      )}
+      <View style={[s.btn, selectedCities.length === 0 ? s.btnDisabled : null]}>
+        <Text style={s.btnText}>Продолжить</Text>
+      </View>
+    </View>
+  );
+}
+
+export function OnboardingCitiesStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <Screen search="" selectedCities={[]} />
+      </StateSection>
+      <StateSection title="SEARCH">
+        <Screen search="Мос" selectedCities={[]} showResults />
+      </StateSection>
+      <StateSection title="SELECTED">
+        <Screen search="" selectedCities={['Москва', 'Санкт-Петербург', 'Казань']} />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing.lg },
+  progress: { height: 4, backgroundColor: Colors.bgSecondary, borderRadius: 2 },
+  progressBar: { height: 4, backgroundColor: Colors.brandPrimary, borderRadius: 2 },
+  step: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm },
+  chip: {
+    flexDirection: 'row', alignItems: 'center', backgroundColor: Colors.bgSecondary,
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.xs, borderRadius: BorderRadius.full, gap: Spacing.xs,
+  },
+  chipText: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium },
+  chipRemove: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, marginLeft: 2 },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  results: { borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.md, backgroundColor: Colors.bgCard, overflow: 'hidden' },
+  searchItem: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary,
+  },
+  searchText: { fontSize: Typography.fontSize.base, color: Colors.textPrimary },
+  searchAdd: { fontSize: Typography.fontSize.lg, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.bold },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnDisabled: { opacity: 0.45 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/OnboardingFnsStates.tsx
+++ b/components/proto/states/OnboardingFnsStates.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function Screen({ inn, status }: { inn: string; status: 'default' | 'verified' | 'error' }) {
+  return (
+    <View style={s.container}>
+      <View style={s.progress}><View style={[s.progressBar, { width: '80%' }]} /></View>
+      <Text style={s.step}>Шаг 4 из 5</Text>
+      <Text style={s.title}>Привязка к ФНС</Text>
+      <Text style={s.subtitle}>Введите ИНН для верификации в системе</Text>
+      <View style={s.form}>
+        <Text style={s.label}>ИНН</Text>
+        <View style={s.inputRow}>
+          <TextInput
+            value={inn}
+            editable={false}
+            placeholder="123456789012"
+            placeholderTextColor={Colors.textMuted}
+            style={[
+              s.input,
+              status === 'verified' ? s.inputSuccess : null,
+              status === 'error' ? s.inputError : null,
+            ]}
+          />
+          {status === 'verified' && (
+            <View style={s.statusIcon}>
+              <Text style={s.checkIcon}>{'✓'}</Text>
+            </View>
+          )}
+        </View>
+        {status === 'verified' && (
+          <View style={s.verifiedBox}>
+            <Text style={s.verifiedIcon}>{'✓'}</Text>
+            <View style={s.verifiedInfo}>
+              <Text style={s.verifiedName}>ИП Петров Алексей Сергеевич</Text>
+              <Text style={s.verifiedDetails}>ИФНС №46 по г. Москве | УСН 6%</Text>
+            </View>
+          </View>
+        )}
+        {status === 'error' && (
+          <Text style={s.error}>ИНН не найден в реестре ФНС. Проверьте правильность ввода.</Text>
+        )}
+      </View>
+      <View style={[s.btn, status !== 'verified' ? s.btnDisabled : null]}>
+        <Text style={s.btnText}>Продолжить</Text>
+      </View>
+      <Text style={s.skip}>Пропустить этот шаг</Text>
+    </View>
+  );
+}
+
+export function OnboardingFnsStates() {
+  return (
+    <>
+      <StateSection title="DEFAULT">
+        <Screen inn="" status="default" />
+      </StateSection>
+      <StateSection title="VERIFIED">
+        <Screen inn="771234567890" status="verified" />
+      </StateSection>
+      <StateSection title="ERROR">
+        <Screen inn="000000000000" status="error" />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing.lg },
+  progress: { height: 4, backgroundColor: Colors.bgSecondary, borderRadius: 2 },
+  progressBar: { height: 4, backgroundColor: Colors.brandPrimary, borderRadius: 2 },
+  step: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  form: { gap: Spacing.sm },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  inputRow: { position: 'relative' },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  inputSuccess: { borderColor: Colors.statusSuccess },
+  inputError: { borderColor: Colors.statusError },
+  statusIcon: { position: 'absolute', right: 14, top: 12 },
+  checkIcon: { fontSize: 20, color: Colors.statusSuccess },
+  verifiedBox: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
+    backgroundColor: '#e6f4ed', padding: Spacing.md, borderRadius: BorderRadius.md,
+  },
+  verifiedIcon: { fontSize: 20, color: Colors.statusSuccess },
+  verifiedInfo: { flex: 1, gap: 2 },
+  verifiedName: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  verifiedDetails: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  error: { fontSize: Typography.fontSize.xs, color: Colors.statusError },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnDisabled: { opacity: 0.45 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  skip: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, textAlign: 'center' },
+});

--- a/components/proto/states/OnboardingProfileStates.tsx
+++ b/components/proto/states/OnboardingProfileStates.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function Screen({ filled }: { filled: boolean }) {
+  return (
+    <View style={s.container}>
+      <View style={s.progress}><View style={[s.progressBar, { width: '100%' }]} /></View>
+      <Text style={s.step}>Шаг 5 из 5</Text>
+      <Text style={s.title}>Расскажите о себе</Text>
+      <Text style={s.subtitle}>Информация поможет клиентам выбрать вас</Text>
+      <View style={s.form}>
+        <View style={s.avatarRow}>
+          <View style={s.avatar}>
+            <Text style={s.avatarText}>{filled ? 'АП' : '?'}</Text>
+          </View>
+          <Text style={s.avatarHint}>Загрузить фото</Text>
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>О себе</Text>
+          <TextInput
+            value={filled ? 'Налоговый консультант с опытом работы 8 лет. Специализация — НДФЛ, имущественные вычеты, регистрация ИП.' : ''}
+            editable={false}
+            placeholder="Расскажите о вашем опыте и специализации..."
+            placeholderTextColor={Colors.textMuted}
+            multiline
+            style={s.textarea}
+          />
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Стоимость консультации</Text>
+          <TextInput
+            value={filled ? '2 000 ₽' : ''}
+            editable={false}
+            placeholder="Например: 2 000 ₽"
+            placeholderTextColor={Colors.textMuted}
+            style={s.input}
+          />
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Опыт работы</Text>
+          <TextInput
+            value={filled ? '8 лет' : ''}
+            editable={false}
+            placeholder="Например: 5 лет"
+            placeholderTextColor={Colors.textMuted}
+            style={s.input}
+          />
+        </View>
+      </View>
+      <View style={s.btn}>
+        <Text style={s.btnText}>Завершить регистрацию</Text>
+      </View>
+    </View>
+  );
+}
+
+export function OnboardingProfileStates() {
+  return (
+    <>
+      <StateSection title="DEFAULT">
+        <Screen filled={false} />
+      </StateSection>
+      <StateSection title="FILLED">
+        <Screen filled />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing.lg },
+  progress: { height: 4, backgroundColor: Colors.bgSecondary, borderRadius: 2 },
+  progressBar: { height: 4, backgroundColor: Colors.statusSuccess, borderRadius: 2 },
+  step: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  form: { gap: Spacing.lg },
+  avatarRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.md },
+  avatar: {
+    width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  avatarText: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  avatarHint: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium },
+  field: { gap: Spacing.xs },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  textarea: {
+    minHeight: 96, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, padding: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+    textAlignVertical: 'top',
+  },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/OnboardingServicesStates.tsx
+++ b/components/proto/states/OnboardingServicesStates.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_SERVICES } from '../../../constants/protoMockData';
+
+function ServiceItem({ name, selected }: { name: string; selected: boolean }) {
+  return (
+    <TouchableOpacity style={[s.item, selected ? s.itemSelected : null]}>
+      <View style={[s.check, selected ? s.checkSelected : null]}>
+        {selected && <Text style={s.checkMark}>{'✓'}</Text>}
+      </View>
+      <Text style={[s.itemText, selected ? s.itemTextSelected : null]}>{name}</Text>
+    </TouchableOpacity>
+  );
+}
+
+function Screen({ selectedIds }: { selectedIds: string[] }) {
+  return (
+    <View style={s.container}>
+      <View style={s.progress}><View style={[s.progressBar, { width: '60%' }]} /></View>
+      <Text style={s.step}>Шаг 3 из 5</Text>
+      <Text style={s.title}>Какие услуги вы оказываете?</Text>
+      <Text style={s.subtitle}>Выберите все подходящие</Text>
+      <View style={s.list}>
+        {MOCK_SERVICES.map((svc) => (
+          <ServiceItem key={svc.id} name={svc.name} selected={selectedIds.includes(svc.id)} />
+        ))}
+      </View>
+      <View style={[s.btn, selectedIds.length === 0 ? s.btnDisabled : null]}>
+        <Text style={s.btnText}>Продолжить {selectedIds.length > 0 ? `(${selectedIds.length})` : ''}</Text>
+      </View>
+    </View>
+  );
+}
+
+export function OnboardingServicesStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <Screen selectedIds={[]} />
+      </StateSection>
+      <StateSection title="SELECTED">
+        <Screen selectedIds={['1', '3', '5', '7']} />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing.lg },
+  progress: { height: 4, backgroundColor: Colors.bgSecondary, borderRadius: 2 },
+  progressBar: { height: 4, backgroundColor: Colors.brandPrimary, borderRadius: 2 },
+  step: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  list: { gap: Spacing.sm },
+  item: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md,
+    borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.md, backgroundColor: Colors.bgCard,
+  },
+  itemSelected: { borderColor: Colors.brandPrimary, backgroundColor: '#EBF3FB' },
+  check: {
+    width: 22, height: 22, borderWidth: 1.5, borderColor: Colors.border,
+    borderRadius: BorderRadius.sm, alignItems: 'center', justifyContent: 'center',
+  },
+  checkSelected: { backgroundColor: Colors.brandPrimary, borderColor: Colors.brandPrimary },
+  checkMark: { color: '#FFF', fontSize: 14, fontWeight: Typography.fontWeight.bold },
+  itemText: { fontSize: Typography.fontSize.base, color: Colors.textPrimary },
+  itemTextSelected: { fontWeight: Typography.fontWeight.medium, color: Colors.brandPrimary },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnDisabled: { opacity: 0.45 },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/OnboardingUsernameStates.tsx
+++ b/components/proto/states/OnboardingUsernameStates.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function Screen({ value, error }: { value: string; error?: string }) {
+  return (
+    <View style={s.container}>
+      <View style={s.progress}><View style={[s.progressBar, { width: '20%' }]} /></View>
+      <Text style={s.step}>Шаг 1 из 5</Text>
+      <Text style={s.title}>Как вас зовут?</Text>
+      <Text style={s.subtitle}>Это имя будет отображаться в вашем профиле</Text>
+      <View style={s.form}>
+        <Text style={s.label}>Имя пользователя</Text>
+        <TextInput
+          value={value}
+          editable={false}
+          placeholder="Например: Елена Васильева"
+          placeholderTextColor={Colors.textMuted}
+          style={[s.input, error ? s.inputError : null]}
+        />
+        {error ? <Text style={s.error}>{error}</Text> : null}
+      </View>
+      <View style={s.btn}>
+        <Text style={s.btnText}>Продолжить</Text>
+      </View>
+    </View>
+  );
+}
+
+export function OnboardingUsernameStates() {
+  return (
+    <>
+      <StateSection title="DEFAULT">
+        <Screen value="" />
+      </StateSection>
+      <StateSection title="VALIDATION_ERROR">
+        <Screen value="Ел" error="Имя должно содержать минимум 3 символа" />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing['2xl'], gap: Spacing.lg },
+  progress: { height: 4, backgroundColor: Colors.bgSecondary, borderRadius: 2 },
+  progressBar: { height: 4, backgroundColor: Colors.brandPrimary, borderRadius: 2 },
+  step: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  title: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  form: { gap: Spacing.xs },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  inputError: { borderColor: Colors.statusError },
+  error: { fontSize: Typography.fontSize.xs, color: Colors.statusError },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/PricingStates.tsx
+++ b/components/proto/states/PricingStates.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_PRICING_PLANS } from '../../../constants/protoMockData';
+
+function PlanCard({ name, price, period, features, highlighted }: {
+  name: string; price: string; period: string; features: string[]; highlighted: boolean;
+}) {
+  return (
+    <View style={[s.planCard, highlighted ? s.planHighlighted : null]}>
+      {highlighted && <View style={s.popularBadge}><Text style={s.popularText}>Популярный</Text></View>}
+      <Text style={[s.planName, highlighted ? s.planNameHL : null]}>{name}</Text>
+      <View style={s.priceRow}>
+        <Text style={[s.price, highlighted ? s.priceHL : null]}>{price}</Text>
+        <Text style={s.period}>/ {period}</Text>
+      </View>
+      <View style={s.featureList}>
+        {features.map((f) => (
+          <View key={f} style={s.featureRow}>
+            <Text style={[s.featureCheck, highlighted ? s.featureCheckHL : null]}>{'✓'}</Text>
+            <Text style={s.featureText}>{f}</Text>
+          </View>
+        ))}
+      </View>
+      <View style={[s.planBtn, highlighted ? s.planBtnHL : null]}>
+        <Text style={[s.planBtnText, highlighted ? s.planBtnTextHL : null]}>
+          {highlighted ? 'Начать' : 'Выбрать'}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export function PricingStates() {
+  return (
+    <StateSection title="PLANS_COMPARISON" maxWidth={800}>
+      <View style={s.container}>
+        <View style={s.header}>
+          <Text style={s.title}>Тарифы</Text>
+          <Text style={s.subtitle}>Выберите подходящий план для вашей работы</Text>
+        </View>
+        <View style={s.plans}>
+          {MOCK_PRICING_PLANS.map((plan) => (
+            <PlanCard key={plan.id} {...plan} />
+          ))}
+        </View>
+        <View style={s.faq}>
+          <Text style={s.faqTitle}>Частые вопросы</Text>
+          {[
+            { q: 'Можно ли сменить тариф?', a: 'Да, вы можете перейти на другой тариф в любой момент.' },
+            { q: 'Есть ли пробный период?', a: 'Профессиональный тариф включает 14 дней бесплатного использования.' },
+          ].map((item) => (
+            <View key={item.q} style={s.faqItem}>
+              <Text style={s.faqQ}>{item.q}</Text>
+              <Text style={s.faqA}>{item.a}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </StateSection>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing['2xl'] },
+  header: { alignItems: 'center', gap: Spacing.sm },
+  title: { fontSize: 24, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subtitle: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
+  plans: { gap: Spacing.md },
+  planCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md, position: 'relative',
+  },
+  planHighlighted: { borderColor: Colors.brandPrimary, borderWidth: 2 },
+  popularBadge: {
+    position: 'absolute', top: -12, right: Spacing.lg,
+    backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  popularText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.bold, color: '#FFF' },
+  planName: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  planNameHL: { color: Colors.brandPrimary },
+  priceRow: { flexDirection: 'row', alignItems: 'baseline', gap: Spacing.xs },
+  price: { fontSize: 28, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  priceHL: { color: Colors.brandPrimary },
+  period: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  featureList: { gap: Spacing.sm },
+  featureRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
+  featureCheck: { fontSize: 16, color: Colors.statusSuccess },
+  featureCheckHL: { color: Colors.brandPrimary },
+  featureText: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary },
+  planBtn: {
+    height: 44, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border, marginTop: Spacing.xs,
+  },
+  planBtnHL: { backgroundColor: Colors.brandPrimary, borderColor: Colors.brandPrimary },
+  planBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  planBtnTextHL: { color: '#FFF' },
+  faq: { gap: Spacing.md },
+  faqTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  faqItem: { gap: Spacing.xs, paddingBottom: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary },
+  faqQ: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  faqA: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, lineHeight: 20 },
+});

--- a/components/proto/states/ProfileStates.tsx
+++ b/components/proto/states/ProfileStates.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={s.infoRow}>
+      <Text style={s.infoLabel}>{label}</Text>
+      <Text style={s.infoValue}>{value}</Text>
+    </View>
+  );
+}
+
+function ViewMode() {
+  return (
+    <View style={s.container}>
+      <View style={s.profileHeader}>
+        <View style={s.avatar}><Text style={s.avatarText}>ЕВ</Text></View>
+        <View>
+          <Text style={s.name}>Елена Васильева</Text>
+          <Text style={s.role}>Клиент</Text>
+        </View>
+      </View>
+      <View style={s.card}>
+        <InfoRow label="Email" value="elena@mail.ru" />
+        <InfoRow label="Город" value="Москва" />
+        <InfoRow label="Дата регистрации" value="15.02.2026" />
+        <InfoRow label="Заявки" value="5 (3 активных)" />
+      </View>
+      <View style={s.btn}><Text style={s.btnText}>Редактировать</Text></View>
+    </View>
+  );
+}
+
+function EditMode() {
+  return (
+    <View style={s.container}>
+      <View style={s.profileHeader}>
+        <View style={s.avatar}><Text style={s.avatarText}>ЕВ</Text></View>
+        <Text style={s.changePhoto}>Изменить фото</Text>
+      </View>
+      <View style={s.form}>
+        <View style={s.field}>
+          <Text style={s.label}>Имя</Text>
+          <TextInput value="Елена Васильева" editable={false} style={s.input} />
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Email</Text>
+          <TextInput value="elena@mail.ru" editable={false} style={[s.input, s.inputDisabled]} />
+          <Text style={s.hint}>Email нельзя изменить</Text>
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Город</Text>
+          <TextInput value="Москва" editable={false} style={s.input} />
+        </View>
+      </View>
+      <View style={s.actions}>
+        <View style={s.btnPrimary}><Text style={s.btnPrimaryText}>Сохранить</Text></View>
+        <View style={s.btnSecondary}><Text style={s.btnSecondaryText}>Отмена</Text></View>
+      </View>
+    </View>
+  );
+}
+
+export function ProfileStates() {
+  return (
+    <>
+      <StateSection title="VIEW">
+        <ViewMode />
+      </StateSection>
+      <StateSection title="EDIT_MODE">
+        <EditMode />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  profileHeader: { flexDirection: 'row', alignItems: 'center', gap: Spacing.lg },
+  avatar: {
+    width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  avatarText: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  name: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  role: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  changePhoto: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  infoRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  infoLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  infoValue: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  form: { gap: Spacing.lg },
+  field: { gap: Spacing.xs },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  inputDisabled: { opacity: 0.5 },
+  hint: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  actions: { gap: Spacing.sm },
+  btnPrimary: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnPrimaryText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  btnSecondary: {
+    height: 48, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  btnSecondaryText: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
+});

--- a/components/proto/states/PublicRequestDetailStates.tsx
+++ b/components/proto/states/PublicRequestDetailStates.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function DetailView({ showRespondPopup }: { showRespondPopup?: boolean }) {
+  return (
+    <View style={[s.container, showRespondPopup ? { minHeight: 550 } : null]}>
+      {showRespondPopup && (
+        <View style={s.overlay}>
+          <View style={s.popup}>
+            <Text style={s.popupTitle}>Откликнуться на заявку</Text>
+            <View style={s.popupField}>
+              <Text style={s.popupLabel}>Ваша цена</Text>
+              <TextInput value="4 500" editable={false} style={s.popupInput} />
+            </View>
+            <View style={s.popupField}>
+              <Text style={s.popupLabel}>Сообщение</Text>
+              <TextInput
+                value="Готов помочь! Опыт работы 8 лет."
+                editable={false}
+                multiline
+                style={s.popupTextarea}
+              />
+            </View>
+            <View style={s.popupActions}>
+              <View style={s.popupBtnPrimary}><Text style={s.popupBtnPrimaryText}>Отправить</Text></View>
+              <View style={s.popupBtnCancel}><Text style={s.popupBtnCancelText}>Отмена</Text></View>
+            </View>
+          </View>
+        </View>
+      )}
+
+      <View style={s.detailCard}>
+        <Text style={s.title}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+        <Text style={s.desc}>
+          Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры. Документы готовы.
+        </Text>
+        <View style={s.tags}>
+          <View style={s.tag}><Text style={s.tagText}>Москва</Text></View>
+          <View style={s.tag}><Text style={s.tagText}>Декларация 3-НДФЛ</Text></View>
+        </View>
+        <View style={s.meta}>
+          <View style={s.metaRow}>
+            <Text style={s.metaLabel}>Бюджет</Text>
+            <Text style={s.metaValue}>3 000 — 5 000 ₽</Text>
+          </View>
+          <View style={s.metaRow}>
+            <Text style={s.metaLabel}>Дата</Text>
+            <Text style={s.metaValue}>08.04.2026</Text>
+          </View>
+          <View style={s.metaRow}>
+            <Text style={s.metaLabel}>Клиент</Text>
+            <Text style={s.metaValue}>Елена В.</Text>
+          </View>
+        </View>
+      </View>
+      <View style={s.respondBtn}><Text style={s.respondBtnText}>Откликнуться</Text></View>
+      <Text style={s.loginHint}>Для отклика необходимо войти как специалист</Text>
+    </View>
+  );
+}
+
+export function PublicRequestDetailStates() {
+  return (
+    <>
+      <StateSection title="DETAIL">
+        <DetailView />
+      </StateSection>
+      <StateSection title="RESPOND_POPUP">
+        <DetailView showRespondPopup />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg, position: 'relative' },
+  detailCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  title: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  desc: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 22 },
+  tags: { flexDirection: 'row', gap: Spacing.sm },
+  tag: { backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 3, borderRadius: BorderRadius.full },
+  tagText: { fontSize: Typography.fontSize.xs, color: Colors.brandPrimary },
+  meta: { gap: Spacing.sm, paddingTop: Spacing.sm, borderTopWidth: 1, borderTopColor: Colors.bgSecondary },
+  metaRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  metaLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  metaValue: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary },
+  respondBtn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  respondBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  loginHint: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, textAlign: 'center' },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing['2xl'],
+    width: '100%', maxWidth: 380, gap: Spacing.md,
+  },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupField: { gap: Spacing.xs },
+  popupLabel: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  popupInput: {
+    height: 44, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  popupTextarea: {
+    minHeight: 72, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md,
+    padding: Spacing.md, fontSize: Typography.fontSize.sm, color: Colors.textPrimary, textAlignVertical: 'top',
+  },
+  popupActions: { gap: Spacing.sm },
+  popupBtnPrimary: {
+    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  popupBtnPrimaryText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  popupBtnCancel: {
+    height: 44, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  popupBtnCancelText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+});

--- a/components/proto/states/PublicRequestsStates.tsx
+++ b/components/proto/states/PublicRequestsStates.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_REQUESTS } from '../../../constants/protoMockData';
+
+function RequestFeedCard({ title, description, city, service, budget, date }: {
+  title: string; description: string; city: string; service: string; budget: string; date: string;
+}) {
+  return (
+    <View style={s.card}>
+      <Text style={s.cardTitle}>{title}</Text>
+      <Text style={s.cardDesc} numberOfLines={2}>{description}</Text>
+      <View style={s.cardTags}>
+        <View style={s.tag}><Text style={s.tagText}>{city}</Text></View>
+        <View style={s.tag}><Text style={s.tagText}>{service}</Text></View>
+      </View>
+      <View style={s.cardBottom}>
+        <Text style={s.budget}>{budget}</Text>
+        <Text style={s.date}>{date}</Text>
+      </View>
+    </View>
+  );
+}
+
+function FilterPanel() {
+  return (
+    <View style={s.filterPanel}>
+      <Text style={s.filterTitle}>Фильтры</Text>
+      <View style={s.filterGroup}>
+        <Text style={s.filterLabel}>Город</Text>
+        <View style={s.filterSelect}><Text style={s.filterSelectText}>Все города</Text></View>
+      </View>
+      <View style={s.filterGroup}>
+        <Text style={s.filterLabel}>Услуга</Text>
+        <View style={s.filterSelect}><Text style={s.filterSelectText}>Все услуги</Text></View>
+      </View>
+      <View style={s.filterGroup}>
+        <Text style={s.filterLabel}>Бюджет до</Text>
+        <TextInput value="" editable={false} placeholder="Макс. сумма" placeholderTextColor={Colors.textMuted} style={s.filterInput} />
+      </View>
+      <View style={s.filterBtn}><Text style={s.filterBtnText}>Применить</Text></View>
+    </View>
+  );
+}
+
+export function PublicRequestsStates() {
+  return (
+    <>
+      <StateSection title="FEED">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Заявки</Text>
+            <View style={s.filterToggle}><Text style={s.filterToggleText}>Фильтры</Text></View>
+          </View>
+          {MOCK_REQUESTS.filter(r => r.status !== 'CANCELLED').map((r) => (
+            <RequestFeedCard key={r.id} title={r.title} description={r.description} city={r.city} service={r.service} budget={r.budget} date={r.createdAt} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="FILTERS_OPEN">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Заявки</Text>
+          </View>
+          <FilterPanel />
+          {MOCK_REQUESTS.slice(0, 2).map((r) => (
+            <RequestFeedCard key={r.id} title={r.title} description={r.description} city={r.city} service={r.service} budget={r.budget} date={r.createdAt} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <View style={s.topBar}>
+            <Text style={s.pageTitle}>Заявки</Text>
+            <View style={s.filterToggle}><Text style={s.filterToggleText}>Фильтры</Text></View>
+          </View>
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Нет заявок по вашим фильтрам</Text>
+            <Text style={s.emptyText}>Попробуйте изменить параметры поиска</Text>
+          </View>
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md },
+  topBar: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  filterToggle: {
+    paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  filterToggleText: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  cardTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  cardDesc: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  cardTags: { flexDirection: 'row', gap: Spacing.sm },
+  tag: { backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  tagText: { fontSize: Typography.fontSize.xs, color: Colors.brandPrimary },
+  cardBottom: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: Spacing.xs },
+  budget: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.brandPrimary },
+  date: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  filterPanel: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  filterTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  filterGroup: { gap: Spacing.xs },
+  filterLabel: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.medium, color: Colors.textMuted },
+  filterSelect: {
+    height: 40, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md, justifyContent: 'center',
+  },
+  filterSelectText: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary },
+  filterInput: {
+    height: 40, backgroundColor: Colors.bgPrimary, borderRadius: BorderRadius.md,
+    paddingHorizontal: Spacing.md, fontSize: Typography.fontSize.sm, color: Colors.textPrimary,
+  },
+  filterBtn: {
+    height: 40, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  filterBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  emptyWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/components/proto/states/ResponsesStates.tsx
+++ b/components/proto/states/ResponsesStates.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_RESPONSES } from '../../../constants/protoMockData';
+
+function ResponseItem({ name, price, message, rating, reviews }: {
+  name: string; price: string; message: string; rating: number; reviews: number;
+}) {
+  const stars = '★'.repeat(Math.round(rating)) + '☆'.repeat(5 - Math.round(rating));
+  return (
+    <View style={s.card}>
+      <View style={s.cardTop}>
+        <View style={s.avatar}><Text style={s.avatarText}>{name[0]}</Text></View>
+        <View style={s.info}>
+          <Text style={s.name}>{name}</Text>
+          <View style={s.ratingRow}>
+            <Text style={s.starsText}>{stars}</Text>
+            <Text style={s.ratingLabel}>{rating} ({reviews})</Text>
+          </View>
+        </View>
+        <Text style={s.price}>{price}</Text>
+      </View>
+      <Text style={s.message} numberOfLines={2}>{message}</Text>
+      <View style={s.actions}>
+        <View style={s.btnAccept}><Text style={s.btnAcceptText}>Принять</Text></View>
+        <View style={s.btnDecline}><Text style={s.btnDeclineText}>Отклонить</Text></View>
+      </View>
+    </View>
+  );
+}
+
+function Popup({ type }: { type: 'accept' | 'decline' }) {
+  const isAccept = type === 'accept';
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <Text style={s.popupIcon}>{isAccept ? '✓' : '✕'}</Text>
+        <Text style={s.popupTitle}>{isAccept ? 'Принять отклик?' : 'Отклонить отклик?'}</Text>
+        <Text style={s.popupText}>
+          {isAccept
+            ? 'Специалист Алексей Петров будет назначен исполнителем вашей заявки'
+            : 'Отклик от Алексея Петрова будет отклонён'}
+        </Text>
+        <View style={s.popupActions}>
+          <View style={[s.popupBtn, isAccept ? s.popupBtnAccept : s.popupBtnDecline]}>
+            <Text style={s.popupBtnPrimaryText}>{isAccept ? 'Подтвердить' : 'Отклонить'}</Text>
+          </View>
+          <View style={s.popupBtnCancel}><Text style={s.popupBtnCancelText}>Отмена</Text></View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function ResponsesStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Отклики</Text>
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Нет откликов</Text>
+            <Text style={s.emptyText}>Специалисты ещё не откликнулись на ваши заявки</Text>
+          </View>
+        </View>
+      </StateSection>
+      <StateSection title="LIST">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Отклики (3)</Text>
+          {MOCK_RESPONSES.map((r) => (
+            <ResponseItem key={r.id} name={r.specialistName} price={r.price} message={r.message} rating={r.rating} reviews={r.reviewCount} />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="ACCEPT_POPUP">
+        <View style={[s.container, { minHeight: 400 }]}>
+          <Text style={s.pageTitle}>Отклики (3)</Text>
+          <ResponseItem name="Алексей Петров" price="4 500 ₽" message="Готов помочь с декларацией." rating={4.8} reviews={42} />
+          <Popup type="accept" />
+        </View>
+      </StateSection>
+      <StateSection title="DECLINE_POPUP">
+        <View style={[s.container, { minHeight: 400 }]}>
+          <Text style={s.pageTitle}>Отклики (3)</Text>
+          <ResponseItem name="Алексей Петров" price="4 500 ₽" message="Готов помочь с декларацией." rating={4.8} reviews={42} />
+          <Popup type="decline" />
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md, position: 'relative' },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  cardTop: { flexDirection: 'row', alignItems: 'center', gap: Spacing.md },
+  avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  info: { flex: 1 },
+  name: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  ratingRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
+  starsText: { fontSize: 12, color: Colors.brandPrimary },
+  ratingLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  price: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  message: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary },
+  actions: { flexDirection: 'row', gap: Spacing.sm, marginTop: Spacing.xs },
+  btnAccept: {
+    flex: 1, height: 36, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnAcceptText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  btnDecline: {
+    flex: 1, height: 36, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  btnDeclineText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  emptyWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing['2xl'],
+    alignItems: 'center', gap: Spacing.md, width: '100%', maxWidth: 340,
+  },
+  popupIcon: { fontSize: 40, color: Colors.brandPrimary },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  popupActions: { width: '100%', gap: Spacing.sm },
+  popupBtn: { height: 44, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center' },
+  popupBtnAccept: { backgroundColor: Colors.brandPrimary },
+  popupBtnDecline: { backgroundColor: Colors.statusError },
+  popupBtnPrimaryText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  popupBtnCancel: {
+    height: 44, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  popupBtnCancelText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+});

--- a/components/proto/states/SettingsStates.tsx
+++ b/components/proto/states/SettingsStates.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function SettingRow({ label, value, danger }: { label: string; value?: string; danger?: boolean }) {
+  return (
+    <View style={s.row}>
+      <Text style={[s.rowLabel, danger ? s.rowLabelDanger : null]}>{label}</Text>
+      {value && <Text style={s.rowValue}>{value}</Text>}
+      <Text style={s.rowArrow}>{'>'}</Text>
+    </View>
+  );
+}
+
+function ToggleRow({ label, enabled }: { label: string; enabled: boolean }) {
+  return (
+    <View style={s.row}>
+      <Text style={s.rowLabel}>{label}</Text>
+      <View style={[s.toggle, enabled ? s.toggleOn : null]}>
+        <View style={[s.toggleDot, enabled ? s.toggleDotOn : null]} />
+      </View>
+    </View>
+  );
+}
+
+export function SettingsStates() {
+  return (
+    <StateSection title="DEFAULT">
+      <View style={s.container}>
+        <Text style={s.pageTitle}>Настройки</Text>
+
+        <View style={s.section}>
+          <Text style={s.sectionTitle}>Уведомления</Text>
+          <View style={s.card}>
+            <ToggleRow label="Email-уведомления" enabled />
+            <ToggleRow label="Push-уведомления" enabled={false} />
+            <ToggleRow label="Уведомления о новых откликах" enabled />
+          </View>
+        </View>
+
+        <View style={s.section}>
+          <Text style={s.sectionTitle}>Аккаунт</Text>
+          <View style={s.card}>
+            <SettingRow label="Email" value="elena@mail.ru" />
+            <SettingRow label="Язык" value="Русский" />
+            <SettingRow label="Тема" value="Светлая" />
+          </View>
+        </View>
+
+        <View style={s.section}>
+          <Text style={s.sectionTitle}>Прочее</Text>
+          <View style={s.card}>
+            <SettingRow label="Политика конфиденциальности" />
+            <SettingRow label="Условия использования" />
+            <SettingRow label="Версия" value="1.0.0" />
+          </View>
+        </View>
+
+        <View style={s.dangerCard}>
+          <SettingRow label="Выйти из аккаунта" danger />
+          <SettingRow label="Удалить аккаунт" danger />
+        </View>
+      </View>
+    </StateSection>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  section: { gap: Spacing.sm },
+  sectionTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: Colors.border, overflow: 'hidden',
+  },
+  dangerCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    borderWidth: 1, borderColor: '#fde8e8', overflow: 'hidden',
+  },
+  row: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md,
+    borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary,
+  },
+  rowLabel: { flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textPrimary },
+  rowLabelDanger: { color: Colors.statusError },
+  rowValue: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, marginRight: Spacing.sm },
+  rowArrow: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  toggle: {
+    width: 44, height: 24, borderRadius: 12, backgroundColor: Colors.border,
+    justifyContent: 'center', paddingHorizontal: 2,
+  },
+  toggleOn: { backgroundColor: Colors.brandPrimary },
+  toggleDot: {
+    width: 20, height: 20, borderRadius: 10, backgroundColor: '#FFF',
+  },
+  toggleDotOn: { alignSelf: 'flex-end' },
+});

--- a/components/proto/states/SpecialistDashboardStates.tsx
+++ b/components/proto/states/SpecialistDashboardStates.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { MOCK_REQUESTS } from '../../../constants/protoMockData';
+
+function RequestCard({ title, city, budget, service, date }: {
+  title: string; city: string; budget: string; service: string; date: string;
+}) {
+  return (
+    <View style={s.card}>
+      <Text style={s.cardTitle} numberOfLines={2}>{title}</Text>
+      <View style={s.cardMeta}>
+        <Text style={s.metaItem}>{city}</Text>
+        <Text style={s.dot}>{'·'}</Text>
+        <Text style={s.metaItem}>{service}</Text>
+      </View>
+      <View style={s.cardBottom}>
+        <Text style={s.budget}>{budget}</Text>
+        <Text style={s.date}>{date}</Text>
+      </View>
+      <View style={s.respondBtn}><Text style={s.respondBtnText}>Откликнуться</Text></View>
+    </View>
+  );
+}
+
+export function SpecialistDashboardStates() {
+  return (
+    <>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <Text style={s.greeting}>Добрый день, Алексей!</Text>
+          <View style={s.statsRow}>
+            <View style={s.stat}><Text style={s.statValue}>0</Text><Text style={s.statLabel}>Новые</Text></View>
+            <View style={s.stat}><Text style={s.statValue}>0</Text><Text style={s.statLabel}>В работе</Text></View>
+            <View style={s.stat}><Text style={s.statValue}>0</Text><Text style={s.statLabel}>Завершены</Text></View>
+          </View>
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Нет заявок в вашем городе</Text>
+            <Text style={s.emptyText}>Когда клиенты создадут заявки в Санкт-Петербурге, вы увидите их здесь</Text>
+          </View>
+        </View>
+      </StateSection>
+      <StateSection title="WITH_REQUESTS">
+        <View style={s.container}>
+          <Text style={s.greeting}>Добрый день, Алексей!</Text>
+          <View style={s.statsRow}>
+            <View style={s.stat}><Text style={[s.statValue, { color: Colors.brandPrimary }]}>5</Text><Text style={s.statLabel}>Новые</Text></View>
+            <View style={s.stat}><Text style={[s.statValue, { color: '#D97706' }]}>2</Text><Text style={s.statLabel}>В работе</Text></View>
+            <View style={s.stat}><Text style={[s.statValue, { color: Colors.statusSuccess }]}>18</Text><Text style={s.statLabel}>Завершены</Text></View>
+          </View>
+          <Text style={s.sectionTitle}>Заявки в вашем городе</Text>
+          {MOCK_REQUESTS.filter(r => r.status === 'NEW' || r.status === 'ACTIVE').map((r) => (
+            <RequestCard key={r.id} title={r.title} city={r.city} budget={r.budget} service={r.service} date={r.createdAt} />
+          ))}
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg },
+  greeting: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  statsRow: { flexDirection: 'row', gap: Spacing.sm },
+  stat: {
+    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
+    padding: Spacing.md, alignItems: 'center', borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
+  },
+  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  cardTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  cardMeta: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
+  metaItem: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  dot: { fontSize: Typography.fontSize.xs, color: Colors.border },
+  cardBottom: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  budget: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.brandPrimary },
+  date: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  respondBtn: {
+    height: 38, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', marginTop: Spacing.xs,
+  },
+  respondBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  emptyWrap: { alignItems: 'center', padding: Spacing['2xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/components/proto/states/SpecialistProfilePublicStates.tsx
+++ b/components/proto/states/SpecialistProfilePublicStates.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_REVIEWS } from '../../../constants/protoMockData';
+
+function ReviewItem({ author, rating, text, date }: { author: string; rating: number; text: string; date: string }) {
+  const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating);
+  return (
+    <View style={s.review}>
+      <View style={s.reviewTop}>
+        <Text style={s.reviewAuthor}>{author}</Text>
+        <Text style={s.reviewDate}>{date}</Text>
+      </View>
+      <Text style={s.reviewStars}>{stars}</Text>
+      <Text style={s.reviewText}>{text}</Text>
+    </View>
+  );
+}
+
+function ProfileScreen({ showReviewsPopup }: { showReviewsPopup?: boolean }) {
+  return (
+    <View style={[s.container, showReviewsPopup ? { minHeight: 600 } : null]}>
+      {showReviewsPopup && (
+        <View style={s.overlay}>
+          <View style={s.popup}>
+            <View style={s.popupHeader}>
+              <Text style={s.popupTitle}>Все отзывы (42)</Text>
+              <Text style={s.popupClose}>{'x'}</Text>
+            </View>
+            {MOCK_REVIEWS.slice(0, 3).map((r) => (
+              <ReviewItem key={r.id} author={r.author} rating={r.rating} text={r.text} date={r.date} />
+            ))}
+          </View>
+        </View>
+      )}
+      <View style={s.profileCard}>
+        <View style={s.profileTop}>
+          <View style={s.avatar}><Text style={s.avatarText}>АП</Text></View>
+          <View style={s.profileInfo}>
+            <Text style={s.name}>Алексей Петров</Text>
+            <Text style={s.city}>Санкт-Петербург</Text>
+            <View style={s.ratingRow}>
+              <Text style={s.stars}>{'★★★★★'}</Text>
+              <Text style={s.ratingText}>4.8 (42 отзыва)</Text>
+            </View>
+          </View>
+        </View>
+        <View style={s.verified}>
+          <Text style={s.verifiedIcon}>{'✓'}</Text>
+          <Text style={s.verifiedText}>Верифицирован через ФНС</Text>
+        </View>
+        <Text style={s.bio}>
+          Налоговый консультант с опытом работы в ФНС. Специализация — НДФЛ и имущественные вычеты.
+          Более 200 успешно поданных деклараций.
+        </Text>
+      </View>
+
+      <View style={s.section}>
+        <Text style={s.sectionTitle}>Услуги</Text>
+        <View style={s.servicesList}>
+          {['Декларация 3-НДФЛ', 'Налоговый вычет', 'Консультация по налогам'].map((svc) => (
+            <View key={svc} style={s.serviceChip}>
+              <Text style={s.serviceText}>{svc}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+
+      <View style={s.section}>
+        <View style={s.statsRow}>
+          <View style={s.statItem}>
+            <Text style={s.statValue}>8 лет</Text>
+            <Text style={s.statLabel}>Опыт</Text>
+          </View>
+          <View style={s.statItem}>
+            <Text style={s.statValue}>215</Text>
+            <Text style={s.statLabel}>Заказов</Text>
+          </View>
+          <View style={s.statItem}>
+            <Text style={s.statValue}>98%</Text>
+            <Text style={s.statLabel}>Успешных</Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={s.section}>
+        <View style={s.reviewsHeader}>
+          <Text style={s.sectionTitle}>Отзывы</Text>
+          <Text style={s.viewAll}>Все 42 {'>'}</Text>
+        </View>
+        {MOCK_REVIEWS.slice(0, 2).map((r) => (
+          <ReviewItem key={r.id} author={r.author} rating={r.rating} text={r.text} date={r.date} />
+        ))}
+      </View>
+
+      <View style={s.contactBtn}><Text style={s.contactBtnText}>Связаться</Text></View>
+    </View>
+  );
+}
+
+export function SpecialistProfilePublicStates() {
+  return (
+    <>
+      <StateSection title="FULL">
+        <ProfileScreen />
+      </StateSection>
+      <StateSection title="REVIEWS_POPUP">
+        <ProfileScreen showReviewsPopup />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg, position: 'relative' },
+  profileCard: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md,
+  },
+  profileTop: { flexDirection: 'row', gap: Spacing.lg },
+  avatar: { width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  profileInfo: { flex: 1, gap: 2 },
+  name: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  city: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  ratingRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, marginTop: 2 },
+  stars: { fontSize: 14, color: Colors.brandPrimary },
+  ratingText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  verified: {
+    flexDirection: 'row', alignItems: 'center', gap: Spacing.sm,
+    backgroundColor: '#e6f4ed', padding: Spacing.sm, borderRadius: BorderRadius.sm,
+  },
+  verifiedIcon: { fontSize: 16, color: Colors.statusSuccess },
+  verifiedText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.medium, color: Colors.statusSuccess },
+  bio: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  section: { gap: Spacing.md },
+  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  servicesList: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm },
+  serviceChip: {
+    backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.full,
+  },
+  serviceText: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary },
+  statsRow: { flexDirection: 'row', gap: Spacing.sm },
+  statItem: {
+    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.md,
+    alignItems: 'center', borderWidth: 1, borderColor: Colors.border,
+  },
+  statValue: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  reviewsHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  viewAll: { fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium },
+  review: { gap: Spacing.xs, paddingVertical: Spacing.sm, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary },
+  reviewTop: { flexDirection: 'row', justifyContent: 'space-between' },
+  reviewAuthor: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  reviewDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  reviewStars: { fontSize: 12, color: Colors.brandPrimary },
+  reviewText: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
+  contactBtn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  contactBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing.lg,
+    width: '100%', maxWidth: 380, maxHeight: 500, gap: Spacing.md,
+  },
+  popupHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupClose: { fontSize: Typography.fontSize.lg, color: Colors.textMuted, padding: Spacing.xs },
+});

--- a/components/proto/states/SpecialistRespondStates.tsx
+++ b/components/proto/states/SpecialistRespondStates.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+function Popup({ type }: { type: 'success' | 'error' }) {
+  const isSuccess = type === 'success';
+  return (
+    <View style={s.overlay}>
+      <View style={s.popup}>
+        <Text style={s.popupIcon}>{isSuccess ? '✓' : '✕'}</Text>
+        <Text style={s.popupTitle}>{isSuccess ? 'Отклик отправлен!' : 'Ошибка отправки'}</Text>
+        <Text style={s.popupText}>
+          {isSuccess
+            ? 'Клиент получит уведомление о вашем отклике и сможет связаться с вами'
+            : 'Не удалось отправить отклик. Попробуйте ещё раз.'}
+        </Text>
+        <View style={[s.popupBtn, isSuccess ? null : s.popupBtnError]}>
+          <Text style={s.popupBtnText}>{isSuccess ? 'К моим откликам' : 'Попробовать снова'}</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function FormScreen({ showPopup }: { showPopup?: 'success' | 'error' }) {
+  return (
+    <View style={[s.container, showPopup ? { minHeight: 500 } : null]}>
+      {showPopup && <Popup type={showPopup} />}
+      <View style={s.requestInfo}>
+        <Text style={s.requestTitle}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+        <View style={s.requestMeta}>
+          <Text style={s.metaText}>Москва</Text>
+          <Text style={s.dot}>{'·'}</Text>
+          <Text style={s.metaText}>3 000 — 5 000 ₽</Text>
+        </View>
+      </View>
+      <View style={s.form}>
+        <View style={s.field}>
+          <Text style={s.label}>Ваша цена *</Text>
+          <TextInput
+            value="4 500"
+            editable={false}
+            placeholder="Укажите стоимость в рублях"
+            placeholderTextColor={Colors.textMuted}
+            style={s.input}
+          />
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Сообщение клиенту *</Text>
+          <TextInput
+            value="Здравствуйте! Готов помочь с декларацией. Опыт — 8 лет, 200+ успешных деклараций."
+            editable={false}
+            multiline
+            style={s.textarea}
+          />
+        </View>
+        <View style={s.field}>
+          <Text style={s.label}>Срок выполнения</Text>
+          <TextInput
+            value="2 рабочих дня"
+            editable={false}
+            style={s.input}
+          />
+        </View>
+      </View>
+      <View style={s.btn}><Text style={s.btnText}>Отправить отклик</Text></View>
+    </View>
+  );
+}
+
+export function SpecialistRespondStates() {
+  return (
+    <>
+      <StateSection title="FORM">
+        <FormScreen />
+      </StateSection>
+      <StateSection title="SUCCESS_POPUP">
+        <FormScreen showPopup="success" />
+      </StateSection>
+      <StateSection title="ERROR_POPUP">
+        <FormScreen showPopup="error" />
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.lg, position: 'relative' },
+  requestInfo: {
+    backgroundColor: Colors.bgSecondary, padding: Spacing.lg, borderRadius: BorderRadius.md, gap: Spacing.sm,
+  },
+  requestTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  requestMeta: { flexDirection: 'row', gap: Spacing.xs, alignItems: 'center' },
+  metaText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  dot: { fontSize: Typography.fontSize.xs, color: Colors.border },
+  form: { gap: Spacing.lg },
+  field: { gap: Spacing.xs },
+  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
+  input: {
+    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+  },
+  textarea: {
+    minHeight: 80, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, padding: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
+    textAlignVertical: 'top',
+  },
+  btn: {
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)', zIndex: 10, alignItems: 'center', justifyContent: 'center',
+    padding: Spacing.lg,
+  },
+  popup: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.lg, padding: Spacing['2xl'],
+    alignItems: 'center', gap: Spacing.md, width: '100%', maxWidth: 340,
+  },
+  popupIcon: { fontSize: 44, color: Colors.statusSuccess },
+  popupTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  popupText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  popupBtn: {
+    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.md,
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: Spacing['2xl'], width: '100%',
+  },
+  popupBtnError: { backgroundColor: Colors.statusError },
+  popupBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: '#FFF' },
+});

--- a/components/proto/states/SpecialistsCatalogStates.tsx
+++ b/components/proto/states/SpecialistsCatalogStates.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+import { MOCK_SPECIALISTS } from '../../../constants/protoMockData';
+
+function SpecialistCard({ name, city, services, rating, reviews, experience, completedOrders }: {
+  name: string; city: string; services: string[]; rating: number; reviews: number; experience: string; completedOrders: number;
+}) {
+  const stars = '★'.repeat(Math.round(rating)) + '☆'.repeat(5 - Math.round(rating));
+  return (
+    <View style={s.card}>
+      <View style={s.cardTop}>
+        <View style={s.avatar}><Text style={s.avatarText}>{name.split(' ').map(n => n[0]).join('')}</Text></View>
+        <View style={s.info}>
+          <Text style={s.name}>{name}</Text>
+          <Text style={s.city}>{city}</Text>
+          <View style={s.ratingRow}>
+            <Text style={s.starsText}>{stars}</Text>
+            <Text style={s.ratingLabel}>{rating} ({reviews})</Text>
+          </View>
+        </View>
+      </View>
+      <View style={s.chipRow}>
+        {services.slice(0, 2).map((svc) => (
+          <View key={svc} style={s.chip}><Text style={s.chipText}>{svc}</Text></View>
+        ))}
+        {services.length > 2 && (
+          <View style={s.chip}><Text style={s.chipText}>+{services.length - 2}</Text></View>
+        )}
+      </View>
+      <View style={s.cardMeta}>
+        <Text style={s.metaItem}>Опыт: {experience}</Text>
+        <Text style={s.metaDot}>{'·'}</Text>
+        <Text style={s.metaItem}>{completedOrders} заказов</Text>
+      </View>
+      <View style={s.cardBtn}><Text style={s.cardBtnText}>Подробнее</Text></View>
+    </View>
+  );
+}
+
+export function SpecialistsCatalogStates() {
+  return (
+    <>
+      <StateSection title="LIST">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Специалисты</Text>
+          <TextInput
+            value=""
+            editable={false}
+            placeholder="Поиск по имени, городу, услуге..."
+            placeholderTextColor={Colors.textMuted}
+            style={s.searchInput}
+          />
+          {MOCK_SPECIALISTS.map((sp) => (
+            <SpecialistCard
+              key={sp.id} name={sp.name} city={sp.city} services={sp.services}
+              rating={sp.rating} reviews={sp.reviewCount} experience={sp.experience} completedOrders={sp.completedOrders}
+            />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="SEARCH">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Специалисты</Text>
+          <TextInput
+            value="Москва 3-НДФЛ"
+            editable={false}
+            style={s.searchInput}
+          />
+          <Text style={s.resultCount}>Найдено: 2 специалиста</Text>
+          {MOCK_SPECIALISTS.filter(sp => sp.city === 'Москва').map((sp) => (
+            <SpecialistCard
+              key={sp.id} name={sp.name} city={sp.city} services={sp.services}
+              rating={sp.rating} reviews={sp.reviewCount} experience={sp.experience} completedOrders={sp.completedOrders}
+            />
+          ))}
+        </View>
+      </StateSection>
+      <StateSection title="EMPTY">
+        <View style={s.container}>
+          <Text style={s.pageTitle}>Специалисты</Text>
+          <TextInput
+            value="Якутск аудит"
+            editable={false}
+            style={s.searchInput}
+          />
+          <View style={s.emptyWrap}>
+            <Text style={s.emptyTitle}>Специалисты не найдены</Text>
+            <Text style={s.emptyText}>Попробуйте изменить параметры поиска</Text>
+          </View>
+        </View>
+      </StateSection>
+    </>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { padding: Spacing.lg, gap: Spacing.md },
+  pageTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  searchInput: {
+    height: 44, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
+    borderRadius: BorderRadius.md, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.sm, color: Colors.textPrimary,
+  },
+  resultCount: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
+  card: {
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
+  },
+  cardTop: { flexDirection: 'row', gap: Spacing.md },
+  avatar: { width: 48, height: 48, borderRadius: 24, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' },
+  avatarText: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary },
+  info: { flex: 1, gap: 1 },
+  name: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  city: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  ratingRow: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, marginTop: 2 },
+  starsText: { fontSize: 12, color: Colors.brandPrimary },
+  ratingLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.xs },
+  chip: { backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full },
+  chipText: { fontSize: Typography.fontSize.xs, color: Colors.brandPrimary },
+  cardMeta: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
+  metaItem: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+  metaDot: { fontSize: Typography.fontSize.xs, color: Colors.border },
+  cardBtn: {
+    height: 38, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
+    borderWidth: 1, borderColor: Colors.brandPrimary,
+  },
+  cardBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.brandPrimary },
+  emptyWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.sm },
+  emptyTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+});

--- a/constants/protoMockData.ts
+++ b/constants/protoMockData.ts
@@ -1,0 +1,315 @@
+// Shared mock data for proto pages — realistic Russian names, cities, services
+
+export const MOCK_USERS = [
+  { id: '1', name: 'Елена Васильева', email: 'elena@mail.ru', role: 'CLIENT' as const, city: 'Москва', avatar: null },
+  { id: '2', name: 'Алексей Петров', email: 'apetrov@yandex.ru', role: 'SPECIALIST' as const, city: 'Санкт-Петербург', avatar: null },
+  { id: '3', name: 'Ольга Смирнова', email: 'olga.s@gmail.com', role: 'SPECIALIST' as const, city: 'Новосибирск', avatar: null },
+  { id: '4', name: 'Дмитрий Козлов', email: 'dkozlov@mail.ru', role: 'CLIENT' as const, city: 'Екатеринбург', avatar: null },
+  { id: '5', name: 'Анна Морозова', email: 'anna.m@yandex.ru', role: 'SPECIALIST' as const, city: 'Казань', avatar: null },
+  { id: '6', name: 'Игорь Новиков', email: 'inovikov@mail.ru', role: 'SPECIALIST' as const, city: 'Москва', avatar: null },
+  { id: '7', name: 'Татьяна Фёдорова', email: 'tfedorova@gmail.com', role: 'CLIENT' as const, city: 'Ростов-на-Дону', avatar: null },
+];
+
+export const MOCK_CITIES = [
+  'Москва', 'Санкт-Петербург', 'Новосибирск', 'Екатеринбург',
+  'Казань', 'Ростов-на-Дону', 'Нижний Новгород', 'Краснодар',
+  'Самара', 'Воронеж', 'Уфа', 'Челябинск',
+];
+
+export const MOCK_SERVICES = [
+  { id: '1', name: 'Декларация 3-НДФЛ', category: 'Декларации' },
+  { id: '2', name: 'Регистрация ИП', category: 'Регистрация' },
+  { id: '3', name: 'Консультация по налогам', category: 'Консультации' },
+  { id: '4', name: 'Бухгалтерский учёт', category: 'Бухгалтерия' },
+  { id: '5', name: 'Оптимизация налогов', category: 'Консультации' },
+  { id: '6', name: 'Закрытие ИП', category: 'Регистрация' },
+  { id: '7', name: 'Налоговый вычет', category: 'Вычеты' },
+  { id: '8', name: 'Представление в ФНС', category: 'Представительство' },
+  { id: '9', name: 'Проверка контрагентов', category: 'Проверки' },
+  { id: '10', name: 'Декларация по УСН', category: 'Декларации' },
+];
+
+export type RequestStatus = 'NEW' | 'ACTIVE' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+
+export interface MockRequest {
+  id: string;
+  title: string;
+  description: string;
+  city: string;
+  service: string;
+  status: RequestStatus;
+  budget: string;
+  createdAt: string;
+  clientName: string;
+  responseCount: number;
+}
+
+export const MOCK_REQUESTS: MockRequest[] = [
+  {
+    id: '1',
+    title: 'Заполнить декларацию 3-НДФЛ за 2025 год',
+    description: 'Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры. Документы готовы.',
+    city: 'Москва',
+    service: 'Декларация 3-НДФЛ',
+    status: 'NEW',
+    budget: '3 000 — 5 000 ₽',
+    createdAt: '2026-04-08',
+    clientName: 'Елена Васильева',
+    responseCount: 0,
+  },
+  {
+    id: '2',
+    title: 'Регистрация ИП на УСН',
+    description: 'Планирую открыть ИП для фриланса (IT-услуги). Нужна помощь с выбором ОКВЭД и системы налогообложения.',
+    city: 'Санкт-Петербург',
+    service: 'Регистрация ИП',
+    status: 'ACTIVE',
+    budget: '5 000 — 8 000 ₽',
+    createdAt: '2026-04-07',
+    clientName: 'Дмитрий Козлов',
+    responseCount: 3,
+  },
+  {
+    id: '3',
+    title: 'Оптимизация налогов для ООО',
+    description: 'Нужна консультация по оптимизации налоговой нагрузки для небольшого ООО (торговля). Оборот ~5 млн в год.',
+    city: 'Казань',
+    service: 'Оптимизация налогов',
+    status: 'IN_PROGRESS',
+    budget: '10 000 — 15 000 ₽',
+    createdAt: '2026-04-05',
+    clientName: 'Татьяна Фёдорова',
+    responseCount: 5,
+  },
+  {
+    id: '4',
+    title: 'Представление в налоговой при камеральной проверке',
+    description: 'Получил требование о предоставлении документов. Нужен специалист, который поможет подготовить ответ и представит мои интересы.',
+    city: 'Екатеринбург',
+    service: 'Представление в ФНС',
+    status: 'COMPLETED',
+    budget: '15 000 — 25 000 ₽',
+    createdAt: '2026-03-20',
+    clientName: 'Елена Васильева',
+    responseCount: 2,
+  },
+  {
+    id: '5',
+    title: 'Закрытие ИП с долгами по налогам',
+    description: 'Нужно закрыть ИП, есть задолженность по взносам. Помогите разобраться с долгами и правильно закрыть.',
+    city: 'Ростов-на-Дону',
+    service: 'Закрытие ИП',
+    status: 'CANCELLED',
+    budget: '7 000 — 12 000 ₽',
+    createdAt: '2026-03-15',
+    clientName: 'Дмитрий Козлов',
+    responseCount: 1,
+  },
+];
+
+export interface MockResponse {
+  id: string;
+  specialistName: string;
+  specialistCity: string;
+  rating: number;
+  reviewCount: number;
+  price: string;
+  message: string;
+  createdAt: string;
+}
+
+export const MOCK_RESPONSES: MockResponse[] = [
+  {
+    id: '1',
+    specialistName: 'Алексей Петров',
+    specialistCity: 'Санкт-Петербург',
+    rating: 4.8,
+    reviewCount: 42,
+    price: '4 500 ₽',
+    message: 'Здравствуйте! Готов помочь с декларацией. Опыт работы — 8 лет, более 200 успешных деклараций. Срок выполнения — 2 рабочих дня.',
+    createdAt: '2026-04-08',
+  },
+  {
+    id: '2',
+    specialistName: 'Ольга Смирнова',
+    specialistCity: 'Новосибирск',
+    rating: 4.9,
+    reviewCount: 67,
+    price: '3 800 ₽',
+    message: 'Добрый день! Специализируюсь на налоговых вычетах. Помогу заполнить декларацию и проконтролирую возврат.',
+    createdAt: '2026-04-08',
+  },
+  {
+    id: '3',
+    specialistName: 'Анна Морозова',
+    specialistCity: 'Казань',
+    rating: 4.6,
+    reviewCount: 28,
+    price: '5 000 ₽',
+    message: 'Работаю с физлицами и ИП. Полное сопровождение от подготовки до подачи.',
+    createdAt: '2026-04-09',
+  },
+];
+
+export interface MockMessage {
+  id: string;
+  text: string;
+  fromMe: boolean;
+  time: string;
+}
+
+export const MOCK_MESSAGES: MockMessage[] = [
+  { id: '1', text: 'Здравствуйте! Интересует ваше предложение по декларации 3-НДФЛ.', fromMe: true, time: '10:30' },
+  { id: '2', text: 'Добрый день! Да, готов помочь. Какие документы у вас на руках?', fromMe: false, time: '10:32' },
+  { id: '3', text: 'Есть справка 2-НДФЛ, договор купли-продажи квартиры и акт приёма-передачи.', fromMe: true, time: '10:35' },
+  { id: '4', text: 'Отлично, этого достаточно. Ещё понадобится копия паспорта и реквизиты для возврата.', fromMe: false, time: '10:37' },
+  { id: '5', text: 'Хорошо, подготовлю всё. Когда можно начать?', fromMe: true, time: '10:40' },
+  { id: '6', text: 'Можем начать завтра. Пришлите сканы документов, и я приступлю.', fromMe: false, time: '10:42' },
+  { id: '7', text: 'Договорились! Отправлю сегодня вечером.', fromMe: true, time: '10:45' },
+  { id: '8', text: 'Жду. Если возникнут вопросы по документам — пишите.', fromMe: false, time: '10:46' },
+  { id: '9', text: 'Скажите, а сколько обычно занимает возврат после подачи?', fromMe: true, time: '11:00' },
+  { id: '10', text: 'Обычно 3-4 месяца с момента подачи. Но бывает и быстрее, если всё оформлено корректно.', fromMe: false, time: '11:03' },
+];
+
+export interface MockThread {
+  id: string;
+  name: string;
+  lastMessage: string;
+  time: string;
+  unread: number;
+}
+
+export const MOCK_THREADS: MockThread[] = [
+  { id: '1', name: 'Алексей Петров', lastMessage: 'Обычно 3-4 месяца с момента подачи.', time: '11:03', unread: 1 },
+  { id: '2', name: 'Ольга Смирнова', lastMessage: 'Документы получила, начну завтра.', time: 'Вчера', unread: 0 },
+  { id: '3', name: 'Анна Морозова', lastMessage: 'Здравствуйте! Готова обсудить детали.', time: 'Вчера', unread: 2 },
+  { id: '4', name: 'Игорь Новиков', lastMessage: 'Спасибо за обращение!', time: '05.04', unread: 0 },
+  { id: '5', name: 'Техподдержка', lastMessage: 'Ваш вопрос решён. Обращайтесь!', time: '01.04', unread: 0 },
+];
+
+export interface MockSpecialist {
+  id: string;
+  name: string;
+  city: string;
+  services: string[];
+  rating: number;
+  reviewCount: number;
+  experience: string;
+  description: string;
+  completedOrders: number;
+}
+
+export const MOCK_SPECIALISTS: MockSpecialist[] = [
+  {
+    id: '1',
+    name: 'Алексей Петров',
+    city: 'Санкт-Петербург',
+    services: ['Декларация 3-НДФЛ', 'Налоговый вычет', 'Консультация по налогам'],
+    rating: 4.8,
+    reviewCount: 42,
+    experience: '8 лет',
+    description: 'Налоговый консультант с опытом работы в ФНС. Специализация — НДФЛ и имущественные вычеты.',
+    completedOrders: 215,
+  },
+  {
+    id: '2',
+    name: 'Ольга Смирнова',
+    city: 'Новосибирск',
+    services: ['Бухгалтерский учёт', 'Регистрация ИП', 'Декларация по УСН'],
+    rating: 4.9,
+    reviewCount: 67,
+    experience: '12 лет',
+    description: 'Главный бухгалтер с опытом в малом и среднем бизнесе. Веду ИП и ООО под ключ.',
+    completedOrders: 340,
+  },
+  {
+    id: '3',
+    name: 'Анна Морозова',
+    city: 'Казань',
+    services: ['Оптимизация налогов', 'Представление в ФНС', 'Проверка контрагентов'],
+    rating: 4.6,
+    reviewCount: 28,
+    experience: '5 лет',
+    description: 'Юрист по налоговому праву. Защита интересов в налоговых спорах и при проверках.',
+    completedOrders: 89,
+  },
+  {
+    id: '4',
+    name: 'Игорь Новиков',
+    city: 'Москва',
+    services: ['Декларация 3-НДФЛ', 'Регистрация ИП', 'Закрытие ИП'],
+    rating: 4.7,
+    reviewCount: 35,
+    experience: '6 лет',
+    description: 'Практикующий бухгалтер. Быстро и качественно — от регистрации до ликвидации.',
+    completedOrders: 156,
+  },
+  {
+    id: '5',
+    name: 'Марина Соколова',
+    city: 'Краснодар',
+    services: ['Бухгалтерский учёт', 'Декларация по УСН', 'Консультация по налогам'],
+    rating: 5.0,
+    reviewCount: 12,
+    experience: '3 года',
+    description: 'Молодой специалист с современным подходом. Работаю удалённо по всей России.',
+    completedOrders: 45,
+  },
+];
+
+export interface MockReview {
+  id: string;
+  author: string;
+  rating: number;
+  text: string;
+  date: string;
+  specialistName: string;
+}
+
+export const MOCK_REVIEWS: MockReview[] = [
+  { id: '1', author: 'Елена В.', rating: 5, text: 'Отличный специалист! Всё сделал быстро и профессионально. Вычет получила за 2 месяца.', date: '05.04.2026', specialistName: 'Алексей Петров' },
+  { id: '2', author: 'Дмитрий К.', rating: 4, text: 'Хорошая работа, но немного затянулись сроки. В целом доволен результатом.', date: '01.04.2026', specialistName: 'Алексей Петров' },
+  { id: '3', author: 'Татьяна Ф.', rating: 5, text: 'Рекомендую! Помогла разобраться с оптимизацией налогов, сэкономили значительную сумму.', date: '28.03.2026', specialistName: 'Анна Морозова' },
+  { id: '4', author: 'Игорь Н.', rating: 3, text: 'Работа выполнена, но коммуникация могла быть лучше. Долго отвечала на сообщения.', date: '20.03.2026', specialistName: 'Ольга Смирнова' },
+  { id: '5', author: 'Анна М.', rating: 5, text: 'Супер! Закрыл ИП за 3 дня, всё чётко и по делу.', date: '15.03.2026', specialistName: 'Игорь Новиков' },
+];
+
+export const MOCK_ADMIN_STATS = {
+  totalUsers: 1247,
+  totalSpecialists: 189,
+  totalRequests: 3456,
+  activeRequests: 127,
+  completedRequests: 2890,
+  revenue: '1 245 000 ₽',
+  newUsersToday: 23,
+  newRequestsToday: 15,
+  pendingModeration: 8,
+  avgRating: 4.7,
+};
+
+export const MOCK_PRICING_PLANS = [
+  {
+    id: 'free',
+    name: 'Бесплатный',
+    price: '0 ₽',
+    period: 'навсегда',
+    features: ['До 3 заявок в месяц', 'Базовый поиск специалистов', 'Чат с исполнителями'],
+    highlighted: false,
+  },
+  {
+    id: 'pro',
+    name: 'Профессионал',
+    price: '990 ₽',
+    period: 'в месяц',
+    features: ['Безлимитные заявки', 'Приоритет в выдаче', 'Расширенный профиль', 'Аналитика', 'Верификация ФНС'],
+    highlighted: true,
+  },
+  {
+    id: 'business',
+    name: 'Бизнес',
+    price: '2 490 ₽',
+    period: 'в месяц',
+    features: ['Всё из Профессионала', 'Команда до 5 человек', 'API доступ', 'Персональный менеджер', 'Приоритетная поддержка'],
+    highlighted: false,
+  },
+];

--- a/constants/protoRegistry.ts
+++ b/constants/protoRegistry.ts
@@ -1,0 +1,70 @@
+export type ProtoGroup = 'Auth' | 'Onboarding' | 'Dashboard' | 'Specialist' | 'Public' | 'Admin';
+
+export interface ProtoPage {
+  id: string;
+  title: string;
+  group: ProtoGroup;
+  route: string;
+  stateCount: number;
+}
+
+export const PROTO_GROUPS: ProtoGroup[] = [
+  'Auth',
+  'Onboarding',
+  'Dashboard',
+  'Specialist',
+  'Public',
+  'Admin',
+];
+
+export const protoRegistry: ProtoPage[] = [
+  // Auth
+  { id: 'auth-email', title: 'Вход — Email', group: 'Auth', route: '/(auth)/login', stateCount: 3 },
+  { id: 'auth-otp', title: 'Вход — OTP код', group: 'Auth', route: '/(auth)/otp', stateCount: 4 },
+
+  // Onboarding
+  { id: 'onboarding-username', title: 'Имя пользователя', group: 'Onboarding', route: '/(onboarding)/username', stateCount: 2 },
+  { id: 'onboarding-cities', title: 'Выбор городов', group: 'Onboarding', route: '/(onboarding)/cities', stateCount: 3 },
+  { id: 'onboarding-services', title: 'Выбор услуг', group: 'Onboarding', route: '/(onboarding)/services', stateCount: 2 },
+  { id: 'onboarding-fns', title: 'Привязка ФНС', group: 'Onboarding', route: '/(onboarding)/fns', stateCount: 3 },
+  { id: 'onboarding-profile', title: 'Заполнение профиля', group: 'Onboarding', route: '/(onboarding)/profile', stateCount: 2 },
+
+  // Dashboard (Client)
+  { id: 'dashboard', title: 'Главная', group: 'Dashboard', route: '/(dashboard)', stateCount: 3 },
+  { id: 'my-requests', title: 'Мои заявки', group: 'Dashboard', route: '/(dashboard)/my-requests', stateCount: 3 },
+  { id: 'my-requests-new', title: 'Новая заявка', group: 'Dashboard', route: '/(dashboard)/new-request', stateCount: 4 },
+  { id: 'my-request-detail', title: 'Детали заявки', group: 'Dashboard', route: '/(dashboard)/request/1', stateCount: 3 },
+  { id: 'responses', title: 'Отклики', group: 'Dashboard', route: '/(dashboard)/responses', stateCount: 4 },
+  { id: 'messages', title: 'Сообщения', group: 'Dashboard', route: '/(dashboard)/messages', stateCount: 2 },
+  { id: 'message-thread', title: 'Чат', group: 'Dashboard', route: '/(dashboard)/messages/1', stateCount: 3 },
+  { id: 'profile', title: 'Профиль', group: 'Dashboard', route: '/(dashboard)/profile', stateCount: 2 },
+  { id: 'settings', title: 'Настройки', group: 'Dashboard', route: '/(dashboard)/settings', stateCount: 1 },
+
+  // Specialist
+  { id: 'specialist-dashboard', title: 'Кабинет специалиста', group: 'Specialist', route: '/specialist', stateCount: 2 },
+  { id: 'specialist-respond', title: 'Отклик специалиста', group: 'Specialist', route: '/specialist/respond', stateCount: 3 },
+  { id: 'specialist-profile-public', title: 'Публичный профиль', group: 'Specialist', route: '/specialists/1', stateCount: 2 },
+
+  // Public
+  { id: 'landing', title: 'Лендинг', group: 'Public', route: '/', stateCount: 4 },
+  { id: 'public-requests', title: 'Лента заявок', group: 'Public', route: '/requests', stateCount: 3 },
+  { id: 'public-request-detail', title: 'Детали заявки (публ.)', group: 'Public', route: '/requests/1', stateCount: 2 },
+  { id: 'specialists-catalog', title: 'Каталог специалистов', group: 'Public', route: '/specialists', stateCount: 3 },
+  { id: 'pricing', title: 'Тарифы', group: 'Public', route: '/pricing', stateCount: 1 },
+
+  // Admin
+  { id: 'admin-dashboard', title: 'Админ — Главная', group: 'Admin', route: '/(admin)', stateCount: 1 },
+  { id: 'admin-users', title: 'Админ — Пользователи', group: 'Admin', route: '/(admin)/users', stateCount: 2 },
+  { id: 'admin-requests', title: 'Админ — Заявки', group: 'Admin', route: '/(admin)/requests', stateCount: 2 },
+  { id: 'admin-moderation', title: 'Админ — Модерация', group: 'Admin', route: '/(admin)/moderation', stateCount: 3 },
+  { id: 'admin-reviews', title: 'Админ — Отзывы', group: 'Admin', route: '/(admin)/reviews', stateCount: 1 },
+  { id: 'admin-promotions', title: 'Админ — Промо', group: 'Admin', route: '/(admin)/promotions', stateCount: 1 },
+];
+
+export function getPageById(id: string): ProtoPage | undefined {
+  return protoRegistry.find((p) => p.id === id);
+}
+
+export function getPagesByGroup(group: ProtoGroup): ProtoPage[] {
+  return protoRegistry.filter((p) => p.group === group);
+}


### PR DESCRIPTION
## Summary
- Proto dashboard at `/proto` with grouped tiles (Auth, Onboarding, Dashboard, Specialist, Public, Admin)
- State showcase at `/proto/states/[page]` showing all UI states per page
- 30 pages, 74 states total, realistic Russian mock data
- Shared components: ProtoLayout, StateSection, ProtoCard
- Brand "Государственный" tokens applied throughout

## Test plan
- [ ] Open http://localhost:8081/proto — dashboard loads with all tiles
- [ ] Click any tile — opens state showcase in new tab
- [ ] Check responsive: mobile 430px + desktop
- [ ] Verify brand colors/typography match

🤖 Generated with [Claude Code](https://claude.com/claude-code)