### PR TITLE
fix(proto): set data-state-name for text API

### DIFF
--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -39,9 +39,11 @@ import { AdminReviewsStates } from '../../../components/proto/states/AdminReview
 import { AdminPromotionsStates } from '../../../components/proto/states/AdminPromotionsStates';
 import { NavComponentsStates } from '../../../components/proto/states/NavComponentsStates';
 import { ComponentsStates } from '../../../components/proto/states/ComponentsStates';
+import { BrandStates } from '../../../components/proto/states/BrandStates';
 
 const STATE_MAP: Record<string, React.ComponentType> = {
   'overview': OverviewStates,
+  'brand': BrandStates,
   'nav-components': NavComponentsStates,
   'brand-style': BrandStyleStates,
   'components': ComponentsStates,

--- a/components/proto/StateSection.tsx
+++ b/components/proto/StateSection.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useRef, useEffect } from 'react';
 import { View, Text, StyleSheet, Platform } from 'react-native';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { getPageById } from '../../constants/pageRegistry';
@@ -19,10 +19,17 @@ export function StateSection({ title, children, maxWidth = 430, pageId: pageIdPr
   const contextPageId = useContext(PageIdContext);
   const pageId = pageIdProp || contextPageId;
   const page = pageId ? getPageById(pageId) : undefined;
-  const webProps = Platform.OS === 'web' ? { 'data-state-name': title } : {};
+  const ref = useRef<View>(null);
+
+  useEffect(() => {
+    if (Platform.OS === 'web' && ref.current) {
+      // Set data attribute directly on DOM element for text/screenshot API
+      (ref.current as unknown as HTMLElement).setAttribute('data-state-name', title);
+    }
+  }, [title]);
 
   return (
-    <View {...webProps} style={styles.section}>
+    <View ref={ref} style={styles.section}>
       <View style={styles.labelRow}>
         <View style={styles.labelBadge}>
           <Text style={styles.labelText}>{title}</Text>

--- a/components/proto/states/BrandStates.tsx
+++ b/components/proto/states/BrandStates.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { StateSection } from '../StateSection';
+
+export function BrandStates() {
+  return (
+    <View style={styles.container}>
+      <StateSection title="Brand">
+        <View style={styles.placeholder}>
+          <Text style={styles.text}>Brand page stub</Text>
+        </View>
+      </StateSection>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, gap: 32 },
+  placeholder: { padding: 24, alignItems: 'center' },
+  text: { fontSize: 16, color: '#666' },
+});

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -43,6 +43,7 @@ export const pageRegistry: PageEntry[] = [
   { id: 'overview', title: 'Project Overview', group: 'Overview', route: '/', stateCount: 1, nav: 'none' },
 
   // Brand
+  { id: 'brand', title: 'Brand', group: 'Brand', route: '/proto/brand', stateCount: 1, nav: 'none' },
   { id: 'nav-components', title: 'Navigation Components', group: 'Brand', route: '/proto/nav', stateCount: 11, nav: 'none' },
   { id: 'brand-style', title: 'Бренд и стили', group: 'Brand', route: '/brand', stateCount: 1, nav: 'none', qaCycles: 1, qaScore: 10,
       notes: [


### PR DESCRIPTION
Enables state detection in /api/text endpoint via useEffect+setAttribute approach. Also adds brand page stub.