### PR TITLE
Fix issue #707: SA gap: Onboarding and catalog use hardcoded FNS_OFFICES constant instead of API

### DIFF
--- a/api/src/ifns/ifns.controller.ts
+++ b/api/src/ifns/ifns.controller.ts
@@ -9,4 +9,14 @@ export class IfnsController {
   search(@Query('q') q: string) {
     return this.ifnsService.search(q || '');
   }
+
+  @Get()
+  findAll(@Query('city_id') cityId?: string) {
+    return this.ifnsService.findAll(cityId);
+  }
+
+  @Get('cities')
+  getCities() {
+    return this.ifnsService.getCities();
+  }
 }

--- a/api/src/ifns/ifns.service.ts
+++ b/api/src/ifns/ifns.service.ts
@@ -5,6 +5,15 @@ import { PrismaService } from '../prisma/prisma.service';
 export class IfnsService {
   constructor(private readonly prisma: PrismaService) {}
 
+  async findAll(cityId?: string) {
+    const where = cityId ? { cityId } : {};
+    return this.prisma.ifns.findMany({
+      where,
+      include: { city: true },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async search(query: string) {
     const where = query
       ? {
@@ -20,6 +29,12 @@ export class IfnsService {
       where,
       include: { city: true },
       take: 20,
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async getCities() {
+    return this.prisma.city.findMany({
       orderBy: { name: 'asc' },
     });
   }

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -20,7 +20,7 @@ import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../consta
 import { Header } from '../../components/Header';
 import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
-import { FNS_OFFICES, FNSOffice } from '../../constants/FNS';
+import { useFnsSearch, FnsOfficeItem } from '../../hooks/useFnsData';
 import { shortFnsLabel } from '../../lib/format';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
 

--- a/app/(onboarding)/fns.tsx
+++ b/app/(onboarding)/fns.tsx
@@ -14,8 +14,8 @@ import { Button } from '../../components/Button';
 import { shortFnsLabel } from '../../lib/format';
 import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { OnboardingProgress } from '../../components/OnboardingProgress';
-import { FNS_OFFICES, FNSOffice } from '../../constants/FNS';
 import { FNS_DEPARTMENTS } from '../../constants/FNS_DEPARTMENTS';
+import { useFnsSearch, FnsOfficeItem } from '../../hooks/useFnsData';
 
 interface FnsDeptEntry {
   office: string;
@@ -24,7 +24,7 @@ interface FnsDeptEntry {
 
 export default function FNSScreen() {
   const router = useRouter();
-  const [selected, setSelected] = useState<FNSOffice[]>([]);
+  const [selected, setSelected] = useState<FnsOfficeItem[]>([]);
   const [search, setSearch] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -33,16 +33,12 @@ export default function FNSScreen() {
 
   const selectedNames = new Set(selected.map((o) => o.name));
 
-  const searchTerms = search.trim().toLowerCase().split(/\s+/).filter(Boolean);
-  const suggestions = searchTerms.length > 0
-    ? FNS_OFFICES.filter((o) => {
-        if (selectedNames.has(o.name)) return false;
-        const text = `${o.name} ${o.city}`.toLowerCase();
-        return searchTerms.every((t) => text.includes(t));
-      }).slice(0, 8)
-    : [];
+  // Use API-backed search instead of hardcoded FNS_OFFICES
+  const { results: suggestions } = useFnsSearch(search);
 
-  function addOffice(office: FNSOffice) {
+  const filteredSuggestions = suggestions.filter((o) => !selectedNames.has(o.name)).slice(0, 8);
+
+  function addOffice(office: FnsOfficeItem) {
     setSelected((prev) => [...prev, office]);
     setDepartmentsMap((prev) => ({ ...prev, [office.name]: [] }));
     setExpandedOffice(office.name);
@@ -87,7 +83,7 @@ export default function FNSScreen() {
     }
     setIsLoading(true);
     try {
-      const cities = [...new Set(selected.map((o) => o.city))];
+      const cities = [...new Set(selected.map((o) => o.city.name))];
       const fnsNames = selected.map((o) => o.name);
       const fnsDepartmentsData: FnsDeptEntry[] = selected.map((o) => ({
         office: o.name,
@@ -138,9 +134,9 @@ export default function FNSScreen() {
               placeholderTextColor={Colors.textMuted}
               autoCorrect={false}
             />
-            {suggestions.length > 0 && (
+            {filteredSuggestions.length > 0 && (
               <View style={styles.dropdown}>
-                {suggestions.map((office) => (
+                {filteredSuggestions.map((office) => (
                   <TouchableOpacity
                     key={office.code}
                     onPress={() => addOffice(office)}
@@ -150,7 +146,7 @@ export default function FNSScreen() {
                     <Text style={styles.dropdownName} numberOfLines={2}>
                       {office.name}
                     </Text>
-                    <Text style={styles.dropdownCity}>{office.city}</Text>
+                    <Text style={styles.dropdownCity}>{office.city.name}</Text>
                   </TouchableOpacity>
                 ))}
               </View>
@@ -172,7 +168,7 @@ export default function FNSScreen() {
                       activeOpacity={0.7}
                     >
                       <Text style={styles.chipText} numberOfLines={1}>
-                        {shortFnsLabel(office.name, office.city)}
+                        {shortFnsLabel(office.name, office.city.name)}
                       </Text>
                       <Text style={styles.deptCount}>
                         {(departmentsMap[office.name] || []).length} отд.

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -24,8 +24,7 @@ import { LandingHeader } from '../../components/LandingHeader';
 import { Footer } from '../../components/Footer';
 import { Stars } from '../../components/Stars';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
-import { FNS_OFFICES, FNSOffice } from '../../constants/FNS';
-import { RUSSIAN_CITIES } from '../../constants/Cities';
+import { useFnsSearch, useCities, FnsOfficeItem } from '../../hooks/useFnsData';
 
 const APP_URL = process.env.EXPO_PUBLIC_APP_URL || 'https://p2ptax.smartlaunchhub.com';
 
@@ -69,29 +68,22 @@ export default function SpecialistsCatalogScreen() {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedCity, setSelectedCity] = useState('');
   const [selectedSort, setSelectedSort] = useState('');
-  const [selectedFns, setSelectedFns] = useState<FNSOffice[]>([]);
+  const [selectedFns, setSelectedFns] = useState<FnsOfficeItem[]>([]);
 
   useEffect(() => {
     api.get<ServiceCategory[]>('/categories')
       .then(data => setServiceCategories(data))
       .catch(() => {});
   }, []);
-  const [fnsQuery, setFnsQuery] = useState('');
-  const [fnsDropdown, setFnsDropdown] = useState<FNSOffice[]>([]);
 
-  // Local FNS dropdown filtering
-  useEffect(() => {
-    if (fnsQuery.trim().length < 2) {
-      setFnsDropdown([]);
-      return;
-    }
-    const q = fnsQuery.trim().toLowerCase();
-    const selectedCodes = new Set(selectedFns.map((o) => o.code));
-    const results = FNS_OFFICES.filter(
-      (o) => !selectedCodes.has(o.code) && (o.name.toLowerCase().includes(q) || o.city.toLowerCase().includes(q))
-    ).slice(0, 8);
-    setFnsDropdown(results);
-  }, [fnsQuery, selectedFns]);
+  const { cities: apiCities } = useCities();
+  const [fnsQuery, setFnsQuery] = useState('');
+  const { results: fnsSearchResults } = useFnsSearch(fnsQuery, 300);
+
+  // FNS dropdown: filter API search results to exclude already selected
+  const fnsDropdown = fnsSearchResults
+    .filter((o) => !selectedFns.some((s) => s.code === o.code))
+    .slice(0, 8);
 
   const fnsFilterParam = selectedFns.map((o) => o.name).join(',');
 
@@ -309,7 +301,6 @@ export default function SpecialistsCatalogScreen() {
                       onPress={() => {
                         setSelectedFns((prev) => [...prev, office]);
                         setFnsQuery('');
-                        setFnsDropdown([]);
                       }}
                       style={styles.fnsDropdownItem}
                       activeOpacity={0.7}
@@ -317,7 +308,7 @@ export default function SpecialistsCatalogScreen() {
                       <Text style={styles.fnsDropdownName} numberOfLines={2}>
                         {office.name}
                       </Text>
-                      <Text style={styles.fnsDropdownCity}>{office.city}</Text>
+                      <Text style={styles.fnsDropdownCity}>{office.city.name}</Text>
                     </TouchableOpacity>
                   ))}
                 </View>
@@ -337,7 +328,7 @@ export default function SpecialistsCatalogScreen() {
                     activeOpacity={0.7}
                   >
                     <Text style={styles.fnsChipText} numberOfLines={1}>
-                      {office.name} ({office.city})
+                      {office.name} ({office.city.name})
                     </Text>
                     <Text style={styles.fnsChipRemove}>x</Text>
                   </TouchableOpacity>

--- a/hooks/useFnsData.ts
+++ b/hooks/useFnsData.ts
@@ -1,0 +1,184 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { api } from '../lib/api';
+
+// ---------------------------------------------------------------------------
+// Types matching the API response (Ifns with included city)
+// ---------------------------------------------------------------------------
+export interface CityItem {
+  id: string;
+  name: string;
+  slug: string;
+  region: string | null;
+}
+
+export interface FnsOfficeItem {
+  id: string;
+  code: string;
+  name: string;
+  slug: string;
+  address: string | null;
+  searchAliases: string | null;
+  cityId: string;
+  city: CityItem;
+}
+
+// ---------------------------------------------------------------------------
+// Simple in-memory cache (survives re-renders across screens)
+// ---------------------------------------------------------------------------
+const cache = {
+  cities: null as CityItem[] | null,
+  citiesPromise: null as Promise<CityItem[]> | null,
+  fnsByCity: new Map<string, FnsOfficeItem[]>(),
+  fnsByCityPromise: new Map<string, Promise<FnsOfficeItem[]>>(),
+  allFns: null as FnsOfficeItem[] | null,
+  allFnsPromise: null as Promise<FnsOfficeItem[]> | null,
+};
+
+// ---------------------------------------------------------------------------
+// Hook: useCities
+// ---------------------------------------------------------------------------
+export function useCities() {
+  const [cities, setCities] = useState<CityItem[]>(cache.cities ?? []);
+  const [loading, setLoading] = useState(!cache.cities);
+
+  useEffect(() => {
+    if (cache.cities) {
+      setCities(cache.cities);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    if (!cache.citiesPromise) {
+      cache.citiesPromise = api.get<CityItem[]>('/ifns/cities');
+    }
+
+    cache.citiesPromise
+      .then((data) => {
+        cache.cities = data;
+        if (!cancelled) {
+          setCities(data);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { cities, loading };
+}
+
+// ---------------------------------------------------------------------------
+// Hook: useFnsOffices — optionally filtered by cityId
+// ---------------------------------------------------------------------------
+export function useFnsOffices(cityId?: string) {
+  const [offices, setOffices] = useState<FnsOfficeItem[]>(
+    cityId ? (cache.fnsByCity.get(cityId) ?? []) : (cache.allFns ?? []),
+  );
+  const [loading, setLoading] = useState(
+    cityId ? !cache.fnsByCity.has(cityId) : !cache.allFns,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (cityId) {
+      // Filtered by city
+      if (cache.fnsByCity.has(cityId)) {
+        setOffices(cache.fnsByCity.get(cityId)!);
+        setLoading(false);
+        return;
+      }
+
+      if (!cache.fnsByCityPromise.has(cityId)) {
+        cache.fnsByCityPromise.set(
+          cityId,
+          api.get<FnsOfficeItem[]>(`/ifns?city_id=${encodeURIComponent(cityId)}`),
+        );
+      }
+
+      cache.fnsByCityPromise
+        .get(cityId)!
+        .then((data) => {
+          cache.fnsByCity.set(cityId, data);
+          if (!cancelled) {
+            setOffices(data);
+            setLoading(false);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setLoading(false);
+        });
+    } else {
+      // All offices
+      if (cache.allFns) {
+        setOffices(cache.allFns);
+        setLoading(false);
+        return;
+      }
+
+      if (!cache.allFnsPromise) {
+        cache.allFnsPromise = api.get<FnsOfficeItem[]>('/ifns');
+      }
+
+      cache.allFnsPromise
+        .then((data) => {
+          cache.allFns = data;
+          if (!cancelled) {
+            setOffices(data);
+            setLoading(false);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [cityId]);
+
+  return { offices, loading };
+}
+
+// ---------------------------------------------------------------------------
+// Hook: useFnsSearch — debounced search via API (used for typeahead)
+// ---------------------------------------------------------------------------
+export function useFnsSearch(query: string, debounceMs = 300) {
+  const [results, setResults] = useState<FnsOfficeItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    timerRef.current = setTimeout(() => {
+      api
+        .get<FnsOfficeItem[]>(`/ifns/search?q=${encodeURIComponent(trimmed)}`)
+        .then((data) => setResults(data))
+        .catch(() => setResults([]))
+        .finally(() => setLoading(false));
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [query, debounceMs]);
+
+  return { results, loading };
+}


### PR DESCRIPTION
This pull request fixes #707.

The PR successfully addresses the core issue of replacing hardcoded FNS constants with API calls. Here's what was done:

**Backend changes:**
- Added `findAll(cityId?)` method to `IfnsService` that queries the database with optional city filtering and includes related city data
- Added `getCities()` method that returns all cities from the database
- Added two new controller endpoints: `GET /ifns` (with optional `city_id` query param) and `GET /ifns/cities`

**Frontend changes:**
- Created a new `hooks/useFnsData.ts` with three hooks: `useCities()`, `useFnsOffices(cityId?)`, and `useFnsSearch(query, debounceMs)` — all backed by API calls
- Implemented client-side caching in the hooks module (in-memory cache for cities, FNS by city, and all FNS) to avoid redundant API calls
- Updated `app/(onboarding)/fns.tsx` to use `useFnsSearch` instead of filtering `FNS_OFFICES` locally
- Updated `app/specialists/index.tsx` to use `useFnsSearch` and `useCities` instead of `FNS_OFFICES` and `RUSSIAN_CITIES`
- Updated `app/(dashboard)/profile.tsx` to import from the new hooks instead of constants
- Adjusted all references from `office.city` (string) to `office.city.name` (object property) to match the new API response shape

**Acceptance criteria met:**
- ✅ Replace FNS_OFFICES constant usage with API calls
- ✅ Add GET /api/fns?city_id=X endpoint
- ✅ Onboarding and specialists screens use API-backed search
- ✅ Cache API responses client-side (in-memory cache in hooks)
- ⚠️ The hardcoded constants files aren't explicitly deleted in the patch, but they're no longer imported by the modified files. The `FNS_DEPARTMENTS` import remains in `fns.tsx` which appears intentional as that's a separate concern.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌