### PR TITLE
Fix issue #679: SA gap: Response model — add price, deadline, status fields per SA lifecycle

### DIFF
--- a/api/prisma/migrations/20260413200000_response_required_fields/migration.sql
+++ b/api/prisma/migrations/20260413200000_response_required_fields/migration.sql
@@ -1,0 +1,11 @@
+-- Rename message column to comment
+ALTER TABLE "responses" RENAME COLUMN "message" TO "comment";
+
+-- Make price required (set default 0 for any existing NULL rows, then add NOT NULL)
+UPDATE "responses" SET "price" = 0 WHERE "price" IS NULL;
+ALTER TABLE "responses" ALTER COLUMN "price" SET NOT NULL;
+ALTER TABLE "responses" ALTER COLUMN "price" SET DEFAULT 0;
+
+-- Make deadline required (set a far-future default for any existing NULL rows, then add NOT NULL)
+UPDATE "responses" SET "deadline" = NOW() + INTERVAL '30 days' WHERE "deadline" IS NULL;
+ALTER TABLE "responses" ALTER COLUMN "deadline" SET NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -186,10 +186,10 @@ model Response {
   specialist   User         @relation(fields: [specialistId], references: [id])
   requestId    String
   request      Request      @relation(fields: [requestId], references: [id])
-  message      String
+  comment      String
   status       ResponseStatus @default(sent)
-  price        Int?
-  deadline     DateTime?
+  price        Int
+  deadline     DateTime
   viewedAt     DateTime?
   acceptedAt   DateTime?
   createdAt    DateTime     @default(now())

--- a/api/src/requests/dto/respond-request.dto.ts
+++ b/api/src/requests/dto/respond-request.dto.ts
@@ -1,8 +1,15 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsInt, Min, IsDateString } from 'class-validator';
 
 export class RespondRequestDto {
   @IsString()
   @IsNotEmpty()
   @MaxLength(500)
-  message!: string;
+  comment!: string;
+
+  @IsInt()
+  @Min(0)
+  price!: number;
+
+  @IsDateString()
+  deadline!: string;
 }

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Put,
   Patch,
   Delete,
   Param,
@@ -167,5 +168,25 @@ export class RequestsController {
     }
     // Otherwise update fields (description, city, budget, category)
     return this.requestsService.updateFields(req.user.id, id, dto);
+  }
+
+  // PUT /responses/:id/accept — client accepts a response
+  @Put('responses/:id/accept')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  acceptResponse(@Request() req: any, @Param('id') id: string) {
+    return this.requestsService.acceptResponse(id, req.user.id);
+  }
+
+  // PATCH /responses/:id — specialist deactivates own response
+  @Patch('responses/:id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.SPECIALIST)
+  patchResponse(
+    @Request() req: any,
+    @Param('id') id: string,
+    @Body() body: { status: string },
+  ) {
+    return this.requestsService.patchResponse(id, req.user.id, body.status);
   }
 }

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -11,7 +11,7 @@ import { EmailService } from '../notifications/email.service';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { CreateQuickRequestDto } from './dto/create-quick-request.dto';
 import { RespondRequestDto } from './dto/respond-request.dto';
-import { RequestStatus, Prisma } from '@prisma/client';
+import { RequestStatus, ResponseStatus, Prisma } from '@prisma/client';
 
 const PAGE_SIZE = 20;
 
@@ -181,6 +181,12 @@ export class RequestsService {
     if (!request) throw new NotFoundException('Request not found');
     if (request.clientId !== userId) throw new ForbiddenException('Only the request owner can view responses');
 
+    // Bulk-update sent → viewed for this request's responses
+    await this.prisma.response.updateMany({
+      where: { requestId, status: ResponseStatus.sent },
+      data: { status: ResponseStatus.viewed, viewedAt: new Date() },
+    });
+
     return this.prisma.response.findMany({
       where: { requestId },
       include: {
@@ -252,6 +258,12 @@ export class RequestsService {
   }
 
   async respond(specialistId: string, requestId: string, dto: RespondRequestDto) {
+    // Validate deadline is in the future
+    const deadlineDate = new Date(dto.deadline);
+    if (deadlineDate <= new Date()) {
+      throw new BadRequestException('Deadline must be a future date');
+    }
+
     // Check request exists and is open
     const request = await this.prisma.request.findUnique({
       where: { id: requestId },
@@ -290,7 +302,9 @@ export class RequestsService {
         data: {
           specialistId,
           requestId,
-          message: dto.message,
+          comment: dto.comment,
+          price: dto.price,
+          deadline: deadlineDate,
         },
       });
 
@@ -461,6 +475,85 @@ export class RequestsService {
     return this.prisma.request.update({
       where: { id: requestId },
       data: { status },
+    });
+  }
+
+  /**
+   * Accept a response: changes status to accepted + creates/ensures thread exists.
+   * Only the request owner (client) can accept.
+   */
+  async acceptResponse(responseId: string, clientId: string) {
+    const response = await this.prisma.response.findUnique({
+      where: { id: responseId },
+      include: { request: { select: { clientId: true } } },
+    });
+    if (!response) throw new NotFoundException('Response not found');
+    if (response.request.clientId !== clientId) {
+      throw new ForbiddenException('Only the request owner can accept responses');
+    }
+    if (response.status === ResponseStatus.accepted) {
+      throw new ConflictException('Response is already accepted');
+    }
+    if (response.status === ResponseStatus.deactivated) {
+      throw new ConflictException('Cannot accept a deactivated response');
+    }
+
+    const now = new Date();
+
+    // Update response + ensure thread in transaction
+    const result = await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.response.update({
+        where: { id: responseId },
+        data: { status: ResponseStatus.accepted, acceptedAt: now },
+      });
+
+      // Create thread: enforce participant1Id < participant2Id
+      const specialistId = response.specialistId;
+      const [p1, p2] =
+        specialistId < clientId
+          ? [specialistId, clientId]
+          : [clientId, specialistId];
+
+      const thread = await tx.thread.upsert({
+        where: { participant1Id_participant2Id: { participant1Id: p1, participant2Id: p2 } },
+        create: { participant1Id: p1, participant2Id: p2 },
+        update: {},
+      });
+
+      return { response: updated, thread };
+    });
+
+    return result;
+  }
+
+  /**
+   * Patch a response: specialist can deactivate a sent/viewed response.
+   * Deactivating an accepted response returns 409.
+   */
+  async patchResponse(responseId: string, specialistId: string, status: string) {
+    const response = await this.prisma.response.findUnique({
+      where: { id: responseId },
+    });
+    if (!response) throw new NotFoundException('Response not found');
+    if (response.specialistId !== specialistId) {
+      throw new ForbiddenException('You can only modify your own responses');
+    }
+
+    if (status !== 'deactivated') {
+      throw new BadRequestException('Only status=deactivated is supported');
+    }
+
+    if (response.status === ResponseStatus.accepted) {
+      throw new ConflictException('Cannot deactivate an accepted response');
+    }
+
+    if (response.status === ResponseStatus.deactivated) {
+      throw new ConflictException('Response is already deactivated');
+    }
+
+    return this.prisma.response.update({
+      where: { id: responseId },
+      data: { status: ResponseStatus.deactivated },
     });
   }
 }


### PR DESCRIPTION
This pull request fixes #679.

The PR successfully addresses all acceptance criteria from the issue:

1. **Response model has required fields**: The schema changes `price Int?` → `price Int` and `deadline DateTime?` → `deadline DateTime`, making both required. The `status ResponseStatus @default(sent)` was already present. The `message` field is correctly renamed to `comment`.

2. **ResponseStatus enum**: Already existed in the schema (referenced as `ResponseStatus @default(sent)`), containing the required values (SENT, VIEWED, ACCEPTED, DEACTIVATED).

3. **RespondRequestDto validates price and deadline**: The DTO now includes `@IsInt()` and `@Min(0)` for price, and `@IsDateString()` for deadline. The service layer adds additional validation that deadline must be a future date.

4. **GET /requests/:id/responses bulk-updates sent → viewed**: The `getResponses` method now calls `updateMany` to change status from `sent` to `viewed` and set `viewedAt` before returning responses.

5. **PUT /responses/:id/accept changes status to accepted + creates thread**: The `acceptResponse` method updates status to `accepted`, sets `acceptedAt`, and uses a transaction to upsert a `Thread` with the correct participant ordering.

6. **PATCH /responses/:id with status=deactivated works for sent/viewed only**: The `patchResponse` method only allows `status=deactivated` and permits it for non-accepted, non-deactivated responses.

7. **Deactivating accepted response returns 409**: The `patchResponse` method throws `ConflictException` (HTTP 409) when the response status is `accepted`.

8. **Migration runs without data loss**: The migration renames `message` → `comment`, sets default values for existing NULL rows in `price` (0) and `deadline` (30 days from now), then adds NOT NULL constraints. This preserves existing data while enforcing the new schema requirements.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌