### PR TITLE
Fix issue #732: QA follow-up #709: MyResponses PR only added proto states, no actual route

### DIFF
--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -25,6 +25,7 @@ import { ProfileStates } from '../../../components/proto/states/ProfileStates';
 import { SettingsStates } from '../../../components/proto/states/SettingsStates';
 import { SpecialistDashboardStates } from '../../../components/proto/states/SpecialistDashboardStates';
 import { SpecialistRespondStates } from '../../../components/proto/states/SpecialistRespondStates';
+import { SpecialistMyResponsesStates } from '../../../components/proto/states/SpecialistMyResponsesStates';
 import { SpecialistProfilePublicStates } from '../../../components/proto/states/SpecialistProfilePublicStates';
 import { LandingStates } from '../../../components/proto/states/LandingStates';
 import { PublicRequestsStates } from '../../../components/proto/states/PublicRequestsStates';
@@ -61,6 +62,7 @@ const STATE_MAP: Record<string, React.ComponentType> = {
   'settings': SettingsStates,
   'specialist-dashboard': SpecialistDashboardStates,
   'specialist-respond': SpecialistRespondStates,
+  'specialist-my-responses': SpecialistMyResponsesStates,
   'specialist-profile-public': SpecialistProfilePublicStates,
   'landing': LandingStates,
   'public-requests': PublicRequestsStates,

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -211,6 +211,15 @@ export const pageRegistry: PageEntry[] = [
     { name: 'Успешная отправка отклика', steps: ['open /proto/states/specialist-respond', 'verify SUBMITTED state shows success', 'tap "К моим откликам"', 'verify navigation to specialist-dashboard'] },
     { name: 'Ошибка отправки отклика', steps: ['open /proto/states/specialist-respond', 'verify ERROR state visible', 'verify error message shown', 'tap "Попробовать снова"'] },
   ] },
+  { id: 'specialist-my-responses', title: 'Мои отклики', group: 'Specialist', route: '/specialist/my-responses', stateCount: 3, nav: 'specialist', activeTab: 'dashboard', qaCycles: 0, qaScore: 0, navTo: ['public-requests', 'message-thread'], navFrom: ['specialist-dashboard', 'specialist-respond'], api: [
+    'GET /api/specialist/responses',
+    'PATCH /api/specialist/responses/:id/deactivate',
+  ], testScenarios: [
+    { name: 'Loading state — skeleton cards', steps: ['open /proto/states/specialist-my-responses', 'verify LOADING state visible', 'verify skeleton filter chips', 'verify skeleton response cards'] },
+    { name: 'Empty state — no responses', steps: ['open /proto/states/specialist-my-responses', 'verify EMPTY state visible', 'verify "Вы ещё не откликались на заявки" message', 'verify CTA "Посмотреть заявки" navigates to public-requests'] },
+    { name: 'Populated state — filter and list', steps: ['open /proto/states/specialist-my-responses', 'verify POPULATED state visible', 'verify filter chips: Все, Активные, Деактивированные', 'verify response cards with status badges', 'tap filter chip "Активные"', 'verify list filters correctly'] },
+    { name: 'Deactivate response', steps: ['open /proto/states/specialist-my-responses', 'verify POPULATED state visible', 'tap "Деактивировать" on sent response', 'verify confirmation dialog'] },
+  ] },
   { id: 'specialist-profile-public', title: 'Публичный профиль', group: 'Specialist', route: '/specialists/1', stateCount: 2, nav: 'public', qaCycles: 5, qaScore: 11, api: [
     'GET /api/specialists/:id',
     'GET /api/specialists/:id/reviews?page=:page',
@@ -566,6 +575,7 @@ const SPECIALIST_ONLY_PAGES = [
   'onboarding-profile',
   'specialist-dashboard',
   'specialist-respond',
+  'specialist-my-responses',
   'messages',
   'message-thread',
   'profile',

--- a/tests/test_specialist_my_responses_route.py
+++ b/tests/test_specialist_my_responses_route.py
@@ -1,0 +1,93 @@
+"""
+Tests for specialist-my-responses route registration.
+
+Validates that the SpecialistMyResponses page has:
+1. A States component file
+2. An import and STATE_MAP entry in [page].tsx
+3. A pageRegistry entry
+4. An entry in SPECIALIST_ONLY_PAGES
+"""
+
+import unittest
+
+class TestSpecialistMyResponsesRoute(unittest.TestCase):
+    """Validate specialist-my-responses is fully wired as a route."""
+
+    def setUp(self):
+        with open("/workspace/app/proto/states/[page].tsx") as f:
+            self.page_tsx = f.read()
+        with open("/workspace/constants/pageRegistry.ts") as f:
+            self.registry = f.read()
+        with open("/workspace/components/proto/states/SpecialistMyResponsesStates.tsx") as f:
+            self.states_tsx = f.read()
+
+    def test_states_component_exists_and_exports(self):
+        """SpecialistMyResponsesStates must be exported from the States file."""
+        self.assertIn(
+            "export function SpecialistMyResponsesStates",
+            self.states_tsx,
+            "SpecialistMyResponsesStates export not found in States file",
+        )
+
+    def test_page_tsx_imports_states_component(self):
+        """[page].tsx must import SpecialistMyResponsesStates."""
+        self.assertIn(
+            "import { SpecialistMyResponsesStates }",
+            self.page_tsx,
+            "SpecialistMyResponsesStates import missing from [page].tsx",
+        )
+
+    def test_page_tsx_state_map_entry(self):
+        """STATE_MAP must contain 'specialist-my-responses' key."""
+        self.assertIn(
+            "'specialist-my-responses': SpecialistMyResponsesStates",
+            self.page_tsx,
+            "specialist-my-responses not found in STATE_MAP",
+        )
+
+    def test_page_registry_entry_exists(self):
+        """pageRegistry must have an entry with id 'specialist-my-responses'."""
+        self.assertIn(
+            "id: 'specialist-my-responses'",
+            self.registry,
+            "specialist-my-responses not found in pageRegistry",
+        )
+
+    def test_page_registry_has_route(self):
+        """pageRegistry entry must define a route."""
+        self.assertIn(
+            "route: '/specialist/my-responses'",
+            self.registry,
+            "Route not defined for specialist-my-responses in pageRegistry",
+        )
+
+    def test_page_registry_has_state_count(self):
+        """pageRegistry entry must have stateCount matching the States file."""
+        self.assertIn(
+            "stateCount: 3",
+            self.registry.split("id: 'specialist-my-responses'")[1].split("},")[0],
+            "stateCount should be 3 (POPULATED, EMPTY, LOADING)",
+        )
+
+    def test_page_registry_has_test_scenarios(self):
+        """pageRegistry entry must have testScenarios."""
+        entry_section = self.registry.split("id: 'specialist-my-responses'")[1].split("{ id:")[0]
+        self.assertIn("testScenarios:", entry_section)
+
+    def test_specialist_only_pages_includes_entry(self):
+        """SPECIALIST_ONLY_PAGES must include specialist-my-responses."""
+        self.assertIn(
+            "'specialist-my-responses'",
+            self.registry,
+            "specialist-my-responses not in SPECIALIST_ONLY_PAGES",
+        )
+        # More specific: check it's in the SPECIALIST_ONLY_PAGES array
+        specialist_section = self.registry.split("SPECIALIST_ONLY_PAGES")[1].split("] as const")[0]
+        self.assertIn(
+            "specialist-my-responses",
+            specialist_section,
+            "specialist-my-responses not in SPECIALIST_ONLY_PAGES array",
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #732.

The issue stated that PR #720 only added the component file (`SpecialistMyResponsesStates.tsx`) and mock data (`protoMockData.ts`) but never wired up the actual route, meaning specialists couldn't navigate to their responses page.

The changes directly address this gap:

1. **`app/proto/states/[page].tsx`**: Added the import of `SpecialistMyResponsesStates` and registered it in `STATE_MAP` under the key `'specialist-my-responses'`. This is the critical missing piece — it connects the dynamic `[page].tsx` route handler to the existing component, so navigating to `/proto/states/specialist-my-responses` will now render the correct screen.

2. **`constants/pageRegistry.ts`**: Added a full page entry with `id: 'specialist-my-responses'`, including route (`/specialist/my-responses`), state count (3), API endpoints, navigation links (`navTo`/`navFrom`), and test scenarios. This makes the page discoverable in the registry and enables navigation from other pages (like `specialist-dashboard` and `specialist-respond`).

3. **`constants/pageRegistry.ts`**: Added `'specialist-my-responses'` to the `SPECIALIST_ONLY_PAGES` array, ensuring proper role-based access control.

These three changes complete the route wiring that was missing. The component already existed; it just needed to be connected to the routing infrastructure. The 8 new tests validate all these integration points (import exists, STATE_MAP entry exists, registry entry with correct route/stateCount/testScenarios, SPECIALIST_ONLY_PAGES inclusion), and all pass along with the 65 pre-existing tests.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌