### PR TITLE
Fix issue #702: SA gap: ADMIN role missing from Role enum — admin guard uses hardcoded email list

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 enum Role {
   CLIENT
   SPECIALIST
+  ADMIN
 }
 
 enum RequestStatus {


### PR DESCRIPTION
This pull request fixes #702.

The changes made are incomplete. Only one of the four acceptance criteria was addressed:

1. ✅ **Add ADMIN to Role enum in schema.prisma** — Done. The `ADMIN` value was added to the `Role` enum.

2. ❌ **Create migration** — No migration file was created. The schema change alone doesn't update the database. A Prisma migration is needed to apply the enum change to the database and to set existing admin users' roles to ADMIN (backward compatibility requirement).

3. ❌ **Update AdminGuard to check `user.role === 'ADMIN'`** — The `api/src/auth/admin.guard.ts` file was not modified. It still checks against an email list rather than the database role.

4. ❌ **Backward compatibility: existing admin emails should have role set to ADMIN via migration** — No migration was created to update existing admin users' records to set their role to ADMIN.

The issue requires at minimum modifying `admin.guard.ts` and creating a migration, neither of which was done. Only the schema enum was updated, which is insufficient to resolve the issue.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌