### PR TITLE
refactor: BrandStates to NativeWind (-46% code)

### DIFF
--- a/components/proto/states/BrandStates.tsx
+++ b/components/proto/states/BrandStates.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../../constants/Colors';
 
@@ -27,27 +27,36 @@ function useLayout() {
 // -- Hero --
 function HeroSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={[bs.heroWrap, isDesktop && bs.heroWrapDesktop]}>
-      <View style={bs.heroLogoRow}>
-        <View style={bs.heroLogoIcon}>
+    <View
+      className={`items-center gap-3 rounded-xl border bg-bgPrimary p-8 ${isDesktop ? 'p-10' : ''}`}
+      style={{ borderColor: Colors.borderLight }}
+    >
+      <View className="flex-row items-center gap-3">
+        <View className="h-11 w-11 items-center justify-center rounded-lg bg-brandPrimary">
           <Feather name="shield" size={isDesktop ? 28 : 22} color={Colors.white} />
         </View>
-        <Text style={[bs.heroLogoText, isDesktop && bs.heroLogoTextDesktop]}>
+        <Text
+          className={`font-bold tracking-tight text-textPrimary ${isDesktop ? 'text-3xl' : 'text-2xl'}`}
+          style={{ fontSize: isDesktop ? Typography.fontSize.display : Typography.fontSize['3xl'] }}
+        >
           Nalogovik
         </Text>
       </View>
-      <Text style={[bs.heroTagline, isDesktop && bs.heroTaglineDesktop]}>
+      <Text
+        className={`text-center font-medium text-textSecondary ${isDesktop ? 'text-xl' : 'text-lg'}`}
+        style={{ marginTop: Spacing.xs }}
+      >
         Система дизайна
       </Text>
-      <Text style={bs.heroSub}>
+      <Text className="text-center text-sm text-textMuted">
         Визуальный язык маркетплейса налоговых специалистов
       </Text>
-      <View style={bs.heroDivider} />
-      <View style={bs.heroBrandStrip}>
-        <View style={[bs.heroBrandBlock, { backgroundColor: Colors.brandPrimary }]} />
-        <View style={[bs.heroBrandBlock, { backgroundColor: Colors.brandPrimaryHover }]} />
-        <View style={[bs.heroBrandBlock, { backgroundColor: Colors.brandSecondary }]} />
-        <View style={[bs.heroBrandBlock, { backgroundColor: Colors.textPrimary }]} />
+      <View className="my-2 h-px w-10" style={{ backgroundColor: Colors.border }} />
+      <View className="flex-row gap-2">
+        <View className="h-[5px] w-10 rounded-full" style={{ backgroundColor: Colors.brandPrimary }} />
+        <View className="h-[5px] w-10 rounded-full" style={{ backgroundColor: Colors.brandPrimaryHover }} />
+        <View className="h-[5px] w-10 rounded-full" style={{ backgroundColor: Colors.brandSecondary }} />
+        <View className="h-[5px] w-10 rounded-full" style={{ backgroundColor: Colors.textPrimary }} />
       </View>
     </View>
   );
@@ -102,24 +111,33 @@ const COLOR_GROUPS = [
 
 function ColorPaletteSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Палитра цветов</Text>
-      <Text style={bs.sectionDesc}>Дизайн-токены из Colors.ts</Text>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Палитра цветов</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Дизайн-токены из Colors.ts</Text>
       {COLOR_GROUPS.map((group) => (
-        <View key={group.group} style={bs.colorGroup}>
-          <Text style={bs.colorGroupLabel}>{group.group}</Text>
-          <View style={[bs.colorGrid, isDesktop && bs.colorGridDesktop]}>
+        <View key={group.group} className="mt-1 gap-2">
+          <Text className="text-sm font-semibold text-textSecondary">{group.group}</Text>
+          <View className={`flex-row flex-wrap gap-2 ${isDesktop ? 'gap-3' : ''}`}>
             {group.items.map((c) => {
               const light = isLight(c.value);
               return (
-                <View key={c.token} style={bs.colorCard}>
-                  <View style={[bs.colorSwatch, { backgroundColor: c.value }, light && bs.swatchBorder]}>
-                    <Text style={[bs.colorHex, { color: light ? Colors.textPrimary : Colors.white }]}>
+                <View key={c.token} className="items-center gap-[3px]">
+                  <View
+                    className="h-11 w-[72px] items-center justify-center rounded-md"
+                    style={[
+                      { backgroundColor: c.value },
+                      light && { borderWidth: 1, borderColor: Colors.border },
+                    ]}
+                  >
+                    <Text
+                      className="font-medium tracking-wide"
+                      style={{ fontSize: 9, color: light ? Colors.textPrimary : Colors.white }}
+                    >
                       {c.value}
                     </Text>
                   </View>
-                  <Text style={bs.colorName}>{c.label}</Text>
-                  <Text style={bs.colorToken}>{c.token}</Text>
+                  <Text className="text-xs font-medium text-textPrimary">{c.label}</Text>
+                  <Text className="text-textMuted" style={{ fontSize: 9 }}>{c.token}</Text>
                 </View>
               );
             })}
@@ -147,15 +165,17 @@ const TYPO_SAMPLES = [
 
 function TypographySection() {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Типографика</Text>
-      <Text style={bs.sectionDesc}>Семейство Nunito — размеры, начертания, иерархия</Text>
-      <View style={bs.typoList}>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Типографика</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Семейство Nunito — размеры, начертания, иерархия</Text>
+      <View className="gap-3">
         {TYPO_SAMPLES.map((t) => (
-          <View key={t.label} style={bs.typoRow}>
-            <View style={bs.typoMeta}>
-              <Text style={bs.typoLabel}>{t.label}</Text>
-              <Text style={bs.typoSize}>{t.size}px</Text>
+          <View key={t.label} className="gap-[3px] border-b pb-3" style={{ borderBottomColor: Colors.borderLight }}>
+            <View className="flex-row items-center gap-2">
+              <Text className="min-w-[48px] text-xs font-bold uppercase tracking-wide text-brandPrimary">
+                {t.label}
+              </Text>
+              <Text className="text-xs text-textMuted">{t.size}px</Text>
             </View>
             <Text
               style={{
@@ -177,71 +197,71 @@ function TypographySection() {
 // -- Buttons --
 function ButtonsSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Кнопки</Text>
-      <Text style={bs.sectionDesc}>Варианты, размеры и состояния</Text>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Кнопки</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Варианты, размеры и состояния</Text>
 
-      <Text style={bs.subLabel}>Основная</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <Pressable style={bs.btnPrimary} onPress={() => {}}>
-          <Text style={bs.btnPrimaryText}>Обычная</Text>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">Основная</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <Pressable className="items-center justify-center rounded-lg bg-brandPrimary px-5 py-3" onPress={() => {}}>
+          <Text className="text-sm font-semibold text-white">Обычная</Text>
         </Pressable>
-        <Pressable style={[bs.btnPrimary, { backgroundColor: Colors.brandPrimaryHover }]} onPress={() => {}}>
-          <Text style={bs.btnPrimaryText}>Наведение</Text>
+        <Pressable className="items-center justify-center rounded-lg px-5 py-3" style={{ backgroundColor: Colors.brandPrimaryHover }} onPress={() => {}}>
+          <Text className="text-sm font-semibold text-white">Наведение</Text>
         </Pressable>
-        <Pressable style={[bs.btnPrimary, { backgroundColor: Colors.brandSecondary }]} onPress={() => {}}>
-          <Text style={bs.btnPrimaryText}>Нажатие</Text>
+        <Pressable className="items-center justify-center rounded-lg bg-brandSecondary px-5 py-3" onPress={() => {}}>
+          <Text className="text-sm font-semibold text-white">Нажатие</Text>
         </Pressable>
-        <Pressable style={[bs.btnPrimary, bs.btnDisabled]} disabled onPress={() => {}}>
-          <Text style={bs.btnPrimaryText}>Неактивная</Text>
+        <Pressable className="items-center justify-center rounded-lg bg-brandPrimary px-5 py-3 opacity-40" disabled onPress={() => {}}>
+          <Text className="text-sm font-semibold text-white">Неактивная</Text>
         </Pressable>
       </View>
 
-      <Text style={bs.subLabel}>Вторичная / Контурная / Призрак</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <Pressable style={bs.btnSecondary} onPress={() => {}}>
-          <Text style={bs.btnSecondaryText}>Вторичная</Text>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">Вторичная / Контурная / Призрак</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <Pressable className="items-center justify-center rounded-lg bg-bgSecondary px-5 py-3" onPress={() => {}}>
+          <Text className="text-sm font-semibold text-brandPrimary">Вторичная</Text>
         </Pressable>
-        <Pressable style={bs.btnOutline} onPress={() => {}}>
-          <Text style={bs.btnOutlineText}>Контурная</Text>
+        <Pressable className="items-center justify-center rounded-lg border border-brandPrimary px-5 py-[11px]" onPress={() => {}}>
+          <Text className="text-sm font-semibold text-brandPrimary">Контурная</Text>
         </Pressable>
-        <Pressable style={bs.btnGhost} onPress={() => {}}>
-          <Text style={bs.btnGhostText}>Призрак</Text>
+        <Pressable className="items-center justify-center rounded-lg px-5 py-3" onPress={() => {}}>
+          <Text className="text-sm font-semibold text-brandPrimary">Призрак</Text>
         </Pressable>
       </View>
 
-      <Text style={bs.subLabel}>Семантические</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <Pressable style={bs.btnDestructive} onPress={() => {}}>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">Семантические</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <Pressable className="flex-row items-center gap-1 rounded-lg bg-statusError px-5 py-3" onPress={() => {}}>
           <Feather name="trash-2" size={14} color={Colors.white} />
-          <Text style={bs.btnPrimaryText}>Удалить</Text>
+          <Text className="text-sm font-semibold text-white">Удалить</Text>
         </Pressable>
-        <Pressable style={bs.btnSuccess} onPress={() => {}}>
+        <Pressable className="flex-row items-center gap-1 rounded-lg bg-statusSuccess px-5 py-3" onPress={() => {}}>
           <Feather name="check" size={14} color={Colors.white} />
-          <Text style={bs.btnPrimaryText}>Подтвердить</Text>
+          <Text className="text-sm font-semibold text-white">Подтвердить</Text>
         </Pressable>
-        <Pressable style={bs.btnWarning} onPress={() => {}}>
+        <Pressable className="flex-row items-center gap-1 rounded-lg bg-statusWarning px-5 py-3" onPress={() => {}}>
           <Feather name="alert-triangle" size={14} color={Colors.white} />
-          <Text style={bs.btnPrimaryText}>Предупреждение</Text>
+          <Text className="text-sm font-semibold text-white">Предупреждение</Text>
         </Pressable>
       </View>
 
-      <Text style={bs.subLabel}>С иконками + размеры</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <Pressable style={bs.btnLarge} onPress={() => {}}>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">С иконками + размеры</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <Pressable className="flex-row items-center gap-2 rounded-lg bg-brandPrimary px-6 py-4" onPress={() => {}}>
           <Feather name="plus" size={18} color={Colors.white} />
-          <Text style={bs.btnLargeText}>Большая кнопка</Text>
+          <Text className="text-base font-semibold text-white">Большая кнопка</Text>
         </Pressable>
-        <Pressable style={bs.btnIconPrimary} onPress={() => {}}>
+        <Pressable className="flex-row items-center gap-2 rounded-lg bg-brandPrimary px-5 py-3" onPress={() => {}}>
           <Feather name="send" size={14} color={Colors.white} />
-          <Text style={bs.btnPrimaryText}>Отправить</Text>
+          <Text className="text-sm font-semibold text-white">Отправить</Text>
         </Pressable>
-        <Pressable style={bs.btnIconOutline} onPress={() => {}}>
+        <Pressable className="flex-row items-center gap-2 rounded-lg border border-brandPrimary px-5 py-[11px]" onPress={() => {}}>
           <Feather name="filter" size={14} color={Colors.brandPrimary} />
-          <Text style={bs.btnOutlineText}>Фильтр</Text>
+          <Text className="text-sm font-semibold text-brandPrimary">Фильтр</Text>
         </Pressable>
-        <Pressable style={bs.btnSmall} onPress={() => {}}>
-          <Text style={bs.btnSmallText}>Маленькая</Text>
+        <Pressable className="rounded bg-brandPrimary px-3 py-[5px]" onPress={() => {}}>
+          <Text className="text-xs font-semibold text-white">Маленькая</Text>
         </Pressable>
       </View>
     </View>
@@ -251,67 +271,76 @@ function ButtonsSection({ isDesktop }: { isDesktop: boolean }) {
 // -- Inputs --
 function InputsSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Поля ввода</Text>
-      <Text style={bs.sectionDesc}>Текстовые поля во всех состояниях</Text>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Поля ввода</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Текстовые поля во всех состояниях</Text>
 
-      <View style={[bs.inputGrid, isDesktop && bs.inputGridDesktop]}>
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>Пустое</Text>
+      <View className={`gap-4 ${isDesktop ? 'flex-row flex-wrap' : ''}`}>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">Пустое</Text>
           <TextInput
-            style={[bs.inputWrap, bs.textInput]}
+            className="h-11 justify-center rounded-lg bg-bgCard px-3 text-base text-textPrimary"
+            style={{ borderWidth: 1, borderColor: Colors.border, outlineStyle: 'none' as any }}
             placeholder="Введите текст..."
             placeholderTextColor={Colors.textMuted}
           />
         </View>
 
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>В фокусе</Text>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">В фокусе</Text>
           <TextInput
-            style={[bs.inputWrap, bs.inputFocused, bs.textInput]}
+            className="h-11 justify-center rounded-lg bg-bgCard px-3 text-base text-textPrimary"
+            style={{ borderWidth: 2, borderColor: Colors.brandPrimary, outlineStyle: 'none' as any }}
             defaultValue="Ввод текста"
             placeholderTextColor={Colors.textMuted}
           />
         </View>
 
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>Заполненное</Text>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">Заполненное</Text>
           <TextInput
-            style={[bs.inputWrap, bs.textInput]}
+            className="h-11 justify-center rounded-lg bg-bgCard px-3 text-base text-textPrimary"
+            style={{ borderWidth: 1, borderColor: Colors.border, outlineStyle: 'none' as any }}
             defaultValue="ivan@mail.ru"
             placeholderTextColor={Colors.textMuted}
           />
         </View>
 
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>Ошибка</Text>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">Ошибка</Text>
           <TextInput
-            style={[bs.inputWrap, bs.inputError, bs.textInput]}
+            className="h-11 justify-center rounded-lg bg-bgCard px-3 text-base text-textPrimary"
+            style={{ borderWidth: 2, borderColor: Colors.statusError, outlineStyle: 'none' as any }}
             defaultValue="некорректное значение"
             placeholderTextColor={Colors.textMuted}
           />
-          <View style={bs.errorRow}>
+          <View className="flex-row items-center gap-1">
             <Feather name="alert-circle" size={12} color={Colors.statusError} />
-            <Text style={bs.inputErrorText}>Неверный формат</Text>
+            <Text className="text-xs text-statusError">Неверный формат</Text>
           </View>
         </View>
 
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>Неактивное</Text>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">Неактивное</Text>
           <TextInput
-            style={[bs.inputWrap, bs.inputDisabledWrap, bs.textInput, { color: Colors.textMuted }]}
+            className="h-11 justify-center rounded-lg bg-bgSecondary px-3 text-base opacity-60"
+            style={{ borderWidth: 1, borderColor: Colors.border, color: Colors.textMuted, outlineStyle: 'none' as any }}
             defaultValue="Неактивное поле"
             editable={false}
             placeholderTextColor={Colors.textMuted}
           />
         </View>
 
-        <View style={[bs.inputGroup, isDesktop && bs.inputGroupDesktop]}>
-          <Text style={bs.inputStateLabel}>С иконкой</Text>
-          <View style={[bs.inputWrap, bs.inputWithIconWrap]}>
+        <View className={`gap-1 ${isDesktop ? 'min-w-[200px] flex-1' : 'w-full'}`}>
+          <Text className="text-xs font-semibold uppercase tracking-wide text-textMuted">С иконкой</Text>
+          <View
+            className="h-11 flex-row items-center gap-2 rounded-lg bg-bgCard px-3"
+            style={{ borderWidth: 1, borderColor: Colors.border }}
+          >
             <Feather name="search" size={16} color={Colors.textMuted} />
             <TextInput
-              style={[bs.textInput, { flex: 1 }]}
+              className="flex-1 text-base text-textPrimary"
+              style={{ outlineStyle: 'none' as any, padding: 0 }}
               placeholder="Поиск..."
               placeholderTextColor={Colors.textMuted}
             />
@@ -325,50 +354,54 @@ function InputsSection({ isDesktop }: { isDesktop: boolean }) {
 // -- Badges & Tags --
 function BadgesSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Бейджи и теги</Text>
-      <Text style={bs.sectionDesc}>Индикаторы статуса и категории</Text>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Бейджи и теги</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Индикаторы статуса и категории</Text>
 
-      <Text style={bs.subLabel}>Статусные бейджи</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.success }]}>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">Статусные бейджи</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.success }}>
           <Feather name="check-circle" size={12} color={Colors.statusSuccess} />
-          <Text style={[bs.badgeText, { color: Colors.statusSuccess }]}>Подтверждён</Text>
+          <Text className="text-xs font-semibold text-statusSuccess">Подтверждён</Text>
         </View>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.info }]}>
-          <View style={bs.onlineDot} />
-          <Text style={[bs.badgeText, { color: Colors.brandPrimary }]}>Онлайн</Text>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.info }}>
+          <View className="h-1.5 w-1.5 rounded-full bg-statusSuccess" />
+          <Text className="text-xs font-semibold text-brandPrimary">Онлайн</Text>
         </View>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.warning }]}>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.warning }}>
           <Feather name="clock" size={12} color={Colors.statusWarning} />
-          <Text style={[bs.badgeText, { color: Colors.statusWarning }]}>Ожидание</Text>
+          <Text className="text-xs font-semibold text-statusWarning">Ожидание</Text>
         </View>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.error }]}>
-          <Text style={[bs.badgeText, { color: Colors.statusError }]}>Отклонён</Text>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.error }}>
+          <Text className="text-xs font-semibold text-statusError">Отклонён</Text>
         </View>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.neutral }]}>
-          <Text style={[bs.badgeText, { color: Colors.statusNeutral }]}>Черновик</Text>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.neutral }}>
+          <Text className="text-xs font-semibold" style={{ color: Colors.statusNeutral }}>Черновик</Text>
         </View>
-        <View style={[bs.badge, { backgroundColor: Colors.statusBg.accent }]}>
+        <View className="flex-row items-center gap-1 rounded-full px-2 py-1" style={{ backgroundColor: Colors.statusBg.accent }}>
           <Feather name="zap" size={12} color={Colors.brandPrimary} />
-          <Text style={[bs.badgeText, { color: Colors.brandPrimary }]}>Новый</Text>
+          <Text className="text-xs font-semibold text-brandPrimary">Новый</Text>
         </View>
       </View>
 
-      <Text style={bs.subLabel}>Теги услуг</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop]}>
-        <Pressable style={bs.tag} onPress={() => {}}>
-          <Text style={bs.tagText}>3-НДФЛ</Text>
+      <Text className="mt-3 text-xs font-semibold uppercase tracking-wider text-textMuted">Теги услуг</Text>
+      <View className={`flex-row flex-wrap items-center gap-2 ${isDesktop ? 'gap-3' : ''}`}>
+        <Pressable className="flex-row items-center gap-1 rounded-full border bg-bgCard px-2 py-1" style={{ borderColor: Colors.border }} onPress={() => {}}>
+          <Text className="text-xs font-medium text-textSecondary">3-НДФЛ</Text>
         </Pressable>
-        <Pressable style={bs.tag} onPress={() => {}}>
-          <Text style={bs.tagText}>Регистрация ИП</Text>
+        <Pressable className="flex-row items-center gap-1 rounded-full border bg-bgCard px-2 py-1" style={{ borderColor: Colors.border }} onPress={() => {}}>
+          <Text className="text-xs font-medium text-textSecondary">Регистрация ИП</Text>
         </Pressable>
-        <Pressable style={[bs.tag, bs.tagActive]} onPress={() => {}}>
+        <Pressable
+          className="flex-row items-center gap-1 rounded-full border border-brandPrimary px-2 py-1"
+          style={{ backgroundColor: Colors.statusBg.info }}
+          onPress={() => {}}
+        >
           <Feather name="check" size={11} color={Colors.brandPrimary} />
-          <Text style={[bs.tagText, { color: Colors.brandPrimary }]}>Налоговая проверка</Text>
+          <Text className="text-xs font-medium text-brandPrimary">Налоговая проверка</Text>
         </Pressable>
-        <Pressable style={bs.tag} onPress={() => {}}>
-          <Text style={bs.tagText}>Консультация</Text>
+        <Pressable className="flex-row items-center gap-1 rounded-full border bg-bgCard px-2 py-1" style={{ borderColor: Colors.border }} onPress={() => {}}>
+          <Text className="text-xs font-medium text-textSecondary">Консультация</Text>
         </Pressable>
       </View>
     </View>
@@ -390,16 +423,22 @@ const SPACING_ITEMS: { label: string; value: number }[] = [
 
 function SpacingSection() {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Токены отступов</Text>
-      <Text style={bs.sectionDesc}>Единая шкала отступов</Text>
-      <View style={bs.spacingList}>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Токены отступов</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Единая шкала отступов</Text>
+      <View
+        className="gap-2 rounded-lg border bg-bgPrimary p-4"
+        style={{ borderColor: Colors.borderLight }}
+      >
         {SPACING_ITEMS.map((sp) => (
-          <View key={sp.label} style={bs.spacingRow}>
-            <Text style={bs.spacingLabel}>{sp.label}</Text>
-            <Text style={bs.spacingValue}>{sp.value}px</Text>
-            <View style={bs.spacingBarWrap}>
-              <View style={[bs.spacingBar, { width: Math.min(sp.value * 4, 200) }]} />
+          <View key={sp.label} className="flex-row items-center gap-2">
+            <Text className="w-8 text-xs font-semibold text-textSecondary">{sp.label}</Text>
+            <Text className="w-9 text-right text-xs text-textMuted">{sp.value}px</Text>
+            <View className="flex-1 h-2.5 overflow-hidden rounded-sm bg-bgSecondary">
+              <View
+                className="h-full rounded-sm bg-brandPrimary"
+                style={{ width: Math.min(sp.value * 4, 200), minWidth: 4 }}
+              />
             </View>
           </View>
         ))}
@@ -423,15 +462,18 @@ function RadiusSection({ isDesktop }: { isDesktop: boolean }) {
   ];
 
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Скругления</Text>
-      <Text style={bs.sectionDesc}>Токены скруглений</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop, { gap: Spacing.lg }]}>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Скругления</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Токены скруглений</Text>
+      <View className={`flex-row flex-wrap items-center ${isDesktop ? 'gap-4' : 'gap-2'}`} style={{ gap: Spacing.lg }}>
         {radii.map((r) => (
-          <View key={r.label} style={bs.radiusItem}>
-            <View style={[bs.radiusBox, { borderRadius: r.value }]} />
-            <Text style={bs.radiusLabel}>{r.label}</Text>
-            <Text style={bs.radiusValue}>{r.value}px</Text>
+          <View key={r.label} className="items-center gap-1">
+            <View
+              className="h-12 w-12 border bg-bgSecondary"
+              style={{ borderRadius: r.value, borderColor: Colors.border }}
+            />
+            <Text className="text-xs font-semibold text-textPrimary">{r.label}</Text>
+            <Text className="text-textMuted" style={{ fontSize: 9 }}>{r.value}px</Text>
           </View>
         ))}
       </View>
@@ -442,21 +484,21 @@ function RadiusSection({ isDesktop }: { isDesktop: boolean }) {
 // -- Shadows --
 function ShadowsSection({ isDesktop }: { isDesktop: boolean }) {
   return (
-    <View style={bs.section}>
-      <Text style={bs.sectionTitle}>Тени</Text>
-      <Text style={bs.sectionDesc}>Уровни подъёма</Text>
-      <View style={[bs.row, isDesktop && bs.rowDesktop, { gap: Spacing.xl }]}>
-        <View style={bs.shadowItem}>
-          <View style={[bs.shadowBox, Shadows.sm]} />
-          <Text style={bs.shadowLabel}>sm</Text>
+    <View className="gap-4">
+      <Text className="text-xl font-bold text-textPrimary">Тени</Text>
+      <Text className="-mt-2 text-sm text-textMuted">Уровни подъёма</Text>
+      <View className={`flex-row flex-wrap items-center ${isDesktop ? 'gap-5' : 'gap-2'}`} style={{ gap: Spacing.xl }}>
+        <View className="items-center gap-2">
+          <View className="h-14 w-20 rounded-lg bg-bgCard" style={Shadows.sm} />
+          <Text className="text-xs font-semibold text-textSecondary">sm</Text>
         </View>
-        <View style={bs.shadowItem}>
-          <View style={[bs.shadowBox, Shadows.md]} />
-          <Text style={bs.shadowLabel}>md</Text>
+        <View className="items-center gap-2">
+          <View className="h-14 w-20 rounded-lg bg-bgCard" style={Shadows.md} />
+          <Text className="text-xs font-semibold text-textSecondary">md</Text>
         </View>
-        <View style={bs.shadowItem}>
-          <View style={[bs.shadowBox, Shadows.lg]} />
-          <Text style={bs.shadowLabel}>lg</Text>
+        <View className="items-center gap-2">
+          <View className="h-14 w-20 rounded-lg bg-bgCard" style={Shadows.lg} />
+          <Text className="text-xs font-semibold text-textSecondary">lg</Text>
         </View>
       </View>
     </View>
@@ -470,11 +512,11 @@ function ShadowsSection({ isDesktop }: { isDesktop: boolean }) {
 // -- Shared small components --
 function LogoBlock() {
   return (
-    <View style={ns.logoRow}>
-      <View style={ns.logoIcon}>
+    <View className="flex-row items-center gap-2">
+      <View className="h-7 w-7 items-center justify-center rounded-md bg-brandPrimary">
         <Feather name="shield" size={16} color={Colors.white} />
       </View>
-      <Text style={ns.logoText}>Nalogovik</Text>
+      <Text className="text-lg font-bold text-textPrimary">Nalogovik</Text>
     </View>
   );
 }
@@ -483,15 +525,20 @@ function NotifBell({ hasNotif = false }: { hasNotif?: boolean }) {
   return (
     <Pressable onPress={() => {}}>
       <Feather name="bell" size={20} color={Colors.textSecondary} />
-      {hasNotif && <View style={ns.redDot} />}
+      {hasNotif && (
+        <View className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-statusError" />
+      )}
     </Pressable>
   );
 }
 
 function AvatarCircle({ initials }: { initials: string }) {
   return (
-    <View style={ns.avatarCircle}>
-      <Text style={ns.avatarText}>{initials}</Text>
+    <View
+      className="h-8 w-8 items-center justify-center rounded-full border bg-bgSecondary"
+      style={{ borderColor: Colors.border }}
+    >
+      <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
     </View>
   );
 }
@@ -504,53 +551,63 @@ function PublicHeader() {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   return (
-    <View style={ns.section}>
-      <Text style={ns.sectionTitle}>Шапка (гость)</Text>
-      <Text style={ns.sectionDesc}>Навигация для неавторизованного пользователя</Text>
+    <View className="gap-3">
+      <Text className="text-xl font-bold text-textPrimary">Шапка (гость)</Text>
+      <Text className="-mt-1 text-sm text-textMuted">Навигация для неавторизованного пользователя</Text>
 
       {isDesktop ? (
-        <View style={ns.headerBar}>
+        <View
+          className="h-14 flex-row items-center rounded-lg border bg-bgCard px-4"
+          style={{ borderColor: Colors.borderLight, ...Shadows.sm }}
+        >
           <LogoBlock />
-          <View style={ns.navLinks}>
+          <View className="ml-8 flex-1 flex-row gap-5">
             {PUBLIC_NAV_LINKS.map((link, i) => (
               <Pressable key={link} onPress={() => {}}>
-                <Text style={[ns.navLink, i === 0 && ns.navLinkActive]}>{link}</Text>
+                <Text className={`text-sm font-medium ${i === 0 ? 'font-semibold text-brandPrimary' : 'text-textSecondary'}`}>
+                  {link}
+                </Text>
               </Pressable>
             ))}
           </View>
-          <View style={ns.headerRight}>
-            <Pressable style={ns.navBtnOutline}>
-              <Text style={ns.navBtnOutlineText}>Войти</Text>
+          <View className="flex-row items-center gap-3">
+            <Pressable className="rounded-lg border border-brandPrimary px-4 py-2">
+              <Text className="text-sm font-semibold text-brandPrimary">Войти</Text>
             </Pressable>
-            <Pressable style={ns.navBtnPrimary}>
-              <Text style={ns.navBtnPrimaryText}>Разместить заявку</Text>
+            <Pressable className="rounded-lg bg-brandPrimary px-4 py-2">
+              <Text className="text-sm font-semibold text-white">Разместить заявку</Text>
             </Pressable>
           </View>
         </View>
       ) : (
         <>
-          <View style={ns.mobileHeaderBar}>
+          <View
+            className="h-14 flex-row items-center justify-between rounded-lg border bg-bgCard px-4"
+            style={{ borderColor: Colors.borderLight, ...Shadows.sm }}
+          >
             <LogoBlock />
             <Pressable onPress={() => setMenuOpen(!menuOpen)}>
               <Feather name={menuOpen ? 'x' : 'menu'} size={22} color={Colors.textPrimary} />
             </Pressable>
           </View>
           {menuOpen && (
-            <View style={ns.drawerPanel}>
-              <View style={ns.drawerLinks}>
+            <View className="w-[280px] gap-4 bg-bgCard p-5">
+              <View className="gap-4">
                 {PUBLIC_NAV_LINKS.map((link, i) => (
                   <Pressable key={link} onPress={() => {}}>
-                    <Text style={[ns.drawerLink, i === 0 && ns.drawerLinkActive]}>{link}</Text>
+                    <Text className={`text-base font-medium ${i === 0 ? 'font-semibold text-brandPrimary' : 'text-textSecondary'}`}>
+                      {link}
+                    </Text>
                   </Pressable>
                 ))}
               </View>
-              <View style={ns.drawerDivider} />
-              <View style={ns.drawerButtons}>
-                <Pressable style={ns.navBtnOutlineFull}>
-                  <Text style={ns.navBtnOutlineText}>Войти</Text>
+              <View className="h-px" style={{ backgroundColor: Colors.borderLight }} />
+              <View className="gap-2">
+                <Pressable className="items-center rounded-lg border border-brandPrimary py-3">
+                  <Text className="text-sm font-semibold text-brandPrimary">Войти</Text>
                 </Pressable>
-                <Pressable style={ns.navBtnPrimaryFull}>
-                  <Text style={ns.navBtnPrimaryText}>Разместить заявку</Text>
+                <Pressable className="items-center rounded-lg bg-brandPrimary py-3">
+                  <Text className="text-sm font-semibold text-white">Разместить заявку</Text>
                 </Pressable>
               </View>
             </View>
@@ -577,21 +634,33 @@ function BottomTabBar({ tabs, activeId }: {
   if (width >= 640) return null;
 
   return (
-    <View style={ns.tabBar}>
+    <View
+      className="h-[60px] flex-row items-center rounded-lg border bg-bgCard"
+      style={{ borderColor: Colors.borderLight, ...Shadows.sm }}
+    >
       {tabs.map((tab) => {
         const active = tab.id === activeId;
         return (
-          <Pressable key={tab.id} style={ns.tabItem} onPress={() => {}}>
+          <Pressable key={tab.id} className="flex-1 items-center justify-center gap-[2px]" onPress={() => {}}>
             <View>
               <Feather
                 name={tab.icon as any}
                 size={20}
                 color={active ? Colors.brandPrimary : Colors.textMuted}
               />
-              {tab.badge && <View style={ns.tabBadge} />}
+              {tab.badge && (
+                <View className="absolute -right-1.5 -top-[3px] h-2 w-2 rounded-full bg-statusError" />
+              )}
             </View>
-            <Text style={[ns.tabLabel, active && ns.tabLabelActive]}>{tab.label}</Text>
-            {active && <View style={ns.tabIndicator} />}
+            <Text
+              className={`font-medium ${active ? 'font-bold text-brandPrimary' : 'text-textMuted'}`}
+              style={{ fontSize: 10 }}
+            >
+              {tab.label}
+            </Text>
+            {active && (
+              <View className="absolute bottom-0 h-0.5 w-5 rounded-sm bg-brandPrimary" />
+            )}
           </Pressable>
         );
       })}
@@ -603,29 +672,35 @@ function AuthHeader() {
   const { isDesktop } = useLayout();
 
   return (
-    <View style={ns.section}>
-      <Text style={ns.sectionTitle}>Шапка (авторизован)</Text>
-      <Text style={ns.sectionDesc}>Навигация для авторизованного пользователя</Text>
+    <View className="gap-3">
+      <Text className="text-xl font-bold text-textPrimary">Шапка (авторизован)</Text>
+      <Text className="-mt-1 text-sm text-textMuted">Навигация для авторизованного пользователя</Text>
 
       {isDesktop ? (
-        <View style={ns.headerBar}>
+        <View
+          className="h-14 flex-row items-center rounded-lg border bg-bgCard px-4"
+          style={{ borderColor: Colors.borderLight, ...Shadows.sm }}
+        >
           <LogoBlock />
-          <View style={ns.navLinks}>
-            <Pressable onPress={() => {}}><Text style={[ns.navLink, ns.navLinkActive]}>Главная</Text></Pressable>
-            <Pressable onPress={() => {}}><Text style={ns.navLink}>Заявки</Text></Pressable>
-            <Pressable onPress={() => {}}><Text style={ns.navLink}>Сообщения</Text></Pressable>
-            <Pressable onPress={() => {}}><Text style={ns.navLink}>Профиль</Text></Pressable>
+          <View className="ml-8 flex-1 flex-row gap-5">
+            <Pressable onPress={() => {}}><Text className="text-sm font-semibold text-brandPrimary">Главная</Text></Pressable>
+            <Pressable onPress={() => {}}><Text className="text-sm font-medium text-textSecondary">Заявки</Text></Pressable>
+            <Pressable onPress={() => {}}><Text className="text-sm font-medium text-textSecondary">Сообщения</Text></Pressable>
+            <Pressable onPress={() => {}}><Text className="text-sm font-medium text-textSecondary">Профиль</Text></Pressable>
           </View>
-          <View style={ns.headerRight}>
+          <View className="flex-row items-center gap-3">
             <NotifBell hasNotif />
             <AvatarCircle initials="ИВ" />
           </View>
         </View>
       ) : (
         <>
-          <View style={ns.mobileHeaderBar}>
+          <View
+            className="h-14 flex-row items-center justify-between rounded-lg border bg-bgCard px-4"
+            style={{ borderColor: Colors.borderLight, ...Shadows.sm }}
+          >
             <LogoBlock />
-            <View style={ns.headerRight}>
+            <View className="flex-row items-center gap-3">
               <NotifBell hasNotif />
               <AvatarCircle initials="ИВ" />
             </View>
@@ -645,7 +720,7 @@ export function BrandStates() {
 
   return (
     <ScrollView
-      style={{ flex: 1, backgroundColor: Colors.white }}
+      className="flex-1 bg-white"
       contentContainerStyle={[
         { padding: Spacing.xl, gap: Spacing['3xl'], paddingBottom: 100 },
         isDesktop && { maxWidth: 960, alignSelf: 'center' as const, paddingHorizontal: 48 },
@@ -662,701 +737,10 @@ export function BrandStates() {
       <RadiusSection isDesktop={isDesktop} />
       <ShadowsSection isDesktop={isDesktop} />
 
-      <View style={{ height: 1, backgroundColor: Colors.border, marginVertical: Spacing.xl }} />
+      <View className="my-5 h-px" style={{ backgroundColor: Colors.border }} />
 
       <PublicHeader />
       <AuthHeader />
     </ScrollView>
   );
 }
-
-// =====================================================================
-// BRAND STYLE STYLES (bs)
-// =====================================================================
-const bs = StyleSheet.create({
-  // Sections
-  section: { gap: Spacing.lg },
-  sectionTitle: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  sectionDesc: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    marginTop: -Spacing.sm,
-  },
-  subLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    marginTop: Spacing.md,
-  },
-
-  // Hero
-  heroWrap: {
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.xl,
-    padding: Spacing['3xl'],
-    alignItems: 'center',
-    gap: Spacing.md,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-  },
-  heroWrapDesktop: { padding: Spacing['4xl'] },
-  heroLogoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-  },
-  heroLogoIcon: {
-    width: 44,
-    height: 44,
-    borderRadius: BorderRadius.lg,
-    backgroundColor: Colors.brandPrimary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  heroLogoText: {
-    fontSize: Typography.fontSize['3xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    letterSpacing: -0.5,
-  },
-  heroLogoTextDesktop: { fontSize: Typography.fontSize.display },
-  heroTagline: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    marginTop: Spacing.xs,
-  },
-  heroTaglineDesktop: { fontSize: Typography.fontSize.xl },
-  heroSub: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    textAlign: 'center',
-  },
-  heroDivider: {
-    width: 40,
-    height: 1,
-    backgroundColor: Colors.border,
-    marginVertical: Spacing.sm,
-  },
-  heroBrandStrip: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  heroBrandBlock: {
-    width: 40,
-    height: 5,
-    borderRadius: BorderRadius.full,
-  },
-
-  // Colors
-  colorGroup: { gap: Spacing.sm, marginTop: Spacing.xs },
-  colorGroupLabel: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-  },
-  colorGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.sm,
-  },
-  colorGridDesktop: { gap: Spacing.md },
-  colorCard: { alignItems: 'center', gap: 3 },
-  colorSwatch: {
-    width: 72,
-    height: 44,
-    borderRadius: BorderRadius.md,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  swatchBorder: { borderWidth: 1, borderColor: Colors.border },
-  colorHex: {
-    fontSize: 9,
-    fontWeight: Typography.fontWeight.medium,
-    letterSpacing: 0.3,
-  },
-  colorName: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textPrimary,
-  },
-  colorToken: { fontSize: 9, color: Colors.textMuted },
-
-  // Typography
-  typoList: { gap: Spacing.md },
-  typoRow: {
-    gap: Spacing.xxs,
-    paddingBottom: Spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.borderLight,
-  },
-  typoMeta: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  typoLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.brandPrimary,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    minWidth: 48,
-  },
-  typoSize: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-
-  // Buttons
-  row: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.sm,
-    alignItems: 'center',
-  },
-  rowDesktop: { gap: Spacing.md },
-  btnPrimary: {
-    backgroundColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  btnPrimaryText: {
-    color: Colors.white,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  btnSecondary: {
-    backgroundColor: Colors.bgSecondary,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  btnSecondaryText: {
-    color: Colors.brandPrimary,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  btnOutline: {
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md - 1,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  btnOutlineText: {
-    color: Colors.brandPrimary,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  btnGhost: {
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  btnGhostText: {
-    color: Colors.brandPrimary,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  btnDestructive: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    backgroundColor: Colors.statusError,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-  },
-  btnSuccess: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    backgroundColor: Colors.statusSuccess,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-  },
-  btnWarning: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    backgroundColor: Colors.statusWarning,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-  },
-  btnDisabled: { opacity: 0.4 },
-  btnLarge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    backgroundColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing['2xl'],
-    paddingVertical: Spacing.lg,
-    borderRadius: BorderRadius.btn,
-  },
-  btnLargeText: {
-    color: Colors.white,
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  btnIconPrimary: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    backgroundColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-  },
-  btnIconOutline: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md - 1,
-    borderRadius: BorderRadius.btn,
-  },
-  btnSmall: {
-    backgroundColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: 5,
-    borderRadius: BorderRadius.sm,
-  },
-  btnSmallText: {
-    color: Colors.white,
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-
-  // Inputs
-  inputGrid: { gap: Spacing.lg },
-  inputGridDesktop: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.lg,
-  },
-  inputGroup: { gap: Spacing.xs, width: '100%' as any },
-  inputGroupDesktop: { minWidth: 200, flex: 1, width: 'auto' as any },
-  inputStateLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  inputWrap: {
-    height: 44,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.md,
-    justifyContent: 'center',
-    backgroundColor: Colors.bgCard,
-  },
-  inputFocused: {
-    borderColor: Colors.brandPrimary,
-    borderWidth: 2,
-  },
-  inputError: {
-    borderColor: Colors.statusError,
-    borderWidth: 2,
-  },
-  inputDisabledWrap: {
-    backgroundColor: Colors.bgSecondary,
-    opacity: 0.6,
-  },
-  inputWithIconWrap: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  textInput: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    outlineStyle: 'none' as any,
-    padding: 0,
-  },
-  inputPlaceholder: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-  inputValue: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-  },
-  inputDisabledText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-  errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-  },
-  inputErrorText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.statusError,
-  },
-
-  // Badges
-  badge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: Spacing.sm,
-    paddingVertical: 4,
-    borderRadius: BorderRadius.full,
-  },
-  badgeText: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  onlineDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: Colors.statusSuccess,
-  },
-
-  // Tags
-  tag: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: Spacing.sm,
-    paddingVertical: Spacing.xs,
-    borderRadius: BorderRadius.full,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    backgroundColor: Colors.bgCard,
-  },
-  tagText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  tagActive: {
-    borderColor: Colors.brandPrimary,
-    backgroundColor: Colors.statusBg.info,
-  },
-
-  // Spacing
-  spacingList: {
-    gap: Spacing.sm,
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.lg,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-  },
-  spacingRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  spacingLabel: {
-    width: 32,
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-  },
-  spacingValue: {
-    width: 36,
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textAlign: 'right',
-  },
-  spacingBarWrap: {
-    flex: 1,
-    height: 10,
-    backgroundColor: Colors.bgSecondary,
-    borderRadius: BorderRadius.sm,
-    overflow: 'hidden',
-  },
-  spacingBar: {
-    height: '100%',
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.sm,
-    minWidth: 4,
-  },
-
-  // Border Radius
-  radiusItem: { alignItems: 'center', gap: 4 },
-  radiusBox: {
-    width: 48,
-    height: 48,
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  radiusLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  radiusValue: {
-    fontSize: 9,
-    color: Colors.textMuted,
-  },
-
-  // Shadows
-  shadowItem: { alignItems: 'center', gap: Spacing.sm },
-  shadowBox: {
-    width: 80,
-    height: 56,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-  },
-  shadowLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-  },
-});
-
-// =====================================================================
-// NAV COMPONENT STYLES (ns)
-// =====================================================================
-const ns = StyleSheet.create({
-  // Sections
-  section: { gap: Spacing.md },
-  sectionTitle: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  sectionDesc: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    marginTop: -Spacing.xs,
-  },
-  variantLabel: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textMuted,
-    textTransform: 'uppercase' as const,
-    letterSpacing: 0.6,
-    marginTop: Spacing.xs,
-  },
-  spacer: { height: Spacing.md },
-
-  // Logo
-  logoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  logoIcon: {
-    width: 28,
-    height: 28,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.brandPrimary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  logoText: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-
-  // Notification dot
-  redDot: {
-    position: 'absolute',
-    top: -2,
-    right: -2,
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.statusError,
-  },
-
-  // Avatar
-  avatarCircle: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  avatarText: {
-    fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.brandPrimary,
-  },
-
-  // Desktop header bar
-  headerBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 56,
-    paddingHorizontal: Spacing.lg,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    ...Shadows.sm,
-  },
-  navLinks: {
-    flexDirection: 'row',
-    gap: Spacing.xl,
-    marginLeft: Spacing['3xl'],
-    flex: 1,
-  },
-  navLink: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-  },
-  navLinkActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  headerRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-  },
-
-  // Nav Buttons (prefixed to avoid clash with brand button styles)
-  navBtnOutline: {
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.btn,
-  },
-  navBtnOutlineText: {
-    color: Colors.brandPrimary,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  navBtnPrimary: {
-    backgroundColor: Colors.brandPrimary,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.btn,
-  },
-  navBtnPrimaryText: {
-    color: Colors.white,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  navBtnOutlineFull: {
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-  },
-  navBtnPrimaryFull: {
-    backgroundColor: Colors.brandPrimary,
-    paddingVertical: Spacing.md,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-  },
-
-  // Mobile header bar
-  mobileHeaderBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    height: 56,
-    paddingHorizontal: Spacing.lg,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    ...Shadows.sm,
-  },
-
-  // Drawer
-  drawerPanel: {
-    width: 280,
-    backgroundColor: Colors.bgCard,
-    padding: Spacing.xl,
-    gap: Spacing.lg,
-  },
-  drawerLinks: { gap: Spacing.lg },
-  drawerLink: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-  },
-  drawerLinkActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  drawerDivider: {
-    height: 1,
-    backgroundColor: Colors.borderLight,
-  },
-  drawerButtons: { gap: Spacing.sm },
-
-  // Tab bar
-  tabBar: {
-    flexDirection: 'row',
-    height: 60,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    alignItems: 'center',
-    ...Shadows.sm,
-  },
-  tabItem: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 2,
-  },
-  tabLabel: {
-    fontSize: 10,
-    color: Colors.textMuted,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  tabLabelActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.bold,
-  },
-  tabBadge: {
-    position: 'absolute',
-    top: -3,
-    right: -6,
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.statusError,
-  },
-  tabIndicator: {
-    position: 'absolute',
-    bottom: 0,
-    width: 20,
-    height: 2,
-    borderRadius: 1,
-    backgroundColor: Colors.brandPrimary,
-  },
-});


### PR DESCRIPTION
## Summary
- Rewrite BrandStates from StyleSheet.create to NativeWind className
- 1363 → 746 lines (removed 688 lines of style definitions)
- All tailwind custom colors from tailwind.config.js
- Inline style only for dynamic values (color swatches, shadows, typography samples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)