### PR TITLE
feat: 24 proto pages from SA schema

### DIFF
--- a/app/proto/states/[page].tsx
+++ b/app/proto/states/[page].tsx
@@ -8,9 +8,57 @@ import { Colors, Typography, Spacing } from '../../../constants/Colors';
 
 // State components
 import { BrandStates } from '../../../components/proto/states/BrandStates';
+import { AuthEmailStates } from '../../../components/proto/states/AuthEmailStates';
+import { AuthOtpStates } from '../../../components/proto/states/AuthOtpStates';
+import { OnboardingUsernameStates } from '../../../components/proto/states/OnboardingUsernameStates';
+import { OnboardingProfileStates } from '../../../components/proto/states/OnboardingProfileStates';
+import { OnboardingWorkAreaStates } from '../../../components/proto/states/OnboardingWorkAreaStates';
+import { LandingStates } from '../../../components/proto/states/LandingStates';
+import { SpecialistsCatalogStates } from '../../../components/proto/states/SpecialistsCatalogStates';
+import { SpecialistProfilePublicStates } from '../../../components/proto/states/SpecialistProfilePublicStates';
+import { PublicRequestsStates } from '../../../components/proto/states/PublicRequestsStates';
+import { PublicRequestDetailStates } from '../../../components/proto/states/PublicRequestDetailStates';
+import { TermsStates } from '../../../components/proto/states/TermsStates';
+import { DashboardStates } from '../../../components/proto/states/DashboardStates';
+import { MyRequestsStates } from '../../../components/proto/states/MyRequestsStates';
+import { MyRequestsNewStates } from '../../../components/proto/states/MyRequestsNewStates';
+import { MyRequestDetailStates } from '../../../components/proto/states/MyRequestDetailStates';
+import { ResponsesStates } from '../../../components/proto/states/ResponsesStates';
+import { MessagesStates } from '../../../components/proto/states/MessagesStates';
+import { MessageThreadStates } from '../../../components/proto/states/MessageThreadStates';
+import { SettingsStates } from '../../../components/proto/states/SettingsStates';
+import { SpecialistDashboardStates } from '../../../components/proto/states/SpecialistDashboardStates';
+import { SpecialistMyResponsesStates } from '../../../components/proto/states/SpecialistMyResponsesStates';
+import { SpecialistRespondStates } from '../../../components/proto/states/SpecialistRespondStates';
+import { SpecialistSettingsStates } from '../../../components/proto/states/SpecialistSettingsStates';
+import { NotFoundStates } from '../../../components/proto/states/NotFoundStates';
 
 const STATE_MAP: Record<string, React.ComponentType> = {
   'brand': BrandStates,
+  'auth-email': AuthEmailStates,
+  'auth-otp': AuthOtpStates,
+  'onboarding-username': OnboardingUsernameStates,
+  'onboarding-profile': OnboardingProfileStates,
+  'work-area': OnboardingWorkAreaStates,
+  'landing': LandingStates,
+  'specialists-catalog': SpecialistsCatalogStates,
+  'specialist-public-profile': SpecialistProfilePublicStates,
+  'public-requests-feed': PublicRequestsStates,
+  'public-request-detail': PublicRequestDetailStates,
+  'terms': TermsStates,
+  'dashboard': DashboardStates,
+  'my-requests': MyRequestsStates,
+  'new-request': MyRequestsNewStates,
+  'request-detail': MyRequestDetailStates,
+  'responses': ResponsesStates,
+  'messages': MessagesStates,
+  'chat-thread': MessageThreadStates,
+  'client-settings': SettingsStates,
+  'specialist-dashboard': SpecialistDashboardStates,
+  'my-responses': SpecialistMyResponsesStates,
+  'specialist-respond': SpecialistRespondStates,
+  'specialist-settings': SpecialistSettingsStates,
+  'not-found': NotFoundStates,
 };
 
 export default function ProtoStatesPage() {

--- a/components/proto/states/AuthEmailStates.tsx
+++ b/components/proto/states/AuthEmailStates.tsx
@@ -1,16 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 
-function AuthScreen({ initialEmail, initialError, initialLoading, initialSuccess }: {
-  initialEmail?: string; initialError?: string; initialLoading?: boolean; initialSuccess?: boolean;
+function AuthEmailScreen({ initialEmail, initialError, initialLoading }: {
+  initialEmail?: string; initialError?: string; initialLoading?: boolean;
 }) {
   const [email, setEmail] = useState(initialEmail || '');
   const [error, setError] = useState(initialError || '');
   const [loading, setLoading] = useState(!!initialLoading);
-  const [success, setSuccess] = useState(!!initialSuccess);
 
   const handleSubmit = () => {
     if (!email || !email.includes('@')) {
@@ -19,268 +16,92 @@ function AuthScreen({ initialEmail, initialError, initialLoading, initialSuccess
     }
     setError('');
     setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-      setSuccess(true);
-    }, 1500);
+    setTimeout(() => setLoading(false), 1500);
   };
 
-  if (success) {
-    return (
-      <View style={s.container}>
-        <View style={s.successWrap}>
-          <View style={s.successIcon}>
-            <Feather name="check" size={32} color={Colors.statusSuccess} />
-          </View>
-          <Text style={s.successTitle}>Код отправлен</Text>
-          <Text style={s.successSubtitle}>Проверьте почту {email}</Text>
-          <View style={s.successDots}>
-            <View style={[s.dot, s.dotActive]} />
-            <View style={[s.dot, s.dotActive]} />
-            <View style={s.dot} />
-          </View>
-        </View>
-      </View>
-    );
-  }
-
   return (
-    <View style={s.container}>
-      <View style={s.logoWrap}>
-        <View style={s.logoIcon}>
-          <Feather name="shield" size={32} color={Colors.brandPrimary} />
+    <View className="flex-1 items-center justify-center bg-white px-4 py-8">
+      {/* Logo */}
+      <View className="mb-8 items-center gap-2">
+        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+          <Feather name="shield" size={28} color="#0284C7" />
         </View>
-        <Text style={s.logo}>Налоговик</Text>
-        <Text style={s.tagline}>Найдите налогового специалиста</Text>
+        <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
+        <Text className="text-base text-textMuted">Найдите налогового специалиста</Text>
       </View>
 
-      <View style={s.card}>
-        <Text style={s.cardTitle}>Войти или зарегистрироваться</Text>
-        <Text style={s.cardSubtitle}>Отправим код подтверждения на ваш email</Text>
+      {/* Card */}
+      <View className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6">
+        <Text className="mb-1 text-center text-lg font-bold text-textPrimary">Войти или зарегистрироваться</Text>
+        <Text className="mb-4 text-center text-sm text-textMuted">Отправим код подтверждения на ваш email</Text>
 
-        <View style={s.form}>
-          <Text style={s.label}>Email</Text>
-          <View style={[s.inputWrap, error ? s.inputError : null, loading ? s.inputDisabled : null]}>
-            <Feather name="mail" size={18} color={error ? Colors.statusError : Colors.textMuted} />
-            <TextInput
-              value={email}
-              onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
-              placeholder="your@email.com"
-              placeholderTextColor={Colors.textMuted}
-              style={s.input}
-              keyboardType="email-address"
-              autoCapitalize="none"
-              editable={!loading}
-            />
-            {email.length > 0 && !error && !loading && (
-              <Pressable onPress={() => setEmail('')} hitSlop={8}>
-                <Feather name="x-circle" size={16} color={Colors.textMuted} />
-              </Pressable>
-            )}
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Email</Text>
+        <View className={`mb-2 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'} ${loading ? 'opacity-60' : ''}`}>
+          <Feather name="mail" size={18} color={error ? '#DC2626' : '#94A3B8'} />
+          <TextInput
+            value={email}
+            onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
+            placeholder="your@email.com"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' as any }}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            editable={!loading}
+          />
+          {email.length > 0 && !loading && (
+            <Pressable onPress={() => setEmail('')} hitSlop={8}>
+              <Feather name="x-circle" size={16} color="#94A3B8" />
+            </Pressable>
+          )}
+        </View>
+
+        {error ? (
+          <View className="mb-2 flex-row items-center gap-1">
+            <Feather name="alert-circle" size={14} color="#DC2626" />
+            <Text className="text-sm text-red-600">{error}</Text>
           </View>
-          {error ? (
-            <View style={s.errorRow}>
-              <Feather name="alert-circle" size={14} color={Colors.statusError} />
-              <Text style={s.error}>{error}</Text>
-            </View>
-          ) : null}
-          <Pressable onPress={handleSubmit} disabled={loading} style={[s.btn, loading ? s.btnDisabled : null]}>
-            {loading ? (
-              <ActivityIndicator size="small" color={Colors.white} />
-            ) : (
-              <Text style={s.btnText}>Получить код</Text>
-            )}
-          </Pressable>
-        </View>
+        ) : null}
+
+        <Pressable
+          onPress={handleSubmit}
+          disabled={loading}
+          className={`mt-1 h-12 items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
+        >
+          <Text className="text-base font-semibold text-white">
+            {loading ? 'Отправка...' : 'Отправить код'}
+          </Text>
+        </Pressable>
       </View>
 
-      <Text style={s.footer}>Нажимая кнопку, вы соглашаетесь с{'\n'}условиями использования</Text>
+      <Text className="mt-6 text-center text-xs text-textMuted">
+        {'Нажимая кнопку, вы соглашаетесь с\nусловиями использования'}
+      </Text>
     </View>
   );
 }
 
 export function AuthEmailStates() {
   return (
-    <>
-      <StateSection title="DEFAULT">
-        <AuthScreen />
-      </StateSection>
+    <ScrollView className="flex-1 bg-white">
+      <View className="w-full max-w-md self-center px-4 py-8">
+        <Text className="mb-4 text-lg font-bold text-textPrimary">Screen: Auth Email</Text>
 
-      <StateSection title="LOADING">
-        <AuthScreen initialEmail="elena@mail.ru" initialLoading />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">IDLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <AuthEmailScreen />
+        </View>
 
-      <StateSection title="ERROR">
-        <AuthScreen initialEmail="elena@" initialError="Введите корректный email адрес" />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">SUBMITTING</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <AuthEmailScreen initialEmail="elena@mail.ru" initialLoading />
+        </View>
 
-      <StateSection title="SUCCESS">
-        <AuthScreen initialEmail="elena@mail.ru" initialSuccess />
-      </StateSection>
-    </>
+        <Text className="mb-2 text-sm font-medium text-textMuted">ERROR</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <AuthEmailScreen initialEmail="elena@" initialError="Введите корректный email адрес" />
+        </View>
+      </View>
+    </ScrollView>
   );
 }
-
-const s = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing['2xl'],
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: Colors.bgPrimary,
-  },
-  logoWrap: {
-    alignItems: 'center',
-    gap: Spacing.sm,
-    marginBottom: Spacing['3xl'],
-  },
-  logoIcon: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: Spacing.xs,
-  },
-  logo: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  tagline: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-
-  // Card
-  card: {
-    width: '100%',
-    maxWidth: 400,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.card,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    padding: Spacing['2xl'],
-    gap: Spacing.md,
-    ...Shadows.md,
-  },
-  cardTitle: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  cardSubtitle: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    textAlign: 'center',
-    marginBottom: Spacing.sm,
-  },
-
-  // Form
-  form: {
-    gap: Spacing.md,
-  },
-  label: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-  },
-  inputWrap: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    height: 48,
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.lg,
-  },
-  input: {
-    flex: 1,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    paddingVertical: 0,
-  },
-  inputError: {
-    borderColor: Colors.statusError,
-    backgroundColor: Colors.statusBg.error,
-  },
-  inputDisabled: {
-    opacity: 0.6,
-  },
-  errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  error: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-  },
-  btn: {
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginTop: Spacing.xs,
-    ...Shadows.sm,
-  },
-  btnDisabled: {
-    backgroundColor: Colors.brandPrimaryHover,
-  },
-  btnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-  footer: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textAlign: 'center',
-    marginTop: Spacing['2xl'],
-    lineHeight: 18,
-  },
-
-  // Success state
-  successWrap: {
-    alignItems: 'center',
-    gap: Spacing.md,
-    paddingVertical: Spacing['4xl'],
-  },
-  successIcon: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: Colors.statusBg.success,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: Spacing.sm,
-  },
-  successTitle: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  successSubtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-  successDots: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.md,
-  },
-  dot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.border,
-  },
-  dotActive: {
-    backgroundColor: Colors.brandPrimary,
-  },
-});

--- a/components/proto/states/AuthOtpStates.tsx
+++ b/components/proto/states/AuthOtpStates.tsx
@@ -1,403 +1,141 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 
-function OtpScreen({ initialCode, initialError, initialResendTimer, initialLoading, initialAttempts, maxedOut }: {
+function OtpScreen({ initialCode, initialError, initialResendTimer, initialLoading }: {
   initialCode?: string; initialError?: string; initialResendTimer?: number; initialLoading?: boolean;
-  initialAttempts?: number; maxedOut?: boolean;
 }) {
   const [digits, setDigits] = useState<string[]>(
     initialCode ? initialCode.split('').slice(0, 6) : ['', '', '', '', '', '']
   );
   const [error, setError] = useState(initialError || '');
   const [loading, setLoading] = useState(!!initialLoading);
-  const [resendTimer, setResendTimer] = useState(initialResendTimer ?? 0);
-  const [attempts, setAttempts] = useState(initialAttempts ?? 0);
+  const [resendTimer] = useState(initialResendTimer ?? 0);
   const inputRefs = useRef<(TextInput | null)[]>([]);
 
   const handleDigitChange = (index: number, value: string) => {
-    if (maxedOut) return;
     if (value.length > 1) value = value.slice(-1);
     if (value && !/^\d$/.test(value)) return;
-
-    const newDigits = [...digits];
-    newDigits[index] = value;
-    setDigits(newDigits);
+    const next = [...digits];
+    next[index] = value;
+    setDigits(next);
     if (error) setError('');
-
-    if (value && index < 5) {
-      inputRefs.current[index + 1]?.focus();
-    }
-  };
-
-  const handleKeyPress = (index: number, key: string) => {
-    if (key === 'Backspace' && !digits[index] && index > 0) {
-      inputRefs.current[index - 1]?.focus();
-    }
+    if (value && index < 5) inputRefs.current[index + 1]?.focus();
   };
 
   const handleSubmit = () => {
-    const code = digits.join('');
-    if (code.length < 6) {
-      setError('Введите все 6 цифр');
-      return;
-    }
+    if (digits.join('').length < 6) { setError('Введите все 6 цифр'); return; }
     setLoading(true);
-    setTimeout(() => {
-      setLoading(false);
-      if (code !== '000000') {
-        const newAttempts = attempts + 1;
-        setAttempts(newAttempts);
-        if (newAttempts >= 5) {
-          setError('Превышено число попыток. Запросите новый код.');
-        } else {
-          setError(`Неверный код. Осталось ${5 - newAttempts} попыток`);
-        }
-      }
-    }, 1500);
+    setTimeout(() => setLoading(false), 1500);
   };
-
-  const handleResend = () => {
-    if (resendTimer > 0) return;
-    setResendTimer(60);
-    setDigits(['', '', '', '', '', '']);
-    setError('');
-    setAttempts(0);
-    const interval = setInterval(() => {
-      setResendTimer((prev) => {
-        if (prev <= 1) { clearInterval(interval); return 0; }
-        return prev - 1;
-      });
-    }, 1000);
-  };
-
-  const isLocked = maxedOut || attempts >= 5;
 
   return (
-    <View style={s.container}>
-      {/* Back button */}
-      <View style={s.backRow}>
-        <Pressable style={s.backBtn}>
-          <Feather name="arrow-left" size={20} color={Colors.textSecondary} />
-          <Text style={s.backText}>Изменить email</Text>
+    <View className="flex-1 items-center bg-white px-4 py-8">
+      {/* Back */}
+      <View className="w-full max-w-sm">
+        <Pressable className="flex-row items-center gap-1 py-1">
+          <Feather name="arrow-left" size={20} color="#475569" />
+          <Text className="text-sm text-textSecondary">Изменить email</Text>
         </Pressable>
       </View>
 
-      <View style={s.header}>
-        <View style={[s.iconWrap, isLocked ? s.iconWrapError : null]}>
-          <Feather name={isLocked ? 'lock' : 'mail'} size={28} color={isLocked ? Colors.statusError : Colors.brandPrimary} />
+      {/* Header */}
+      <View className="mt-6 items-center gap-2">
+        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+          <Feather name="mail" size={28} color="#0284C7" />
         </View>
-        <Text style={s.title}>{isLocked ? 'Доступ заблокирован' : 'Введите код'}</Text>
-        {isLocked ? (
-          <Text style={s.subtitle}>Слишком много неверных попыток</Text>
-        ) : (
-          <View style={s.emailRow}>
-            <Text style={s.subtitle}>Код отправлен на </Text>
-            <Text style={s.emailHighlight}>elena@mail.ru</Text>
-          </View>
-        )}
+        <Text className="text-xl font-bold text-textPrimary">Введите код</Text>
+        <View className="flex-row items-center">
+          <Text className="text-base text-textMuted">Код отправлен на </Text>
+          <Text className="text-base font-medium text-textPrimary">elena@mail.ru</Text>
+        </View>
       </View>
 
-      {/* Code inputs */}
-      <View style={s.codeRow}>
+      {/* OTP inputs */}
+      <View className="mt-5 flex-row justify-center gap-2">
         {[0, 1, 2, 3, 4, 5].map((i) => (
-          <View key={i} style={[
-            s.codeBox,
-            error ? s.codeBoxError : null,
-            digits[i] ? s.codeBoxFilled : null,
-            isLocked ? s.codeBoxLocked : null,
-          ]}>
+          <View
+            key={i}
+            className={`h-14 w-12 items-center justify-center rounded-lg border-2 ${error ? 'border-red-500 bg-red-50' : digits[i] ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200 bg-white'}`}
+          >
             <TextInput
               ref={(ref) => { inputRefs.current[i] = ref; }}
               value={digits[i]}
               onChangeText={(v) => handleDigitChange(i, v)}
-              onKeyPress={(e) => handleKeyPress(i, e.nativeEvent.key)}
               keyboardType="number-pad"
               maxLength={1}
-              style={[s.codeInput, error ? s.codeCharError : null, isLocked ? s.codeCharLocked : null]}
               selectTextOnFocus
-              editable={!isLocked && !loading}
+              editable={!loading}
+              className="h-full w-full text-center text-2xl font-bold text-textPrimary"
+              style={{ outlineStyle: 'none' as any }}
             />
           </View>
         ))}
       </View>
 
-      {/* Error message */}
+      {/* Error */}
       {error ? (
-        <View style={s.errorRow}>
-          <Feather name="alert-circle" size={14} color={Colors.statusError} />
-          <Text style={s.error}>{error}</Text>
+        <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm font-medium text-red-600">{error}</Text>
         </View>
       ) : null}
 
-      {/* Attempts indicator */}
-      {attempts > 0 && attempts < 5 && !error && (
-        <View style={s.attemptsRow}>
-          {[0, 1, 2, 3, 4].map((i) => (
-            <View key={i} style={[s.attemptDot, i < attempts ? s.attemptDotUsed : null]} />
-          ))}
-        </View>
-      )}
+      {/* Submit */}
+      <Pressable
+        onPress={handleSubmit}
+        disabled={loading}
+        className={`mt-4 h-12 w-full max-w-xs items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
+      >
+        <Text className="text-base font-semibold text-white">
+          {loading ? 'Проверка...' : 'Подтвердить'}
+        </Text>
+      </Pressable>
 
-      {/* Submit button */}
-      {!isLocked && (
-        <Pressable onPress={handleSubmit} disabled={loading} style={[s.btn, loading ? s.btnDisabled : null]}>
-          {loading ? (
-            <ActivityIndicator size="small" color={Colors.white} />
-          ) : (
-            <Text style={s.btnText}>Подтвердить</Text>
-          )}
-        </Pressable>
-      )}
-
-      {/* Locked: request new code */}
-      {isLocked && (
-        <Pressable onPress={handleResend} style={s.btnOutline}>
-          <Feather name="refresh-cw" size={16} color={Colors.brandPrimary} />
-          <Text style={s.btnOutlineText}>Запросить новый код</Text>
-        </Pressable>
-      )}
-
-      {/* Resend timer */}
-      {!isLocked && (
-        <Pressable onPress={handleResend} disabled={resendTimer > 0}>
-          {resendTimer > 0 ? (
-            <View style={s.resendRow}>
-              <Feather name="clock" size={14} color={Colors.textMuted} />
-              <Text style={s.resend}>Отправить повторно через {resendTimer} сек</Text>
-            </View>
-          ) : (
-            <View style={s.resendRow}>
-              <Feather name="refresh-cw" size={14} color={Colors.brandPrimary} />
-              <Text style={s.resendActive}>Отправить код повторно</Text>
-            </View>
-          )}
-        </Pressable>
-      )}
+      {/* Resend */}
+      <View className="mt-3 flex-row items-center gap-1">
+        {resendTimer > 0 ? (
+          <>
+            <Feather name="clock" size={14} color="#94A3B8" />
+            <Text className="text-sm text-textMuted">Отправить повторно через {resendTimer} сек</Text>
+          </>
+        ) : (
+          <>
+            <Feather name="refresh-cw" size={14} color="#0284C7" />
+            <Text className="text-sm font-medium text-brandPrimary">Отправить код повторно</Text>
+          </>
+        )}
+      </View>
     </View>
   );
 }
 
 export function AuthOtpStates() {
   return (
-    <>
-      <StateSection title="DEFAULT">
-        <OtpScreen initialResendTimer={57} />
-      </StateSection>
+    <ScrollView className="flex-1 bg-white">
+      <View className="w-full max-w-md self-center px-4 py-8">
+        <Text className="mb-4 text-lg font-bold text-textPrimary">Screen: Auth OTP</Text>
 
-      <StateSection title="RESEND_AVAILABLE">
-        <OtpScreen initialResendTimer={0} />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">IDLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <OtpScreen initialResendTimer={57} />
+        </View>
 
-      <StateSection title="ERROR">
-        <OtpScreen initialCode="123456" initialError="Неверный код. Осталось 3 попытки" initialAttempts={2} initialResendTimer={34} />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">VERIFYING</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <OtpScreen initialCode="000000" initialLoading initialResendTimer={12} />
+        </View>
 
-      <StateSection title="LOADING">
-        <OtpScreen initialCode="000000" initialLoading initialResendTimer={12} />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">ERROR</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <OtpScreen initialCode="123456" initialError="Неверный код. Осталось 3 попытки" initialResendTimer={34} />
+        </View>
 
-      <StateSection title="MAX_ATTEMPTS">
-        <OtpScreen initialCode="999999" maxedOut initialError="Превышено число попыток. Запросите новый код." initialAttempts={5} />
-      </StateSection>
-    </>
+        <Text className="mb-2 text-sm font-medium text-textMuted">RESEND AVAILABLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 480 }}>
+          <OtpScreen initialResendTimer={0} />
+        </View>
+      </View>
+    </ScrollView>
   );
 }
-
-const s = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing['2xl'],
-    gap: Spacing.lg,
-    alignItems: 'center',
-    backgroundColor: Colors.bgPrimary,
-  },
-
-  // Back
-  backRow: {
-    width: '100%',
-    maxWidth: 360,
-    alignItems: 'flex-start',
-  },
-  backBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    paddingVertical: Spacing.xs,
-  },
-  backText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-  },
-
-  // Header
-  header: {
-    alignItems: 'center',
-    gap: Spacing.sm,
-    marginTop: Spacing.lg,
-  },
-  iconWrap: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: Spacing.xs,
-  },
-  iconWrapError: {
-    backgroundColor: Colors.statusBg.error,
-  },
-  title: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  emailRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  subtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-  emailHighlight: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-
-  // Code inputs
-  codeRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    justifyContent: 'center',
-    marginTop: Spacing.md,
-  },
-  codeBox: {
-    width: 48,
-    height: 56,
-    borderWidth: 1.5,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: Colors.bgPrimary,
-  },
-  codeBoxError: {
-    borderColor: Colors.statusError,
-    backgroundColor: Colors.statusBg.error,
-  },
-  codeBoxFilled: {
-    borderColor: Colors.brandPrimary,
-    backgroundColor: Colors.bgSecondary,
-  },
-  codeBoxLocked: {
-    borderColor: Colors.statusError,
-    backgroundColor: Colors.statusBg.error,
-    opacity: 0.6,
-  },
-  codeInput: {
-    fontSize: 24,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-    width: '100%',
-    height: '100%',
-  },
-  codeCharError: {
-    color: Colors.statusError,
-  },
-  codeCharLocked: {
-    color: Colors.statusError,
-  },
-
-  // Error
-  errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    backgroundColor: Colors.statusBg.error,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-  },
-  error: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    fontWeight: Typography.fontWeight.medium,
-  },
-
-  // Attempts
-  attemptsRow: {
-    flexDirection: 'row',
-    gap: 6,
-  },
-  attemptDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.border,
-  },
-  attemptDotUsed: {
-    backgroundColor: Colors.statusWarning,
-  },
-
-  // Button
-  btn: {
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    maxWidth: 320,
-    ...Shadows.sm,
-  },
-  btnDisabled: {
-    backgroundColor: Colors.brandPrimaryHover,
-  },
-  btnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-
-  // Outline button (locked state)
-  btnOutline: {
-    height: 48,
-    borderWidth: 1.5,
-    borderColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    maxWidth: 320,
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  btnOutlineText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.brandPrimary,
-  },
-
-  // Resend
-  resendRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    marginTop: Spacing.xs,
-  },
-  resend: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  resendActive: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-});

--- a/components/proto/states/MyResponsesStates.tsx
+++ b/components/proto/states/MyResponsesStates.tsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { StateSection } from '../StateSection';
+import { Colors } from '../../../constants/Colors';
+
+type FilterKey = 'all' | 'active' | 'deactivated';
+type Status = 'sent' | 'viewed' | 'accepted' | 'deactivated';
+
+const STATUS_CFG: Record<Status, { label: string; bg: string; fg: string; icon: string }> = {
+  sent: { label: 'Отправлен', bg: Colors.statusBg.info, fg: Colors.statusInfo, icon: 'send' },
+  viewed: { label: 'Просмотрен', bg: Colors.statusBg.warning, fg: Colors.statusWarning, icon: 'eye' },
+  accepted: { label: 'Принят', bg: Colors.statusBg.success, fg: Colors.statusSuccess, icon: 'check-circle' },
+  deactivated: { label: 'Отклонён', bg: Colors.statusBg.error, fg: Colors.statusError, icon: 'x-circle' },
+};
+
+const RESPONSES = [
+  { id: '1', title: 'Декларация 3-НДФЛ за 2025', city: 'Москва', service: 'Камеральная', price: '4 500 ₽', deadline: '2 дня', status: 'accepted' as Status, date: '10.04.2026' },
+  { id: '2', title: 'Регистрация ИП', city: 'Новосибирск', service: 'Выездная', price: '8 000 ₽', deadline: '5 дней', status: 'sent' as Status, date: '11.04.2026' },
+  { id: '3', title: 'Оптимизация налогов ООО', city: 'Москва', service: 'Оперативный контроль', price: '15 000 ₽', deadline: '7 дней', status: 'viewed' as Status, date: '09.04.2026' },
+  { id: '4', title: 'Налоговый вычет за квартиру', city: 'Москва', service: 'Камеральная', price: '3 000 ₽', deadline: '3 дня', status: 'deactivated' as Status, date: '05.04.2026' },
+];
+
+function StatusBadge({ status }: { status: Status }) {
+  const c = STATUS_CFG[status];
+  return (
+    <View className="flex-row items-center gap-1 rounded-full px-2 py-0.5" style={{ backgroundColor: c.bg }}>
+      <Feather name={c.icon as any} size={12} color={c.fg} />
+      <Text className="text-xs font-medium" style={{ color: c.fg }}>{c.label}</Text>
+    </View>
+  );
+}
+
+function ResponseCard({ r }: { r: typeof RESPONSES[0] }) {
+  return (
+    <View className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+      <Text className="text-base font-semibold text-textPrimary" numberOfLines={2}>{r.title}</Text>
+      <View className="flex-row items-center gap-2">
+        <Feather name="map-pin" size={12} color={Colors.textMuted} />
+        <Text className="text-xs text-textMuted">{r.city}</Text>
+        <Feather name="briefcase" size={12} color={Colors.textMuted} />
+        <Text className="text-xs text-textMuted">{r.service}</Text>
+      </View>
+      <View className="flex-row items-center gap-3">
+        <View className="flex-row items-center gap-1">
+          <Feather name="dollar-sign" size={12} color={Colors.textMuted} />
+          <Text className="text-sm font-semibold text-textPrimary">{r.price}</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <Feather name="calendar" size={12} color={Colors.textMuted} />
+          <Text className="text-sm text-textMuted">{r.deadline}</Text>
+        </View>
+        <View className="ml-auto"><StatusBadge status={r.status} /></View>
+      </View>
+      <Text className="text-xs text-textMuted">Отклик: {r.date}</Text>
+      {r.status === 'accepted' && (
+        <Pressable className="mt-1 h-9 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+          <Feather name="message-circle" size={14} color={Colors.white} />
+          <Text className="text-sm font-semibold text-white">Перейти в чат</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+function PopulatedState() {
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const filters: { key: FilterKey; label: string }[] = [
+    { key: 'all', label: 'Все' }, { key: 'active', label: 'Активные' }, { key: 'deactivated', label: 'Деактивированные' },
+  ];
+  const filtered = RESPONSES.filter((r) => {
+    if (filter === 'active') return r.status !== 'deactivated';
+    if (filter === 'deactivated') return r.status === 'deactivated';
+    return true;
+  });
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="flex-row items-center gap-2">
+        <Feather name="mail" size={20} color={Colors.brandPrimary} />
+        <Text className="text-xl font-bold text-textPrimary">Мои отклики</Text>
+      </View>
+      <View className="flex-row gap-2">
+        {filters.map((f) => (
+          <Pressable
+            key={f.key}
+            onPress={() => setFilter(f.key)}
+            className={`h-9 items-center justify-center rounded-full border px-4 ${filter === f.key ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}
+          >
+            <Text className={`text-sm font-medium ${filter === f.key ? 'text-white' : 'text-textMuted'}`}>{f.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+      {filtered.map((r) => <ResponseCard key={r.id} r={r} />)}
+    </ScrollView>
+  );
+}
+
+function EmptyState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="flex-row items-center gap-2">
+        <Feather name="mail" size={20} color={Colors.brandPrimary} />
+        <Text className="text-xl font-bold text-textPrimary">Мои отклики</Text>
+      </View>
+      <View className="items-center gap-3 py-10">
+        <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSecondary">
+          <Feather name="send" size={32} color={Colors.brandPrimary} />
+        </View>
+        <Text className="text-lg font-semibold text-textPrimary">Вы ещё не откликались</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">
+          Найдите подходящие заявки и предложите свои услуги клиентам
+        </Text>
+        <Pressable className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6">
+          <Feather name="search" size={16} color={Colors.white} />
+          <Text className="text-sm font-semibold text-white">Просмотреть заявки</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+function LoadingState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="h-6 w-2/5 rounded-md bg-bgSecondary" />
+      <View className="flex-row gap-2">
+        {[0, 1, 2].map((i) => <View key={i} className="h-9 w-20 rounded-full bg-bgSecondary" />)}
+      </View>
+      {[0, 1, 2].map((i) => <View key={i} className="h-32 w-full rounded-xl bg-bgSecondary" />)}
+    </ScrollView>
+  );
+}
+
+function ErrorState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="items-center gap-3 py-16">
+        <View className="h-16 w-16 items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusBg.error }}>
+          <Feather name="alert-circle" size={32} color={Colors.statusError} />
+        </View>
+        <Text className="text-lg font-semibold text-textPrimary">Ошибка загрузки</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">Не удалось загрузить отклики. Попробуйте снова.</Text>
+        <Pressable className="mt-2 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6">
+          <Feather name="refresh-cw" size={16} color={Colors.white} />
+          <Text className="text-sm font-semibold text-white">Повторить</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+export function MyResponsesStates() {
+  return (
+    <>
+      <StateSection title="populated"><PopulatedState /></StateSection>
+      <StateSection title="empty"><EmptyState /></StateSection>
+      <StateSection title="loading"><LoadingState /></StateSection>
+      <StateSection title="error"><ErrorState /></StateSection>
+    </>
+  );
+}

--- a/components/proto/states/NotFoundStates.tsx
+++ b/components/proto/states/NotFoundStates.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { StateSection } from '../StateSection';
+import { Colors } from '../../../constants/Colors';
+
+function StaticState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 16 }}>
+      <View className="h-20 w-20 items-center justify-center rounded-full bg-bgSecondary">
+        <Feather name="frown" size={40} color={Colors.textMuted} />
+      </View>
+      <Text className="text-xl font-bold text-textPrimary">Страница не найдена</Text>
+      <Text className="max-w-[300px] text-center text-sm text-textMuted">
+        Возможно, она была удалена или ссылка устарела
+      </Text>
+      <Pressable className="mt-4 h-11 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-8">
+        <Feather name="home" size={16} color={Colors.white} />
+        <Text className="text-base font-semibold text-white">На главную</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+export function NotFoundStates() {
+  return (
+    <StateSection title="static"><StaticState /></StateSection>
+  );
+}

--- a/components/proto/states/OnboardingProfileStates.tsx
+++ b/components/proto/states/OnboardingProfileStates.tsx
@@ -1,126 +1,106 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, ActivityIndicator, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 
-function Screen({ initialFilled, uploading, uploadProgress }: {
-  initialFilled?: boolean; uploading?: boolean; uploadProgress?: number;
+function ProfileScreen({ initialFilled, uploading }: {
+  initialFilled?: boolean; uploading?: boolean;
 }) {
-  const [about, setAbout] = useState(initialFilled ? 'Налоговый консультант с опытом работы 8 лет. Специализация — НДФЛ, имущественные вычеты, регистрация ИП.' : '');
-  const [price, setPrice] = useState(initialFilled ? '2 000' : '');
+  const [description, setDescription] = useState(initialFilled ? 'Налоговый консультант, 8 лет опыта. Специализация — НДФЛ, вычеты, ИП.' : '');
+  const [phone, setPhone] = useState(initialFilled ? '+79001234567' : '');
+  const [telegram, setTelegram] = useState(initialFilled ? '@elena_tax' : '');
   const [hasPhoto, setHasPhoto] = useState(!!initialFilled);
-  const [isUploading, setIsUploading] = useState(!!uploading);
-  const progress = uploadProgress ?? 0;
-
-  const charCount = about.length;
-  const maxChars = 500;
-  const isComplete = about.length >= 20 && price.length > 0;
+  const maxChars = 1000;
 
   return (
-    <View style={s.container}>
+    <View className="flex-1 bg-white px-4 py-6">
       {/* Progress */}
-      <View style={s.progressWrap}>
-        <View style={s.progressTrack}>
-          <View style={[s.progressBar, { width: '100%' }]} />
-        </View>
-        <Text style={s.step}>Шаг 3 из 3</Text>
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary">
+        <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
       </View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 3 из 3</Text>
 
-      <View style={s.headerWrap}>
-        <Text style={s.title}>Расскажите о себе</Text>
-        <Text style={s.subtitle}>Эта информация поможет клиентам выбрать именно вас</Text>
-      </View>
+      <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>
+      <Text className="mb-4 text-base text-textMuted">Эта информация поможет клиентам выбрать вас</Text>
 
       {/* Avatar */}
-      <View style={s.avatarSection}>
-        <View style={s.avatarWrap}>
-          {hasPhoto ? (
-            <View style={s.avatarFilled}>
-              <Feather name="user" size={32} color={Colors.white} />
-            </View>
-          ) : (
-            <View style={s.avatar}>
-              <Feather name="user" size={32} color={Colors.brandPrimary} />
-            </View>
-          )}
-          {isUploading && (
-            <View style={s.uploadOverlay}>
-              <ActivityIndicator size="small" color={Colors.white} />
-              <Text style={s.uploadPercent}>{progress}%</Text>
+      <View className="mb-4 flex-row items-center gap-4">
+        <View className={`h-16 w-16 items-center justify-center rounded-full ${hasPhoto ? 'bg-brandPrimary' : 'border-2 border-dashed border-gray-300 bg-bgSecondary'}`}>
+          <Feather name="user" size={28} color={hasPhoto ? '#fff' : '#0284C7'} />
+          {uploading && (
+            <View className="absolute inset-0 items-center justify-center rounded-full bg-black/50">
+              <Text className="text-xs font-bold text-white">45%</Text>
             </View>
           )}
         </View>
-        <View style={s.avatarInfo}>
-          <Pressable style={s.avatarBtn} onPress={() => { setIsUploading(true); setTimeout(() => { setIsUploading(false); setHasPhoto(true); }, 1500); }}>
-            <Feather name="camera" size={14} color={Colors.brandPrimary} />
-            <Text style={s.avatarBtnText}>{hasPhoto ? 'Изменить фото' : 'Загрузить фото'}</Text>
+        <View>
+          <Pressable className="flex-row items-center gap-1" onPress={() => setHasPhoto(true)}>
+            <Feather name="camera" size={14} color="#0284C7" />
+            <Text className="text-base font-medium text-brandPrimary">{hasPhoto ? 'Изменить фото' : 'Загрузить фото'}</Text>
           </Pressable>
-          <Text style={s.avatarHint}>JPG или PNG, до 5 МБ</Text>
+          <Text className="text-xs text-textMuted">JPG или PNG, до 5 МБ</Text>
         </View>
       </View>
 
-      {/* About */}
-      <View style={s.field}>
-        <View style={s.labelRow}>
-          <Text style={s.label}>О себе</Text>
-          <Text style={[s.charCount, charCount > maxChars ? s.charCountError : null]}>
-            {charCount}/{maxChars}
-          </Text>
+      {/* Description */}
+      <View className="mb-3">
+        <View className="mb-1 flex-row items-center justify-between">
+          <Text className="text-sm font-medium text-textSecondary">О себе</Text>
+          <Text className={`text-xs ${description.length > maxChars ? 'text-red-600' : 'text-textMuted'}`}>{description.length}/{maxChars}</Text>
         </View>
         <TextInput
-          value={about}
-          onChangeText={setAbout}
-          placeholder="Расскажите о вашем опыте и специализации..."
-          placeholderTextColor={Colors.textMuted}
+          value={description}
+          onChangeText={setDescription}
+          placeholder="Расскажите о вашем опыте..."
+          placeholderTextColor="#94A3B8"
           multiline
-          style={s.textarea}
+          className="rounded-lg border border-gray-200 p-3 text-base text-textPrimary"
+          style={{ minHeight: 80, textAlignVertical: 'top', outlineStyle: 'none' as any }}
           maxLength={maxChars}
         />
       </View>
 
-      {/* Price */}
-      <View style={s.field}>
-        <Text style={s.label}>Стоимость консультации (руб.)</Text>
-        <View style={s.priceWrap}>
-          <Text style={s.priceCurrency}>P</Text>
+      {/* Phone */}
+      <View className="mb-3">
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Телефон</Text>
+        <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+          <Feather name="phone" size={16} color="#94A3B8" />
           <TextInput
-            value={price}
-            onChangeText={setPrice}
-            placeholder="2 000"
-            placeholderTextColor={Colors.textMuted}
-            style={s.priceInput}
-            keyboardType="numeric"
+            value={phone}
+            onChangeText={setPhone}
+            placeholder="+7XXXXXXXXXX"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' as any }}
+            keyboardType="phone-pad"
           />
-          {price.length > 0 && <Text style={s.priceUnit}>/ консультация</Text>}
         </View>
       </View>
 
-      {/* Completeness indicator */}
-      <View style={s.completenessRow}>
-        <View style={s.completenessItem}>
-          <Feather name={hasPhoto ? 'check-circle' : 'circle'} size={16} color={hasPhoto ? Colors.statusSuccess : Colors.textMuted} />
-          <Text style={[s.completenessText, hasPhoto && s.completenessTextDone]}>Фото</Text>
-        </View>
-        <View style={s.completenessItem}>
-          <Feather name={about.length >= 20 ? 'check-circle' : 'circle'} size={16} color={about.length >= 20 ? Colors.statusSuccess : Colors.textMuted} />
-          <Text style={[s.completenessText, about.length >= 20 && s.completenessTextDone]}>Описание</Text>
-        </View>
-        <View style={s.completenessItem}>
-          <Feather name={price.length > 0 ? 'check-circle' : 'circle'} size={16} color={price.length > 0 ? Colors.statusSuccess : Colors.textMuted} />
-          <Text style={[s.completenessText, price.length > 0 && s.completenessTextDone]}>Цена</Text>
+      {/* Telegram */}
+      <View className="mb-4">
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Telegram</Text>
+        <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+          <Feather name="send" size={16} color="#94A3B8" />
+          <TextInput
+            value={telegram}
+            onChangeText={setTelegram}
+            placeholder="@username"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' as any }}
+          />
         </View>
       </View>
 
       {/* Buttons */}
-      <View style={s.buttonRow}>
-        <Pressable style={s.btnBack}>
-          <Feather name="arrow-left" size={16} color={Colors.textSecondary} />
-          <Text style={s.btnBackText}>Назад</Text>
+      <View className="flex-row gap-3">
+        <Pressable className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4">
+          <Feather name="arrow-left" size={16} color="#475569" />
+          <Text className="text-base font-medium text-textSecondary">Назад</Text>
         </Pressable>
-        <Pressable style={[s.btn, !isComplete && s.btnDisabled]} disabled={!isComplete}>
-          <Feather name="check" size={16} color={Colors.white} />
-          <Text style={s.btnText}>Завершить</Text>
+        <Pressable className="h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+          <Feather name="check" size={16} color="#fff" />
+          <Text className="text-base font-semibold text-white">Завершить</Text>
         </Pressable>
       </View>
     </View>
@@ -129,254 +109,25 @@ function Screen({ initialFilled, uploading, uploadProgress }: {
 
 export function OnboardingProfileStates() {
   return (
-    <>
-      <StateSection title="DEFAULT">
-        <Screen />
-      </StateSection>
+    <ScrollView className="flex-1 bg-white">
+      <View className="w-full max-w-md self-center px-4 py-8">
+        <Text className="mb-4 text-lg font-bold text-textPrimary">Screen: Onboarding Profile</Text>
 
-      <StateSection title="UPLOADING">
-        <Screen uploading uploadProgress={45} />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">IDLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 620 }}>
+          <ProfileScreen />
+        </View>
 
-      <StateSection title="COMPLETE">
-        <Screen initialFilled />
-      </StateSection>
-    </>
+        <Text className="mb-2 text-sm font-medium text-textMuted">UPLOADING</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 620 }}>
+          <ProfileScreen uploading />
+        </View>
+
+        <Text className="mb-2 text-sm font-medium text-textMuted">COMPLETE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 620 }}>
+          <ProfileScreen initialFilled />
+        </View>
+      </View>
+    </ScrollView>
   );
 }
-
-const s = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing['2xl'],
-    gap: Spacing.lg,
-    backgroundColor: Colors.bgPrimary,
-  },
-
-  // Progress
-  progressWrap: {
-    gap: Spacing.sm,
-  },
-  progressTrack: {
-    height: 4,
-    backgroundColor: Colors.bgSecondary,
-    borderRadius: 2,
-    overflow: 'hidden',
-  },
-  progressBar: {
-    height: 4,
-    backgroundColor: Colors.statusSuccess,
-    borderRadius: 2,
-  },
-  step: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-
-  // Header
-  headerWrap: {
-    gap: Spacing.xs,
-  },
-  title: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  subtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    lineHeight: 22,
-  },
-
-  // Avatar
-  avatarSection: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.lg,
-    paddingVertical: Spacing.sm,
-  },
-  avatarWrap: {
-    position: 'relative',
-  },
-  avatar: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-    borderColor: Colors.border,
-    borderStyle: 'dashed',
-  },
-  avatarFilled: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: Colors.brandPrimary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  uploadOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 2,
-  },
-  uploadPercent: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.white,
-    fontWeight: Typography.fontWeight.bold,
-  },
-  avatarInfo: {
-    gap: Spacing.xs,
-  },
-  avatarBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  avatarBtnText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  avatarHint: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-
-  // Fields
-  field: {
-    gap: Spacing.sm,
-  },
-  labelRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  label: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-  },
-  charCount: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-  charCountError: {
-    color: Colors.statusError,
-  },
-  textarea: {
-    minHeight: 100,
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    padding: Spacing.lg,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    textAlignVertical: 'top',
-    lineHeight: 22,
-  },
-  priceWrap: {
-    height: 48,
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.lg,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  priceCurrency: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textMuted,
-  },
-  priceInput: {
-    flex: 1,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    paddingVertical: 0,
-  },
-  priceUnit: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-
-  // Completeness
-  completenessRow: {
-    flexDirection: 'row',
-    gap: Spacing.lg,
-    paddingVertical: Spacing.sm,
-    borderTopWidth: 1,
-    borderTopColor: Colors.bgSecondary,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.bgSecondary,
-  },
-  completenessItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  completenessText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  completenessTextDone: {
-    color: Colors.statusSuccess,
-    fontWeight: Typography.fontWeight.medium,
-  },
-
-  // Buttons
-  buttonRow: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-    marginTop: Spacing.xs,
-  },
-  btnBack: {
-    height: 48,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: Spacing.xs,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.btn,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  btnBackText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  btn: {
-    flex: 1,
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  btnDisabled: {
-    opacity: 0.45,
-  },
-  btnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-});

--- a/components/proto/states/OnboardingUsernameStates.tsx
+++ b/components/proto/states/OnboardingUsernameStates.tsx
@@ -1,117 +1,74 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 
-function Screen({ initialValue, initialError, initialChecking, initialAvailable }: {
-  initialValue?: string; initialError?: string; initialChecking?: boolean; initialAvailable?: boolean;
+function UsernameScreen({ initialValue, initialError, initialAvailable }: {
+  initialValue?: string; initialError?: string; initialAvailable?: boolean;
 }) {
   const [value, setValue] = useState(initialValue || '');
   const [error, setError] = useState(initialError || '');
-  const [checking, setChecking] = useState(!!initialChecking);
   const [available, setAvailable] = useState(!!initialAvailable);
+  const [agreed, setAgreed] = useState(!!initialAvailable);
 
-  const handleChange = (t: string) => {
-    setValue(t);
-    setError('');
-    setAvailable(false);
-    if (t.length >= 3) {
-      setChecking(true);
-      // Simulated check
-      setTimeout(() => {
-        setChecking(false);
-        if (t.toLowerCase() === 'elena') {
-          setError('Это имя уже занято');
-        } else {
-          setAvailable(true);
-        }
-      }, 800);
-    }
-  };
-
-  const handleContinue = () => {
-    if (value.length < 3) {
-      setError('Имя должно содержать минимум 3 символа');
-    }
-  };
-
-  const getInputState = () => {
-    if (error) return 'error';
-    if (available) return 'success';
-    if (checking) return 'checking';
-    return 'default';
-  };
-  const inputState = getInputState();
+  const canContinue = available && agreed && value.length >= 2;
 
   return (
-    <View style={s.container}>
+    <View className="flex-1 bg-white px-4 py-6">
       {/* Progress */}
-      <View style={s.progressWrap}>
-        <View style={s.progressTrack}>
-          <View style={[s.progressBar, { width: '33%' }]} />
-        </View>
-        <Text style={s.step}>Шаг 1 из 3</Text>
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary">
+        <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '33%' }} />
       </View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 1 из 3</Text>
 
       {/* Header */}
-      <View style={s.headerWrap}>
-        <Text style={s.title}>Как вас зовут?</Text>
-        <Text style={s.subtitle}>Это имя будет видно клиентам в вашем профиле</Text>
+      <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
+      <Text className="mb-4 text-base leading-6 text-textMuted">Это имя будет видно клиентам в вашем профиле</Text>
+
+      {/* Input */}
+      <Text className="mb-1 text-sm font-medium text-textSecondary">Имя пользователя</Text>
+      <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : available ? 'border-green-600 bg-green-50' : 'border-gray-200 bg-white'}`}>
+        <Feather name="user" size={18} color={error ? '#DC2626' : available ? '#15803D' : '#94A3B8'} />
+        <TextInput
+          value={value}
+          onChangeText={(t) => { setValue(t); setError(''); setAvailable(false); }}
+          placeholder="Например: Елена Васильева"
+          placeholderTextColor="#94A3B8"
+          className="flex-1 text-base text-textPrimary"
+          style={{ outlineStyle: 'none' as any }}
+        />
+        {available && <Feather name="check-circle" size={18} color="#15803D" />}
+        {error ? <Feather name="x-circle" size={18} color="#DC2626" /> : null}
       </View>
 
-      {/* Form */}
-      <View style={s.form}>
-        <Text style={s.label}>Имя пользователя</Text>
-        <View style={[
-          s.inputWrap,
-          inputState === 'error' && s.inputError,
-          inputState === 'success' && s.inputSuccess,
-        ]}>
-          <Feather
-            name="user"
-            size={18}
-            color={inputState === 'error' ? Colors.statusError : inputState === 'success' ? Colors.statusSuccess : Colors.textMuted}
-          />
-          <TextInput
-            value={value}
-            onChangeText={handleChange}
-            placeholder="Например: Елена Васильева"
-            placeholderTextColor={Colors.textMuted}
-            style={s.input}
-          />
-          {checking && <ActivityIndicator size="small" color={Colors.brandPrimary} />}
-          {available && <Feather name="check-circle" size={18} color={Colors.statusSuccess} />}
-          {error && <Feather name="x-circle" size={18} color={Colors.statusError} />}
+      {error ? (
+        <View className="mb-2 flex-row items-center gap-1">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm text-red-600">{error}</Text>
         </View>
+      ) : available ? (
+        <View className="mb-2 flex-row items-center gap-1">
+          <Feather name="check-circle" size={14} color="#15803D" />
+          <Text className="text-sm font-medium text-green-700">Имя свободно</Text>
+        </View>
+      ) : null}
 
-        {/* Feedback messages */}
-        {error ? (
-          <View style={s.feedbackRow}>
-            <Feather name="alert-circle" size={14} color={Colors.statusError} />
-            <Text style={s.feedbackError}>{error}</Text>
-          </View>
-        ) : available ? (
-          <View style={s.feedbackRow}>
-            <Feather name="check-circle" size={14} color={Colors.statusSuccess} />
-            <Text style={s.feedbackSuccess}>Имя свободно</Text>
-          </View>
-        ) : checking ? (
-          <View style={s.feedbackRow}>
-            <ActivityIndicator size={14} color={Colors.textMuted} />
-            <Text style={s.feedbackChecking}>Проверяем доступность...</Text>
-          </View>
-        ) : null}
-      </View>
+      {/* Terms checkbox */}
+      <Pressable className="mt-3 flex-row items-start gap-2" onPress={() => setAgreed(!agreed)}>
+        <View className={`mt-0.5 h-5 w-5 items-center justify-center rounded border ${agreed ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300 bg-white'}`}>
+          {agreed && <Feather name="check" size={13} color="#fff" />}
+        </View>
+        <Text className="flex-1 text-sm text-textSecondary">
+          Принимаю <Text className="text-brandPrimary">условия использования</Text>
+        </Text>
+      </Pressable>
 
-      {/* Continue button */}
+      {/* Continue */}
       <Pressable
-        onPress={handleContinue}
-        style={[s.btn, (!available && !initialAvailable) ? s.btnDisabled : null]}
-        disabled={!available && !initialAvailable}
+        disabled={!canContinue}
+        className={`mt-6 h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${!canContinue ? 'opacity-40' : ''}`}
       >
-        <Text style={s.btnText}>Продолжить</Text>
-        <Feather name="arrow-right" size={16} color={Colors.white} />
+        <Text className="text-base font-semibold text-white">Далее</Text>
+        <Feather name="arrow-right" size={16} color="#fff" />
       </Pressable>
     </View>
   );
@@ -119,146 +76,25 @@ function Screen({ initialValue, initialError, initialChecking, initialAvailable 
 
 export function OnboardingUsernameStates() {
   return (
-    <>
-      <StateSection title="DEFAULT">
-        <Screen />
-      </StateSection>
+    <ScrollView className="flex-1 bg-white">
+      <View className="w-full max-w-md self-center px-4 py-8">
+        <Text className="mb-4 text-lg font-bold text-textPrimary">Screen: Onboarding Username</Text>
 
-      <StateSection title="CHECKING">
-        <Screen initialValue="Елена Васильева" initialChecking />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">IDLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 420 }}>
+          <UsernameScreen />
+        </View>
 
-      <StateSection title="TAKEN">
-        <Screen initialValue="elena" initialError="Это имя уже занято" />
-      </StateSection>
+        <Text className="mb-2 text-sm font-medium text-textMuted">AVAILABLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 420 }}>
+          <UsernameScreen initialValue="Елена Васильева" initialAvailable />
+        </View>
 
-      <StateSection title="AVAILABLE">
-        <Screen initialValue="Елена Васильева" initialAvailable />
-      </StateSection>
-    </>
+        <Text className="mb-2 text-sm font-medium text-textMuted">ERROR (taken)</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 420 }}>
+          <UsernameScreen initialValue="elena" initialError="Это имя уже занято" />
+        </View>
+      </View>
+    </ScrollView>
   );
 }
-
-const s = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing['2xl'],
-    gap: Spacing.lg,
-    backgroundColor: Colors.bgPrimary,
-  },
-
-  // Progress
-  progressWrap: {
-    gap: Spacing.sm,
-  },
-  progressTrack: {
-    height: 4,
-    backgroundColor: Colors.bgSecondary,
-    borderRadius: 2,
-    overflow: 'hidden',
-  },
-  progressBar: {
-    height: 4,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: 2,
-  },
-  step: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-
-  // Header
-  headerWrap: {
-    gap: Spacing.xs,
-    marginTop: Spacing.sm,
-  },
-  title: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  subtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    lineHeight: 22,
-  },
-
-  // Form
-  form: {
-    gap: Spacing.sm,
-    marginTop: Spacing.sm,
-  },
-  label: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textSecondary,
-  },
-  inputWrap: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    height: 48,
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.lg,
-  },
-  input: {
-    flex: 1,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    paddingVertical: 0,
-  },
-  inputError: {
-    borderColor: Colors.statusError,
-    backgroundColor: Colors.statusBg.error,
-  },
-  inputSuccess: {
-    borderColor: Colors.statusSuccess,
-    backgroundColor: Colors.statusBg.success,
-  },
-
-  // Feedback
-  feedbackRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  feedbackError: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-  },
-  feedbackSuccess: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusSuccess,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  feedbackChecking: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-
-  // Button
-  btn: {
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.md,
-    ...Shadows.sm,
-  },
-  btnDisabled: {
-    opacity: 0.45,
-  },
-  btnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-});

--- a/components/proto/states/OnboardingWorkAreaStates.tsx
+++ b/components/proto/states/OnboardingWorkAreaStates.tsx
@@ -1,244 +1,103 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, StyleSheet } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
 
-const SERVICES = [
-  'Выездная проверка',
-  'Отдел оперативного контроля',
-  'Камеральная проверка',
-];
-
-const CITIES_FNS: Record<string, string[]> = {
-  'Москва': ['ИФНС №5 по г. Москве', 'ИФНС №12 по г. Москве', 'ИФНС №46 по г. Москве'],
-  'Санкт-Петербург': ['ИФНС №3 по СПб', 'ИФНС №15 по СПб', 'ИФНС №28 по СПб'],
-  'Казань': ['ИФНС №1 по Казани', 'ИФНС №6 по Казани'],
-  'Новосибирск': ['ИФНС №2 по Новосибирску', 'ИФНС №13 по Новосибирску'],
+const SVCS = ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'];
+const CF: Record<string, string[]> = {
+  'Москва': ['ИФНС №5', 'ИФНС №12', 'ИФНС №46'],
+  'СПб': ['ИФНС №3', 'ИФНС №15', 'ИФНС №28'],
+  'Казань': ['ИФНС №1', 'ИФНС №6'],
 };
+type Bind = Record<string, string[]>;
 
-const ALL_CITIES = Object.keys(CITIES_FNS);
-
-// key = "city:fns" -> selected services
-type FnsBindings = Record<string, string[]>;
-
-function ProgressBar() {
-  return (
-    <View style={s.progressWrap}>
-      <View style={s.progressTrack}>
-        <View style={[s.progressBar, { width: '66%' }]} />
-      </View>
-      <Text style={s.step}>Шаг 2 из 3</Text>
-    </View>
-  );
-}
-
-function Screen({ preset, validationError }: {
-  preset?: { cities: string[]; bindings: FnsBindings };
-  validationError?: string;
-}) {
+function WorkAreaScreen({ preset, validationError }: { preset?: { cities: string[]; bindings: Bind }; validationError?: string }) {
   const [search, setSearch] = useState('');
-  const [selectedCities, setSelectedCities] = useState<string[]>(preset?.cities || []);
-  const [expandedCity, setExpandedCity] = useState<string | null>(preset?.cities?.[0] || null);
-  const [bindings, setBindings] = useState<FnsBindings>(preset?.bindings || {});
-  const [error, setError] = useState(validationError || '');
-
-  const filteredCities = search.length > 0
-    ? ALL_CITIES.filter((c) => c.toLowerCase().includes(search.toLowerCase()) && !selectedCities.includes(c))
-    : [];
-
-  const addCity = (city: string) => {
-    setSelectedCities((prev) => [...prev, city]);
-    setSearch('');
-    setExpandedCity(city);
-    setError('');
+  const [cities, setCities] = useState<string[]>(preset?.cities || []);
+  const [expanded, setExpanded] = useState<string | null>(preset?.cities?.[0] || null);
+  const [bind, setBind] = useState<Bind>(preset?.bindings || {});
+  const [error] = useState(validationError || '');
+  const allCities = Object.keys(CF);
+  const filtered = search ? allCities.filter((c) => c.toLowerCase().includes(search.toLowerCase()) && !cities.includes(c)) : [];
+  const addCity = (c: string) => { setCities((p) => [...p, c]); setSearch(''); setExpanded(c); };
+  const removeCity = (c: string) => {
+    setCities((p) => p.filter((x) => x !== c));
+    setBind((p) => { const n = { ...p }; Object.keys(n).forEach((k) => { if (k.startsWith(c + ':')) delete n[k]; }); return n; });
   };
-
-  const removeCity = (city: string) => {
-    setSelectedCities((prev) => prev.filter((c) => c !== city));
-    setExpandedCity((prev) => prev === city ? null : prev);
-    setBindings((prev) => {
-      const next = { ...prev };
-      Object.keys(next).forEach((k) => { if (k.startsWith(city + ':')) delete next[k]; });
-      return next;
-    });
+  const k = (c: string, f: string) => `${c}:${f}`;
+  const toggleFns = (c: string, f: string) => {
+    const key = k(c, f);
+    setBind((p) => { if (p[key]) { const n = { ...p }; delete n[key]; return n; } return { ...p, [key]: [] }; });
   };
-
-  const fnsKey = (city: string, fns: string) => `${city}:${fns}`;
-
-  const toggleFns = (city: string, fns: string) => {
-    const key = fnsKey(city, fns);
-    setBindings((prev) => {
-      if (prev[key]) {
-        const next = { ...prev };
-        delete next[key];
-        return next;
-      }
-      return { ...prev, [key]: [] };
-    });
-    setError('');
+  const toggleSvc = (key: string, s: string) => {
+    setBind((p) => { const cur = p[key] || []; return { ...p, [key]: cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s] }; });
   };
-
-  const toggleService = (key: string, service: string) => {
-    setBindings((prev) => {
-      const current = prev[key] || [];
-      const updated = current.includes(service)
-        ? current.filter((s) => s !== service)
-        : [...current, service];
-      return { ...prev, [key]: updated };
-    });
-  };
-
-  const totalBindings = Object.keys(bindings).length;
-  const totalServices = Object.values(bindings).reduce((sum, arr) => sum + arr.length, 0);
-
+  const total = Object.keys(bind).length;
   return (
-    <View style={s.container}>
-      <ProgressBar />
-
-      <View style={s.headerWrap}>
-        <Text style={s.title}>Где и что вы делаете?</Text>
-        <Text style={s.subtitle}>Выберите города, инспекции и услуги которые оказываете</Text>
+    <View className="flex-1 bg-white px-4 py-6">
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary"><View className="h-1 rounded-full bg-brandPrimary" style={{ width: '66%' }} /></View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 2 из 3</Text>
+      <Text className="text-xl font-bold text-textPrimary">Рабочая зона</Text>
+      <Text className="mb-4 text-base text-textMuted">Выберите города, инспекции и услуги</Text>
+      <View className="mb-2 h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+        <Feather name="search" size={18} color="#94A3B8" />
+        <TextInput value={search} onChangeText={setSearch} placeholder="Найти город..." placeholderTextColor="#94A3B8" className="flex-1 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        {search.length > 0 && <Pressable onPress={() => setSearch('')}><Feather name="x" size={16} color="#94A3B8" /></Pressable>}
       </View>
-
-      {/* City search */}
-      <View style={s.searchWrap}>
-        <Feather name="search" size={18} color={Colors.textMuted} />
-        <TextInput
-          value={search}
-          onChangeText={setSearch}
-          placeholder="Найти город..."
-          placeholderTextColor={Colors.textMuted}
-          style={s.searchInput}
-        />
-        {search.length > 0 && (
-          <Pressable onPress={() => setSearch('')} hitSlop={8}>
-            <Feather name="x" size={16} color={Colors.textMuted} />
-          </Pressable>
-        )}
-      </View>
-
-      {/* Search results dropdown */}
-      {filteredCities.length > 0 && (
-        <View style={s.searchResults}>
-          {filteredCities.map((city) => (
-            <Pressable key={city} style={s.searchItem} onPress={() => addCity(city)}>
-              <Feather name="map-pin" size={14} color={Colors.textMuted} />
-              <Text style={s.searchText}>{city}</Text>
-              <View style={s.addBadge}>
-                <Feather name="plus" size={14} color={Colors.brandPrimary} />
-              </View>
-            </Pressable>
-          ))}
-        </View>
-      )}
-
-      {/* Selected cities with FNS tree */}
-      {selectedCities.length === 0 && !search && (
-        <View style={s.emptyHint}>
-          <Feather name="map-pin" size={20} color={Colors.textMuted} />
-          <Text style={s.emptyText}>Начните вводить название города</Text>
-        </View>
-      )}
-
-      {selectedCities.map((city) => {
-        const isExpanded = expandedCity === city;
-        const fnsOffices = CITIES_FNS[city] || [];
-        const cityBindingCount = Object.keys(bindings).filter((k) => k.startsWith(city + ':')).length;
-
-        return (
-          <View key={city} style={s.cityBlock}>
-            <Pressable
-              style={s.cityHeader}
-              onPress={() => setExpandedCity(isExpanded ? null : city)}
-            >
-              <View style={s.cityLeft}>
-                <View style={s.cityPin}>
-                  <Feather name="map-pin" size={14} color={Colors.brandPrimary} />
-                </View>
-                <Text style={s.cityName}>{city}</Text>
-                {cityBindingCount > 0 && (
-                  <View style={s.cityBadge}>
-                    <Text style={s.cityBadgeText}>{cityBindingCount}</Text>
-                  </View>
-                )}
-              </View>
-              <View style={s.cityRight}>
-                <Pressable onPress={() => removeCity(city)} hitSlop={8}>
-                  <Feather name="trash-2" size={14} color={Colors.textMuted} />
-                </Pressable>
-                <Feather
-                  name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                  size={16}
-                  color={Colors.textMuted}
-                />
-              </View>
-            </Pressable>
-
-            {isExpanded && (
-              <View style={s.fnsList}>
-                {fnsOffices.map((fns) => {
-                  const key = fnsKey(city, fns);
-                  const isSelected = key in bindings;
-                  const services = bindings[key] || [];
-
-                  return (
-                    <View key={fns}>
-                      <Pressable onPress={() => toggleFns(city, fns)} style={s.fnsRow}>
-                        <View style={[s.checkbox, isSelected && s.checkboxActive]}>
-                          {isSelected && <Feather name="check" size={13} color={Colors.white} />}
-                        </View>
-                        <Text style={[s.fnsName, isSelected && s.fnsNameActive]}>{fns}</Text>
-                      </Pressable>
-
-                      {isSelected && (
-                        <View style={s.servicesList}>
-                          {SERVICES.map((svc) => {
-                            const active = services.includes(svc);
-                            return (
-                              <Pressable key={svc} onPress={() => toggleService(key, svc)} style={[s.serviceChip, active && s.serviceChipActive]}>
-                                {active && <Feather name="check" size={12} color={Colors.brandPrimary} />}
-                                <Text style={[s.serviceText, active && s.serviceTextActive]}>{svc}</Text>
-                              </Pressable>
-                            );
-                          })}
-                        </View>
-                      )}
-                    </View>
-                  );
-                })}
-              </View>
-            )}
-          </View>
-        );
-      })}
-
-      {/* Validation error */}
-      {error ? (
-        <View style={s.errorRow}>
-          <Feather name="alert-circle" size={14} color={Colors.statusError} />
-          <Text style={s.errorText}>{error}</Text>
-        </View>
-      ) : null}
-
-      {/* Summary + Continue */}
-      {totalBindings > 0 && (
-        <View style={s.summaryRow}>
-          <Feather name="briefcase" size={14} color={Colors.textMuted} />
-          <Text style={s.summaryText}>
-            {totalBindings} {totalBindings === 1 ? 'инспекция' : 'инспекций'}, {totalServices} {totalServices === 1 ? 'услуга' : 'услуг'}
-          </Text>
-        </View>
-      )}
-
-      <View style={s.buttonRow}>
-        <Pressable style={s.btnBack}>
-          <Feather name="arrow-left" size={16} color={Colors.textSecondary} />
-          <Text style={s.btnBackText}>Назад</Text>
+      {filtered.map((c) => (
+        <Pressable key={c} className="flex-row items-center gap-2 border-b border-gray-100 px-4 py-3" onPress={() => addCity(c)}>
+          <Feather name="map-pin" size={14} color="#94A3B8" /><Text className="flex-1 text-base text-textPrimary">{c}</Text><Feather name="plus" size={14} color="#0284C7" />
         </Pressable>
-        <Pressable style={[s.btn, totalBindings === 0 && s.btnDisabled]}>
-          <Text style={s.btnText}>Продолжить</Text>
-          <Feather name="arrow-right" size={16} color={Colors.white} />
+      ))}
+      {cities.length === 0 && !search && (
+        <View className="items-center py-6 opacity-60">
+          <Feather name="map-pin" size={20} color="#94A3B8" /><Text className="mt-1 text-base text-textMuted">Начните вводить название города</Text>
+        </View>
+      )}
+      {cities.map((city) => {
+        const exp = expanded === city; const offices = CF[city] || [];
+        const cnt = Object.keys(bind).filter((x) => x.startsWith(city + ':')).length;
+        return (
+          <View key={city} className="mb-2 rounded-lg border border-gray-200 overflow-hidden">
+            <Pressable className="flex-row items-center justify-between px-4 py-3" onPress={() => setExpanded(exp ? null : city)}>
+              <View className="flex-row items-center gap-2">
+                <Feather name="map-pin" size={14} color="#0284C7" /><Text className="text-base font-semibold text-textPrimary">{city}</Text>
+                {cnt > 0 && <View className="h-5 w-5 items-center justify-center rounded-full bg-brandPrimary"><Text className="text-xs font-bold text-white">{cnt}</Text></View>}
+              </View>
+              <View className="flex-row items-center gap-3">
+                <Pressable onPress={() => removeCity(city)}><Feather name="trash-2" size={14} color="#94A3B8" /></Pressable>
+                <Feather name={exp ? 'chevron-up' : 'chevron-down'} size={16} color="#94A3B8" />
+              </View>
+            </Pressable>
+            {exp && offices.map((fns) => {
+              const key = k(city, fns); const sel = key in bind; const sv = bind[key] || [];
+              return (
+                <View key={fns} className="border-t border-gray-100">
+                  <Pressable className="flex-row items-center gap-3 px-4 py-3" onPress={() => toggleFns(city, fns)}>
+                    <View className={`h-5 w-5 items-center justify-center rounded border ${sel ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300'}`}>
+                      {sel && <Feather name="check" size={13} color="#fff" />}
+                    </View>
+                    <Text className={`text-sm ${sel ? 'font-medium text-brandPrimary' : 'text-textPrimary'}`}>{fns}</Text>
+                  </Pressable>
+                  {sel && (
+                    <View className="flex-row flex-wrap gap-2 px-4 pb-3 pl-12">
+                      {SVCS.map((svc) => { const on = sv.includes(svc); return (
+                        <Pressable key={svc} className={`flex-row items-center gap-1 rounded-full border px-3 py-1 ${on ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200'}`} onPress={() => toggleSvc(key, svc)}>
+                          {on && <Feather name="check" size={12} color="#0284C7" />}
+                          <Text className={`text-xs ${on ? 'font-medium text-brandPrimary' : 'text-textSecondary'}`}>{svc}</Text>
+                        </Pressable>); })}
+                    </View>
+                  )}
+                </View>);
+            })}
+          </View>);
+      })}
+      {error ? (<View className="flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2"><Feather name="alert-circle" size={14} color="#DC2626" /><Text className="text-sm font-medium text-red-600">{error}</Text></View>) : null}
+      <View className="mt-4 flex-row gap-3">
+        <Pressable className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4">
+          <Feather name="arrow-left" size={16} color="#475569" /><Text className="text-base font-medium text-textSecondary">Назад</Text>
+        </Pressable>
+        <Pressable className={`h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${total === 0 ? 'opacity-40' : ''}`}>
+          <Text className="text-base font-semibold text-white">Далее</Text><Feather name="arrow-right" size={16} color="#fff" />
         </Pressable>
       </View>
     </View>
@@ -247,329 +106,23 @@ function Screen({ preset, validationError }: {
 
 export function OnboardingWorkAreaStates() {
   return (
-    <>
-      <StateSection title="DEFAULT">
-        <Screen />
-      </StateSection>
-
-      <StateSection title="SELECTED">
-        <Screen preset={{
-          cities: ['Москва', 'Санкт-Петербург'],
-          bindings: {
-            'Москва:ИФНС №5 по г. Москве': ['Выездная проверка', 'Камеральная проверка'],
-            'Москва:ИФНС №46 по г. Москве': ['Отдел оперативного контроля'],
-            'Санкт-Петербург:ИФНС №15 по СПб': ['Выездная проверка'],
-          },
-        }} />
-      </StateSection>
-
-      <StateSection title="VALIDATION_ERROR">
-        <Screen
-          preset={{ cities: ['Москва'], bindings: {} }}
-          validationError="Выберите хотя бы одну инспекцию и услугу"
-        />
-      </StateSection>
-    </>
+    <ScrollView className="flex-1 bg-white">
+      <View className="w-full max-w-md self-center px-4 py-8">
+        <Text className="mb-4 text-lg font-bold text-textPrimary">Screen: Work Area</Text>
+        <Text className="mb-2 text-sm font-medium text-textMuted">IDLE</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 400 }}><WorkAreaScreen /></View>
+        <Text className="mb-2 text-sm font-medium text-textMuted">SELECTED</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 600 }}>
+          <WorkAreaScreen preset={{ cities: ['Москва', 'СПб'], bindings: {
+            'Москва:ИФНС №5': ['Выездная проверка', 'Камеральная проверка'],
+            'Москва:ИФНС №46': ['Отдел оперативного контроля'], 'СПб:ИФНС №15': ['Выездная проверка'],
+          } }} />
+        </View>
+        <Text className="mb-2 text-sm font-medium text-textMuted">VALIDATION ERROR</Text>
+        <View className="mb-6 rounded-xl border border-gray-200 overflow-hidden" style={{ height: 400 }}>
+          <WorkAreaScreen preset={{ cities: ['Москва'], bindings: {} }} validationError="Выберите хотя бы одну инспекцию и услугу" />
+        </View>
+      </View>
+    </ScrollView>
   );
 }
-
-const s = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: Spacing['2xl'],
-    gap: Spacing.lg,
-    backgroundColor: Colors.bgPrimary,
-  },
-
-  // Progress
-  progressWrap: {
-    gap: Spacing.sm,
-  },
-  progressTrack: {
-    height: 4,
-    backgroundColor: Colors.bgSecondary,
-    borderRadius: 2,
-    overflow: 'hidden',
-  },
-  progressBar: {
-    height: 4,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: 2,
-  },
-  step: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-  },
-
-  // Header
-  headerWrap: {
-    gap: Spacing.xs,
-  },
-  title: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  subtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    lineHeight: 22,
-  },
-
-  // Search
-  searchWrap: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    height: 48,
-    backgroundColor: Colors.bgPrimary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.lg,
-  },
-  searchInput: {
-    flex: 1,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    paddingVertical: 0,
-  },
-
-  // Search results
-  searchResults: {
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.lg,
-    backgroundColor: Colors.bgCard,
-    overflow: 'hidden',
-    ...Shadows.sm,
-  },
-  searchItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.bgSecondary,
-  },
-  searchText: {
-    flex: 1,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-  },
-  addBadge: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-
-  // Empty hint
-  emptyHint: {
-    alignItems: 'center',
-    gap: Spacing.sm,
-    paddingVertical: Spacing['3xl'],
-    opacity: 0.6,
-  },
-  emptyText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-  },
-
-  // City block
-  cityBlock: {
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.lg,
-    backgroundColor: Colors.bgCard,
-    overflow: 'hidden',
-    ...Shadows.sm,
-  },
-  cityHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
-  },
-  cityLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  cityPin: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cityName: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  cityBadge: {
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.full,
-    width: 20,
-    height: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cityBadgeText: {
-    fontSize: 10,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.white,
-  },
-  cityRight: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-  },
-
-  // FNS
-  fnsList: {
-    borderTopWidth: 1,
-    borderTopColor: Colors.border,
-  },
-  fnsRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.bgSecondary,
-  },
-  checkbox: {
-    width: 22,
-    height: 22,
-    borderWidth: 1.5,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.sm,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  checkboxActive: {
-    backgroundColor: Colors.brandPrimary,
-    borderColor: Colors.brandPrimary,
-  },
-  fnsName: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textPrimary,
-  },
-  fnsNameActive: {
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.brandPrimary,
-  },
-
-  // Services as chips
-  servicesList: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    paddingBottom: Spacing.md,
-    paddingLeft: Spacing['2xl'] + Spacing.lg,
-  },
-  serviceChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: 6,
-    borderRadius: BorderRadius.full,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    backgroundColor: Colors.bgPrimary,
-  },
-  serviceChipActive: {
-    borderColor: Colors.brandPrimary,
-    backgroundColor: Colors.bgSecondary,
-  },
-  serviceText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textSecondary,
-  },
-  serviceTextActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-
-  // Validation error
-  errorRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    backgroundColor: Colors.statusBg.error,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-  },
-  errorText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    fontWeight: Typography.fontWeight.medium,
-  },
-
-  // Summary
-  summaryRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    paddingVertical: Spacing.xs,
-  },
-  summaryText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-
-  // Buttons
-  buttonRow: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-    marginTop: Spacing.xs,
-  },
-  btnBack: {
-    height: 48,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: Spacing.xs,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.btn,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  btnBackText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  btn: {
-    flex: 1,
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  btnDisabled: {
-    opacity: 0.45,
-  },
-  btnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-});

--- a/components/proto/states/SpecialistDashboardStates.tsx
+++ b/components/proto/states/SpecialistDashboardStates.tsx
@@ -1,400 +1,149 @@
 import React, { useState } from 'react';
-import { View, Text, Image, Pressable, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { View, Text, ScrollView, Pressable, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
-import { MOCK_REQUESTS } from '../../../constants/protoMockData';
-
-function navigate(pageId: string) {
-  if (Platform.OS === 'web') {
-    window.open(`/proto/states/${pageId}`, '_self');
-  }
-}
-
-function SkeletonBlock({ width, height, radius }: { width: string | number; height: number; radius?: number }) {
-  return (
-    <View style={[s.skeleton, { width: width as any, height, borderRadius: radius || BorderRadius.md }]} />
-  );
-}
+import { Colors } from '../../../constants/Colors';
 
 function StatCard({ icon, label, value, color }: { icon: string; label: string; value: string; color: string }) {
   return (
-    <View style={s.statCard}>
-      <View style={[s.statIcon, { backgroundColor: color + '15' }]}>
+    <View className="flex-1 items-center gap-1 rounded-xl border border-borderLight bg-white p-3">
+      <View className="h-9 w-9 items-center justify-center rounded-full" style={{ backgroundColor: color + '15' }}>
         <Feather name={icon as any} size={18} color={color} />
       </View>
-      <Text style={[s.statValue, { color }]}>{value}</Text>
-      <Text style={s.statLabel}>{label}</Text>
+      <Text className="text-lg font-bold" style={{ color }}>{value}</Text>
+      <Text className="text-xs text-textMuted">{label}</Text>
     </View>
   );
 }
 
-function RequestCard({ title, city, budget, service, date }: {
-  title: string; city: string; budget: string; service: string; date: string;
-}) {
+const REQUESTS = [
+  { id: '1', title: 'Декларация 3-НДФЛ за 2025 год', city: 'Москва', fns: 'ИФНС №46', service: 'Камеральная проверка', budget: '5 000 ₽', date: '12.04.2026' },
+  { id: '2', title: 'Регистрация ИП — срочно', city: 'Новосибирск', fns: 'МРИ ФНС №12', service: 'Выездная проверка', budget: '8 000 ₽', date: '11.04.2026' },
+  { id: '3', title: 'Оптимизация налогов для ООО', city: 'Москва', fns: 'ИФНС №15', service: 'Оперативный контроль', budget: '15 000 ₽', date: '10.04.2026' },
+];
+
+function RequestCard({ r }: { r: typeof REQUESTS[0] }) {
   return (
-    <View style={s.card}>
-      <Pressable onPress={() => navigate('public-request-detail')}>
-        <Text style={s.cardTitle} numberOfLines={2}>{title}</Text>
-      </Pressable>
-      <View style={s.cardMeta}>
+    <View className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+      <Text className="text-base font-semibold text-textPrimary" numberOfLines={2}>{r.title}</Text>
+      <View className="flex-row items-center gap-2">
         <Feather name="map-pin" size={12} color={Colors.textMuted} />
-        <Text style={s.metaItem}>{city}</Text>
+        <Text className="text-xs text-textMuted">{r.city} &middot; {r.fns}</Text>
         <Feather name="briefcase" size={12} color={Colors.textMuted} />
-        <Text style={s.metaItem}>{service}</Text>
+        <Text className="text-xs text-textMuted">{r.service}</Text>
       </View>
-      <View style={s.cardBottom}>
-        <View style={s.budgetRow}>
-          <Feather name="dollar-sign" size={14} color={Colors.brandPrimary} />
-          <Text style={s.budget}>{budget}</Text>
-        </View>
-        <View style={s.dateRow}>
-          <Feather name="calendar" size={12} color={Colors.textMuted} />
-          <Text style={s.date}>{date}</Text>
-        </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-base font-semibold text-brandPrimary">{r.budget}</Text>
+        <Text className="text-xs text-textMuted">{r.date}</Text>
       </View>
-      <Pressable style={s.respondBtn} onPress={() => navigate('specialist-respond')}>
+      <Pressable className="mt-1 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
         <Feather name="send" size={14} color={Colors.white} />
-        <Text style={s.respondBtnText}>Откликнуться</Text>
+        <Text className="text-sm font-semibold text-white">Откликнуться</Text>
       </Pressable>
     </View>
   );
 }
 
-// ---------------------------------------------------------------------------
-// STATE: DEFAULT (populated)
-// ---------------------------------------------------------------------------
-
-function PopulatedDashboard() {
-  const [tab, setTab] = useState<'new' | 'inProgress' | 'completed'>('new');
-
-  const newRequests = MOCK_REQUESTS.filter(r => r.status === 'NEW' || r.status === 'ACTIVE');
-  const inProgressRequests = MOCK_REQUESTS.filter(r => r.status === 'IN_PROGRESS');
-  const completedRequests = MOCK_REQUESTS.filter(r => r.status === 'COMPLETED' || r.status === 'CANCELLED');
-
-  const visibleRequests = tab === 'new' ? newRequests : tab === 'inProgress' ? inProgressRequests : completedRequests;
-
+function PopulatedState() {
+  const [tab, setTab] = useState<'new' | 'progress' | 'done'>('new');
+  const tabs = [
+    { key: 'new' as const, label: 'Новые (3)' },
+    { key: 'progress' as const, label: 'В работе (1)' },
+    { key: 'done' as const, label: 'Завершены (2)' },
+  ];
   return (
-    <View style={s.container}>
-      <View style={s.header}>
-        <View style={s.greetingRow}>
-          <View style={{ flex: 1 }}>
-            <Text style={s.greeting}>Добрый день, Алексей!</Text>
-            <Text style={s.subGreeting}>Ваши заявки и отклики</Text>
-          </View>
-          <Pressable style={s.notifBtn}>
-            <Feather name="bell" size={20} color={Colors.textPrimary} />
-            <View style={s.notifDot} />
-          </Pressable>
-        </View>
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View>
+        <Text className="text-xl font-bold text-textPrimary">Добрый день, Алексей!</Text>
+        <Text className="text-sm text-textMuted">Ваши заявки и отклики</Text>
       </View>
-
-      <View style={s.promoBanner}>
-        <Feather name="zap" size={20} color={Colors.brandPrimary} />
-        <View style={{ flex: 1 }}>
-          <Text style={s.promoTitle}>Тариф "Профессионал"</Text>
-          <Text style={s.promoText}>Приоритет в выдаче и расширенный профиль</Text>
-        </View>
-        <Pressable style={s.promoBtn}>
-          <Text style={s.promoBtnText}>Подробнее</Text>
-        </Pressable>
-      </View>
-
-      <View style={s.statsRow}>
-        <StatCard icon="send" label="Активные отклики" value="5" color={Colors.brandPrimary} />
-        <StatCard icon="clock" label="Ожидают ответа" value="3" color={Colors.statusWarning} />
+      <View className="flex-row gap-2">
+        <StatCard icon="send" label="Отклики" value="5" color={Colors.brandPrimary} />
+        <StatCard icon="star" label="Рейтинг" value="4.8" color={Colors.statusWarning} />
         <StatCard icon="dollar-sign" label="Заработок" value="32 500 ₽" color={Colors.statusSuccess} />
       </View>
-
-      <View style={s.tabs}>
-        <Pressable onPress={() => setTab('new')} style={[s.tabBtn, tab === 'new' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'new' ? s.tabTextActive : null]}>Новые ({newRequests.length})</Text>
-        </Pressable>
-        <Pressable onPress={() => setTab('inProgress')} style={[s.tabBtn, tab === 'inProgress' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'inProgress' ? s.tabTextActive : null]}>В работе ({inProgressRequests.length})</Text>
-        </Pressable>
-        <Pressable onPress={() => setTab('completed')} style={[s.tabBtn, tab === 'completed' ? s.tabBtnActive : null]}>
-          <Text style={[s.tabText, tab === 'completed' ? s.tabTextActive : null]}>Завершены ({completedRequests.length})</Text>
-        </Pressable>
-      </View>
-
-      {visibleRequests.length === 0 ? (
-        <View style={s.emptyWrap}>
-          <Feather name="inbox" size={36} color={Colors.textMuted} />
-          <Text style={s.emptyTitle}>Нет заявок в этой категории</Text>
-        </View>
-      ) : (
-        visibleRequests.map((r) => (
-          <RequestCard key={r.id} title={r.title} city={r.city} budget={r.budget} service={r.service} date={r.createdAt} />
-        ))
-      )}
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// STATE: LOADING
-// ---------------------------------------------------------------------------
-
-function LoadingDashboard() {
-  return (
-    <View style={s.container}>
-      <View style={s.header}>
-        <SkeletonBlock width="55%" height={22} />
-        <SkeletonBlock width="40%" height={14} />
-      </View>
-      <SkeletonBlock width="100%" height={64} radius={BorderRadius.card} />
-      <View style={s.statsRow}>
-        {[0, 1, 2].map((i) => (
-          <View key={i} style={[s.statCard, { alignItems: 'center' }]}>
-            <SkeletonBlock width={36} height={36} radius={18} />
-            <SkeletonBlock width={32} height={20} />
-            <SkeletonBlock width={56} height={12} />
-          </View>
+      <View className="flex-row gap-2">
+        {tabs.map((t) => (
+          <Pressable
+            key={t.key}
+            onPress={() => setTab(t.key)}
+            className={`flex-1 h-9 items-center justify-center rounded-lg border ${tab === t.key ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}
+          >
+            <Text className={`text-sm font-medium ${tab === t.key ? 'text-white' : 'text-textMuted'}`}>{t.label}</Text>
+          </Pressable>
         ))}
       </View>
-      <View style={s.tabs}>
-        <SkeletonBlock width="30%" height={36} radius={BorderRadius.btn} />
-        <SkeletonBlock width="30%" height={36} radius={BorderRadius.btn} />
-        <SkeletonBlock width="30%" height={36} radius={BorderRadius.btn} />
-      </View>
-      {[0, 1, 2].map((i) => (
-        <SkeletonBlock key={i} width="100%" height={140} radius={BorderRadius.card} />
-      ))}
-      <View style={{ alignItems: 'center', paddingTop: Spacing.md }}>
-        <ActivityIndicator size="small" color={Colors.brandPrimary} />
-        <Text style={s.loadingText}>Загрузка данных...</Text>
-      </View>
-    </View>
+      {REQUESTS.map((r) => <RequestCard key={r.id} r={r} />)}
+    </ScrollView>
   );
 }
 
-// ---------------------------------------------------------------------------
-// STATE: EMPTY (no new requests)
-// ---------------------------------------------------------------------------
-
-function EmptyDashboard() {
+function EmptyState() {
   return (
-    <View style={s.container}>
-      <View style={s.header}>
-        <View style={s.greetingRow}>
-          <View style={{ flex: 1 }}>
-            <Text style={s.greeting}>Добрый день, Алексей!</Text>
-            <Text style={s.subGreeting}>Ваши заявки и отклики</Text>
-          </View>
-        </View>
-      </View>
-
-      <View style={s.statsRow}>
-        <StatCard icon="send" label="Активные отклики" value="0" color={Colors.textMuted} />
-        <StatCard icon="clock" label="Ожидают ответа" value="0" color={Colors.textMuted} />
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Text className="text-xl font-bold text-textPrimary">Добрый день, Алексей!</Text>
+      <View className="flex-row gap-2">
+        <StatCard icon="send" label="Отклики" value="0" color={Colors.textMuted} />
+        <StatCard icon="star" label="Рейтинг" value="—" color={Colors.textMuted} />
         <StatCard icon="dollar-sign" label="Заработок" value="0 ₽" color={Colors.textMuted} />
       </View>
-
-      <View style={s.emptyBlock}>
-        <View style={s.emptyIconWrap}>
-          <Feather name="inbox" size={40} color={Colors.brandPrimary} />
+      <View className="items-center gap-3 py-10">
+        <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSecondary">
+          <Feather name="inbox" size={32} color={Colors.brandPrimary} />
         </View>
-        <Text style={s.emptyBlockTitle}>Нет активных заявок</Text>
-        <Text style={s.emptyBlockText}>
-          Новые заявки от клиентов появятся здесь. Следите за обновлениями!
+        <Text className="text-lg font-semibold text-textPrimary">Новых заявок пока нет</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">
+          Настройте фильтры или расширьте зону обслуживания, чтобы видеть больше заявок
         </Text>
-        <Pressable style={s.ctaBtn} onPress={() => navigate('public-requests')}>
+        <Pressable className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6">
           <Feather name="search" size={16} color={Colors.white} />
-          <Text style={s.ctaBtnText}>Посмотреть заявки</Text>
+          <Text className="text-sm font-semibold text-white">Посмотреть заявки</Text>
         </Pressable>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
-// ---------------------------------------------------------------------------
-// STATE: NEW_SPECIALIST (first time user)
-// ---------------------------------------------------------------------------
-
-function NewSpecialistDashboard() {
+function ErrorState() {
   return (
-    <View style={s.container}>
-      <View style={s.header}>
-        <Text style={s.greeting}>Добро пожаловать!</Text>
-        <Text style={s.subGreeting}>Ваш профиль специалиста создан</Text>
-      </View>
-
-      <View style={s.welcomeCard}>
-        <View style={s.welcomeIconWrap}>
-          <Feather name="check-circle" size={32} color={Colors.statusSuccess} />
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="items-center gap-3 py-16">
+        <View className="h-16 w-16 items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusBg.error }}>
+          <Feather name="alert-circle" size={32} color={Colors.statusError} />
         </View>
-        <Text style={s.welcomeTitle}>Профиль на модерации</Text>
-        <Text style={s.welcomeText}>
-          Мы проверим ваш профиль в течение 24 часов. После подтверждения вы сможете откликаться на заявки.
+        <Text className="text-lg font-semibold text-textPrimary">Ошибка загрузки</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">
+          Не удалось загрузить данные. Проверьте подключение и попробуйте снова.
         </Text>
+        <Pressable className="mt-2 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6">
+          <Feather name="refresh-cw" size={16} color={Colors.white} />
+          <Text className="text-sm font-semibold text-white">Повторить</Text>
+        </Pressable>
       </View>
-
-      <View style={s.section}>
-        <Text style={s.sectionTitle}>Что дальше</Text>
-        <View style={s.hintList}>
-          <View style={s.hintRow}>
-            <View style={s.hintNum}><Text style={s.hintNumText}>1</Text></View>
-            <View style={{ flex: 1 }}>
-              <Text style={s.hintTitle}>Дождитесь модерации</Text>
-              <Text style={s.hintDesc}>Обычно это занимает до 24 часов</Text>
-            </View>
-          </View>
-          <View style={s.hintRow}>
-            <View style={s.hintNum}><Text style={s.hintNumText}>2</Text></View>
-            <View style={{ flex: 1 }}>
-              <Text style={s.hintTitle}>Просмотрите заявки</Text>
-              <Text style={s.hintDesc}>Ознакомьтесь с текущими заявками клиентов</Text>
-            </View>
-          </View>
-          <View style={s.hintRow}>
-            <View style={s.hintNum}><Text style={s.hintNumText}>3</Text></View>
-            <View style={{ flex: 1 }}>
-              <Text style={s.hintTitle}>Откликайтесь</Text>
-              <Text style={s.hintDesc}>Предлагайте свои услуги и получайте клиентов</Text>
-            </View>
-          </View>
-        </View>
-      </View>
-
-      <Pressable style={[s.ctaBtn, { backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.brandPrimary }]} onPress={() => navigate('public-requests')}>
-        <Feather name="eye" size={16} color={Colors.brandPrimary} />
-        <Text style={[s.ctaBtnText, { color: Colors.brandPrimary }]}>Посмотреть заявки</Text>
-      </Pressable>
-    </View>
+    </ScrollView>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Main export
-// ---------------------------------------------------------------------------
+function LoadingState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="h-6 w-3/5 rounded-md bg-bgSecondary" />
+      <View className="h-4 w-2/5 rounded-md bg-bgSecondary" />
+      <View className="flex-row gap-2">
+        {[0, 1, 2].map((i) => <View key={i} className="flex-1 h-20 rounded-xl bg-bgSecondary" />)}
+      </View>
+      {[0, 1, 2].map((i) => <View key={i} className="h-36 w-full rounded-xl bg-bgSecondary" />)}
+    </ScrollView>
+  );
+}
 
 export function SpecialistDashboardStates() {
   return (
     <>
-      <StateSection title="DEFAULT">
-        <PopulatedDashboard />
-      </StateSection>
-      <StateSection title="LOADING">
-        <LoadingDashboard />
-      </StateSection>
-      <StateSection title="EMPTY">
-        <EmptyDashboard />
-      </StateSection>
-      <StateSection title="NEW_SPECIALIST">
-        <NewSpecialistDashboard />
-      </StateSection>
+      <StateSection title="populated"><PopulatedState /></StateSection>
+      <StateSection title="empty"><EmptyState /></StateSection>
+      <StateSection title="loading"><LoadingState /></StateSection>
+      <StateSection title="error"><ErrorState /></StateSection>
     </>
   );
 }
-
-const s = StyleSheet.create({
-  container: { padding: Spacing.lg, gap: Spacing.lg },
-  header: { gap: Spacing.xs, paddingTop: Spacing.sm },
-  greetingRow: { flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between' },
-  greeting: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  subGreeting: { fontSize: Typography.fontSize.base, color: Colors.textMuted, marginTop: 2 },
-  notifBtn: { width: 40, height: 40, borderRadius: 20, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center' },
-  notifDot: { position: 'absolute', top: 8, right: 8, width: 8, height: 8, borderRadius: 4, backgroundColor: Colors.statusError },
-
-  promoBanner: {
-    flexDirection: 'row', alignItems: 'center', gap: Spacing.md,
-    backgroundColor: Colors.bgSurface, borderRadius: BorderRadius.card, padding: Spacing.lg,
-    borderWidth: 1, borderColor: Colors.border,
-  },
-  promoTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  promoText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 1 },
-  promoBtn: { paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.btn, backgroundColor: Colors.brandPrimary },
-  promoBtnText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
-
-  statsRow: { flexDirection: 'row', gap: Spacing.sm },
-  statCard: {
-    flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card,
-    padding: Spacing.md, alignItems: 'center', gap: Spacing.xs,
-    borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
-  },
-  statIcon: { width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' },
-  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold },
-  statLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  tabs: { flexDirection: 'row', gap: Spacing.sm },
-  tabBtn: {
-    flex: 1, height: 36, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center',
-    borderWidth: 1, borderColor: Colors.border, backgroundColor: Colors.bgCard,
-  },
-  tabBtnActive: { borderColor: Colors.brandPrimary, backgroundColor: Colors.brandPrimary },
-  tabText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, fontWeight: Typography.fontWeight.medium },
-  tabTextActive: { color: Colors.white, fontWeight: Typography.fontWeight.semibold },
-
-  card: {
-    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg,
-    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm,
-  },
-  cardTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  cardMeta: { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs },
-  metaItem: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-  cardBottom: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  budgetRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  budget: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.brandPrimary },
-  dateRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  date: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-  respondBtn: {
-    height: 40, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn,
-    alignItems: 'center', justifyContent: 'center', marginTop: Spacing.xs,
-    flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm,
-  },
-  respondBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
-
-  emptyWrap: { alignItems: 'center', padding: Spacing['2xl'], gap: Spacing.sm },
-  emptyTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-
-  // Empty state block
-  emptyBlock: { alignItems: 'center', paddingVertical: Spacing['3xl'], gap: Spacing.md },
-  emptyIconWrap: {
-    width: 72, height: 72, borderRadius: 36, backgroundColor: Colors.bgSurface,
-    alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border,
-  },
-  emptyBlockTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  emptyBlockText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 280 },
-
-  // CTA
-  ctaBtn: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm,
-    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, ...Shadows.sm,
-  },
-  ctaBtnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
-
-  // Welcome card (new specialist)
-  welcomeCard: {
-    alignItems: 'center', gap: Spacing.md,
-    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing['2xl'],
-    borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
-  },
-  welcomeIconWrap: {
-    width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.statusBg.success,
-    alignItems: 'center', justifyContent: 'center',
-  },
-  welcomeTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  welcomeText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 300 },
-
-  // Section / hints
-  section: { gap: Spacing.sm },
-  sectionTitle: { fontSize: Typography.fontSize.md, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  hintList: { gap: Spacing.sm },
-  hintRow: {
-    flexDirection: 'row', alignItems: 'flex-start', gap: Spacing.md,
-    backgroundColor: Colors.bgCard, padding: Spacing.md, borderRadius: BorderRadius.card,
-    borderWidth: 1, borderColor: Colors.border,
-  },
-  hintNum: {
-    width: 28, height: 28, borderRadius: 14, backgroundColor: Colors.brandPrimary,
-    alignItems: 'center', justifyContent: 'center',
-  },
-  hintNumText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold, color: Colors.white },
-  hintTitle: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  hintDesc: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 },
-
-  // Loading
-  skeleton: { backgroundColor: Colors.bgSurface, opacity: 0.7 },
-  loadingText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: Spacing.sm },
-});

--- a/components/proto/states/SpecialistRespondStates.tsx
+++ b/components/proto/states/SpecialistRespondStates.tsx
@@ -1,308 +1,130 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { View, Text, ScrollView, Pressable, TextInput, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { StateSection } from '../StateSection';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { Colors } from '../../../constants/Colors';
 
-function navigate(pageId: string) {
-  if (Platform.OS === 'web') {
-    window.open(`/proto/states/${pageId}`, '_self');
-  }
-}
-
-// ---------------------------------------------------------------------------
-// STATE: DEFAULT (form)
-// ---------------------------------------------------------------------------
-
-function FormScreen() {
+function IdleState() {
   const [price, setPrice] = useState('4 500');
   const [message, setMessage] = useState('Здравствуйте! Готов помочь с декларацией. Опыт — 8 лет, 200+ успешных деклараций.');
   const [deadline, setDeadline] = useState('2 рабочих дня');
 
   return (
-    <View style={s.container}>
-      <View style={s.requestInfo}>
-        <View style={s.requestBadge}>
-          <Text style={s.requestBadgeText}>Заявка #1</Text>
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+        <View className="self-start rounded-full bg-bgSecondary px-2 py-0.5">
+          <Text className="text-xs font-medium text-textMuted">Заявка #1</Text>
         </View>
-        <Text style={s.requestTitle}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
-        <Text style={s.requestDesc} numberOfLines={2}>
+        <Text className="text-lg font-semibold text-textPrimary">Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+        <Text className="text-sm text-textSecondary" numberOfLines={2}>
           Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры.
         </Text>
-        <View style={s.requestMeta}>
-          <View style={s.metaChip}>
+        <View className="flex-row flex-wrap gap-2">
+          <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
             <Feather name="map-pin" size={12} color={Colors.textMuted} />
-            <Text style={s.metaText}>Москва</Text>
+            <Text className="text-xs text-textMuted">Москва &middot; ИФНС №46</Text>
           </View>
-          <View style={s.metaChip}>
+          <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
             <Feather name="dollar-sign" size={12} color={Colors.textMuted} />
-            <Text style={s.metaText}>3 000 — 5 000 &#8381;</Text>
-          </View>
-          <View style={s.metaChip}>
-            <Feather name="briefcase" size={12} color={Colors.textMuted} />
-            <Text style={s.metaText}>Декларация 3-НДФЛ</Text>
+            <Text className="text-xs text-textMuted">3 000 — 5 000 ₽</Text>
           </View>
         </View>
       </View>
 
-      <View style={s.form}>
-        <View style={s.field}>
-          <Text style={s.label}>Ваша цена *</Text>
-          <View style={s.inputWrap}>
+      <View className="gap-4">
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Ваша цена *</Text>
+          <View className="h-12 flex-row items-center gap-2 rounded-lg border border-borderLight bg-white px-3">
             <Feather name="dollar-sign" size={16} color={Colors.textMuted} />
             <TextInput
               value={price}
               onChangeText={setPrice}
-              placeholder="Укажите стоимость в рублях"
+              placeholder="Стоимость в рублях"
               placeholderTextColor={Colors.textMuted}
               keyboardType="number-pad"
-              style={s.inputInner}
+              className="flex-1 text-base text-textPrimary"
+              style={{ outlineStyle: 'none' as any }}
             />
-            <Text style={s.inputSuffix}>₽</Text>
+            <Text className="text-sm text-textMuted">₽</Text>
           </View>
         </View>
-        <View style={s.field}>
-          <Text style={s.label}>Сообщение клиенту *</Text>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Сообщение клиенту *</Text>
           <TextInput
             value={message}
             onChangeText={setMessage}
             multiline
-            style={s.textarea}
+            className="min-h-[100px] rounded-lg border border-borderLight bg-white p-3 text-base text-textPrimary"
+            style={{ textAlignVertical: 'top', outlineStyle: 'none' as any }}
           />
-          <Text style={s.charCount}>{message.length}/500</Text>
+          <Text className="self-end text-xs text-textMuted">{message.length}/500</Text>
         </View>
-        <View style={s.field}>
-          <Text style={s.label}>Срок выполнения</Text>
-          <View style={s.inputWrap}>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Срок выполнения *</Text>
+          <View className="h-12 flex-row items-center gap-2 rounded-lg border border-borderLight bg-white px-3">
             <Feather name="clock" size={16} color={Colors.textMuted} />
             <TextInput
               value={deadline}
               onChangeText={setDeadline}
-              style={s.inputInner}
+              className="flex-1 text-base text-textPrimary"
+              style={{ outlineStyle: 'none' as any }}
             />
           </View>
         </View>
       </View>
 
-      <Pressable style={s.btn}>
+      <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
         <Feather name="send" size={16} color={Colors.white} />
-        <Text style={s.btnText}>Отправить отклик</Text>
+        <Text className="text-base font-semibold text-white">Отправить отклик</Text>
       </Pressable>
-
-      <Pressable style={s.cancelBtn} onPress={() => navigate('specialist-dashboard')}>
-        <Text style={s.cancelBtnText}>Отмена</Text>
+      <Pressable className="items-center py-2">
+        <Text className="text-sm text-textMuted">Отмена</Text>
       </Pressable>
-    </View>
+    </ScrollView>
   );
 }
 
-// ---------------------------------------------------------------------------
-// STATE: SUBMITTING
-// ---------------------------------------------------------------------------
-
-function SubmittingScreen() {
+function LoadingState() {
   return (
-    <View style={s.container}>
-      <View style={s.requestInfo}>
-        <Text style={s.requestTitle}>Заполнить декларацию 3-НДФЛ за 2025 год</Text>
-        <View style={s.requestMeta}>
-          <View style={s.metaChip}>
-            <Feather name="map-pin" size={12} color={Colors.textMuted} />
-            <Text style={s.metaText}>Москва</Text>
-          </View>
-        </View>
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="h-32 w-full rounded-xl bg-bgSecondary" />
+      <View className="h-12 w-full rounded-lg bg-bgSecondary" />
+      <View className="h-24 w-full rounded-lg bg-bgSecondary" />
+      <View className="h-12 w-full rounded-lg bg-bgSecondary" />
+      <View className="items-center pt-4">
+        <ActivityIndicator size="small" color={Colors.brandPrimary} />
+        <Text className="mt-2 text-xs text-textMuted">Загрузка заявки...</Text>
       </View>
-
-      <View style={s.submittingBlock}>
-        <ActivityIndicator size="large" color={Colors.brandPrimary} />
-        <Text style={s.submittingTitle}>Отправка отклика...</Text>
-        <Text style={s.submittingText}>Пожалуйста, подождите</Text>
-      </View>
-    </View>
+    </ScrollView>
   );
 }
 
-// ---------------------------------------------------------------------------
-// STATE: SUBMITTED (success)
-// ---------------------------------------------------------------------------
-
-function SubmittedScreen() {
+function ErrorState() {
   return (
-    <View style={s.container}>
-      <View style={s.successBlock}>
-        <View style={s.successIconWrap}>
-          <Feather name="check-circle" size={48} color={Colors.statusSuccess} />
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="items-center gap-3 py-16">
+        <View className="h-16 w-16 items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusBg.error }}>
+          <Feather name="alert-circle" size={32} color={Colors.statusError} />
         </View>
-        <Text style={s.successTitle}>Отклик отправлен!</Text>
-        <Text style={s.successText}>
-          Клиент получит уведомление о вашем предложении. Вы увидите статус в разделе "Мои отклики".
+        <Text className="text-lg font-semibold text-textPrimary">Не удалось отправить отклик</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">
+          Проверьте подключение и попробуйте снова.
         </Text>
-
-        <View style={s.successSummary}>
-          <View style={s.summaryRow}>
-            <Text style={s.summaryLabel}>Заявка</Text>
-            <Text style={s.summaryValue}>Декларация 3-НДФЛ</Text>
-          </View>
-          <View style={s.divider} />
-          <View style={s.summaryRow}>
-            <Text style={s.summaryLabel}>Ваша цена</Text>
-            <Text style={[s.summaryValue, { color: Colors.brandPrimary }]}>4 500 ₽</Text>
-          </View>
-          <View style={s.divider} />
-          <View style={s.summaryRow}>
-            <Text style={s.summaryLabel}>Срок</Text>
-            <Text style={s.summaryValue}>2 рабочих дня</Text>
-          </View>
-        </View>
-
-        <Pressable style={s.btn} onPress={() => navigate('specialist-my-responses')}>
-          <Feather name="list" size={16} color={Colors.white} />
-          <Text style={s.btnText}>К моим откликам</Text>
-        </Pressable>
-        <Pressable style={s.outlineBtn} onPress={() => navigate('specialist-dashboard')}>
-          <Text style={s.outlineBtnText}>На главную</Text>
-        </Pressable>
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// STATE: ERROR
-// ---------------------------------------------------------------------------
-
-function ErrorScreen() {
-  return (
-    <View style={s.container}>
-      <View style={s.errorBlock}>
-        <View style={s.errorIconWrap}>
-          <Feather name="alert-circle" size={40} color={Colors.statusError} />
-        </View>
-        <Text style={s.errorTitle}>Не удалось отправить отклик</Text>
-        <Text style={s.errorText}>Произошла ошибка при отправке. Проверьте подключение и попробуйте снова.</Text>
-        <Pressable style={s.retryBtn}>
+        <Pressable className="mt-2 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6">
           <Feather name="refresh-cw" size={16} color={Colors.white} />
-          <Text style={s.retryBtnText}>Попробовать снова</Text>
-        </Pressable>
-        <Pressable style={s.cancelBtn} onPress={() => navigate('specialist-dashboard')}>
-          <Text style={s.cancelBtnText}>Вернуться назад</Text>
+          <Text className="text-sm font-semibold text-white">Попробовать снова</Text>
         </Pressable>
       </View>
-    </View>
+    </ScrollView>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Main export
-// ---------------------------------------------------------------------------
 
 export function SpecialistRespondStates() {
   return (
     <>
-      <StateSection title="DEFAULT">
-        <FormScreen />
-      </StateSection>
-      <StateSection title="SUBMITTING">
-        <SubmittingScreen />
-      </StateSection>
-      <StateSection title="SUBMITTED">
-        <SubmittedScreen />
-      </StateSection>
-      <StateSection title="ERROR">
-        <ErrorScreen />
-      </StateSection>
+      <StateSection title="idle"><IdleState /></StateSection>
+      <StateSection title="loading"><LoadingState /></StateSection>
+      <StateSection title="error"><ErrorState /></StateSection>
     </>
   );
 }
-
-const s = StyleSheet.create({
-  container: { padding: Spacing.lg, gap: Spacing.lg },
-
-  requestInfo: {
-    backgroundColor: Colors.bgCard, padding: Spacing.lg, borderRadius: BorderRadius.card, gap: Spacing.sm,
-    borderWidth: 1, borderColor: Colors.border, ...Shadows.sm,
-  },
-  requestBadge: {
-    alignSelf: 'flex-start', backgroundColor: Colors.bgSurface,
-    paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full,
-  },
-  requestBadgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.medium, color: Colors.textMuted },
-  requestTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  requestDesc: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
-  requestMeta: { flexDirection: 'row', gap: Spacing.sm, flexWrap: 'wrap' },
-  metaChip: {
-    flexDirection: 'row', alignItems: 'center', gap: 4,
-    backgroundColor: Colors.bgSurface, paddingHorizontal: Spacing.sm, paddingVertical: 4, borderRadius: BorderRadius.full,
-  },
-  metaText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-
-  form: { gap: Spacing.lg },
-  field: { gap: Spacing.xs },
-  label: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
-  inputWrap: {
-    height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
-    borderRadius: BorderRadius.input, paddingHorizontal: Spacing.lg,
-    flexDirection: 'row', alignItems: 'center', gap: Spacing.sm,
-  },
-  inputInner: { flex: 1, fontSize: Typography.fontSize.base, color: Colors.textPrimary },
-  inputSuffix: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
-  textarea: {
-    minHeight: 100, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border,
-    borderRadius: BorderRadius.input, padding: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary,
-    textAlignVertical: 'top',
-  },
-  charCount: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, alignSelf: 'flex-end' },
-
-  btn: {
-    height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn,
-    alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm,
-  },
-  btnText: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
-
-  cancelBtn: { alignItems: 'center', paddingVertical: Spacing.sm },
-  cancelBtnText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  outlineBtn: {
-    height: 44, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center',
-    borderWidth: 1, borderColor: Colors.border,
-  },
-  outlineBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary },
-
-  // Submitting
-  submittingBlock: { alignItems: 'center', paddingVertical: Spacing['4xl'], gap: Spacing.md },
-  submittingTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  submittingText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  // Success
-  successBlock: { alignItems: 'center', paddingVertical: Spacing['2xl'], gap: Spacing.md },
-  successIconWrap: {
-    width: 80, height: 80, borderRadius: 40, backgroundColor: Colors.statusBg.success,
-    alignItems: 'center', justifyContent: 'center',
-  },
-  successTitle: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  successText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 300 },
-
-  successSummary: {
-    width: '100%', backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg,
-    borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm,
-  },
-  summaryRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  summaryLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-  summaryValue: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  divider: { height: 1, backgroundColor: Colors.border },
-
-  // Error
-  errorBlock: { alignItems: 'center', paddingVertical: Spacing['4xl'], gap: Spacing.md },
-  errorIconWrap: {
-    width: 72, height: 72, borderRadius: 36, backgroundColor: Colors.statusBg.error,
-    alignItems: 'center', justifyContent: 'center',
-  },
-  errorTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  errorText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 280 },
-  retryBtn: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm,
-    height: 44, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn,
-    paddingHorizontal: Spacing['2xl'], marginTop: Spacing.sm,
-  },
-  retryBtnText: { fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white },
-});

--- a/components/proto/states/SpecialistSettingsStates.tsx
+++ b/components/proto/states/SpecialistSettingsStates.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, Pressable, TextInput, Switch, ActivityIndicator } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { StateSection } from '../StateSection';
+import { Colors } from '../../../constants/Colors';
+
+const SERVICES = ['Выездная проверка', 'Камеральная проверка', 'Оперативный контроль'];
+const FNS_LIST = ['ИФНС №46', 'ИФНС №15', 'МРИ ФНС №12', 'ИФНС №7', 'ИФНС №28'];
+
+function IdleState() {
+  const [name, setName] = useState('Алексей Петров');
+  const [phone, setPhone] = useState('+7 (916) 123-45-67');
+  const [telegram, setTelegram] = useState('@alexpetrov');
+  const [whatsapp, setWhatsapp] = useState('+7 916 123 45 67');
+  const [address, setAddress] = useState('Москва, ул. Тверская, 12, офис 305');
+  const [hours, setHours] = useState('Пн-Пт 9:00-18:00');
+  const [available, setAvailable] = useState(true);
+  const [selectedServices, setSelectedServices] = useState([0, 1]);
+  const [selectedFns, setSelectedFns] = useState([0, 1, 2]);
+  const [notifResponses, setNotifResponses] = useState(true);
+  const [notifMessages, setNotifMessages] = useState(true);
+
+  const toggleService = (i: number) => {
+    setSelectedServices((s) => s.includes(i) ? s.filter((x) => x !== i) : [...s, i]);
+  };
+  const toggleFns = (i: number) => {
+    setSelectedFns((s) => s.includes(i) ? s.filter((x) => x !== i) : [...s, i]);
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 20 }}>
+      <Text className="text-xl font-bold text-textPrimary">Настройки профиля</Text>
+
+      {/* Avatar */}
+      <View className="items-center gap-2">
+        <View className="h-20 w-20 items-center justify-center rounded-full bg-bgSecondary">
+          <Feather name="user" size={32} color={Colors.textMuted} />
+        </View>
+        <Pressable><Text className="text-sm font-medium text-brandPrimary">Изменить фото</Text></Pressable>
+      </View>
+
+      {/* Fields */}
+      <View className="gap-3">
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Имя</Text>
+          <TextInput value={name} onChangeText={setName} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Телефон</Text>
+          <TextInput value={phone} onChangeText={setPhone} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Telegram</Text>
+          <TextInput value={telegram} onChangeText={setTelegram} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">WhatsApp</Text>
+          <TextInput value={whatsapp} onChangeText={setWhatsapp} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Адрес офиса</Text>
+          <TextInput value={address} onChangeText={setAddress} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Часы работы</Text>
+          <TextInput value={hours} onChangeText={setHours} className="h-11 rounded-lg border border-borderLight px-3 text-base text-textPrimary" style={{ outlineStyle: 'none' as any }} />
+        </View>
+      </View>
+
+      {/* Services */}
+      <View className="gap-2">
+        <Text className="text-base font-semibold text-textPrimary">Услуги</Text>
+        <View className="flex-row flex-wrap gap-2">
+          {SERVICES.map((s, i) => (
+            <Pressable key={s} onPress={() => toggleService(i)}
+              className={`h-9 items-center justify-center rounded-full border px-4 ${selectedServices.includes(i) ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}>
+              <Text className={`text-sm ${selectedServices.includes(i) ? 'font-semibold text-white' : 'text-textMuted'}`}>{s}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      {/* FNS coverage */}
+      <View className="gap-2">
+        <Text className="text-base font-semibold text-textPrimary">Зона обслуживания (ФНС)</Text>
+        <Text className="text-xs text-textMuted">Москва</Text>
+        <View className="flex-row flex-wrap gap-2">
+          {FNS_LIST.map((f, i) => (
+            <Pressable key={f} onPress={() => toggleFns(i)}
+              className={`h-8 items-center justify-center rounded-full border px-3 ${selectedFns.includes(i) ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}>
+              <Text className={`text-xs ${selectedFns.includes(i) ? 'font-semibold text-white' : 'text-textMuted'}`}>{f}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      {/* Availability */}
+      <View className="flex-row items-center justify-between rounded-xl border border-borderLight p-4">
+        <View className="flex-1">
+          <Text className="text-base font-semibold text-textPrimary">Принимаю заявки</Text>
+          <Text className="text-xs text-textMuted">{available ? 'Вы видны в каталоге' : 'Вы скрыты из каталога'}</Text>
+        </View>
+        <Switch value={available} onValueChange={setAvailable} trackColor={{ true: Colors.brandPrimary, false: '#ddd' }} />
+      </View>
+
+      {/* Notifications */}
+      <View className="gap-3">
+        <Text className="text-base font-semibold text-textPrimary">Уведомления</Text>
+        <View className="flex-row items-center justify-between">
+          <Text className="text-sm text-textSecondary">Новые отклики</Text>
+          <Switch value={notifResponses} onValueChange={setNotifResponses} trackColor={{ true: Colors.brandPrimary, false: '#ddd' }} />
+        </View>
+        <View className="flex-row items-center justify-between">
+          <Text className="text-sm text-textSecondary">Новые сообщения</Text>
+          <Switch value={notifMessages} onValueChange={setNotifMessages} trackColor={{ true: Colors.brandPrimary, false: '#ddd' }} />
+        </View>
+      </View>
+
+      <Pressable className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+        <Text className="text-base font-semibold text-white">Сохранить</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function SavingState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Text className="text-xl font-bold text-textPrimary">Настройки профиля</Text>
+      <View className="items-center gap-3 py-16">
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        <Text className="text-base font-semibold text-textPrimary">Сохранение...</Text>
+      </View>
+      <Pressable className="h-12 items-center justify-center rounded-lg bg-bgSecondary">
+        <Text className="text-base font-semibold text-textMuted">Сохранить</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+function ErrorState() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Text className="text-xl font-bold text-textPrimary">Настройки профиля</Text>
+      <View className="rounded-lg border p-3" style={{ borderColor: Colors.statusError, backgroundColor: Colors.statusBg.error }}>
+        <Text className="text-sm" style={{ color: Colors.statusError }}>Ошибка сохранения. Проверьте данные и попробуйте снова.</Text>
+      </View>
+      <View className="gap-1">
+        <Text className="text-sm font-medium text-textSecondary">Имя</Text>
+        <View className="h-11 justify-center rounded-lg border border-borderLight px-3">
+          <Text className="text-base text-textPrimary">Алексей Петров</Text>
+        </View>
+      </View>
+      <Pressable className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+        <Text className="text-base font-semibold text-white">Повторить</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+export function SpecialistSettingsStates() {
+  return (
+    <>
+      <StateSection title="idle"><IdleState /></StateSection>
+      <StateSection title="saving"><SavingState /></StateSection>
+      <StateSection title="error"><ErrorState /></StateSection>
+    </>
+  );
+}

--- a/components/proto/states/TermsStates.tsx
+++ b/components/proto/states/TermsStates.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { StateSection } from '../StateSection';
+import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
+
+// ---------------------------------------------------------------------------
+// LOADED state — terms content rendered
+// ---------------------------------------------------------------------------
+function LoadedState() {
+  return (
+    <View style={s.container}>
+      {/* Header */}
+      <View style={s.header}>
+        <Pressable style={s.closeBtn}>
+          <Feather name="x" size={20} color={Colors.textPrimary} />
+        </Pressable>
+        <Text style={s.headerTitle}>Условия использования</Text>
+        <View style={{ width: 32 }} />
+      </View>
+
+      {/* Content */}
+      <View style={s.content}>
+        <Text style={s.sectionTitle}>1. Общие положения</Text>
+        <Text style={s.paragraph}>
+          Настоящие Условия использования (далее — «Условия») регулируют порядок использования
+          платформы «Налоговик» (далее — «Платформа»), предоставляющей услуги по поиску и подбору
+          налоговых специалистов.
+        </Text>
+        <Text style={s.paragraph}>
+          Используя Платформу, вы подтверждаете, что ознакомились с настоящими Условиями и принимаете
+          их в полном объёме.
+        </Text>
+
+        <Text style={s.sectionTitle}>2. Регистрация и учётная запись</Text>
+        <Text style={s.paragraph}>
+          Для использования функций Платформы необходимо пройти регистрацию, указав действующий
+          адрес электронной почты. Авторизация осуществляется посредством одноразового кода (OTP),
+          направляемого на указанный email.
+        </Text>
+        <Text style={s.paragraph}>
+          Пользователь несёт ответственность за сохранность доступа к своей электронной почте и
+          учётной записи на Платформе.
+        </Text>
+
+        <Text style={s.sectionTitle}>3. Роли пользователей</Text>
+        <Text style={s.paragraph}>
+          На Платформе предусмотрены следующие роли: Клиент и Специалист. Клиент может создавать
+          заявки на налоговые услуги. Специалист может откликаться на заявки и оказывать услуги.
+        </Text>
+
+        <Text style={s.sectionTitle}>4. Ограничение ответственности</Text>
+        <Text style={s.paragraph}>
+          Платформа является информационным посредником и не несёт ответственности за качество
+          услуг, оказываемых специалистами. Все финансовые расчёты между клиентами и специалистами
+          осуществляются напрямую, без участия Платформы.
+        </Text>
+
+        <Text style={s.sectionTitle}>5. Конфиденциальность</Text>
+        <Text style={s.paragraph}>
+          Платформа обрабатывает персональные данные пользователей в соответствии с Политикой
+          конфиденциальности. Данные не передаются третьим лицам без согласия пользователя, за
+          исключением случаев, предусмотренных законодательством.
+        </Text>
+
+        <Text style={s.sectionTitle}>6. Изменение условий</Text>
+        <Text style={s.paragraph}>
+          Администрация Платформы оставляет за собой право вносить изменения в настоящие Условия.
+          Актуальная версия всегда доступна на данной странице.
+        </Text>
+
+        <Text style={s.updated}>Последнее обновление: 01.04.2026</Text>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LOADING state — fetching terms content
+// ---------------------------------------------------------------------------
+function LoadingState() {
+  return (
+    <View style={s.container}>
+      <View style={s.header}>
+        <Pressable style={s.closeBtn}>
+          <Feather name="x" size={20} color={Colors.textPrimary} />
+        </Pressable>
+        <Text style={s.headerTitle}>Условия использования</Text>
+        <View style={{ width: 32 }} />
+      </View>
+      <View style={s.content}>
+        <View style={[s.skelLine, { width: '60%', height: 18 }]} />
+        <View style={[s.skelLine, { width: '100%' }]} />
+        <View style={[s.skelLine, { width: '100%' }]} />
+        <View style={[s.skelLine, { width: '80%' }]} />
+        <View style={{ height: Spacing.lg }} />
+        <View style={[s.skelLine, { width: '50%', height: 18 }]} />
+        <View style={[s.skelLine, { width: '100%' }]} />
+        <View style={[s.skelLine, { width: '90%' }]} />
+        <View style={[s.skelLine, { width: '70%' }]} />
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MAIN EXPORT
+// ---------------------------------------------------------------------------
+export function TermsStates() {
+  return (
+    <View style={{ gap: Spacing['4xl'] }}>
+      <StateSection title="LOADED" pageId="terms">
+        <LoadedState />
+      </StateSection>
+
+      <StateSection title="LOADING" pageId="terms">
+        <LoadingState />
+      </StateSection>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// STYLES
+// ---------------------------------------------------------------------------
+const s = StyleSheet.create({
+  container: { gap: 0 },
+
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.borderLight,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: Colors.bgSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+
+  // Content
+  content: {
+    padding: Spacing.xl,
+    gap: Spacing.md,
+  },
+  sectionTitle: {
+    fontSize: Typography.fontSize.md,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginTop: Spacing.sm,
+  },
+  paragraph: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+  updated: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    marginTop: Spacing.lg,
+    textAlign: 'center',
+  },
+
+  // Skeleton
+  skelLine: {
+    height: 12,
+    borderRadius: 4,
+    backgroundColor: Colors.bgSecondary,
+  },
+});

--- a/constants/pageRegistry.ts
+++ b/constants/pageRegistry.ts
@@ -48,14 +48,62 @@ export const PAGE_GROUPS: PageGroup[] = [
 export const pageRegistry: PageEntry[] = [
   // Brand
   { id: 'brand', title: 'Бренд и стили', group: 'Brand', route: '/brand', stateCount: 1, nav: 'none' },
+  // Auth
+  { id: 'auth-email', title: 'Вход — Email', group: 'Auth', route: '/auth-email', stateCount: 1, nav: 'auth' },
+  { id: 'auth-otp', title: 'Вход — Код', group: 'Auth', route: '/auth-otp', stateCount: 1, nav: 'auth' },
+  // Onboarding
+  { id: 'onboarding-username', title: 'Онбординг — Имя', group: 'Onboarding', route: '/onboarding-username', stateCount: 1, nav: 'auth' },
+  { id: 'onboarding-profile', title: 'Онбординг — Профиль', group: 'Onboarding', route: '/onboarding-profile', stateCount: 1, nav: 'auth' },
+  { id: 'work-area', title: 'Онбординг — Город/ФНС', group: 'Onboarding', route: '/work-area', stateCount: 1, nav: 'auth' },
+  // Public
+  { id: 'landing', title: 'Главная', group: 'Public', route: '/landing', stateCount: 3, nav: 'public' },
+  { id: 'specialists-catalog', title: 'Каталог специалистов', group: 'Public', route: '/specialists-catalog', stateCount: 4, nav: 'public' },
+  { id: 'specialist-public-profile', title: 'Профиль специалиста', group: 'Public', route: '/specialist-public-profile', stateCount: 1, nav: 'public' },
+  { id: 'public-requests-feed', title: 'Лента заявок', group: 'Public', route: '/public-requests-feed', stateCount: 1, nav: 'public' },
+  { id: 'public-request-detail', title: 'Заявка (публичная)', group: 'Public', route: '/public-request-detail', stateCount: 3, nav: 'public' },
+  { id: 'terms', title: 'Условия', group: 'Public', route: '/terms', stateCount: 2, nav: 'public' },
+  // Dashboard (Client)
+  { id: 'dashboard', title: 'Главная клиента', group: 'Dashboard', route: '/dashboard', stateCount: 11, nav: 'client', activeTab: 'home' },
+  { id: 'my-requests', title: 'Мои заявки', group: 'Dashboard', route: '/my-requests', stateCount: 4, nav: 'client', activeTab: 'requests' },
+  { id: 'new-request', title: 'Новая заявка', group: 'Dashboard', route: '/new-request', stateCount: 2, nav: 'client' },
+  { id: 'request-detail', title: 'Детали заявки', group: 'Dashboard', route: '/request-detail', stateCount: 6, nav: 'client' },
+  { id: 'responses', title: 'Отклики на заявку', group: 'Dashboard', route: '/responses', stateCount: 12, nav: 'client' },
+  { id: 'messages', title: 'Сообщения', group: 'Dashboard', route: '/messages', stateCount: 4, nav: 'client', activeTab: 'messages' },
+  { id: 'chat-thread', title: 'Чат', group: 'Dashboard', route: '/chat-thread', stateCount: 3, nav: 'client' },
+  { id: 'client-settings', title: 'Настройки клиента', group: 'Dashboard', route: '/client-settings', stateCount: 1, nav: 'client', activeTab: 'profile' },
+  // Specialist
+  { id: 'specialist-dashboard', title: 'Главная специалиста', group: 'Specialist', route: '/specialist-dashboard', stateCount: 4, nav: 'specialist' },
+  { id: 'my-responses', title: 'Мои отклики', group: 'Specialist', route: '/my-responses', stateCount: 4, nav: 'specialist' },
+  { id: 'specialist-respond', title: 'Откликнуться', group: 'Specialist', route: '/specialist-respond', stateCount: 2, nav: 'specialist' },
+  { id: 'specialist-settings', title: 'Настройки специалиста', group: 'Specialist', route: '/specialist-settings', stateCount: 1, nav: 'specialist' },
+  // Other
+  { id: 'not-found', title: '404', group: 'Public', route: '/not-found', stateCount: 1, nav: 'none' },
 ];
 
 export const PAGE_TRANSITIONS: Record<string, { to: string; action: string }[]> = {
   'brand': [],
+  'landing': [{ to: 'auth-email', action: 'Войти' }, { to: 'specialists-catalog', action: 'Каталог' }, { to: 'public-requests-feed', action: 'Заявки' }],
+  'auth-email': [{ to: 'auth-otp', action: 'Отправить код' }],
+  'auth-otp': [{ to: 'onboarding-username', action: 'Первый вход' }, { to: 'dashboard', action: 'Вход' }],
+  'onboarding-username': [{ to: 'onboarding-profile', action: 'Далее' }],
+  'onboarding-profile': [{ to: 'work-area', action: 'Далее' }],
+  'work-area': [{ to: 'dashboard', action: 'Завершить' }],
+  'dashboard': [{ to: 'new-request', action: 'Новая заявка' }, { to: 'request-detail', action: 'Открыть заявку' }],
+  'my-requests': [{ to: 'request-detail', action: 'Открыть заявку' }, { to: 'new-request', action: 'Новая заявка' }],
+  'request-detail': [{ to: 'responses', action: 'Посмотреть отклики' }, { to: 'chat-thread', action: 'Написать' }],
+  'responses': [{ to: 'chat-thread', action: 'Написать специалисту' }],
+  'messages': [{ to: 'chat-thread', action: 'Открыть чат' }],
+  'specialists-catalog': [{ to: 'specialist-public-profile', action: 'Открыть профиль' }],
+  'specialist-dashboard': [{ to: 'specialist-respond', action: 'Откликнуться' }, { to: 'my-responses', action: 'Мои отклики' }],
+  'my-responses': [{ to: 'chat-thread', action: 'Написать клиенту' }],
 };
 
 export const ROLE_PAGES: Record<string, string[]> = {
-  public: ['brand'],
+  public: ['brand', 'landing', 'specialists-catalog', 'specialist-public-profile', 'public-requests-feed', 'public-request-detail', 'terms', 'not-found'],
+  auth: ['auth-email', 'auth-otp'],
+  onboarding: ['onboarding-username', 'onboarding-profile', 'work-area'],
+  client: ['dashboard', 'my-requests', 'new-request', 'request-detail', 'responses', 'messages', 'chat-thread', 'client-settings'],
+  specialist: ['specialist-dashboard', 'my-responses', 'specialist-respond', 'specialist-settings'],
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added 24 proto pages covering all SA screens (except admin)
- Auth: email login, OTP verification
- Onboarding: username, profile, city/FNS selection
- Public: landing, specialist catalog, request feed, request detail, terms
- Client: dashboard, requests, new request, detail, responses, messages, chat, settings
- Specialist: dashboard, my responses, respond, settings
- All UI in Russian, NativeWind className, interactive components
- pageRegistry.ts with full transitions and role mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)