### PR TITLE
Fix issue #686: SA gap: GET /api/content/terms — Terms of Service API endpoint

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { StorageModule } from './storage/storage.module';
 import { IfnsModule } from './ifns/ifns.module';
 import { CategoriesModule } from './categories/categories.module';
 import { StatsModule } from './stats/stats.module';
+import { ContentModule } from './content/content.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { StatsModule } from './stats/stats.module';
     IfnsModule,
     CategoriesModule,
     StatsModule,
+    ContentModule,
   ],
   controllers: [AppController],
 })

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -7,6 +7,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
+  TouchableOpacity,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Button } from '../../components/Button';
@@ -34,6 +35,7 @@ export default function UsernameScreen() {
   const [usernameEdited, setUsernameEdited] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [termsAccepted, setTermsAccepted] = useState(false);
 
   // Auto-generate username from firstName + lastName
   const suggestedUsername = useMemo(

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import Head from 'expo-router/head';
+import { Typography, Colors, Spacing } from '../constants/Colors';
+import { LandingHeader } from '../components/LandingHeader';
+import { Footer } from '../components/Footer';
+import { api } from '../lib/api';
+
+interface TermsResponse {
+  title: string;
+  content: string;
+  updatedAt: string;
+}
+
+export default function TermsScreen() {
+  const router = useRouter();
+  const [terms, setTerms] = useState<TermsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    api
+      .get<TermsResponse>('/content/terms')
+      .then(setTerms)
+      .catch(() => setError('Не удалось загрузить условия использования'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Head>
+        <title>Пользовательское соглашение — Налоговик</title>
+      </Head>
+      <Stack.Screen options={{ headerShown: false }} />
+      <LandingHeader />
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <View style={styles.container}>
+          {loading ? (
+            <ActivityIndicator size="large" color={Colors.brandPrimary} />
+          ) : error ? (
+            <Text style={styles.error}>{error}</Text>
+          ) : terms ? (
+            <>
+              <Text style={styles.title}>{terms.title}</Text>
+              <Text style={styles.updatedAt}>
+                Обновлено: {terms.updatedAt}
+              </Text>
+              {Platform.OS === 'web' ? (
+                <div
+                  dangerouslySetInnerHTML={{ __html: terms.content }}
+                  style={{ color: Colors.textSecondary, lineHeight: '1.7' }}
+                />
+              ) : (
+                <Text style={styles.htmlFallback}>{terms.content}</Text>
+              )}
+            </>
+          ) : null}
+        </View>
+        <Footer />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  scroll: {
+    flexGrow: 1,
+  },
+  container: {
+    maxWidth: 700,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing['4xl'],
+    width: '100%',
+    alignSelf: 'center',
+    gap: 16,
+  },
+  title: {
+    fontSize: Typography.fontSize['2xl'],
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginBottom: 4,
+  },
+  updatedAt: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    marginBottom: 12,
+  },
+  error: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.statusError,
+    textAlign: 'center',
+    marginTop: 40,
+  },
+  htmlFallback: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 26,
+  },
+});


### PR DESCRIPTION
This pull request fixes #686.

The changes are incomplete. While the TermsScreen (`app/terms.tsx`) was created and can render HTML content from the API, and the `ContentModule` was registered in the app module, several critical pieces are missing: (1) The actual `ContentModule`, `ContentController`, and `ContentService` files under `api/src/content/` are not included in the diff — only the import in `app.module.ts` exists, meaning the `GET /api/content/terms` endpoint has no implementation and would fail. (2) The username screen diff shows `termsAccepted` state and a `TouchableOpacity` import but the diff is truncated and doesn't show the actual "Accept terms" checkbox UI or a link to `/terms` being rendered. (3) There's no wiring of `termsAccepted` to the submit button to prevent proceeding without accepting terms. The agent's last message indicates it only edited the username file, suggesting the work was not completed.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌