### PR TITLE
Fix issue #760: Implement: Specialist My Responses route — actual screen at /specialist/my-responses (follow-up #732)

### DIFF
--- a/app/specialist/my-responses.tsx
+++ b/app/specialist/my-responses.tsx
@@ -20,7 +20,7 @@ import { Card } from '../../components/Card';
 import { EmptyState } from '../../components/EmptyState';
 
 type ResponseStatus = 'sent' | 'viewed' | 'accepted' | 'deactivated';
-type FilterTab = 'all' | 'active' | 'accepted' | 'deactivated';
+type FilterTab = 'all' | 'active' | 'deactivated';
 
 interface ResponseItem {
   id: string;
@@ -45,13 +45,12 @@ interface ResponseItem {
 const FILTER_TABS: { key: FilterTab; label: string }[] = [
   { key: 'all', label: 'Все' },
   { key: 'active', label: 'Активные' },
-  { key: 'accepted', label: 'Принятые' },
   { key: 'deactivated', label: 'Отклоненные' },
 ];
 
 const STATUS_CONFIG: Record<ResponseStatus, { label: string; bg: string; color: string }> = {
-  sent: { label: 'Отправлен', bg: Colors.statusBg.info, color: Colors.statusInfo },
-  viewed: { label: 'Просмотрен', bg: Colors.statusBg.warning, color: Colors.statusWarning },
+  sent: { label: 'Отправлен', bg: Colors.statusBg.neutral, color: Colors.statusNeutral },
+  viewed: { label: 'Просмотрен', bg: Colors.statusBg.info, color: Colors.statusInfo },
   accepted: { label: 'Принят', bg: Colors.statusBg.success, color: Colors.statusSuccess },
   deactivated: { label: 'Деактивирован', bg: Colors.statusBg.error, color: Colors.statusError },
 };
@@ -60,8 +59,6 @@ function filterResponses(responses: ResponseItem[], tab: FilterTab): ResponseIte
   switch (tab) {
     case 'active':
       return responses.filter((r) => r.status === 'sent' || r.status === 'viewed');
-    case 'accepted':
-      return responses.filter((r) => r.status === 'accepted');
     case 'deactivated':
       return responses.filter((r) => r.status === 'deactivated');
     default:
@@ -119,7 +116,7 @@ export default function SpecialistMyResponsesScreen() {
     if (deactivatingId) return;
     setDeactivatingId(responseId);
     try {
-      await api.patch(`/requests/responses/${responseId}`, { status: 'deactivated' });
+      await api.patch(`/responses/${responseId}`, { status: 'deactivated' });
       setResponses((prev) =>
         prev.map((r) => (r.id === responseId ? { ...r, status: 'deactivated' as ResponseStatus } : r)),
       );
@@ -151,7 +148,11 @@ export default function SpecialistMyResponsesScreen() {
     const canDeactivate = item.status === 'sent' || item.status === 'viewed';
 
     return (
-      <View style={styles.cardWrapper}>
+      <TouchableOpacity
+        style={styles.cardWrapper}
+        activeOpacity={0.7}
+        onPress={() => router.push(`/requests/${item.request.id}`)}
+      >
         <Card padding={Spacing.lg}>
           {/* Title + Status */}
           <View style={styles.topRow}>
@@ -199,7 +200,10 @@ export default function SpecialistMyResponsesScreen() {
           {canDeactivate && (
             <TouchableOpacity
               style={styles.deactivateBtn}
-              onPress={() => handleDeactivate(item.id)}
+              onPress={(e) => {
+                e.stopPropagation();
+                handleDeactivate(item.id);
+              }}
               disabled={deactivatingId === item.id}
               activeOpacity={0.7}
             >
@@ -211,7 +215,7 @@ export default function SpecialistMyResponsesScreen() {
             </TouchableOpacity>
           )}
         </Card>
-      </View>
+      </TouchableOpacity>
     );
   }
 
@@ -255,7 +259,7 @@ export default function SpecialistMyResponsesScreen() {
       title="Нет откликов"
       subtitle={
         activeTab === 'all'
-          ? 'Вы ещё не откликались ни на один запрос'
+          ? "You haven't responded to any requests yet"
           : 'Нет откликов в этой категории'
       }
       ctaLabel={activeTab === 'all' ? 'Смотреть запросы' : undefined}

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -26,6 +26,9 @@ export const Colors = {
   // Utilities
   white: '#FFFFFF',
 
+  // Status neutral (grey)
+  statusNeutral: '#6B7280',
+
   // Status background tints (for badges)
   statusBg: {
     success: '#DCFCE7',
@@ -34,6 +37,7 @@ export const Colors = {
     info: '#E0F2FE',
     accent: '#E0F2FE',
     familiar: '#E0F2FE',
+    neutral: '#F3F4F6',
   },
 
   // Extended text

--- a/tests/test_specialist_my_responses.py
+++ b/tests/test_specialist_my_responses.py
@@ -1,0 +1,161 @@
+"""
+Tests for specialist my-responses screen implementation.
+Validates acceptance criteria by parsing the source files.
+"""
+import os
+import re
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MY_RESPONSES_PATH = os.path.join(ROOT, "app", "specialist", "my-responses.tsx")
+LAYOUT_PATH = os.path.join(ROOT, "app", "specialist", "_layout.tsx")
+COLORS_PATH = os.path.join(ROOT, "constants", "Colors.ts")
+
+def read_file(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+@pytest.fixture
+def source():
+    return read_file(MY_RESPONSES_PATH)
+
+@pytest.fixture
+def layout_source():
+    return read_file(LAYOUT_PATH)
+
+@pytest.fixture
+def colors_source():
+    return read_file(COLORS_PATH)
+
+class TestRouteExists:
+    def test_my_responses_file_exists(self):
+        assert os.path.isfile(MY_RESPONSES_PATH), (
+            "app/specialist/my-responses.tsx must exist"
+        )
+
+    def test_layout_file_exists(self):
+        assert os.path.isfile(LAYOUT_PATH), (
+            "app/specialist/_layout.tsx must exist"
+        )
+
+    def test_layout_uses_stack(self, layout_source):
+        """Stack auto-discovers routes, so my-responses is registered."""
+        assert "<Stack" in layout_source, (
+            "_layout.tsx should use <Stack> for auto route discovery"
+        )
+
+class TestStatusChipColors:
+    """sent=grey, viewed=blue, accepted=green, deactivated=red"""
+
+    def test_sent_uses_neutral_grey(self, source):
+        assert "Colors.statusBg.neutral" in source, (
+            "sent status should use neutral (grey) background"
+        )
+        assert "Colors.statusNeutral" in source, (
+            "sent status should use neutral (grey) text color"
+        )
+
+    def test_viewed_uses_blue_info(self, source):
+        assert "Colors.statusBg.info" in source, (
+            "viewed status should use info (blue) background"
+        )
+        assert "Colors.statusInfo" in source, (
+            "viewed status should use info (blue) text color"
+        )
+
+    def test_accepted_uses_green_success(self, source):
+        assert "Colors.statusBg.success" in source, (
+            "accepted status should use success (green) background"
+        )
+        assert "Colors.statusSuccess" in source, (
+            "accepted status should use success (green) text color"
+        )
+
+    def test_deactivated_uses_red_error(self, source):
+        assert "Colors.statusBg.error" in source, (
+            "deactivated status should use error (red) background"
+        )
+        assert "Colors.statusError" in source, (
+            "deactivated status should use error (red) text color"
+        )
+
+    def test_neutral_color_defined(self, colors_source):
+        assert "statusNeutral" in colors_source, (
+            "Colors.ts must define statusNeutral"
+        )
+        assert "neutral" in colors_source, (
+            "Colors.ts statusBg must include neutral"
+        )
+
+class TestDeactivateEndpoint:
+    def test_deactivate_calls_correct_endpoint(self, source):
+        assert "api.patch(`/responses/${" in source, (
+            "Deactivate should call PATCH /responses/:id"
+        )
+
+    def test_deactivate_sends_status_deactivated(self, source):
+        assert "{ status: 'deactivated' }" in source, (
+            "Deactivate should send status=deactivated"
+        )
+
+    def test_no_old_endpoint(self, source):
+        assert "/requests/responses/" not in source, (
+            "Should not use old /requests/responses/ endpoint"
+        )
+
+class TestFilterTabs:
+    def test_has_all_tab(self, source):
+        assert "key: 'all'" in source
+
+    def test_has_active_tab(self, source):
+        assert "key: 'active'" in source
+
+    def test_has_deactivated_tab(self, source):
+        assert "key: 'deactivated'" in source
+
+    def test_no_accepted_filter_tab(self, source):
+        """Filter tabs should be All/Active/Deactivated only."""
+        # Find the FILTER_TABS array definition
+        match = re.search(
+            r"const FILTER_TABS.*?\[(.+?)\];", source, re.DOTALL
+        )
+        assert match, "FILTER_TABS must be defined"
+        tabs_content = match.group(1)
+        assert "key: 'accepted'" not in tabs_content, (
+            "FILTER_TABS should not include 'accepted' tab"
+        )
+
+class TestFlatListAndAPI:
+    def test_uses_flatlist(self, source):
+        assert "FlatList" in source
+
+    def test_fetches_from_specialist_responses(self, source):
+        assert "/specialist/responses" in source, (
+            "Should fetch from GET /api/specialist/responses"
+        )
+
+    def test_pull_to_refresh(self, source):
+        assert "RefreshControl" in source
+        assert "onRefresh" in source
+
+class TestEmptyState:
+    def test_empty_state_message(self, source):
+        assert "You haven't responded to any requests yet" in source, (
+            "Empty state should show the required message"
+        )
+
+class TestCardNavigation:
+    def test_card_navigates_to_request_detail(self, source):
+        assert "router.push(" in source
+        assert "/requests/" in source, (
+            "Tapping card should navigate to request detail"
+        )
+
+    def test_card_is_touchable(self, source):
+        assert "TouchableOpacity" in source
+
+class TestDeactivateButton:
+    def test_deactivate_button_for_sent_viewed(self, source):
+        assert "item.status === 'sent' || item.status === 'viewed'" in source, (
+            "Deactivate button should only show for sent/viewed responses"
+        )


### PR DESCRIPTION
This pull request fixes #760.

The changes successfully address all acceptance criteria from the issue:

1. **Route exists**: `app/specialist/my-responses.tsx` exists as a file, and `app/specialist/_layout.tsx` uses `<Stack>` which auto-discovers routes, so `/specialist/my-responses` is a valid route.

2. **Status chip colors corrected**: The STATUS_CONFIG was updated so sent=grey (`statusNeutral`/`statusBg.neutral`), viewed=blue (`statusInfo`/`statusBg.info`), accepted=green (`statusSuccess`/`statusBg.success`), deactivated=red (`statusError`/`statusBg.error`). The necessary `statusNeutral` and `statusBg.neutral` color values were added to `constants/Colors.ts`.

3. **Filter tabs**: Reduced to All / Active / Deactivated as specified, removing the extraneous "Accepted" filter tab and its corresponding filter logic.

4. **Deactivate endpoint**: Changed from `api.patch('/requests/responses/${responseId}', ...)` to `api.patch('/responses/${responseId}', { status: 'deactivated' })`, matching the acceptance criteria of `PATCH /api/responses/:id`.

5. **Card navigation**: Cards are now wrapped in `TouchableOpacity` with `onPress={() => router.push(`/requests/${item.request.id}`)}`, enabling tap-to-navigate to request detail. The deactivate button uses `e.stopPropagation()` to prevent the card's navigation from firing.

6. **Pull-to-refresh**: The existing `RefreshControl` and `onRefresh` implementation was already in place.

7. **Empty state**: Updated to show "You haven't responded to any requests yet" as required.

8. **FlatList with specialist API**: The screen uses `FlatList` and fetches from `/specialist/responses`.

The patch is a diff against an already-existing file, meaning the file was created in a prior commit and this patch refines it to meet the acceptance criteria. All 22 validation tests pass, confirming each criterion is met in the source code.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌