### PR TITLE
Fix issue #698: QA follow-up #688: acceptResponse missing RESPONSE_ACCEPTED email notification

### DIFF
--- a/api/src/notifications/email.service.ts
+++ b/api/src/notifications/email.service.ts
@@ -122,6 +122,32 @@ export class EmailService {
     }).catch((err) => this.logger.error('[notifyNewMessage] send failed', err));
   }
 
+  /** Notify specialist that their response was accepted by the client */
+  notifyResponseAccepted(specialistEmail: string, clientName: string, requestTitle: string, userId: string): void {
+    if (!this.client) {
+      this.logger.log(
+        `DEV EMAIL [notifyResponseAccepted]: to=${specialistEmail} client=${clientName} request=${requestTitle}`,
+      );
+      return;
+    }
+
+    const text =
+      `Ваш отклик принят клиентом ${clientName}.\n\n` +
+      `Напишите ему.`;
+
+    const html = `
+      <p>Ваш отклик на запрос <strong>${requestTitle}</strong> принят клиентом <strong>${clientName}</strong>.</p>
+      <p>Напишите ему.</p>`;
+
+    this.send({
+      to: specialistEmail,
+      subject: 'Ваш отклик принят — Налоговик',
+      text,
+      html,
+      userId,
+    }).catch((err) => this.logger.error('[notifyResponseAccepted] send failed', err));
+  }
+
   /** Notify a list of specialists that a new request appeared in their city */
   notifyNewRequestInCity(
     specialistEmails: string[],


### PR DESCRIPTION
This pull request fixes #698.

The changes are only partially complete. The `notifyResponseAccepted` method was added to `EmailService`, which addresses one of the two files that needed modification. However, the issue explicitly requires calling this notification from `acceptResponse()` in `api/src/requests/requests.service.ts` after a successful transaction, and no changes were made to that file. Without the call site being wired up, the new method exists but is never invoked, so the notification will never actually be sent when a client accepts a response. Additionally, the acceptance criteria mention respecting the specialist's `notifyNewMessages` preference (or adding a separate toggle), and there's no evidence that this preference check was implemented in the new method or at the call site. The agent's last message only mentions updating a task list with 3 items, suggesting the work may still be in progress rather than complete.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌