### PR TITLE
Fix issue #721: SA gap: acceptResponse does not send RESPONSE_ACCEPTED email notification

### DIFF
--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -543,7 +543,10 @@ export class RequestsService {
   async acceptResponse(responseId: string, clientId: string) {
     const response = await this.prisma.response.findUnique({
       where: { id: responseId },
-      include: { request: { select: { clientId: true } } },
+      include: {
+        request: { select: { clientId: true, title: true } },
+        specialist: { select: { id: true, email: true, notifyNewResponses: true } },
+      },
     });
     if (!response) throw new NotFoundException('Response not found');
     if (response.request.clientId !== clientId) {
@@ -580,6 +583,21 @@ export class RequestsService {
 
       return { response: updated, thread };
     });
+
+    // Notify specialist that their response was accepted — fire-and-forget
+    if (response.specialist.notifyNewResponses) {
+      const client = await this.prisma.user.findUnique({
+        where: { id: clientId },
+        select: { email: true, firstName: true, lastName: true },
+      });
+      const clientName = [client?.firstName, client?.lastName].filter(Boolean).join(' ') || client?.email || 'Клиент';
+      this.emailService.notifyResponseAccepted(
+        response.specialist.email,
+        clientName,
+        response.request.title,
+        response.specialist.id,
+      );
+    }
 
     return result;
   }

--- a/tests/test_response_accepted_notification.py
+++ b/tests/test_response_accepted_notification.py
@@ -1,0 +1,104 @@
+"""
+Tests for acceptResponse() sending RESPONSE_ACCEPTED email notification.
+
+Validates acceptance criteria from the SA gap issue:
+1. acceptResponse() calls emailService.notifyResponseAccepted()
+2. Email only sent if specialist has notifyNewResponses: true
+3. Email contains request title and client info
+"""
+
+import unittest
+
+class TestAcceptResponseNotification(unittest.TestCase):
+    """Validate that acceptResponse() in requests.service.ts sends notification."""
+
+    def setUp(self):
+        with open("/workspace/api/src/requests/requests.service.ts") as f:
+            self.service = f.read()
+
+    def _get_accept_response_section(self):
+        start = self.service.index("async acceptResponse(")
+        # Find the next method (async patchResponse)
+        end = self.service.index("async patchResponse(", start)
+        return self.service[start:end]
+
+    def test_accept_response_includes_specialist_in_query(self):
+        """acceptResponse() must include specialist data in the findUnique query."""
+        section = self._get_accept_response_section()
+        self.assertIn("specialist:", section)
+        self.assertIn("email: true", section)
+        self.assertIn("notifyNewResponses: true", section)
+
+    def test_accept_response_includes_request_title_in_query(self):
+        """acceptResponse() must include request title in the findUnique query."""
+        section = self._get_accept_response_section()
+        self.assertIn("title: true", section)
+
+    def test_accept_response_calls_notify_response_accepted(self):
+        """acceptResponse() must call emailService.notifyResponseAccepted()."""
+        section = self._get_accept_response_section()
+        self.assertIn("notifyResponseAccepted", section)
+
+    def test_accept_response_checks_notification_preference(self):
+        """acceptResponse() must check specialist's notifyNewResponses before sending."""
+        section = self._get_accept_response_section()
+        self.assertIn("specialist.notifyNewResponses", section)
+
+    def test_accept_response_passes_specialist_email(self):
+        """acceptResponse() must pass specialist email to notifyResponseAccepted."""
+        section = self._get_accept_response_section()
+        self.assertIn("response.specialist.email", section)
+
+    def test_accept_response_passes_request_title(self):
+        """acceptResponse() must pass request title to notifyResponseAccepted."""
+        section = self._get_accept_response_section()
+        self.assertIn("response.request.title", section)
+
+    def test_accept_response_passes_client_name(self):
+        """acceptResponse() must pass client name to notifyResponseAccepted."""
+        section = self._get_accept_response_section()
+        self.assertIn("clientName", section)
+
+    def test_accept_response_fetches_client_info(self):
+        """acceptResponse() must fetch client firstName/lastName for the email."""
+        section = self._get_accept_response_section()
+        self.assertIn("firstName", section)
+        self.assertIn("lastName", section)
+
+    def test_notification_is_after_transaction(self):
+        """Notification must be sent after the transaction completes (not inside it)."""
+        section = self._get_accept_response_section()
+        tx_end = section.index("return { response: updated, thread };")
+        notify_pos = section.index("notifyResponseAccepted")
+        self.assertGreater(notify_pos, tx_end,
+                           "notifyResponseAccepted must be called after the transaction")
+
+class TestEmailServiceResponseAccepted(unittest.TestCase):
+    """Validate notifyResponseAccepted() exists in email.service.ts."""
+
+    def setUp(self):
+        with open("/workspace/api/src/notifications/email.service.ts") as f:
+            self.email = f.read()
+
+    def test_notify_response_accepted_method_exists(self):
+        """notifyResponseAccepted() method must exist."""
+        self.assertIn("notifyResponseAccepted(", self.email)
+
+    def test_notify_response_accepted_has_subject(self):
+        """Email must have appropriate subject."""
+        self.assertIn("Ваш отклик принят", self.email)
+
+    def test_notify_response_accepted_mentions_client(self):
+        """Email body must mention the client."""
+        self.assertIn("clientName", self.email)
+
+    def test_notify_response_accepted_mentions_request_title(self):
+        """Email body must mention the request title."""
+        self.assertIn("requestTitle", self.email)
+
+    def test_notify_response_accepted_dev_log(self):
+        """Dev mode must log RESPONSE_ACCEPTED type."""
+        self.assertIn("notifyResponseAccepted", self.email)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #721.

The changes directly address all three acceptance criteria from the issue:

1. **`acceptResponse()` now calls `emailService.notifyResponseAccepted()`**: After the transaction completes successfully, the method calls `this.emailService.notifyResponseAccepted(response.specialist.email, clientName, response.request.title, response.specialist.id)`. This is done as fire-and-forget (no `await`), which is appropriate for a non-critical side effect.

2. **Email is only sent if specialist has `notifyNewResponses: true`**: The call is wrapped in `if (response.specialist.notifyNewResponses)`, so specialists who have disabled notifications will not receive the email. The issue mentioned either `notifyNewResponses` or a dedicated `notifyAcceptedResponse` preference — using `notifyNewResponses` is acceptable.

3. **Email contains request title and client info**: The Prisma query was extended to include `request.title` and `specialist.email`/`notifyNewResponses`. The client's name is fetched separately via `prisma.user.findUnique` with `firstName` and `lastName`, composed into a `clientName` string, and passed to the notification method along with `response.request.title`.

The implementation is clean:
- The notification is sent **after** the transaction, not inside it, so a failed email won't roll back the accept operation.
- The specialist data is fetched in the initial query (single DB call), and client info is fetched only when needed (when notifications are enabled).
- The `notifyResponseAccepted` method already existed in `email.service.ts` (from PR #717), so no changes were needed there.

The test file validates the structural correctness of the integration by parsing the source files and checking that the right calls, arguments, and ordering are present. While these are static/structural tests rather than runtime integration tests, they effectively verify the wiring is correct.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌