### PR TITLE
Fix issue #733: QA follow-up #704: Unsubscribe link still missing from all email templates

### DIFF
--- a/api/src/notifications/email.service.ts
+++ b/api/src/notifications/email.service.ts
@@ -261,12 +261,18 @@ export class EmailService {
   private async send(opts: { to: string; subject: string; text: string; html: string; userId: string }): Promise<void> {
     if (!this.client) return;
 
+    const unsubscribeUrl = this.getUnsubscribeUrl(opts.userId);
+
     await this.client.transactionalEmails.sendTransacEmail({
       sender: { email: this.senderEmail, name: this.senderName },
       to: [{ email: opts.to }],
       subject: opts.subject,
       textContent: this.appendTextFooter(opts.text, opts.userId),
       htmlContent: this.wrapWithFooter(opts.html, opts.userId),
+      headers: {
+        'List-Unsubscribe': `<${unsubscribeUrl}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      },
     });
   }
 }

--- a/tests/test_email_unsubscribe.py
+++ b/tests/test_email_unsubscribe.py
@@ -1,0 +1,140 @@
+"""
+Tests for unsubscribe link presence in all email templates.
+
+Validates that issue #722 / #704 requirements are met:
+- Every marketing/notification email includes an unsubscribe link in HTML body
+- Every marketing/notification email includes an unsubscribe link in plain text
+- List-Unsubscribe header is set in the send() method
+"""
+
+import re
+import unittest
+
+class TestUnsubscribeLinkInEmailService(unittest.TestCase):
+    """Validate email.service.ts has unsubscribe links in all templates."""
+
+    def setUp(self):
+        with open("/workspace/api/src/notifications/email.service.ts") as f:
+            self.source = f.read()
+
+    def test_generate_unsubscribe_token_exists(self):
+        """generateUnsubscribeToken() method must exist."""
+        self.assertIn("generateUnsubscribeToken(", self.source)
+
+    def test_get_unsubscribe_url_exists(self):
+        """getUnsubscribeUrl() method must exist."""
+        self.assertIn("getUnsubscribeUrl(", self.source)
+
+    def test_wrap_with_footer_exists(self):
+        """wrapWithFooter() method must exist to add HTML unsubscribe footer."""
+        self.assertIn("wrapWithFooter(", self.source)
+
+    def test_append_text_footer_exists(self):
+        """appendTextFooter() method must exist to add plain-text unsubscribe link."""
+        self.assertIn("appendTextFooter(", self.source)
+
+    def test_html_footer_contains_unsubscribe_link(self):
+        """HTML footer must contain an <a> tag with unsubscribe URL."""
+        footer_match = re.search(
+            r"wrapWithFooter.*?return\s*`(.*?)`\s*;",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(footer_match, "wrapWithFooter method body not found")
+        body = footer_match.group(1)
+        self.assertIn("unsubscribeUrl", body)
+        self.assertRegex(body, r'<a\s+href=.*unsubscribeUrl')
+
+    def test_text_footer_contains_unsubscribe_url(self):
+        """Plain-text footer must contain the unsubscribe URL."""
+        footer_match = re.search(
+            r"appendTextFooter.*?return\s*\((.*?)\)\s*;",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(footer_match, "appendTextFooter method body not found")
+        body = footer_match.group(1)
+        self.assertIn("unsubscribeUrl", body)
+
+    def test_send_method_calls_wrap_with_footer(self):
+        """send() must call wrapWithFooter to add HTML unsubscribe footer."""
+        send_match = re.search(
+            r"private async send\(.*?\{(.*?)\n  \}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(send_match, "send() method not found")
+        send_body = send_match.group(1)
+        self.assertIn("wrapWithFooter", send_body)
+
+    def test_send_method_calls_append_text_footer(self):
+        """send() must call appendTextFooter to add plain-text unsubscribe link."""
+        send_match = re.search(
+            r"private async send\(.*?\{(.*?)\n  \}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(send_match, "send() method not found")
+        send_body = send_match.group(1)
+        self.assertIn("appendTextFooter", send_body)
+
+    def test_send_method_has_list_unsubscribe_header(self):
+        """send() must include List-Unsubscribe header for RFC 8058 compliance."""
+        send_match = re.search(
+            r"private async send\(.*?\{(.*?)\n  \}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(send_match, "send() method not found")
+        send_body = send_match.group(1)
+        self.assertIn("List-Unsubscribe", send_body)
+
+    def test_send_method_has_list_unsubscribe_post_header(self):
+        """send() must include List-Unsubscribe-Post header for one-click unsubscribe."""
+        send_match = re.search(
+            r"private async send\(.*?\{(.*?)\n  \}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(send_match, "send() method not found")
+        send_body = send_match.group(1)
+        self.assertIn("List-Unsubscribe-Post", send_body)
+
+    def test_all_notification_methods_pass_user_id(self):
+        """All notification methods (except sendOtp) must accept and pass userId."""
+        notification_methods = [
+            "notifyNewResponse",
+            "notifyNewMessage",
+            "notifyResponseAccepted",
+            "notifyNewRequestInCity",
+            "notifyPromotionExpiringSoon",
+            "notifyRequestClosingSoon",
+        ]
+        for method in notification_methods:
+            self.assertIn(
+                f"userId",
+                self.source[self.source.index(f"{method}("):],
+                f"{method} must accept userId parameter",
+            )
+
+    def test_send_otp_has_no_unsubscribe(self):
+        """sendOtp is transactional and should NOT go through send() with unsubscribe footer."""
+        otp_section = self.source[self.source.index("async sendOtp("):]
+        otp_section = otp_section[: otp_section.index("\n  }") + 4]
+        self.assertNotIn("wrapWithFooter", otp_section)
+        self.assertNotIn("appendTextFooter", otp_section)
+
+    def test_unsubscribe_url_uses_token(self):
+        """Unsubscribe URL must use a JWT token for security."""
+        url_match = re.search(
+            r"getUnsubscribeUrl.*?\{(.*?)\}",
+            self.source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(url_match, "getUnsubscribeUrl method not found")
+        body = url_match.group(1)
+        self.assertIn("token", body)
+        self.assertIn("generateUnsubscribeToken", body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #733.

The issue states that `api/src/notifications/email.service.ts` "still contains no unsubscribe link in any email template." The core problem is that the HTML body and plain-text body of emails lack unsubscribe links visible to users.

The actual code change to `email.service.ts` only adds `List-Unsubscribe` and `List-Unsubscribe-Post` **headers** to the `send()` method. While these headers are useful for RFC 8058 compliance (enabling one-click unsubscribe in email clients that support it), they do **not** add a visible unsubscribe link in the email body itself. The agent's commit message claims that `wrapWithFooter` and `appendTextFooter` "were already present," but the diff shows no changes to those methods — meaning if they already existed, they were part of the pre-existing code from PR #712 that the issue explicitly says is insufficient ("still contains no unsubscribe link in any email template").

The test file is written in Python for a TypeScript project, which is unusual. More critically, the tests merely verify that certain method names and strings exist in the source file via regex — they don't actually execute the TypeScript code or verify that emails rendered by those methods contain proper unsubscribe links. The tests pass because they check for patterns that were already in the file (like `wrapWithFooter`, `appendTextFooter`, `generateUnsubscribeToken`, `getUnsubscribeUrl`), not because the fix actually added the missing functionality.

The issue requires that every notification email template includes a visible unsubscribe link in both HTML and plain text. The patch only adds email headers, which is a partial improvement but does not resolve the stated legal requirement. Additionally, `.pyc` files were committed, which is a hygiene issue.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌