### PR TITLE
fix: npm install --legacy-peer-deps for API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install API dependencies
         working-directory: ./api
-        run: npm ci
+        run: npm install --legacy-peer-deps
 
       - name: Generate Prisma client
         working-directory: ./api


### PR DESCRIPTION
## Summary
- Self-hosted runner has no package-lock.json in api/ (npm ci fails)
- npm install fails with ERESOLVE (@nestjs/testing@11 vs @nestjs/common@10)
- Use `npm install --legacy-peer-deps` to bypass both issues

## Test plan
- [ ] CI passes
- [ ] https://p2ptax.smartlaunchhub.com/version.json shows new commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)