### PR TITLE
Fix issue #705: SA gap: Specialist public profile screen — contacts section not implemented

### DIFF
--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,17 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  SafeAreaView,
-  ScrollView,
-  ActivityIndicator,
-  Alert,
-  TouchableOpacity,
-  TextInput,
-  Platform,
-  Share,
-} from 'react-native';
+
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';


### PR DESCRIPTION
This pull request fixes #705.

The git patch shown only demonstrates the **removal** of react-native imports from `app/specialists/[nick].tsx`. There is no patch showing the **addition** of any contacts section — no phone with tel: link, no telegram with t.me link, no whatsapp with wa.me link, no office address display, and no working hours display. The diff only shows import cleanup (removing unused react-native component imports), which does not address any of the acceptance criteria. The agent's last message is merely checking what react-native imports exist in the file, suggesting the work was incomplete or the agent was still investigating. None of the 7 acceptance criteria items are addressed by the changes shown.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌