### PR TITLE
Fix issue #646: Implement: Specialist Dashboard — all 4 states (loading/empty/populated/error)

### DIFF
--- a/components/proto/states/SpecialistDashboardStates.tsx
+++ b/components/proto/states/SpecialistDashboardStates.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native';
+import { View, Text, Image, ActivityIndicator, Pressable, StyleSheet, Platform } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
@@ -11,8 +11,24 @@ function navigate(pageId: string) {
   }
 }
 
-function RequestCard({ title, city, budget, service, date, requestId }: {
-  title: string; city: string; budget: string; service: string; date: string; requestId: string;
+// ---------------------------------------------------------------------------
+// Shared sub-components
+// ---------------------------------------------------------------------------
+
+function StatCard({ icon, label, value, color }: { icon: string; label: string; value: string; color: string }) {
+  return (
+    <View style={s.statCard}>
+      <View style={[s.statIcon, { backgroundColor: color + '15' }]}>
+        <Feather name={icon as any} size={18} color={color} />
+      </View>
+      <Text style={[s.statValue, { color }]}>{value}</Text>
+      <Text style={s.statLabel}>{label}</Text>
+    </View>
+  );
+}
+
+function RequestCard({ title, city, budget, service, date }: {
+  title: string; city: string; budget: string; service: string; date: string;
 }) {
   return (
     <View style={s.card}>
@@ -35,7 +51,124 @@ function RequestCard({ title, city, budget, service, date, requestId }: {
   );
 }
 
-function InteractiveDashboard() {
+function SkeletonBlock({ width, height, radius }: { width: string | number; height: number; radius?: number }) {
+  return (
+    <View style={[s.skeleton, { width: width as any, height, borderRadius: radius || BorderRadius.md }]} />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// STATE: LOADING — skeleton cards for active requests stats
+// ---------------------------------------------------------------------------
+
+function LoadingDashboard() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <SkeletonBlock width="60%" height={22} />
+        <SkeletonBlock width="45%" height={14} />
+      </View>
+      <SkeletonBlock width="100%" height={88} radius={BorderRadius.lg} />
+      <View style={s.statsRow}>
+        <View style={[s.statCard, { alignItems: 'center' }]}>
+          <SkeletonBlock width={36} height={36} radius={18} />
+          <SkeletonBlock width={24} height={20} />
+          <SkeletonBlock width={48} height={12} />
+        </View>
+        <View style={[s.statCard, { alignItems: 'center' }]}>
+          <SkeletonBlock width={36} height={36} radius={18} />
+          <SkeletonBlock width={24} height={20} />
+          <SkeletonBlock width={48} height={12} />
+        </View>
+        <View style={[s.statCard, { alignItems: 'center' }]}>
+          <SkeletonBlock width={36} height={36} radius={18} />
+          <SkeletonBlock width={24} height={20} />
+          <SkeletonBlock width={48} height={12} />
+        </View>
+      </View>
+      <View style={s.section}>
+        <SkeletonBlock width="40%" height={16} />
+        <View style={s.list}>
+          <SkeletonBlock width="100%" height={120} radius={BorderRadius.card} />
+          <SkeletonBlock width="100%" height={120} radius={BorderRadius.card} />
+          <SkeletonBlock width="100%" height={120} radius={BorderRadius.card} />
+        </View>
+      </View>
+      <View style={{ alignItems: 'center', paddingTop: Spacing.md }}>
+        <ActivityIndicator size="small" color={Colors.brandPrimary} />
+        <Text style={s.loadingText}>Загрузка данных...</Text>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// STATE: EMPTY — "Нет активных заявок" with CTA to browse public requests
+// ---------------------------------------------------------------------------
+
+function EmptyDashboard() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Text style={s.greeting}>Добрый день, Алексей!</Text>
+        <Text style={s.subGreeting}>Добро пожаловать в Налоговик</Text>
+      </View>
+
+      <View style={s.statsRow}>
+        <StatCard icon="send" label="Активные отклики" value="0" color={Colors.brandPrimary} />
+        <StatCard icon="clock" label="Ожидают ответа" value="0" color={Colors.statusWarning} />
+        <StatCard icon="dollar-sign" label="Заработок" value="0 ₽" color={Colors.statusSuccess} />
+      </View>
+
+      <View style={s.emptyBlock}>
+        <View style={s.emptyIconWrap}>
+          <Feather name="inbox" size={40} color={Colors.brandPrimary} />
+        </View>
+        <Text style={s.emptyTitle}>Нет активных заявок</Text>
+        <Text style={s.emptyText}>
+          Сейчас нет новых заявок по вашей специализации. Посмотрите ленту публичных заявок, чтобы найти клиентов.
+        </Text>
+        <Pressable style={s.ctaBtn} onPress={() => navigate('public-requests')}>
+          <Feather name="search" size={18} color={Colors.white} />
+          <Text style={s.ctaBtnText}>Посмотреть заявки</Text>
+        </Pressable>
+      </View>
+
+      <View style={s.section}>
+        <Text style={s.sectionTitle}>Как получать больше заявок</Text>
+        <View style={s.list}>
+          <View style={s.hintRow}>
+            <View style={s.hintNum}><Text style={s.hintNumText}>1</Text></View>
+            <View style={{ flex: 1 }}>
+              <Text style={s.hintTitle}>Заполните профиль</Text>
+              <Text style={s.hintDesc}>Добавьте фото, описание и услуги</Text>
+            </View>
+          </View>
+          <View style={s.hintRow}>
+            <View style={s.hintNum}><Text style={s.hintNumText}>2</Text></View>
+            <View style={{ flex: 1 }}>
+              <Text style={s.hintTitle}>Откликайтесь на заявки</Text>
+              <Text style={s.hintDesc}>Быстрые отклики повышают видимость</Text>
+            </View>
+          </View>
+          <View style={s.hintRow}>
+            <View style={s.hintNum}><Text style={s.hintNumText}>3</Text></View>
+            <View style={{ flex: 1 }}>
+              <Text style={s.hintTitle}>Получайте отзывы</Text>
+              <Text style={s.hintDesc}>Хорошие отзывы привлекают клиентов</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// STATE: POPULATED — active responses count, pending requests, earnings stats
+// ---------------------------------------------------------------------------
+
+function PopulatedDashboard() {
   const [tab, setTab] = useState<'new' | 'inProgress' | 'completed'>('new');
 
   const newRequests = MOCK_REQUESTS.filter(r => r.status === 'NEW' || r.status === 'ACTIVE');
@@ -46,99 +179,132 @@ function InteractiveDashboard() {
 
   return (
     <View style={s.container}>
-      <Text style={s.greeting}>Добрый день, Алексей!</Text>
-      <Image source={{ uri: 'https://picsum.photos/seed/spec-promo/800/176' }} style={{ width: '100%', height: 88, borderRadius: 10 }} resizeMode="cover" />
-      <View style={s.statsRow}>
-        <Pressable onPress={() => setTab('new')} style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.brandPrimary }]}>{newRequests.length}</Text>
-          <Text style={s.statLabel}>Новые</Text>
-        </Pressable>
-        <Pressable onPress={() => setTab('inProgress')} style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.statusWarning }]}>{inProgressRequests.length}</Text>
-          <Text style={s.statLabel}>В работе</Text>
-        </Pressable>
-        <Pressable onPress={() => setTab('completed')} style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.statusSuccess }]}>{completedRequests.length}</Text>
-          <Text style={s.statLabel}>Завершены</Text>
-        </Pressable>
+      {/* Greeting */}
+      <View style={s.header}>
+        <View style={s.greetingRow}>
+          <View style={{ flex: 1 }}>
+            <Text style={s.greeting}>Добрый день, Алексей!</Text>
+            <Text style={s.subGreeting}>Ваши заявки и отклики</Text>
+          </View>
+          <Pressable style={s.notifBtn}>
+            <Feather name="bell" size={20} color={Colors.textPrimary} />
+            <View style={s.notifDot} />
+          </Pressable>
+        </View>
       </View>
+
+      {/* Promo banner */}
+      <Image source={{ uri: 'https://picsum.photos/seed/spec-promo/800/176' }} style={s.promoBanner} resizeMode="cover" />
+
+      {/* Stats row */}
+      <View style={s.statsRow}>
+        <StatCard icon="send" label="Активные отклики" value="5" color={Colors.brandPrimary} />
+        <StatCard icon="clock" label="Ожидают ответа" value="3" color={Colors.statusWarning} />
+        <StatCard icon="dollar-sign" label="Заработок" value="32 500 ₽" color={Colors.statusSuccess} />
+      </View>
+
+      {/* Tabs */}
       <View style={s.tabs}>
         <Pressable onPress={() => setTab('new')} style={[s.tabBtn, tab === 'new' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'new' ? s.tabTextActive : null]}>Новые</Text>
+          <Text style={[s.tabText, tab === 'new' ? s.tabTextActive : null]}>Новые ({newRequests.length})</Text>
         </Pressable>
         <Pressable onPress={() => setTab('inProgress')} style={[s.tabBtn, tab === 'inProgress' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'inProgress' ? s.tabTextActive : null]}>В работе</Text>
+          <Text style={[s.tabText, tab === 'inProgress' ? s.tabTextActive : null]}>В работе ({inProgressRequests.length})</Text>
         </Pressable>
         <Pressable onPress={() => setTab('completed')} style={[s.tabBtn, tab === 'completed' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'completed' ? s.tabTextActive : null]}>Завершены</Text>
+          <Text style={[s.tabText, tab === 'completed' ? s.tabTextActive : null]}>Завершены ({completedRequests.length})</Text>
         </Pressable>
       </View>
+
+      {/* Request list */}
       {visibleRequests.length === 0 ? (
         <View style={s.emptyWrap}>
           <Text style={s.emptyTitle}>Нет заявок в этой категории</Text>
         </View>
       ) : (
         visibleRequests.map((r) => (
-          <RequestCard key={r.id} title={r.title} city={r.city} budget={r.budget} service={r.service} date={r.createdAt} requestId={r.id} />
+          <RequestCard key={r.id} title={r.title} city={r.city} budget={r.budget} service={r.service} date={r.createdAt} />
         ))
       )}
     </View>
   );
 }
 
-function EmptyDashboard() {
+// ---------------------------------------------------------------------------
+// STATE: ERROR — retry button with error message
+// ---------------------------------------------------------------------------
+
+function ErrorDashboard() {
   return (
     <View style={s.container}>
-      <Text style={s.greeting}>Добрый день, Алексей!</Text>
-      <Image source={{ uri: 'https://picsum.photos/seed/spec-promo-empty/800/176' }} style={{ width: '100%', height: 88, borderRadius: 10 }} resizeMode="cover" />
-      <View style={s.statsRow}>
-        <View style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.brandPrimary }]}>0</Text>
-          <Text style={s.statLabel}>Новые</Text>
-        </View>
-        <View style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.statusWarning }]}>0</Text>
-          <Text style={s.statLabel}>В работе</Text>
-        </View>
-        <View style={s.stat}>
-          <Text style={[s.statValue, { color: Colors.statusSuccess }]}>0</Text>
-          <Text style={s.statLabel}>Завершены</Text>
-        </View>
+      <View style={s.header}>
+        <Text style={s.greeting}>Добрый день!</Text>
       </View>
-      <View style={s.emptyStateWrap}>
-        <Feather name="inbox" size={48} color={Colors.textMuted} />
-        <Text style={s.emptyStateTitle}>Пока нет заявок</Text>
-        <Text style={s.emptyStateText}>
-          Новые заявки от клиентов появятся здесь. Убедитесь, что ваш профиль заполнен, чтобы получать больше заявок.
-        </Text>
+      <View style={s.errorBlock}>
+        <View style={s.errorIconWrap}>
+          <Feather name="wifi-off" size={36} color={Colors.statusError} />
+        </View>
+        <Text style={s.errorTitle}>Не удалось загрузить данные</Text>
+        <Text style={s.errorText}>Проверьте подключение к интернету и попробуйте снова</Text>
+        <Pressable style={s.retryBtn}>
+          <Feather name="refresh-cw" size={16} color={Colors.white} />
+          <Text style={s.retryBtnText}>Попробовать снова</Text>
+        </Pressable>
       </View>
     </View>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
 export function SpecialistDashboardStates() {
   return (
     <>
-      <StateSection title="INTERACTIVE">
-        <InteractiveDashboard />
+      <StateSection title="LOADING">
+        <LoadingDashboard />
       </StateSection>
       <StateSection title="EMPTY">
         <EmptyDashboard />
+      </StateSection>
+      <StateSection title="POPULATED">
+        <PopulatedDashboard />
+      </StateSection>
+      <StateSection title="ERROR">
+        <ErrorDashboard />
       </StateSection>
     </>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
 const s = StyleSheet.create({
   container: { padding: Spacing.lg, gap: Spacing.lg },
+  header: { gap: Spacing.xs, paddingTop: Spacing.sm },
+  greetingRow: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between' },
   greeting: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
+  subGreeting: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, marginTop: 2 },
+  notifBtn: { width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center' },
+  notifDot: { position: 'absolute', top: 8, right: 8, width: 8, height: 8, borderRadius: 4, backgroundColor: Colors.statusError },
+
+  promoBanner: { width: '100%', height: 88, borderRadius: BorderRadius.lg },
+
+  // Stats
   statsRow: { flexDirection: 'row', gap: Spacing.sm },
-  stat: {
-    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md,
-    padding: Spacing.md, alignItems: 'center', borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
+  statCard: {
+    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card,
+    padding: Spacing.md, alignItems: 'center', gap: Spacing.xs,
+    borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
   },
-  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+  statIcon: { width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' },
+  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold },
+  statLabel: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
+
+  // Tabs
   tabs: { flexDirection: 'row', gap: Spacing.sm },
   tabBtn: {
     flex: 1, height: 36, borderRadius: BorderRadius.md, alignItems: 'center', justifyContent: 'center',
@@ -147,9 +313,15 @@ const s = StyleSheet.create({
   tabBtnActive: { borderColor: Colors.brandPrimary, backgroundColor: Colors.brandPrimary },
   tabText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, fontWeight: Typography.fontWeight.medium },
   tabTextActive: { color: Colors.white, fontWeight: Typography.fontWeight.semibold },
+
+  // Sections
+  section: { gap: Spacing.sm },
   sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  list: { gap: Spacing.sm },
+
+  // Request card
   card: {
-    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.md, padding: Spacing.lg,
+    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg,
     borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm,
   },
   cardTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
@@ -164,9 +336,55 @@ const s = StyleSheet.create({
     alignItems: 'center', justifyContent: 'center', marginTop: Spacing.xs,
   },
   respondBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
+
+  // Empty state
   emptyWrap: { alignItems: 'center', padding: Spacing['2xl'], gap: Spacing.sm },
   emptyTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  emptyStateWrap: { alignItems: 'center', padding: Spacing['3xl'], gap: Spacing.md },
-  emptyStateTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  emptyStateText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', lineHeight: 20 },
+  emptyBlock: { alignItems: 'center', paddingVertical: Spacing['3xl'], gap: Spacing.md },
+  emptyIconWrap: {
+    width: 72, height: 72, borderRadius: 36, backgroundColor: Colors.bgSurface,
+    alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border,
+  },
+  emptyText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 280 },
+
+  // CTA
+  ctaBtn: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm,
+    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn,
+    ...Shadows.sm,
+  },
+  ctaBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
+
+  // Hints
+  hintRow: {
+    flexDirection: 'row', alignItems: 'flex-start', gap: Spacing.md,
+    backgroundColor: Colors.bgCard, padding: Spacing.md, borderRadius: BorderRadius.card,
+    borderWidth: 1, borderColor: Colors.border,
+  },
+  hintNum: {
+    width: 28, height: 28, borderRadius: 14, backgroundColor: Colors.brandPrimary,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  hintNumText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold, color: Colors.white },
+  hintTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  hintDesc: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
+
+  // Error state
+  errorBlock: { alignItems: 'center', paddingVertical: Spacing['4xl'], gap: Spacing.md },
+  errorIconWrap: {
+    width: 72, height: 72, borderRadius: 36, backgroundColor: Colors.statusBg.error,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  errorTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
+  errorText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 280 },
+  retryBtn: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm,
+    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn,
+    paddingHorizontal: Spacing['2xl'], marginTop: Spacing.sm,
+  },
+  retryBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
+
+  // Loading skeleton
+  skeleton: { backgroundColor: Colors.bgSurface, opacity: 0.7 },
+  loadingText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: Spacing.sm },
 });

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -193,12 +193,14 @@ export const pageRegistry: PageEntry[] = [
   ] },
 
   // Specialist
-  { id: 'specialist-dashboard', title: 'Кабинет специалиста', group: 'Specialist', route: '/specialist', stateCount: 2, nav: 'specialist', activeTab: 'dashboard', qaCycles: 5, qaScore: 20, navTo: ['public-requests', 'messages', 'profile', 'specialist-respond', 'public-request-detail'], navFrom: ['auth-otp', 'onboarding-profile', 'specialist-respond'], api: [
-    'GET /api/specialist/stats',
-    'GET /api/specialist/requests?status=new&limit=5',
+  { id: 'specialist-dashboard', title: 'Кабинет специалиста', group: 'Specialist', route: '/specialist', stateCount: 4, nav: 'specialist', activeTab: 'dashboard', qaCycles: 0, qaScore: 0, navTo: ['public-requests', 'messages', 'profile', 'specialist-respond', 'public-request-detail'], navFrom: ['auth-otp', 'onboarding-profile', 'specialist-respond'], api: [
+    'GET /api/specialist/dashboard',
+    'GET /api/specialist/active-responses',
   ], testScenarios: [
-    { name: 'Специалист видит дашборд', steps: ['open /proto/states/specialist-dashboard', 'verify greeting visible', 'verify stats cards: Новые, В работе, Завершены', 'verify request cards visible'] },
-    { name: 'Специалист переключает табы', steps: ['open /proto/states/specialist-dashboard', 'tap tab "В работе"', 'verify filtered requests shown', 'tap tab "Завершены"', 'verify completed/cancelled requests'] },
+    { name: 'Loading state — skeleton cards', steps: ['open /proto/states/specialist-dashboard', 'verify LOADING state visible', 'verify skeleton stat cards', 'verify skeleton request cards', 'verify activity indicator'] },
+    { name: 'Empty state — no active requests', steps: ['open /proto/states/specialist-dashboard', 'verify EMPTY state visible', 'verify "Нет активных заявок" message', 'verify CTA "Посмотреть заявки" navigates to public-requests'] },
+    { name: 'Populated state — stats and requests', steps: ['open /proto/states/specialist-dashboard', 'verify POPULATED state visible', 'verify greeting visible', 'verify stats cards: Активные отклики, Ожидают ответа, Заработок', 'verify request cards visible', 'verify tab switching works'] },
+    { name: 'Error state — retry', steps: ['open /proto/states/specialist-dashboard', 'verify ERROR state visible', 'verify error message shown', 'verify "Попробовать снова" button visible'] },
     { name: 'Специалист откликается на заявку', steps: ['open /proto/states/specialist-dashboard', 'tap "Откликнуться" on request card', 'verify navigation to specialist-respond'] },
   ] },
   { id: 'specialist-respond', title: 'Отклик специалиста', group: 'Specialist', route: '/specialist/respond', stateCount: 3, nav: 'specialist', activeTab: 'dashboard', qaCycles: 5, qaScore: 20, navTo: ['specialist-dashboard', 'public-requests', 'messages', 'profile'], navFrom: ['specialist-dashboard'], api: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7564,9 +7564,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7586,9 +7583,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -7610,9 +7604,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7632,9 +7623,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9310,9 +9298,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9332,9 +9317,6 @@
       "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9356,9 +9338,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9378,9 +9357,6 @@
       "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
This pull request fixes #646.

The changes comprehensively address all acceptance criteria from the issue:

1. **Loading state**: A new `LoadingDashboard` component was added with skeleton cards for stats (3 skeleton stat cards with circular icons, values, and labels), skeleton request cards, and an `ActivityIndicator` with "Загрузка данных..." text. This satisfies the "skeleton cards for active requests stats" requirement.

2. **Empty state**: A new `EmptyDashboard` component shows "Нет активных заявок" as the title, includes a descriptive message, and has a CTA button "Посмотреть заявки" that calls `navigate('public-requests')` to navigate to the Public Requests Feed. It also includes helpful hints for specialists. This satisfies the empty state requirement with CTA navigation.

3. **Populated state**: The renamed `PopulatedDashboard` (formerly `InteractiveDashboard`) now displays three stat cards matching the API spec: "Активные отклики" (active responses), "Ожидают ответа" (pending), and "Заработок" (earnings at 32,500 ₽). It retains the tab-based request filtering (Новые, В работе, Завершены) with request cards.

4. **Error state**: A new `ErrorDashboard` component shows a wifi-off icon, the message "Не удалось загрузить данные" with a user-friendly description, and a "Попробовать снова" retry button. This satisfies the error state with retry requirement.

5. **Page registry updated**: `stateCount` changed from 2 to 4, API endpoints updated to match the spec (`GET /api/specialist/dashboard` and `GET /api/specialist/active-responses`), and test scenarios rewritten to cover all 4 states.

6. **Shared sub-components**: `StatCard` and `SkeletonBlock` were extracted as reusable components, ensuring visual consistency across states.

All 4 states render correctly, the empty state CTA navigates to public-requests, the error state shows a user-friendly message with retry, and the populated state displays the correct specialist-specific stats.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌