### PR TITLE
Fix issue #685: SA gap: GET /api/requests/:id/public — dedicated public endpoint without client data

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -100,6 +100,12 @@ export class RequestsController {
     );
   }
 
+  // GET /requests/:id/public — dedicated public endpoint, never exposes client identity
+  @Get(':id/public')
+  getPublicById(@Param('id') id: string) {
+    return this.requestsService.findPublicById(id);
+  }
+
   // GET /requests/:id/responses — owner gets list of responses
   @Get(':id/responses')
   @UseGuards(JwtAuthGuard)
@@ -107,7 +113,7 @@ export class RequestsController {
     return this.requestsService.findResponses(id, req.user.id);
   }
 
-  // GET /requests/:id — public, owner gets full data including responses
+  // GET /requests/:id — owner gets full data including responses
   @Get(':id')
   @UseGuards(OptionalJwtAuthGuard)
   getById(@Request() req: any, @Param('id') id: string) {

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -225,6 +225,33 @@ export class RequestsService {
     return publicFields;
   }
 
+  async findPublicById(requestId: string) {
+    const request = await this.prisma.request.findUnique({
+      where: { id: requestId },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        city: true,
+        ifnsId: true,
+        ifnsName: true,
+        budget: true,
+        category: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        _count: { select: { responses: true } },
+      },
+    });
+
+    if (!request || request.status === RequestStatus.CLOSED) {
+      throw new NotFoundException('Request not found');
+    }
+
+    const { _count, ...rest } = request;
+    return { ...rest, responseCount: _count.responses };
+  }
+
   async respond(specialistId: string, requestId: string, dto: RespondRequestDto) {
     // Check request exists and is open
     const request = await this.prisma.request.findUnique({


### PR DESCRIPTION
This pull request fixes #685.

The changes directly address all acceptance criteria:

1. **New public endpoint**: `GET /requests/:id/public` is added to the controller with no auth guard, satisfying the "no auth required" criterion.

2. **No clientId exposure**: The `findPublicById` method in the service explicitly selects only safe fields (`id`, `title`, `description`, `city`, `ifnsId`, `ifnsName`, `budget`, `category`, `status`, `createdAt`, `updatedAt`) — critically, `clientId` is NOT included in the select, so it can never leak regardless of authentication state.

3. **responseCount included**: The query uses `_count: { select: { responses: true } }` to count responses, then maps `_count.responses` to `responseCount` in the returned object.

4. **404 for non-existent or CLOSED requests**: The service throws `NotFoundException` when the request is not found OR when `request.status === RequestStatus.CLOSED`.

5. **Existing endpoint preserved**: The `GET /requests/:id` route with `OptionalJwtAuthGuard` is untouched (only its comment was updated for clarity), so authenticated users still get full data.

The route ordering is also correct — `:id/public` is registered before `:id`, so NestJS won't interpret "public" as an ID parameter. The implementation is clean and minimal, matching the SA specification exactly.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌