### PR TITLE
feat: proto pages API for canvas integration

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -18,6 +18,7 @@ import { IfnsModule } from './ifns/ifns.module';
 import { CategoriesModule } from './categories/categories.module';
 import { StatsModule } from './stats/stats.module';
 import { ContentModule } from './content/content.module';
+import { ProtoModule } from './proto/proto.module';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { ContentModule } from './content/content.module';
     CategoriesModule,
     StatsModule,
     ContentModule,
+    ProtoModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/proto/proto.controller.ts
+++ b/api/src/proto/proto.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ProtoService } from './proto.service';
+
+@Controller('proto')
+export class ProtoController {
+  constructor(private readonly protoService: ProtoService) {}
+
+  @Get('pages')
+  @Header('Access-Control-Allow-Origin', 'https://protocanvas.smartlaunchhub.com')
+  @Header('Access-Control-Allow-Methods', 'GET')
+  getPages() {
+    return this.protoService.getPages();
+  }
+}

--- a/api/src/proto/proto.module.ts
+++ b/api/src/proto/proto.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProtoController } from './proto.controller';
+import { ProtoService } from './proto.service';
+
+@Module({
+  controllers: [ProtoController],
+  providers: [ProtoService],
+})
+export class ProtoModule {}

--- a/api/src/proto/proto.service.ts
+++ b/api/src/proto/proto.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface PageEntry {
+  id: string;
+  title: string;
+  group: string;
+  route: string;
+  stateCount: number;
+  nav: string;
+  activeTab?: string;
+  notes?: { date: string; state?: string; text: string }[];
+  api?: string[];
+  navTo?: string[];
+  navFrom?: string[];
+  qaScore?: number;
+  qaCycles?: number;
+  testScenarios?: { name: string; steps: string[] }[];
+}
+
+@Injectable()
+export class ProtoService implements OnModuleInit {
+  private readonly logger = new Logger(ProtoService.name);
+  private pages: PageEntry[] = [];
+
+  onModuleInit() {
+    this.loadPages();
+  }
+
+  private loadPages() {
+    // pageRegistry.ts lives at repo root: constants/pageRegistry.ts
+    // __dirname is api/src/proto (dev) or api/dist/proto (prod) — 3 levels up = repo root
+    const registryPath = path.resolve(__dirname, '..', '..', '..', 'constants', 'pageRegistry.ts');
+
+    try {
+      const content = fs.readFileSync(registryPath, 'utf-8');
+      this.pages = this.parsePageRegistry(content);
+      this.logger.log(`Loaded ${this.pages.length} pages from pageRegistry.ts`);
+    } catch (err) {
+      this.logger.error(`Failed to load pageRegistry.ts from ${registryPath}: ${err}`);
+      this.pages = [];
+    }
+  }
+
+  private parsePageRegistry(content: string): PageEntry[] {
+    // Extract the pageRegistry array from the TS source
+    // Strategy: isolate the array literal, then evaluate it as JS
+    const match = content.match(
+      /export\s+const\s+pageRegistry\s*:\s*PageEntry\[\]\s*=\s*(\[[\s\S]*?\n\];)/,
+    );
+    if (!match) {
+      this.logger.error('Could not find pageRegistry array in file');
+      return [];
+    }
+
+    try {
+      // The array uses JS object literals — safe to eval with Function()
+      // eslint-disable-next-line no-new-func
+      const fn = new Function(`return ${match[1]}`);
+      return fn() as PageEntry[];
+    } catch (err) {
+      this.logger.error(`Failed to parse pageRegistry array: ${err}`);
+      return [];
+    }
+  }
+
+  getPages(): PageEntry[] {
+    return this.pages;
+  }
+
+  /** Reload pages from disk (useful if registry changes) */
+  reload(): { count: number } {
+    this.loadPages();
+    return { count: this.pages.length };
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/proto/pages` endpoint returning all 33 pages from `pageRegistry.ts`
- NestJS module: ProtoController + ProtoService
- Reads and parses `constants/pageRegistry.ts` at startup via regex + `Function()` eval
- CORS header for `protocanvas.smartlaunchhub.com`

## Test plan
- [ ] `curl http://localhost:3812/api/proto/pages | jq length` returns 33
- [ ] Response contains all page fields (id, title, group, route, stateCount, etc.)
- [ ] Deploy to staging, verify `https://p2ptax.smartlaunchhub.com/api/proto/pages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)