### PR TITLE
fix: npm ci for API deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install API dependencies
         working-directory: ./api
-        run: npm install --prefer-offline
+        run: npm ci
 
       - name: Generate Prisma client
         working-directory: ./api


### PR DESCRIPTION
## Summary
- Fix deploy failure: `npm install` hits ERESOLVE on @nestjs/testing@11 vs @nestjs/common@10
- Use `npm ci` for API (respects lock file, no peer dep conflicts)

## Test plan
- [ ] CI passes on merge to development
- [ ] https://p2ptax.smartlaunchhub.com/version.json shows new commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)