### PR TITLE
Fix issue #723: SA gap: Request auto-close cron job not implemented

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -37,10 +37,14 @@
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
+        "@nestjs/testing": "^11.1.19",
+        "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.13.0",
         "@types/passport-jwt": "^4.0.1",
+        "jest": "^30.3.0",
         "prisma": "^6.19.3",
+        "ts-jest": "^29.4.9",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.7.3"
       }
@@ -930,152 +934,228 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@borewit/text-codec": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
-      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@getbrevo/brevo": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@getbrevo/brevo/-/brevo-5.0.3.tgz",
-      "integrity": "sha512-AIAFXiUkk5fpl8cVttGWZfxt84PFPS7DnB0+fRqd70kFsbwPvNfdYhrnD0tXL5jLmGrSeLv2pfACkzFD7gYeeA==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@ioredis/commands": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+    "node_modules/@babel/core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
-    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1i
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5355,3 +5435,89 @@
     }
   }
 }
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }

--- a/api/package.json
+++ b/api/package.json
@@ -42,10 +42,14 @@
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
+    "@nestjs/testing": "^11.1.19",
+    "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.13.0",
     "@types/passport-jwt": "^4.0.1",
+    "jest": "^30.3.0",
     "prisma": "^6.19.3",
+    "ts-jest": "^29.4.9",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.3"
   }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -396,11 +396,28 @@ model QuickRequest {
   @@map("quick_requests")
 }
 
+
+
 enum ComplaintReason {
   spam
   fraud
   inappropriate
   other
+}
+
+model Complaint {
+  id         String          @id @default(cuid())
+  reporterId String
+  reporter   User            @relation("ComplaintReporter", fields: [reporterId], references: [id])
+  targetId   String
+  target     User            @relation("ComplaintTarget", fields: [targetId], references: [id])
+  reason     ComplaintReason
+  comment    String?
+  createdAt  DateTime        @default(now())
+
+  @@index([reporterId])
+  @@index([targetId])
+  @@map("complaints")
 }
 
 model Setting {

--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -196,8 +196,8 @@ export class RequestsController {
     return this.requestsService.deleteRequest(req.user.id, id);
   }
 
-  // PATCH /requests/:id/extend — client extends a request (resets lastActivityAt, max 3)
-  @Patch(':id/extend')
+  // POST /requests/:id/extend — client extends a request (resets lastActivityAt, max 3)
+  @Post(':id/extend')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.CLIENT)
   extend(@Request() req: any, @Param('id') id: string) {

--- a/api/src/requests/requests.service.spec.ts
+++ b/api/src/requests/requests.service.spec.ts
@@ -1,0 +1,278 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RequestsService } from './requests.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { EmailService } from '../notifications/email.service';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+
+// Minimal enums to avoid needing full Prisma client generation
+const RequestStatus = {
+  OPEN: 'OPEN',
+  CLOSING_SOON: 'CLOSING_SOON',
+  CLOSED: 'CLOSED',
+  CANCELLED: 'CANCELLED',
+} as const;
+
+describe('RequestsService — lifecycle features', () => {
+  let service: RequestsService;
+  let prisma: any;
+  let emailService: any;
+
+  beforeEach(async () => {
+    prisma = {
+      request: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+        findMany: jest.fn(),
+      },
+      response: {
+        create: jest.fn(),
+        findUnique: jest.fn(),
+      },
+      specialistProfile: {
+        findUnique: jest.fn(),
+      },
+      thread: {
+        upsert: jest.fn(),
+      },
+      setting: {
+        findUnique: jest.fn(),
+      },
+      $transaction: jest.fn((fn: any) => fn(prisma)),
+    };
+
+    emailService = {
+      notifyNewResponse: jest.fn(),
+      notifyNewRequestInCity: jest.fn(),
+      notifyRequestClosingSoon: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RequestsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: EmailService, useValue: emailService },
+      ],
+    }).compile();
+
+    service = module.get<RequestsService>(RequestsService);
+  });
+
+  describe('extend()', () => {
+    it('should reset lastActivityAt and increment extensionsCount', async () => {
+      const request = {
+        id: 'req-1',
+        clientId: 'client-1',
+        status: RequestStatus.OPEN,
+        extensionsCount: 0,
+        lastActivityAt: new Date('2026-03-01'),
+      };
+      prisma.request.findUnique.mockResolvedValue(request);
+      prisma.request.update.mockResolvedValue({
+        ...request,
+        extensionsCount: 1,
+        lastActivityAt: new Date(),
+        status: RequestStatus.OPEN,
+      });
+
+      const result = await service.extend('client-1', 'req-1');
+
+      expect(prisma.request.update).toHaveBeenCalledWith({
+        where: { id: 'req-1' },
+        data: {
+          lastActivityAt: expect.any(Date),
+          extensionsCount: { increment: 1 },
+          status: RequestStatus.OPEN,
+        },
+      });
+      expect(result.extensionsCount).toBe(1);
+    });
+
+    it('should extend a CLOSING_SOON request back to OPEN', async () => {
+      const request = {
+        id: 'req-2',
+        clientId: 'client-1',
+        status: RequestStatus.CLOSING_SOON,
+        extensionsCount: 1,
+        lastActivityAt: new Date('2026-03-01'),
+      };
+      prisma.request.findUnique.mockResolvedValue(request);
+      prisma.request.update.mockResolvedValue({
+        ...request,
+        extensionsCount: 2,
+        status: RequestStatus.OPEN,
+      });
+
+      const result = await service.extend('client-1', 'req-2');
+
+      expect(prisma.request.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: RequestStatus.OPEN }),
+        }),
+      );
+      expect(result.status).toBe(RequestStatus.OPEN);
+    });
+
+    it('should throw 400 when max extensions (3) reached', async () => {
+      prisma.request.findUnique.mockResolvedValue({
+        id: 'req-3',
+        clientId: 'client-1',
+        status: RequestStatus.OPEN,
+        extensionsCount: 3,
+      });
+
+      await expect(service.extend('client-1', 'req-3')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw 404 when request not found', async () => {
+      prisma.request.findUnique.mockResolvedValue(null);
+
+      await expect(service.extend('client-1', 'nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw 403 when not the owner', async () => {
+      prisma.request.findUnique.mockResolvedValue({
+        id: 'req-4',
+        clientId: 'other-client',
+        status: RequestStatus.OPEN,
+        extensionsCount: 0,
+      });
+
+      await expect(service.extend('client-1', 'req-4')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw 400 when request is CLOSED', async () => {
+      prisma.request.findUnique.mockResolvedValue({
+        id: 'req-5',
+        clientId: 'client-1',
+        status: RequestStatus.CLOSED,
+        extensionsCount: 0,
+      });
+
+      await expect(service.extend('client-1', 'req-5')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('markClosingSoon()', () => {
+    it('should mark stale OPEN requests as CLOSING_SOON and send emails', async () => {
+      const staleRequests = [
+        {
+          id: 'req-stale-1',
+          status: RequestStatus.OPEN,
+          lastActivityAt: new Date('2026-03-10'),
+          client: { id: 'client-1', email: 'client1@test.com' },
+        },
+        {
+          id: 'req-stale-2',
+          status: RequestStatus.OPEN,
+          lastActivityAt: new Date('2026-03-12'),
+          client: { id: 'client-2', email: 'client2@test.com' },
+        },
+      ];
+
+      prisma.request.findMany.mockResolvedValue(staleRequests);
+      prisma.request.updateMany.mockResolvedValue({ count: 2 });
+
+      await service.markClosingSoon();
+
+      expect(prisma.request.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: RequestStatus.OPEN,
+            lastActivityAt: { lt: expect.any(Date) },
+          }),
+        }),
+      );
+
+      expect(prisma.request.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['req-stale-1', 'req-stale-2'] } },
+        data: { status: RequestStatus.CLOSING_SOON },
+      });
+
+      expect(emailService.notifyRequestClosingSoon).toHaveBeenCalledTimes(2);
+      expect(emailService.notifyRequestClosingSoon).toHaveBeenCalledWith(
+        'client1@test.com',
+        'req-stale-1',
+        'client-1',
+      );
+      expect(emailService.notifyRequestClosingSoon).toHaveBeenCalledWith(
+        'client2@test.com',
+        'req-stale-2',
+        'client-2',
+      );
+    });
+
+    it('should do nothing when no stale requests exist', async () => {
+      prisma.request.findMany.mockResolvedValue([]);
+
+      await service.markClosingSoon();
+
+      expect(prisma.request.updateMany).not.toHaveBeenCalled();
+      expect(emailService.notifyRequestClosingSoon).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('autoCloseStale()', () => {
+    it('should close requests with no activity for 30+ days', async () => {
+      prisma.request.updateMany.mockResolvedValue({ count: 3 });
+
+      await service.autoCloseStale();
+
+      expect(prisma.request.updateMany).toHaveBeenCalledWith({
+        where: {
+          status: { in: [RequestStatus.OPEN, RequestStatus.CLOSING_SOON] },
+          lastActivityAt: { lt: expect.any(Date) },
+        },
+        data: { status: RequestStatus.CLOSED },
+      });
+
+      // Verify the cutoff date is approximately 30 days ago
+      const call = prisma.request.updateMany.mock.calls[0][0];
+      const cutoff = call.where.lastActivityAt.lt;
+      const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+      const diff = Math.abs(Date.now() - thirtyDaysMs - cutoff.getTime());
+      expect(diff).toBeLessThan(5000); // within 5 seconds
+    });
+  });
+
+  describe('respond() — lastActivityAt update', () => {
+    it('should update lastActivityAt when a new response is created', async () => {
+      const request = {
+        id: 'req-resp-1',
+        clientId: 'client-1',
+        status: RequestStatus.OPEN,
+        city: 'Moscow',
+        client: { id: 'client-1', email: 'c@test.com', notifyNewResponses: false },
+      };
+
+      prisma.request.findUnique.mockResolvedValue(request);
+      prisma.specialistProfile.findUnique.mockResolvedValue({
+        cities: ['Moscow'],
+      });
+      prisma.response.findUnique.mockResolvedValue(null); // no existing response
+      prisma.response.create.mockResolvedValue({ id: 'resp-1' });
+      prisma.request.update.mockResolvedValue({ ...request, lastActivityAt: new Date() });
+      prisma.thread.upsert.mockResolvedValue({ id: 'thread-1' });
+
+      await service.respond('specialist-1', 'req-resp-1', {
+        comment: 'I can help',
+        price: 5000,
+        deadline: new Date(Date.now() + 86400000).toISOString() as any,
+      });
+
+      // The transaction calls request.update with lastActivityAt
+      expect(prisma.request.update).toHaveBeenCalledWith({
+        where: { id: 'req-resp-1' },
+        data: { lastActivityAt: expect.any(Date) },
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request fixes #723.

The changes address all five acceptance criteria from the issue:

1. **CLOSING_SOON in RequestStatus enum**: The schema already had `CLOSING_SOON` in the enum (confirmed by the service code referencing it). The schema change in this PR adds a missing `Complaint` model that was needed for Prisma generation to succeed — a prerequisite for the whole system to work.

2. **Cron service**: The `requests.service.ts` already contained `markClosingSoon()` (with `@Cron('0 2 * * *')`) that finds OPEN requests with `lastActivityAt < now-27d` and sets them to `CLOSING_SOON`, and `autoCloseStale()` (with `@Cron('0 3 * * *')`) that closes requests with `lastActivityAt < now-30d`. These were implemented in the prior PR #719 and are confirmed working by the new tests.

3. **Email warning 3 days before close**: `markClosingSoon()` calls `emailService.notifyRequestClosingSoon()` for each affected request's client, sending the warning email. The test confirms this behavior.

4. **POST /api/requests/:id/extend**: The controller was changed from `@Patch(':id/extend')` to `@Post(':id/extend')` to match the spec. The `extend()` method in the service resets `lastActivityAt`, increments `extensionsCount` (max 3, throws `BadRequestException` on 4th attempt), and sets status back to `OPEN`. Tests verify all edge cases: success, CLOSING_SOON→OPEN transition, max extensions error (400), not found (404), forbidden (403), and closed request (400).

5. **lastActivityAt updated on new response**: The `respond()` method updates `lastActivityAt` when creating a new response, confirmed by the test.

The new test file (`requests.service.spec.ts`) with 10 tests provides concrete verification of all lifecycle features. The `jest.config.js` and dev dependencies were added to support running these tests. The fix to the Prisma schema (adding the `Complaint` model) resolves what would have been a blocking issue for Prisma client generation, since `User` already referenced complaint relations.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌