### PR TITLE
Fix issue #752: Implement: Specialist My Responses route — actual screen at /specialist/my-responses

### DIFF
--- a/app/specialist/dashboard.tsx
+++ b/app/specialist/dashboard.tsx
@@ -166,6 +166,16 @@ export default function SpecialistDashboard() {
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.actionCard}
+          onPress={() => router.push('/specialist/my-responses')}
+          activeOpacity={0.7}
+        >
+          <View style={styles.actionIconWrap}>
+            <Ionicons name="document-text-outline" size={22} color={Colors.brandPrimary} />
+          </View>
+          <Text style={styles.actionLabel}>Мои отклики</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.actionCard}
           onPress={() => router.push('/(dashboard)/messages')}
           activeOpacity={0.7}
         >

--- a/app/specialist/my-responses.tsx
+++ b/app/specialist/my-responses.tsx
@@ -1,0 +1,431 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useBreakpoints } from '../../hooks/useBreakpoints';
+import { api, ApiError } from '../../lib/api';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { Card } from '../../components/Card';
+import { EmptyState } from '../../components/EmptyState';
+
+type ResponseStatus = 'sent' | 'viewed' | 'accepted' | 'deactivated';
+type FilterTab = 'all' | 'active' | 'accepted' | 'deactivated';
+
+interface ResponseItem {
+  id: string;
+  comment: string;
+  status: ResponseStatus;
+  price: number;
+  deadline: string;
+  viewedAt: string | null;
+  acceptedAt: string | null;
+  createdAt: string;
+  request: {
+    id: string;
+    title: string;
+    description: string;
+    city: string;
+    status: string;
+    createdAt: string;
+    clientId: string;
+  };
+}
+
+const FILTER_TABS: { key: FilterTab; label: string }[] = [
+  { key: 'all', label: 'Все' },
+  { key: 'active', label: 'Активные' },
+  { key: 'accepted', label: 'Принятые' },
+  { key: 'deactivated', label: 'Отклоненные' },
+];
+
+const STATUS_CONFIG: Record<ResponseStatus, { label: string; bg: string; color: string }> = {
+  sent: { label: 'Отправлен', bg: Colors.statusBg.info, color: Colors.statusInfo },
+  viewed: { label: 'Просмотрен', bg: Colors.statusBg.warning, color: Colors.statusWarning },
+  accepted: { label: 'Принят', bg: Colors.statusBg.success, color: Colors.statusSuccess },
+  deactivated: { label: 'Деактивирован', bg: Colors.statusBg.error, color: Colors.statusError },
+};
+
+function filterResponses(responses: ResponseItem[], tab: FilterTab): ResponseItem[] {
+  switch (tab) {
+    case 'active':
+      return responses.filter((r) => r.status === 'sent' || r.status === 'viewed');
+    case 'accepted':
+      return responses.filter((r) => r.status === 'accepted');
+    case 'deactivated':
+      return responses.filter((r) => r.status === 'deactivated');
+    default:
+      return responses;
+  }
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('ru-RU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function formatPrice(price: number): string {
+  return price.toLocaleString('ru-RU') + ' EUR';
+}
+
+export default function SpecialistMyResponsesScreen() {
+  const router = useRouter();
+  const { isMobile } = useBreakpoints();
+  const [responses, setResponses] = useState<ResponseItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState<FilterTab>('all');
+  const [deactivatingId, setDeactivatingId] = useState<string | null>(null);
+
+  const fetchResponses = useCallback(async (isRefresh = false) => {
+    if (!isRefresh) setLoading(true);
+    setError('');
+    try {
+      const data = await api.get<ResponseItem[]>('/specialist/responses');
+      setResponses(data);
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Не удалось загрузить отклики');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchResponses();
+  }, [fetchResponses]);
+
+  function handleRefresh() {
+    setRefreshing(true);
+    fetchResponses(true);
+  }
+
+  async function handleDeactivate(responseId: string) {
+    if (deactivatingId) return;
+    setDeactivatingId(responseId);
+    try {
+      await api.patch(`/requests/responses/${responseId}`, { status: 'deactivated' });
+      setResponses((prev) =>
+        prev.map((r) => (r.id === responseId ? { ...r, status: 'deactivated' as ResponseStatus } : r)),
+      );
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Не удалось деактивировать отклик';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setDeactivatingId(null);
+    }
+  }
+
+  const filtered = filterResponses(responses, activeTab);
+
+  function renderSkeletonCard() {
+    return (
+      <View style={styles.cardWrapper}>
+        <Card padding={Spacing.lg}>
+          <View style={[styles.skeleton, { width: '60%', height: 16 }]} />
+          <View style={[styles.skeleton, { width: '40%', height: 14, marginTop: Spacing.sm }]} />
+          <View style={[styles.skeleton, { width: '100%', height: 14, marginTop: Spacing.md }]} />
+          <View style={[styles.skeleton, { width: '80%', height: 14, marginTop: Spacing.sm }]} />
+        </Card>
+      </View>
+    );
+  }
+
+  function renderItem({ item }: { item: ResponseItem }) {
+    const statusCfg = STATUS_CONFIG[item.status] ?? STATUS_CONFIG.sent;
+    const canDeactivate = item.status === 'sent' || item.status === 'viewed';
+
+    return (
+      <View style={styles.cardWrapper}>
+        <Card padding={Spacing.lg}>
+          {/* Title + Status */}
+          <View style={styles.topRow}>
+            <Text style={styles.requestTitle} numberOfLines={2}>
+              {item.request.title || item.request.description}
+            </Text>
+            <View style={[styles.statusBadge, { backgroundColor: statusCfg.bg }]}>
+              <Text style={[styles.statusText, { color: statusCfg.color }]}>{statusCfg.label}</Text>
+            </View>
+          </View>
+
+          {/* City */}
+          {item.request.city ? (
+            <View style={styles.cityRow}>
+              <Ionicons name="location-outline" size={14} color={Colors.textMuted} />
+              <Text style={styles.cityText}>{item.request.city}</Text>
+            </View>
+          ) : null}
+
+          <View style={styles.divider} />
+
+          {/* Price + Deadline */}
+          <View style={styles.detailsRow}>
+            <View style={styles.detailItem}>
+              <Text style={styles.detailLabel}>Цена</Text>
+              <Text style={styles.detailValue}>{formatPrice(item.price)}</Text>
+            </View>
+            <View style={styles.detailItem}>
+              <Text style={styles.detailLabel}>Срок</Text>
+              <Text style={styles.detailValue}>{formatDate(item.deadline)}</Text>
+            </View>
+          </View>
+
+          {/* Comment */}
+          {item.comment ? (
+            <Text style={styles.comment} numberOfLines={2}>
+              {item.comment}
+            </Text>
+          ) : null}
+
+          {/* Date */}
+          <Text style={styles.dateText}>Отправлен: {formatDate(item.createdAt)}</Text>
+
+          {/* Deactivate button */}
+          {canDeactivate && (
+            <TouchableOpacity
+              style={styles.deactivateBtn}
+              onPress={() => handleDeactivate(item.id)}
+              disabled={deactivatingId === item.id}
+              activeOpacity={0.7}
+            >
+              {deactivatingId === item.id ? (
+                <ActivityIndicator size="small" color={Colors.statusError} />
+              ) : (
+                <Text style={styles.deactivateBtnText}>Деактивировать</Text>
+              )}
+            </TouchableOpacity>
+          )}
+        </Card>
+      </View>
+    );
+  }
+
+  const tabBar = (
+    <View style={styles.tabBar}>
+      {FILTER_TABS.map((tab) => {
+        const isActive = activeTab === tab.key;
+        return (
+          <TouchableOpacity
+            key={tab.key}
+            style={[styles.tab, isActive && styles.tabActive]}
+            onPress={() => setActiveTab(tab.key)}
+            activeOpacity={0.7}
+          >
+            <Text style={[styles.tabText, isActive && styles.tabTextActive]}>{tab.label}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+
+  const listHeader = <View>{tabBar}</View>;
+
+  const emptyContent = loading ? (
+    <View style={styles.skeletonList}>
+      {renderSkeletonCard()}
+      {renderSkeletonCard()}
+      {renderSkeletonCard()}
+    </View>
+  ) : error ? (
+    <EmptyState
+      icon="alert-circle-outline"
+      title="Ошибка загрузки"
+      subtitle={error}
+      ctaLabel="Повторить"
+      onCtaPress={() => fetchResponses()}
+    />
+  ) : (
+    <EmptyState
+      icon="document-text-outline"
+      title="Нет откликов"
+      subtitle={
+        activeTab === 'all'
+          ? 'Вы ещё не откликались ни на один запрос'
+          : 'Нет откликов в этой категории'
+      }
+      ctaLabel={activeTab === 'all' ? 'Смотреть запросы' : undefined}
+      onCtaPress={activeTab === 'all' ? () => router.push('/(dashboard)/city-requests') : undefined}
+    />
+  );
+
+  return (
+    <SafeAreaView style={styles.safe}>
+      <Header title="Мои отклики" showBack />
+      <FlatList
+        data={loading ? [] : filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListHeaderComponent={listHeader}
+        contentContainerStyle={[
+          styles.listContent,
+          !isMobile && styles.listContentWide,
+        ]}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        ListEmptyComponent={emptyContent}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  listContent: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    paddingTop: Spacing.sm,
+  },
+  listContentWide: {
+    maxWidth: 800,
+    alignSelf: 'center',
+    width: '100%',
+  },
+  // Tabs
+  tabBar: {
+    flexDirection: 'row',
+    marginBottom: Spacing.md,
+    gap: Spacing.sm,
+    flexWrap: 'wrap',
+  },
+  tab: {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.bgSecondary,
+    borderWidth: 1,
+    borderColor: Colors.borderLight,
+  },
+  tabActive: {
+    backgroundColor: Colors.brandPrimary,
+    borderColor: Colors.brandPrimary,
+  },
+  tabText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  tabTextActive: {
+    color: Colors.white,
+    fontWeight: Typography.fontWeight.semibold,
+  },
+  // Card
+  cardWrapper: {
+    marginBottom: Spacing.md,
+  },
+  topRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: Spacing.sm,
+  },
+  requestTitle: {
+    flex: 1,
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+    lineHeight: 22,
+  },
+  statusBadge: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: 3,
+    borderRadius: BorderRadius.full,
+  },
+  statusText: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  cityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    marginTop: Spacing.xs,
+  },
+  cityText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Colors.border,
+    marginVertical: Spacing.md,
+  },
+  detailsRow: {
+    flexDirection: 'row',
+    gap: Spacing['2xl'],
+    marginBottom: Spacing.md,
+  },
+  detailItem: {
+    gap: 2,
+  },
+  detailLabel: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    fontWeight: Typography.fontWeight.medium,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  detailValue: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  comment: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: 20,
+    fontStyle: 'italic',
+    marginBottom: Spacing.sm,
+  },
+  dateText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  deactivateBtn: {
+    marginTop: Spacing.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.md,
+    borderWidth: 1,
+    borderColor: Colors.statusError,
+    alignSelf: 'flex-start',
+    minHeight: 36,
+    justifyContent: 'center',
+  },
+  deactivateBtnText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  // Skeleton
+  skeletonList: {
+    gap: Spacing.md,
+  },
+  skeleton: {
+    backgroundColor: Colors.bgSecondary,
+    borderRadius: BorderRadius.sm,
+  },
+});

--- a/tests/test_specialist_my_responses_screen.py
+++ b/tests/test_specialist_my_responses_screen.py
@@ -1,0 +1,246 @@
+"""
+Tests for the actual specialist my-responses screen at app/specialist/my-responses.tsx.
+
+Validates:
+1. Route file exists with correct structure
+2. Required imports are present
+3. Filter tabs are defined (All, Active, Accepted, Deactivated)
+4. Status badges for all ResponseStatus values
+5. Deactivate functionality
+6. Loading/error/empty states
+7. Navigation link from dashboard
+"""
+
+import os
+import re
+import unittest
+
+ROUTE_FILE = "app/specialist/my-responses.tsx"
+DASHBOARD_FILE = "app/specialist/dashboard.tsx"
+
+def read_file(path):
+    with open(os.path.join("/workspace", path), "r") as f:
+        return f.read()
+
+class TestMyResponsesRouteFile(unittest.TestCase):
+    """Validate the route file exists and has correct structure."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_file_exists(self):
+        self.assertTrue(
+            os.path.exists(os.path.join("/workspace", ROUTE_FILE)),
+            f"{ROUTE_FILE} must exist",
+        )
+
+    def test_default_export(self):
+        self.assertIn(
+            "export default function",
+            self.content,
+            "Must have a default export function",
+        )
+
+    def test_imports_react(self):
+        self.assertRegex(
+            self.content,
+            r"import\s+React",
+            "Must import React",
+        )
+
+    def test_imports_flatlist(self):
+        self.assertRegex(
+            self.content,
+            r"import\s*\{[^}]*FlatList[^}]*\}\s*from\s*['\"]react-native['\"]",
+            "Must import FlatList from react-native",
+        )
+
+    def test_imports_safe_area_view(self):
+        self.assertRegex(
+            self.content,
+            r"import\s*\{[^}]*SafeAreaView[^}]*\}\s*from\s*['\"]react-native['\"]",
+            "Must import SafeAreaView from react-native",
+        )
+
+    def test_imports_api(self):
+        self.assertIn("from '../../lib/api'", self.content, "Must import api module")
+
+    def test_imports_header(self):
+        self.assertIn(
+            "from '../../components/Header'",
+            self.content,
+            "Must import Header component",
+        )
+
+    def test_imports_empty_state(self):
+        self.assertIn(
+            "from '../../components/EmptyState'",
+            self.content,
+            "Must import EmptyState component",
+        )
+
+    def test_stylesheet_create(self):
+        self.assertIn(
+            "StyleSheet.create(",
+            self.content,
+            "Must use StyleSheet.create",
+        )
+
+class TestFilterTabs(unittest.TestCase):
+    """Validate filter tabs are defined correctly."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_all_tab(self):
+        self.assertIn("'all'", self.content, "Must have 'all' filter tab")
+
+    def test_active_tab(self):
+        self.assertIn("'active'", self.content, "Must have 'active' filter tab")
+
+    def test_accepted_tab(self):
+        self.assertIn("'accepted'", self.content, "Must have 'accepted' filter tab")
+
+    def test_deactivated_tab(self):
+        self.assertIn("'deactivated'", self.content, "Must have 'deactivated' filter tab")
+
+    def test_filter_function_exists(self):
+        self.assertIn(
+            "filterResponses",
+            self.content,
+            "Must have a filterResponses function",
+        )
+
+    def test_active_filter_includes_sent_and_viewed(self):
+        # The active filter should match sent + viewed statuses
+        self.assertIn("'sent'", self.content)
+        self.assertIn("'viewed'", self.content)
+
+class TestStatusBadges(unittest.TestCase):
+    """Validate status configuration for all response statuses."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_sent_status(self):
+        self.assertIn("sent:", self.content, "Must have 'sent' status config")
+
+    def test_viewed_status(self):
+        self.assertIn("viewed:", self.content, "Must have 'viewed' status config")
+
+    def test_accepted_status(self):
+        self.assertIn("accepted:", self.content, "Must have 'accepted' status config")
+
+    def test_deactivated_status(self):
+        self.assertIn("deactivated:", self.content, "Must have 'deactivated' status config")
+
+    def test_status_badge_style(self):
+        self.assertIn("statusBadge", self.content, "Must have statusBadge style")
+
+class TestDeactivateFeature(unittest.TestCase):
+    """Validate deactivate button functionality."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_deactivate_handler(self):
+        self.assertIn(
+            "handleDeactivate",
+            self.content,
+            "Must have handleDeactivate function",
+        )
+
+    def test_patch_api_call(self):
+        self.assertIn(
+            "/requests/responses/",
+            self.content,
+            "Must call PATCH /requests/responses/:id",
+        )
+
+    def test_deactivate_button(self):
+        self.assertIn(
+            "deactivateBtn",
+            self.content,
+            "Must have deactivate button style",
+        )
+
+    def test_can_deactivate_check(self):
+        self.assertIn(
+            "canDeactivate",
+            self.content,
+            "Must check if response can be deactivated",
+        )
+
+class TestStates(unittest.TestCase):
+    """Validate loading, error, and empty states."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_loading_state(self):
+        self.assertIn("loading", self.content, "Must track loading state")
+
+    def test_skeleton_cards(self):
+        self.assertIn("skeleton", self.content.lower(), "Must have skeleton loading cards")
+
+    def test_error_state(self):
+        self.assertIn("error", self.content, "Must track error state")
+
+    def test_retry_button(self):
+        # EmptyState with ctaLabel for retry
+        self.assertIn("Повторить", self.content, "Must have retry button text")
+
+    def test_empty_state_cta(self):
+        self.assertIn(
+            "Смотреть запросы",
+            self.content,
+            "Empty state must have CTA to browse requests",
+        )
+
+    def test_api_endpoint(self):
+        self.assertIn(
+            "/specialist/responses",
+            self.content,
+            "Must fetch from GET /specialist/responses",
+        )
+
+class TestDashboardNavigation(unittest.TestCase):
+    """Validate navigation link from specialist dashboard."""
+
+    def setUp(self):
+        self.content = read_file(DASHBOARD_FILE)
+
+    def test_my_responses_link(self):
+        self.assertIn(
+            "/specialist/my-responses",
+            self.content,
+            "Dashboard must have navigation link to /specialist/my-responses",
+        )
+
+    def test_my_responses_label(self):
+        self.assertIn(
+            "Мои отклики",
+            self.content,
+            "Dashboard must have 'Мои отклики' label for the nav link",
+        )
+
+class TestResponseInterface(unittest.TestCase):
+    """Validate the ResponseItem interface has required fields."""
+
+    def setUp(self):
+        self.content = read_file(ROUTE_FILE)
+
+    def test_price_field(self):
+        self.assertIn("price", self.content, "ResponseItem must have price field")
+
+    def test_deadline_field(self):
+        self.assertIn("deadline", self.content, "ResponseItem must have deadline field")
+
+    def test_status_field(self):
+        self.assertIn("status", self.content, "ResponseItem must have status field")
+
+    def test_request_title_field(self):
+        self.assertIn("title", self.content, "ResponseItem.request must have title field")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #752.

The implementation addresses all acceptance criteria from the issue:

1. **Route file created** (`app/specialist/my-responses.tsx`): A complete 431-line screen component with proper structure, default export, and all necessary imports (React, FlatList, SafeAreaView, api, Header, EmptyState, etc.).

2. **Fetches from `GET /specialist/responses`**: The `fetchResponses` callback calls `api.get<ResponseItem[]>('/specialist/responses')` and stores the result in state.

3. **Response cards with required data**: Each card displays request title, city, price (formatted with EUR), deadline (formatted date), status badge, comment, and creation date.

4. **Filter tabs**: All four tabs are implemented — All, Active (filters for `sent` + `viewed`), Accepted, Deactivated — with a `filterResponses` function that correctly filters the response list.

5. **Status badges**: All four statuses (`sent`, `viewed`, `accepted`, `deactivated`) have color-coded badge configurations with Russian labels.

6. **Empty state with CTA**: When no responses exist on the "All" tab, an EmptyState component shows "Нет откликов" with a "Смотреть запросы" button that navigates to `/(dashboard)/city-requests`.

7. **Loading state with skeleton cards**: Three skeleton cards are rendered while data is loading, using placeholder views with appropriate dimensions.

8. **Error state with retry**: An EmptyState with "Ошибка загрузки" title and "Повторить" CTA button that re-invokes `fetchResponses()`.

9. **Deactivate button**: A `handleDeactivate` function calls `api.patch(/requests/responses/${responseId}, { status: 'deactivated' })` and optimistically updates local state. The button only appears for `sent` or `viewed` responses (`canDeactivate` check).

10. **Dashboard navigation**: A new "Мои отклики" TouchableOpacity card was added to `app/specialist/dashboard.tsx` that navigates to `/specialist/my-responses`.

The 36 Python tests validate all structural requirements and pass. The implementation is complete, well-structured, and covers all the acceptance criteria specified in the issue.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌