### PR TITLE
Fix issue #522: proto: p2ptax — PC layout + full-page height

### DIFF
--- a/components/proto/StateSection.tsx
+++ b/components/proto/StateSection.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useRef, useEffect } from 'react';
-import { View, Text, StyleSheet, Platform } from 'react-native';
+import { View, Text, StyleSheet, Platform, Dimensions } from 'react-native';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { getPageById } from '../../constants/pageRegistry';
 import { ProtoNavHeader, ProtoNavFooter } from './ProtoNav';
@@ -15,11 +15,14 @@ interface StateSectionProps {
   pageId?: string;
 }
 
-export function StateSection({ title, children, maxWidth = 430, pageId: pageIdProp }: StateSectionProps) {
+export function StateSection({ title, children, maxWidth = 960, pageId: pageIdProp }: StateSectionProps) {
   const contextPageId = useContext(PageIdContext);
   const pageId = pageIdProp || contextPageId;
   const page = pageId ? getPageById(pageId) : undefined;
   const ref = useRef<View>(null);
+
+  const windowHeight = Dimensions.get('window').height;
+  const minHeight = Math.max(844, windowHeight);
 
   useEffect(() => {
     if (Platform.OS === 'web' && ref.current) {
@@ -37,7 +40,7 @@ export function StateSection({ title, children, maxWidth = 430, pageId: pageIdPr
         <View style={styles.line} />
       </View>
       <View style={[styles.content, { maxWidth }]}>
-        <View style={styles.phone}>
+        <View style={[styles.phone, { minHeight }]}>
           {page && <ProtoNavHeader variant={page.nav} activeTab={page.activeTab} />}
           <View style={styles.phoneBody}>
             {children}
@@ -87,7 +90,6 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Colors.border,
     overflow: 'hidden',
-    minHeight: 844,
   },
   phoneBody: {
     flex: 1,

--- a/components/proto/states/AdminDashboardStates.tsx
+++ b/components/proto/states/AdminDashboardStates.tsx
@@ -47,7 +47,7 @@ export function AdminDashboardStates() {
   ];
 
   return (
-    <StateSection title="STATS" maxWidth={800}>
+    <StateSection title="STATS">
       <View style={s.container}>
         <Text style={s.pageTitle}>Панель администратора</Text>
 

--- a/components/proto/states/AdminModerationStates.tsx
+++ b/components/proto/states/AdminModerationStates.tsx
@@ -171,13 +171,13 @@ function ApprovedModeration() {
 export function AdminModerationStates() {
   return (
     <>
-      <StateSection title="DEFAULT" maxWidth={800}>
+      <StateSection title="DEFAULT">
         <DefaultModeration />
       </StateSection>
-      <StateSection title="INTERACTIVE" maxWidth={800}>
+      <StateSection title="INTERACTIVE">
         <InteractiveModeration />
       </StateSection>
-      <StateSection title="APPROVED" maxWidth={800}>
+      <StateSection title="APPROVED">
         <ApprovedModeration />
       </StateSection>
     </>

--- a/components/proto/states/AdminPromotionsStates.tsx
+++ b/components/proto/states/AdminPromotionsStates.tsx
@@ -51,7 +51,7 @@ function PromoCard({ code, discount, type, usages, maxUsages, active, expiry }: 
 
 export function AdminPromotionsStates() {
   return (
-    <StateSection title="LIST" maxWidth={800}>
+    <StateSection title="LIST">
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.pageTitle}>Промо-коды</Text>

--- a/components/proto/states/AdminRequestsStates.tsx
+++ b/components/proto/states/AdminRequestsStates.tsx
@@ -64,7 +64,7 @@ export function AdminRequestsStates() {
 
   return (
     <>
-      <StateSection title="LIST" maxWidth={800}>
+      <StateSection title="LIST">
         <View style={s.container}>
           <Text style={s.pageTitle}>Заявки (3 456)</Text>
           <View style={s.filters}>
@@ -78,7 +78,7 @@ export function AdminRequestsStates() {
           ))}
         </View>
       </StateSection>
-      <StateSection title="MODERATION_POPUP" maxWidth={800}>
+      <StateSection title="MODERATION_POPUP">
         <View style={[s.container, { minHeight: 450 }]}>
           <Text style={s.pageTitle}>Заявки</Text>
           {MOCK_REQUESTS.slice(0, 2).map((r) => (

--- a/components/proto/states/AdminReviewsStates.tsx
+++ b/components/proto/states/AdminReviewsStates.tsx
@@ -36,7 +36,7 @@ function ReviewRow({ author, rating, text, date, specialistName }: {
 
 export function AdminReviewsStates() {
   return (
-    <StateSection title="LIST" maxWidth={800}>
+    <StateSection title="LIST">
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.pageTitle}>Отзывы</Text>

--- a/components/proto/states/AdminUsersStates.tsx
+++ b/components/proto/states/AdminUsersStates.tsx
@@ -101,10 +101,10 @@ function UserListInteractive() {
 export function AdminUsersStates() {
   return (
     <>
-      <StateSection title="LIST" maxWidth={800}>
+      <StateSection title="LIST">
         <UserListInteractive />
       </StateSection>
-      <StateSection title="DETAIL_POPUP" maxWidth={800}>
+      <StateSection title="DETAIL_POPUP">
         <View style={[s.container, { minHeight: 500 }]}>
           <Text style={s.pageTitle}>Пользователи</Text>
           {MOCK_USERS.slice(0, 3).map((u) => (

--- a/components/proto/states/BrandStyleStates.tsx
+++ b/components/proto/states/BrandStyleStates.tsx
@@ -385,7 +385,7 @@ function BurgerSection() {
 // =====================================================================
 export function BrandStyleStates() {
   return (
-    <StateSection title="STYLE GUIDE" maxWidth={800}>
+    <StateSection title="STYLE GUIDE">
       <ScrollView style={s.container} contentContainerStyle={s.containerInner}>
         <View style={s.header}>
           <Text style={s.title}>P2PTax Brand & UI Kit</Text>

--- a/components/proto/states/LandingStates.tsx
+++ b/components/proto/states/LandingStates.tsx
@@ -344,11 +344,11 @@ function FullLanding(props: RequestFormProps) {
 export function LandingStates() {
   return (
     <View style={{ gap: Spacing['4xl'] }}>
-      <StateSection title="DEFAULT" pageId="landing" maxWidth={1024}>
+      <StateSection title="DEFAULT" pageId="landing">
         <FullLanding />
       </StateSection>
 
-      <StateSection title="FORM_FILLING" pageId="landing" maxWidth={1024}>
+      <StateSection title="FORM_FILLING" pageId="landing">
         <FullLanding
           prefill={{
             city: 'Москва',
@@ -358,7 +358,7 @@ export function LandingStates() {
         />
       </StateSection>
 
-      <StateSection title="FORM_VALIDATION" pageId="landing" maxWidth={1024}>
+      <StateSection title="FORM_VALIDATION" pageId="landing">
         <FullLanding
           prefill={{
             city: 'Санкт-Петербург',
@@ -370,7 +370,7 @@ export function LandingStates() {
         />
       </StateSection>
 
-      <StateSection title="FORM_SUCCESS" pageId="landing" maxWidth={1024}>
+      <StateSection title="FORM_SUCCESS" pageId="landing">
         <FullLanding
           prefill={{ email: 'ivan@example.com' }}
           submitted

--- a/components/proto/states/PricingStates.tsx
+++ b/components/proto/states/PricingStates.tsx
@@ -37,7 +37,7 @@ export function PricingStates() {
   const [selectedPlan, setSelectedPlan] = useState<string | null>(null);
 
   return (
-    <StateSection title="PLANS_COMPARISON" maxWidth={1024}>
+    <StateSection title="PLANS_COMPARISON">
       <View style={s.container}>
         <View style={s.header}>
           <Text style={s.title}>Тарифы</Text>

--- a/components/proto/states/PublicRequestDetailStates.tsx
+++ b/components/proto/states/PublicRequestDetailStates.tsx
@@ -71,10 +71,10 @@ function DetailView({ showRespondPopup }: { showRespondPopup?: boolean }) {
 export function PublicRequestDetailStates() {
   return (
     <>
-      <StateSection title="DETAIL" maxWidth={800}>
+      <StateSection title="DETAIL">
         <DetailView />
       </StateSection>
-      <StateSection title="RESPOND_POPUP" maxWidth={800}>
+      <StateSection title="RESPOND_POPUP">
         <DetailView showRespondPopup />
       </StateSection>
     </>

--- a/components/proto/states/PublicRequestsStates.tsx
+++ b/components/proto/states/PublicRequestsStates.tsx
@@ -168,13 +168,13 @@ function LoadingRequests() {
 export function PublicRequestsStates() {
   return (
     <>
-      <StateSection title="INTERACTIVE" maxWidth={1024}>
+      <StateSection title="INTERACTIVE">
         <InteractiveRequests />
       </StateSection>
-      <StateSection title="EMPTY" maxWidth={1024}>
+      <StateSection title="EMPTY">
         <EmptyRequests />
       </StateSection>
-      <StateSection title="LOADING" maxWidth={1024}>
+      <StateSection title="LOADING">
         <LoadingRequests />
       </StateSection>
     </>

--- a/components/proto/states/SpecialistsCatalogStates.tsx
+++ b/components/proto/states/SpecialistsCatalogStates.tsx
@@ -154,13 +154,13 @@ function LoadingCatalog() {
 export function SpecialistsCatalogStates() {
   return (
     <>
-      <StateSection title="INTERACTIVE" maxWidth={1024}>
+      <StateSection title="INTERACTIVE">
         <InteractiveCatalog />
       </StateSection>
-      <StateSection title="EMPTY" maxWidth={1024}>
+      <StateSection title="EMPTY">
         <EmptyCatalog />
       </StateSection>
-      <StateSection title="LOADING" maxWidth={1024}>
+      <StateSection title="LOADING">
         <LoadingCatalog />
       </StateSection>
     </>


### PR DESCRIPTION
This pull request fixes #522.

The issue requested two specific changes to the proto layout: (1) PC layout with maxWidth 960 and centered content, and (2) full-page height for each state.

Both changes were implemented:

1. **maxWidth 960 + centered**: The `StateSection` component's default `maxWidth` prop was changed from `430` to `960`. This is the central wrapper for all proto states, so this change propagates to every page. Additionally, all individual page state files that were previously overriding `maxWidth` to values like 800 or 1024 (e.g., AdminDashboardStates, AdminModerationStates, LandingStates, SpecialistsCatalogStates, PricingStates, etc.) had their explicit `maxWidth` props removed, allowing them to inherit the new default of 960. The `content` style in StateSection already uses `{ maxWidth }` with `alignSelf: 'center'` which centers the content.

2. **Full-page height for each state**: In `StateSection.tsx`, `Dimensions` was imported and used to calculate `minHeight = Math.max(844, windowHeight)`. This dynamic minHeight is applied to the phone container view via `style={[styles.phone, { minHeight }]}`. The hardcoded `minHeight: 844` was removed from the static stylesheet and replaced with this dynamic calculation, ensuring each state fills at least the full viewport height on both mobile and desktop.

These are systemic changes — modifying the core `StateSection` component and removing per-page overrides — which means the fix applies uniformly across all proto pages in the project.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌