### PR TITLE
fix: add missing StyleSheet import (app crash)

### DIFF
--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, ActivityIndicator, SafeAreaView, Image } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';


### PR DESCRIPTION
## Summary
- Fixes #734
- `app/specialists/[nick].tsx` used `StyleSheet.create()` without importing `StyleSheet` from `react-native`
- This crashed the entire app with 500 error

## Test plan
- [ ] App loads without 500 error
- [ ] Specialist profile page renders