### PR TITLE
fix: add overview page in proto

### DIFF
--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -7,6 +7,7 @@ import { getPageById } from '../../../constants/pageRegistry';
 import { Colors, Typography, Spacing } from '../../../constants/Colors';
 
 // State components
+import { OverviewStates } from '../../../components/proto/states/OverviewStates';
 import { BrandStyleStates } from '../../../components/proto/states/BrandStyleStates';
 import { AuthEmailStates } from '../../../components/proto/states/AuthEmailStates';
 import { AuthOtpStates } from '../../../components/proto/states/AuthOtpStates';
@@ -39,6 +40,7 @@ import { AdminPromotionsStates } from '../../../components/proto/states/AdminPro
 import { NavComponentsStates } from '../../../components/proto/states/NavComponentsStates';
 
 const STATE_MAP: Record<string, React.ComponentType> = {
+  'overview': OverviewStates,
   'nav-components': NavComponentsStates,
   'brand-style': BrandStyleStates,
   'auth-email': AuthEmailStates,

--- a/components/proto/states/OverviewStates.tsx
+++ b/components/proto/states/OverviewStates.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { View, Text, ScrollView, StyleSheet, Platform } from 'react-native';
+
+export function OverviewStates() {
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>P2PTax</Text>
+        <Text style={styles.subtitle}>Tax information arbitrage -- find specialists (lawyers, tax consultants) in any city</Text>
+
+        <Text style={styles.sectionTitle}>Roles</Text>
+        <Text style={styles.item}>Guest -- browse public requests, specialists catalog, pricing</Text>
+        <Text style={styles.item}>Client -- create requests, view responses, chat with specialists</Text>
+        <Text style={styles.item}>Specialist -- respond to requests, manage profile, receive messages</Text>
+        <Text style={styles.item}>Admin -- manage users, requests, moderation, reviews, promotions</Text>
+
+        <Text style={styles.sectionTitle}>Pages</Text>
+        <Text style={styles.groupTitle}>Auth</Text>
+        <Text style={styles.item}>Email Login, OTP Verification</Text>
+
+        <Text style={styles.groupTitle}>Onboarding (Specialist)</Text>
+        <Text style={styles.item}>Username, Work Area (City/FNS/Services), Profile</Text>
+
+        <Text style={styles.groupTitle}>Dashboard (Client)</Text>
+        <Text style={styles.item}>Home, My Requests, New Request, Request Detail, Responses, Messages, Chat, Profile, Settings</Text>
+
+        <Text style={styles.groupTitle}>Specialist</Text>
+        <Text style={styles.item}>Dashboard, Respond to Request, Public Profile</Text>
+
+        <Text style={styles.groupTitle}>Public</Text>
+        <Text style={styles.item}>Landing, Public Requests Feed, Request Detail, Specialists Catalog, Pricing</Text>
+
+        <Text style={styles.groupTitle}>Admin</Text>
+        <Text style={styles.item}>Dashboard, Users, Requests, Moderation, Reviews, Promotions</Text>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { minHeight: Platform.OS === 'web' ? ('100vh' as any) : 844, backgroundColor: '#fff' },
+  content: { padding: 32, maxWidth: 600 },
+  title: { fontSize: 28, fontWeight: '700', marginBottom: 8 },
+  subtitle: { fontSize: 16, color: '#666', marginBottom: 32 },
+  sectionTitle: { fontSize: 18, fontWeight: '600', marginBottom: 12, marginTop: 24 },
+  groupTitle: { fontSize: 14, fontWeight: '600', color: '#444', marginTop: 12, marginBottom: 4 },
+  item: { fontSize: 14, color: '#555', marginBottom: 4, paddingLeft: 12 },
+});

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -1,4 +1,4 @@
-export type PageGroup = 'Brand' | 'Auth' | 'Onboarding' | 'Dashboard' | 'Specialist' | 'Public' | 'Admin';
+export type PageGroup = 'Overview' | 'Brand' | 'Auth' | 'Onboarding' | 'Dashboard' | 'Specialist' | 'Public' | 'Admin';
 export type NavVariant = 'none' | 'public' | 'auth' | 'client' | 'specialist' | 'admin';
 
 export interface PageNote {
@@ -28,6 +28,7 @@ export interface PageEntry {
 }
 
 export const PAGE_GROUPS: PageGroup[] = [
+  'Overview',
   'Brand',
   'Auth',
   'Onboarding',
@@ -38,6 +39,9 @@ export const PAGE_GROUPS: PageGroup[] = [
 ];
 
 export const pageRegistry: PageEntry[] = [
+  // Overview
+  { id: 'overview', title: 'Project Overview', group: 'Overview', route: '/', stateCount: 1, nav: 'none' },
+
   // Brand
   { id: 'nav-components', title: 'Navigation Components', group: 'Brand', route: '/proto/nav', stateCount: 11, nav: 'none' },
   { id: 'brand-style', title: 'Бренд и стили', group: 'Brand', route: '/brand', stateCount: 1, nav: 'none', qaCycles: 1, qaScore: 10,


### PR DESCRIPTION
## Summary
- Add `overview` entry to pageRegistry (group: Overview, first in list)
- Create OverviewStates.tsx with static project info (roles, page groups)
- Register overview component in [page].tsx state map

## Test plan
- [ ] Open proto viewer, verify overview page loads without "Page not found"