### PR TITLE
Fix issue #649: Implement: Public Requests Feed — all states + filters

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -66,13 +66,16 @@ export class RequestsController {
     @Query('city') city?: string,
     @Query('page') page?: string,
     @Query('category') category?: string,
+    @Query('service') service?: string,
     @Query('maxBudget') maxBudget?: string,
     @Query('ifnsId') ifnsId?: string,
   ) {
+    // 'service' is an alias for 'category' (both accepted)
+    const effectiveCategory = category || service;
     return this.requestsService.findFeed(
       city,
       page ? parseInt(page, 10) : 1,
-      category,
+      effectiveCategory,
       maxBudget ? parseInt(maxBudget, 10) : undefined,
       ifnsId,
     );

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -150,7 +150,7 @@ export class RequestsService {
       this.prisma.request.count({ where }),
     ]);
 
-    return { items, total, page: pageNum, pageSize: PAGE_SIZE };
+    return { items, total, page: pageNum, pageSize: PAGE_SIZE, hasMore: skip + items.length < total };
   }
 
   async findMy(clientId: string) {

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -96,6 +96,31 @@ interface FeedResponse {
   total: number;
   page: number;
   pageSize: number;
+  hasMore: boolean;
+}
+
+// Skeleton card for loading state
+function SkeletonCard() {
+  return (
+    <View style={styles.cardWrapperMobile}>
+      <Card padding={Spacing.lg} variant="elevated">
+        <View style={styles.skeletonRow}>
+          <View style={[styles.skeletonBlock, { width: '40%', height: 14 }]} />
+          <View style={[styles.skeletonBlock, { width: 60, height: 20, borderRadius: BorderRadius.full }]} />
+        </View>
+        <View style={[styles.skeletonBlock, { width: '90%', height: 14, marginTop: Spacing.sm }]} />
+        <View style={[styles.skeletonBlock, { width: '75%', height: 14 }]} />
+        <View style={styles.skeletonRow}>
+          <View style={[styles.skeletonBlock, { width: 70, height: 20, borderRadius: BorderRadius.full }]} />
+          <View style={[styles.skeletonBlock, { width: 80, height: 20, borderRadius: BorderRadius.full }]} />
+        </View>
+        <View style={styles.skeletonRow}>
+          <View style={[styles.skeletonBlock, { width: 60, height: 12 }]} />
+          <View style={[styles.skeletonBlock, { width: 50, height: 12 }]} />
+        </View>
+      </Card>
+    </View>
+  );
 }
 
 export default function RequestsFeedScreen() {

--- a/components/proto/states/PublicRequestsStates.tsx
+++ b/components/proto/states/PublicRequestsStates.tsx
@@ -165,6 +165,27 @@ function LoadingRequests() {
   );
 }
 
+function ErrorRequests() {
+  return (
+    <View style={s.container}>
+      <View style={s.topBar}>
+        <Text style={s.pageTitle}>Заявки</Text>
+        <View style={s.filterToggle}>
+          <Text style={s.filterToggleText}>Фильтры</Text>
+        </View>
+      </View>
+      <View style={s.errorWrap}>
+        <Feather name="alert-circle" size={48} color={Colors.statusError} />
+        <Text style={s.errorTitle}>Не удалось загрузить заявки</Text>
+        <Text style={s.errorText}>Проверьте подключение к интернету и попробуйте снова</Text>
+        <Pressable style={s.retryBtn} onPress={() => {}}>
+          <Text style={s.retryBtnText}>Повторить</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
 export function PublicRequestsStates() {
   return (
     <>
@@ -176,6 +197,9 @@ export function PublicRequestsStates() {
       </StateSection>
       <StateSection title="LOADING">
         <LoadingRequests />
+      </StateSection>
+      <StateSection title="ERROR">
+        <ErrorRequests />
       </StateSection>
     </>
   );
@@ -238,4 +262,12 @@ const s = StyleSheet.create({
   emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
   emptyStateWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.md },
   skeleton: { backgroundColor: Colors.bgSecondary },
+  errorWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.md },
+  errorTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  errorText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center' },
+  retryBtn: {
+    backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.xl, paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.md, marginTop: Spacing.sm,
+  },
+  retryBtnText: { fontSize: Typography.fontSize.sm, color: '#fff', fontWeight: Typography.fontWeight.semibold },
 });


### PR DESCRIPTION
This pull request fixes #649.

The changes made are partial and incomplete relative to the full issue requirements. Here's what was done:

1. **API changes**: Added `service` query parameter as an alias for `category`, and added `hasMore` to the feed response. These are good but minor.

2. **Loading state (skeleton)**: A `SkeletonCard` component was added to `app/requests/index.tsx`, but it's only defined — there's no evidence it's actually rendered during loading. The component is defined but not integrated into the screen's loading flow.

3. **Error state**: An `ErrorRequests` component was added to the proto/states file (`PublicRequestsStates.tsx`), but this appears to be a design-time state preview component, not the actual production screen. The `onPress` handler for retry is a no-op (`() => {}`).

4. **Empty state**: Already existed in the proto states file but no changes were made to ensure it's properly integrated in the actual screen.

5. **Not addressed at all**:
   - Filter chips that update the list immediately (no filter UI was added to the actual screen)
   - Card navigation to Public Request Detail
   - Respond button on cards opening Specialist Respond
   - Pagination / infinite scroll loading next page on scroll
   - Integration of all 4 states into the actual `RequestsFeedScreen` component

The agent's last message indicates it hit an error ("Missing required parameters"), suggesting it was interrupted mid-work. The changes are scaffolding-level additions to proto files and type definitions, but the actual `RequestsFeedScreen` in `app/requests/index.tsx` was not meaningfully updated to implement the 4 states, filters, pagination, or card interactions. The issue remains largely unresolved.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌