### PR TITLE
Fix issue #660: Implement: Response lifecycle — status field + price/deadline in Response model

### DIFF
--- a/api/prisma/migrations/20260413160000_add_response_lifecycle/migration.sql
+++ b/api/prisma/migrations/20260413160000_add_response_lifecycle/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum: ResponseStatus
+CREATE TYPE "ResponseStatus" AS ENUM ('sent', 'viewed', 'accepted', 'deactivated');
+
+-- AlterTable: add lifecycle fields to responses
+ALTER TABLE "responses" ADD COLUMN "status" "ResponseStatus" NOT NULL DEFAULT 'sent';
+ALTER TABLE "responses" ADD COLUMN "price" INTEGER;
+ALTER TABLE "responses" ADD COLUMN "deadline" TIMESTAMP(3);
+ALTER TABLE "responses" ADD COLUMN "viewedAt" TIMESTAMP(3);
+ALTER TABLE "responses" ADD COLUMN "acceptedAt" TIMESTAMP(3);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -24,6 +24,13 @@ enum PromotionTier {
   TOP
 }
 
+enum ResponseStatus {
+  sent
+  viewed
+  accepted
+  deactivated
+}
+
 model User {
   id          String    @id @default(cuid())
   email       String    @unique
@@ -167,13 +174,18 @@ model Request {
 }
 
 model Response {
-  id           String   @id @default(cuid())
+  id           String       @id @default(cuid())
   specialistId String
-  specialist   User     @relation(fields: [specialistId], references: [id])
+  specialist   User         @relation(fields: [specialistId], references: [id])
   requestId    String
-  request      Request  @relation(fields: [requestId], references: [id])
+  request      Request      @relation(fields: [requestId], references: [id])
   message      String
-  createdAt    DateTime @default(now())
+  status       ResponseStatus @default(sent)
+  price        Int?
+  deadline     DateTime?
+  viewedAt     DateTime?
+  acceptedAt   DateTime?
+  createdAt    DateTime     @default(now())
 
   @@unique([specialistId, requestId])
   @@index([requestId])


### PR DESCRIPTION
This pull request fixes #660.

The changes made only address the database schema portion of the issue. Specifically:

**What was done:**
1. Created a migration adding a `ResponseStatus` enum (sent, viewed, accepted, deactivated) and five new columns (`status`, `price`, `deadline`, `viewedAt`, `acceptedAt`) to the `responses` table.
2. Updated the Prisma schema to include the `ResponseStatus` enum and the new fields on the `Response` model.

**What was NOT done (remaining gaps):**
- **API changes**: No route handlers were created or modified. Missing: POST /api/responses accepting `{price, deadline, comment}`, GET /api/requests/:id/responses with bulk sent→viewed update, PUT /api/responses/:id/accept for accepting and creating a thread, PATCH /api/responses/:id for deactivation with 409 on accepted responses, GET /api/specialist/responses returning status.
- **Frontend changes**: No UI changes were made. Missing: price/deadline inputs on SpecialistRespondScreen, status badges on MyResponsesScreen, deactivate button, filter chips.

Only 2 of the 7 acceptance criteria are partially met (Response model has the required fields, and the default status=sent is set). The remaining 5 criteria (bulk viewed update, accept creates thread, deactivate with 409, status badges, filter chips) are completely unaddressed.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌