### PR TITLE
feat(proto): add data-state-name for viewer state chips

### DIFF
--- a/app/proto/states/_layout.tsx
+++ b/app/proto/states/_layout.tsx
@@ -1,6 +1,23 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { Stack } from 'expo-router';
 
 export default function StatesLayout() {
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type !== 'GET_STATES') return;
+      const elements = document.querySelectorAll('[data-state-name]');
+      const states = Array.from(elements).map(el => ({
+        name: el.getAttribute('data-state-name'),
+        y: (el as HTMLElement).getBoundingClientRect().top + window.scrollY
+      }));
+      (e.source as Window)?.postMessage({ type: 'STATES_LIST', states }, '*');
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+
   return (
     <Stack screenOptions={{ headerShown: false }} />
   );

--- a/components/proto/StateSection.tsx
+++ b/components/proto/StateSection.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Platform } from 'react-native';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { getPageById } from '../../constants/pageRegistry';
 import { ProtoNavHeader, ProtoNavFooter } from './ProtoNav';
@@ -19,9 +19,10 @@ export function StateSection({ title, children, maxWidth = 430, pageId: pageIdPr
   const contextPageId = useContext(PageIdContext);
   const pageId = pageIdProp || contextPageId;
   const page = pageId ? getPageById(pageId) : undefined;
+  const webProps = Platform.OS === 'web' ? { 'data-state-name': title } : {};
 
   return (
-    <View style={styles.section}>
+    <View {...webProps} style={styles.section}>
       <View style={styles.labelRow}>
         <View style={styles.labelBadge}>
           <Text style={styles.labelText}>{title}</Text>


### PR DESCRIPTION
Adds data-state-name attribute to StateSection and postMessage listener for proto viewer chip overlay.