### PR TITLE
fix(proto): rename brand-style → brand, fix CI proto-viewer install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,14 @@ jobs:
           sudo pm2 restart p2ptax-api --update-env || sudo pm2 start dist/main.js --name p2ptax-api
           sudo pm2 save
 
+      - name: Install proto-viewer
+        run: sudo npm i -g github:serter2069/proto-viewer
+
+      - name: Restart proto-viewer
+        run: |
+          sudo pm2 restart proto-p2ptax --update-env || echo "proto-p2ptax not running, skipping"
+          sudo pm2 save
+
       - name: Verify staging
         run: |
           sleep 5

--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -39,13 +39,11 @@ import { AdminReviewsStates } from '../../../components/proto/states/AdminReview
 import { AdminPromotionsStates } from '../../../components/proto/states/AdminPromotionsStates';
 import { NavComponentsStates } from '../../../components/proto/states/NavComponentsStates';
 import { ComponentsStates } from '../../../components/proto/states/ComponentsStates';
-import { BrandStates } from '../../../components/proto/states/BrandStates';
 
 const STATE_MAP: Record<string, React.ComponentType> = {
   'overview': OverviewStates,
-  'brand': BrandStates,
   'nav-components': NavComponentsStates,
-  'brand-style': BrandStyleStates,
+  'brand': BrandStyleStates,
   'components': ComponentsStates,
   'auth-email': AuthEmailStates,
   'auth-otp': AuthOtpStates,

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -43,9 +43,8 @@ export const pageRegistry: PageEntry[] = [
   { id: 'overview', title: 'Project Overview', group: 'Overview', route: '/', stateCount: 1, nav: 'none' },
 
   // Brand
-  { id: 'brand', title: 'Brand', group: 'Brand', route: '/proto/brand', stateCount: 1, nav: 'none' },
   { id: 'nav-components', title: 'Navigation Components', group: 'Brand', route: '/proto/nav', stateCount: 11, nav: 'none' },
-  { id: 'brand-style', title: 'Бренд и стили', group: 'Brand', route: '/brand', stateCount: 1, nav: 'none', qaCycles: 1, qaScore: 10,
+  { id: 'brand', title: 'Бренд и стили', group: 'Brand', route: '/brand', stateCount: 1, nav: 'none', qaCycles: 1, qaScore: 10,
       notes: [
         { date: '2026-04-10', text: '(empty)' },
       ]
@@ -218,7 +217,7 @@ export const pageRegistry: PageEntry[] = [
 export const PAGE_TRANSITIONS: Record<string, { to: string; action: string }[]> = {
   // === Brand ===
   'nav-components': [],
-  'brand-style': [],
+  'brand': [],
   'components': [],
 
   // === Public pages (nav: 'public') ===


### PR DESCRIPTION
## Summary
- Renamed `brand-style` → `brand` in pageRegistry, STATE_MAP, and PAGE_TRANSITIONS
- Removed duplicate old `brand` entry (title "Brand", route "/proto/brand") — consolidated into single entry
- Added `proto-viewer` install from `github:serter2069/proto-viewer` and `proto-p2ptax` PM2 restart to staging deploy workflow

## Files changed
- `constants/pageRegistry.ts` — registry id rename + remove duplicate
- `app/proto/states/[page].tsx` — STATE_MAP key update + remove unused import
- `.github/workflows/deploy.yml` — add proto-viewer install + PM2 restart steps