### PR TITLE
fix: add missing Platform import (app crash)

### DIFF
--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { StyleSheet, View, Text, ScrollView, TouchableOpacity, ActivityIndicator, SafeAreaView, Image } from 'react-native';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, ActivityIndicator, SafeAreaView, Image, Platform } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';


### PR DESCRIPTION
## Summary
- `app/specialists/[nick].tsx` uses `Platform.OS` but didn't import `Platform`
- Crashes app with "Platform is not defined"

## Test plan
- [ ] App loads without 500