### PR TITLE
fix: remove duplicate headers in proto state sections

### DIFF
--- a/components/proto/states/AdminDashboardStates.tsx
+++ b/components/proto/states/AdminDashboardStates.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 import { MOCK_ADMIN_STATS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function StatCard({ label, value, color, trend }: { label: string; value: string | number; color: string; trend?: string }) {
   return (
@@ -39,10 +38,6 @@ export function AdminDashboardStates() {
   const st = MOCK_ADMIN_STATS;
   return (
     <StateSection title="STATS" maxWidth={800}>
-      <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-        <ProtoHeader variant="auth" />
-        <View style={{ flex: 1 }}>
-
       <View style={s.container}>
         <Text style={s.pageTitle}>Панель администратора</Text>
 
@@ -83,10 +78,7 @@ export function AdminDashboardStates() {
           ))}
         </View>
       </View>
-            </View>
-        <ProtoTabBar activeTab="home" />
-      </View>
-</StateSection>
+    </StateSection>
   );
 }
 

--- a/components/proto/states/AdminModerationStates.tsx
+++ b/components/proto/states/AdminModerationStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, Image, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function ModerationCard({ name, type, date, onApprove, onReject, onView }: {
   name: string; type: string; date: string;
@@ -173,35 +172,14 @@ export function AdminModerationStates() {
   return (
     <>
       <StateSection title="DEFAULT" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DefaultModeration />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="INTERACTIVE" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveModeration />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="APPROVED" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <ApprovedModeration />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/AdminPromotionsStates.tsx
+++ b/components/proto/states/AdminPromotionsStates.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 const PROMO_DATA = [
   { id: '1', code: 'WELCOME30', discount: '30%', type: 'Скидка на тариф', usages: 45, maxUsages: 100, active: true, expiry: '30.06.2026' },
@@ -51,10 +50,6 @@ function PromoCard({ code, discount, type, usages, maxUsages, active, expiry }: 
 export function AdminPromotionsStates() {
   return (
     <StateSection title="LIST" maxWidth={800}>
-      <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-        <ProtoHeader variant="auth" />
-        <View style={{ flex: 1 }}>
-
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.pageTitle}>Промо-коды</Text>
@@ -78,10 +73,7 @@ export function AdminPromotionsStates() {
           <PromoCard key={p.id} {...p} />
         ))}
       </View>
-            </View>
-        <ProtoTabBar activeTab="home" />
-      </View>
-</StateSection>
+    </StateSection>
   );
 }
 

--- a/components/proto/states/AdminRequestsStates.tsx
+++ b/components/proto/states/AdminRequestsStates.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_REQUESTS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 const STATUS_MAP: Record<string, { label: string; color: string }> = {
   NEW: { label: 'Новая', color: Colors.brandPrimary },
@@ -63,10 +62,6 @@ export function AdminRequestsStates() {
   return (
     <>
       <StateSection title="LIST" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <Text style={s.pageTitle}>Заявки (3 456)</Text>
           <View style={s.filters}>
@@ -79,15 +74,8 @@ export function AdminRequestsStates() {
             <RequestRow key={r.id} title={r.title} client={r.clientName} status={r.status} date={r.createdAt} city={r.city} />
           ))}
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="MODERATION_POPUP" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={[s.container, { minHeight: 450 }]}>
           <Text style={s.pageTitle}>Заявки</Text>
           {MOCK_REQUESTS.slice(0, 2).map((r) => (
@@ -95,10 +83,7 @@ export function AdminRequestsStates() {
           ))}
           <ModerationPopup />
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/AdminReviewsStates.tsx
+++ b/components/proto/states/AdminReviewsStates.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_REVIEWS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function ReviewRow({ author, rating, text, date, specialistName }: {
   author: string; rating: number; text: string; date: string; specialistName: string;
@@ -37,10 +36,6 @@ function ReviewRow({ author, rating, text, date, specialistName }: {
 export function AdminReviewsStates() {
   return (
     <StateSection title="LIST" maxWidth={800}>
-      <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-        <ProtoHeader variant="auth" />
-        <View style={{ flex: 1 }}>
-
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.pageTitle}>Отзывы</Text>
@@ -68,10 +63,7 @@ export function AdminReviewsStates() {
           <ReviewRow key={r.id} author={r.author} rating={r.rating} text={r.text} date={r.date} specialistName={r.specialistName} />
         ))}
       </View>
-            </View>
-        <ProtoTabBar activeTab="home" />
-      </View>
-</StateSection>
+    </StateSection>
   );
 }
 

--- a/components/proto/states/AdminUsersStates.tsx
+++ b/components/proto/states/AdminUsersStates.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, Text, TextInput, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Image, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_USERS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function UserRow({ name, email, role, city }: { name: string; email: string; role: string; city: string }) {
   return (
@@ -55,10 +54,6 @@ export function AdminUsersStates() {
   return (
     <>
       <StateSection title="LIST" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <Text style={s.pageTitle}>Пользователи (1 247)</Text>
           <TextInput
@@ -77,15 +72,8 @@ export function AdminUsersStates() {
             <UserRow key={u.id} name={u.name} email={u.email} role={u.role} city={u.city} />
           ))}
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="DETAIL_POPUP" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={[s.container, { minHeight: 500 }]}>
           <Text style={s.pageTitle}>Пользователи</Text>
           {MOCK_USERS.slice(0, 3).map((u) => (
@@ -93,10 +81,7 @@ export function AdminUsersStates() {
           ))}
           <UserPopup />
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/AuthEmailStates.tsx
+++ b/components/proto/states/AuthEmailStates.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function AuthScreen({ initialEmail, initialError, initialLoading }: { initialEmail: string; initialError?: string; initialLoading?: boolean }) {
   const [email, setEmail] = useState(initialEmail);
@@ -54,35 +53,14 @@ export function AuthEmailStates() {
   return (
     <>
       <StateSection title="DEFAULT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <AuthScreen initialEmail="" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="ERROR">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <AuthScreen initialEmail="invalid-email" initialError="Введите корректный email адрес" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <AuthScreen initialEmail="elena@mail.ru" initialLoading />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/AuthOtpStates.tsx
+++ b/components/proto/states/AuthOtpStates.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function OtpScreen({ initialCode, initialError, initialResendTimer, initialLoading }: {
   initialCode?: string; initialError?: string; initialResendTimer?: number; initialLoading?: boolean;
@@ -110,45 +109,17 @@ export function AuthOtpStates() {
   return (
     <>
       <StateSection title="DEFAULT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <OtpScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="ERROR">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <OtpScreen initialCode="123456" initialError="Неверный код. Попробуйте ещё раз." />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="RESEND">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <OtpScreen initialResendTimer={42} />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <OtpScreen initialCode="000000" initialLoading />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/DashboardStates.tsx
+++ b/components/proto/states/DashboardStates.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { View, Text, Image, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function StatCard({ label, value, color }: { label: string; value: string; color: string }) {
   return (
@@ -87,35 +86,14 @@ export function DashboardStates() {
   return (
     <>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <EmptyDashboard />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="WITH_DATA">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <WithDataDashboard />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingDashboard />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/LandingStates.tsx
+++ b/components/proto/states/LandingStates.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TextInput, Pressable, Image, Platform } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TextInput, Pressable, Image } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { StateSection } from '../StateSection';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 const BRAND = {
   primary: Colors.textPrimary,
   action: Colors.brandPrimary,
-  accent: Colors.statusWarning,
+  accent: '#D4A843',
   bg: Colors.bgPrimary,
   card: Colors.bgCard,
   textPrimary: Colors.textPrimary,
@@ -346,21 +345,10 @@ export function LandingStates() {
   return (
     <View style={{ gap: Spacing['4xl'] }}>
       <StateSection title="DEFAULT" pageId="landing" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FullLanding />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
 
       <StateSection title="FORM_FILLING" pageId="landing" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FullLanding
           prefill={{
             city: 'Москва',
@@ -368,16 +356,9 @@ export function LandingStates() {
             description: 'Нужна помощь с камеральной проверкой за 2025 год. Получил требование из налоговой.',
           }}
         />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
 
       <StateSection title="FORM_VALIDATION" pageId="landing" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FullLanding
           prefill={{
             city: 'Санкт-Петербург',
@@ -387,24 +368,14 @@ export function LandingStates() {
           }}
           errors={{ email: true }}
         />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
 
       <StateSection title="FORM_SUCCESS" pageId="landing" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FullLanding
           prefill={{ email: 'ivan@example.com' }}
           submitted
         />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </View>
   );
 }

--- a/components/proto/states/MessageThreadStates.tsx
+++ b/components/proto/states/MessageThreadStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, Image, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_MESSAGES, MockMessage } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function ChatHeader() {
   return (
@@ -90,30 +89,12 @@ export function MessageThreadStates() {
   return (
     <>
       <StateSection title="INTERACTIVE_CHAT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveChat initialMessages={MOCK_MESSAGES} />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveChat initialMessages={[]} />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="TYPING_INDICATOR">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <ChatHeader />
           <View style={s.messages}>
@@ -153,10 +134,7 @@ export function MessageThreadStates() {
             </View>
           </View>
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/MessagesStates.tsx
+++ b/components/proto/states/MessagesStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_THREADS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function ThreadItem({ name, lastMessage, time, unread, selected, onPress }: {
   name: string; lastMessage: string; time: string; unread: number; selected: boolean; onPress: () => void;
@@ -57,20 +56,9 @@ export function MessagesStates() {
   return (
     <>
       <StateSection title="INTERACTIVE">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveMessages />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <Text style={s.pageTitle}>Сообщения</Text>
           <View style={s.emptyWrap}>
@@ -78,10 +66,7 @@ export function MessagesStates() {
             <Text style={s.emptyText}>Сообщения появятся после принятия отклика специалиста</Text>
           </View>
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/MyRequestDetailStates.tsx
+++ b/components/proto/states/MyRequestDetailStates.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_RESPONSES } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
   return (
@@ -100,35 +99,14 @@ export function MyRequestDetailStates() {
   return (
     <>
       <StateSection title="WITH_RESPONSES">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DetailScreen mode="responses" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="NO_RESPONSES">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DetailScreen mode="no_responses" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="CLOSED">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DetailScreen mode="closed" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/MyRequestsNewStates.tsx
+++ b/components/proto/states/MyRequestsNewStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_CITIES, MOCK_SERVICES } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function FormScreen() {
   const [title, setTitle] = useState('');
@@ -250,45 +249,17 @@ export function MyRequestsNewStates() {
   return (
     <View style={{ gap: Spacing['4xl'] }}>
       <StateSection title="INTERACTIVE_FORM">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FormScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingState />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="SUCCESS">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <SuccessState />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="VALIDATION">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <ValidationState />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </View>
   );
 }

--- a/components/proto/states/MyRequestsStates.tsx
+++ b/components/proto/states/MyRequestsStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_REQUESTS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 const STATUS_MAP: Record<string, { label: string; color: string }> = {
   NEW: { label: 'Новая', color: Colors.brandPrimary },
@@ -79,20 +78,9 @@ export function MyRequestsStates() {
   return (
     <>
       <StateSection title="INTERACTIVE_TABS">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveList />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <View style={s.topBar}>
             <Text style={s.pageTitle}>Мои заявки</Text>
@@ -103,15 +91,8 @@ export function MyRequestsStates() {
             <Text style={s.emptyText}>Создайте заявку, чтобы получить предложения от специалистов</Text>
           </View>
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <View style={s.topBar}>
             <Text style={s.pageTitle}>Мои заявки</Text>
@@ -120,10 +101,7 @@ export function MyRequestsStates() {
             <ActivityIndicator size="large" color={Colors.brandPrimary} />
           </View>
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/OnboardingProfileStates.tsx
+++ b/components/proto/states/OnboardingProfileStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Screen({ initialFilled }: { initialFilled?: boolean }) {
   const [about, setAbout] = useState(initialFilled ? 'Налоговый консультант с опытом работы 8 лет. Специализация — НДФЛ, имущественные вычеты, регистрация ИП.' : '');
@@ -55,25 +54,11 @@ export function OnboardingProfileStates() {
   return (
     <>
       <StateSection title="DEFAULT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="FILLED">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen initialFilled />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/OnboardingUsernameStates.tsx
+++ b/components/proto/states/OnboardingUsernameStates.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Screen({ initialValue, initialError }: { initialValue?: string; initialError?: string }) {
   const [value, setValue] = useState(initialValue || '');
@@ -44,25 +43,11 @@ export function OnboardingUsernameStates() {
   return (
     <>
       <StateSection title="DEFAULT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="VALIDATION_ERROR">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen initialValue="Ел" initialError="Имя должно содержать минимум 3 символа" />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/OnboardingWorkAreaStates.tsx
+++ b/components/proto/states/OnboardingWorkAreaStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 const SERVICES = [
   'Выездная проверка',
@@ -195,20 +194,9 @@ export function OnboardingWorkAreaStates() {
   return (
     <>
       <StateSection title="DEFAULT">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="FILLED">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <Screen preset={{
           cities: ['Москва', 'Санкт-Петербург'],
           bindings: {
@@ -217,10 +205,7 @@ export function OnboardingWorkAreaStates() {
             'Санкт-Петербург:ИФНС №15 по СПб': ['Выездная проверка'],
           },
         }} />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/PricingStates.tsx
+++ b/components/proto/states/PricingStates.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_PRICING_PLANS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function PlanCard({ name, price, period, features, highlighted }: {
   name: string; price: string; period: string; features: string[]; highlighted: boolean;
@@ -37,10 +36,6 @@ function PlanCard({ name, price, period, features, highlighted }: {
 export function PricingStates() {
   return (
     <StateSection title="PLANS_COMPARISON" maxWidth={1024}>
-      <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-        <ProtoHeader variant="auth" />
-        <View style={{ flex: 1 }}>
-
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.title}>Тарифы</Text>
@@ -64,10 +59,7 @@ export function PricingStates() {
           ))}
         </View>
       </View>
-            </View>
-        <ProtoTabBar activeTab="home" />
-      </View>
-</StateSection>
+    </StateSection>
   );
 }
 

--- a/components/proto/states/ProfileStates.tsx
+++ b/components/proto/states/ProfileStates.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, Image, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
@@ -109,25 +108,11 @@ export function ProfileStates() {
   return (
     <>
       <StateSection title="INTERACTIVE">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveProfile />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingProfile />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/PublicRequestDetailStates.tsx
+++ b/components/proto/states/PublicRequestDetailStates.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { View, Text, TextInput, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function DetailView({ showRespondPopup }: { showRespondPopup?: boolean }) {
   return (
@@ -66,25 +65,11 @@ export function PublicRequestDetailStates() {
   return (
     <>
       <StateSection title="DETAIL" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DetailView />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="RESPOND_POPUP" maxWidth={800}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <DetailView showRespondPopup />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/PublicRequestsStates.tsx
+++ b/components/proto/states/PublicRequestsStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_REQUESTS, MOCK_CITIES, MOCK_SERVICES } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function RequestFeedCard({ title, description, city, service, budget, date }: {
   title: string; description: string; city: string; service: string; budget: string; date: string;
@@ -170,35 +169,14 @@ export function PublicRequestsStates() {
   return (
     <>
       <StateSection title="INTERACTIVE" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveRequests />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <EmptyRequests />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingRequests />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/ResponsesStates.tsx
+++ b/components/proto/states/ResponsesStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable, StyleSheet, ActivityIndicator, Platform } from 'react-native';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_RESPONSES } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
   return (
@@ -153,20 +152,9 @@ export function ResponsesStates() {
   return (
     <>
       <StateSection title="INTERACTIVE">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveResponses />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <View style={s.container}>
           <Text style={s.pageTitle}>Отклики</Text>
           <View style={s.emptyWrap}>
@@ -174,30 +162,13 @@ export function ResponsesStates() {
             <Text style={s.emptyText}>Специалисты ещё не откликнулись на ваши заявки</Text>
           </View>
         </View>
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingResponses />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="ACCEPTED">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <AcceptedResponse />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/SettingsStates.tsx
+++ b/components/proto/states/SettingsStates.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function SettingRow({ label, value, danger, onPress }: { label: string; value?: string; danger?: boolean; onPress?: () => void }) {
   return (
@@ -72,15 +71,8 @@ function InteractiveSettings() {
 export function SettingsStates() {
   return (
     <StateSection title="INTERACTIVE">
-      <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-        <ProtoHeader variant="auth" />
-        <View style={{ flex: 1 }}>
-
       <InteractiveSettings />
-            </View>
-        <ProtoTabBar activeTab="home" />
-      </View>
-</StateSection>
+    </StateSection>
   );
 }
 

--- a/components/proto/states/SpecialistDashboardStates.tsx
+++ b/components/proto/states/SpecialistDashboardStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 import { MOCK_REQUESTS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function RequestCard({ title, city, budget, service, date }: {
   title: string; city: string; budget: string; service: string; date: string;
@@ -111,25 +110,11 @@ export function SpecialistDashboardStates() {
   return (
     <>
       <StateSection title="INTERACTIVE">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveDashboard />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <EmptyDashboard />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/SpecialistProfilePublicStates.tsx
+++ b/components/proto/states/SpecialistProfilePublicStates.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_REVIEWS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
   return (
@@ -123,25 +122,11 @@ export function SpecialistProfilePublicStates() {
   return (
     <>
       <StateSection title="FULL">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <ProfileScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="REVIEWS_POPUP">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <ProfileScreen showReviewsPopup />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/SpecialistRespondStates.tsx
+++ b/components/proto/states/SpecialistRespondStates.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Popup({ type, onClose }: { type: 'success' | 'error'; onClose: () => void }) {
   const isSuccess = type === 'success';
@@ -122,35 +121,14 @@ export function SpecialistRespondStates() {
   return (
     <>
       <StateSection title="INTERACTIVE_FORM">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <FormScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="SUBMITTED">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <SubmittedScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="ERROR">
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <ErrorScreen />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }

--- a/components/proto/states/SpecialistsCatalogStates.tsx
+++ b/components/proto/states/SpecialistsCatalogStates.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { View, Text, Image, TextInput, Pressable, StyleSheet, ActivityIndicator, Platform } from 'react-native';
+import { View, Text, Image, TextInput, Pressable, StyleSheet, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { MOCK_SPECIALISTS } from '../../../constants/protoMockData';
-import { ProtoHeader, ProtoTabBar } from '../NavComponents';
 
 function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
   return (
@@ -156,35 +155,14 @@ export function SpecialistsCatalogStates() {
   return (
     <>
       <StateSection title="INTERACTIVE" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <InteractiveCatalog />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="EMPTY" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <EmptyCatalog />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
       <StateSection title="LOADING" maxWidth={1024}>
-        <View style={{ minHeight: Platform.OS === 'web' ? '100vh' : 844 }}>
-          <ProtoHeader variant="auth" />
-          <View style={{ flex: 1 }}>
-
         <LoadingCatalog />
-                </View>
-          <ProtoTabBar activeTab="home" />
-        </View>
-</StateSection>
+      </StateSection>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Reverted pageshell commit (8f3e15a) changes from all 28 proto state files
- StateSection already renders ProtoNavHeader/ProtoNavFooter via page registry — the extra ProtoHeader+ProtoTabBar inside children caused double navigation on every proto page
- 28 files changed, 601 lines removed (all duplicate wrappers)

## Test plan
- [ ] Open proto viewer, check each page has exactly 1 header and 1 footer
- [ ] No blank/missing headers on any state section

🤖 Generated with [Claude Code](https://claude.com/claude-code)