### PR TITLE
feat: proto-canvas.json

### DIFF
--- a/public/proto-canvas.json
+++ b/public/proto-canvas.json
@@ -1,0 +1,22 @@
+{
+  "pages": [
+    {
+      "id": "brand",
+      "title": "Бренд и стили",
+      "group": "Brand",
+      "x": 0,
+      "y": 1144,
+      "w": 390,
+      "h": 844
+    },
+    {
+      "id": "nav-components",
+      "title": "Navigation Components",
+      "group": "Brand",
+      "x": 510,
+      "y": 1144,
+      "w": 390,
+      "h": 844
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `public/proto-canvas.json` with 2 pages (Brand group) and auto-calculated x,y positions
- Screen size: 390x844, horizontal gap 120px, vertical gap 300px

## Test plan
- [ ] Verify JSON is accessible at `/proto-canvas.json` on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)