### PR TITLE
feat: shared UI component library (#801)

### DIFF
--- a/components/ui/CityFnsPicker.tsx
+++ b/components/ui/CityFnsPicker.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export interface CityFnsPickerProps {
+  city: string;
+  selectedFns: string[];
+  onCityChange: (v: string) => void;
+  onFnsToggle: (v: string) => void;
+  onRemoveFns: (v: string) => void;
+  cities: string[];
+  fnsOptions: string[];
+  /** Placeholder for the main picker button */
+  placeholder?: string;
+  /** Show an "all cities" reset option */
+  allCitiesLabel?: string;
+}
+
+export function CityFnsPicker({
+  city,
+  selectedFns,
+  onCityChange,
+  onFnsToggle,
+  onRemoveFns,
+  cities,
+  fnsOptions,
+  placeholder = 'City and FNS',
+  allCitiesLabel,
+}: CityFnsPickerProps) {
+  const [openLevel, setOpenLevel] = useState<'city' | 'fns' | null>(null);
+
+  const summary = city
+    ? selectedFns.length > 0
+      ? `${city} / ${selectedFns.length} FNS`
+      : city
+    : '';
+
+  return (
+    <View className="gap-2">
+      {/* Main picker button */}
+      <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
+        <View
+          className={`h-11 flex-row items-center gap-2 rounded-lg border px-3 ${
+            openLevel ? 'border-brandPrimary' : 'border-borderLight'
+          } bg-white`}
+        >
+          <Feather name="map-pin" size={16} color={Colors.textMuted} />
+          <Text className={`flex-1 text-sm ${summary ? 'text-textPrimary' : 'text-textMuted'}`}>
+            {summary || placeholder}
+          </Text>
+          <Feather
+            name={openLevel ? 'chevron-up' : 'chevron-down'}
+            size={14}
+            color={Colors.textMuted}
+          />
+        </View>
+      </Pressable>
+
+      {/* Cascading panel */}
+      {openLevel && (
+        <View className="overflow-hidden rounded-lg border border-borderLight bg-white shadow-sm">
+          {/* Tabs: City / FNS */}
+          <View className="flex-row border-b border-bgSecondary">
+            <Pressable
+              className={`flex-1 items-center py-2.5 ${
+                openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''
+              }`}
+              onPress={() => setOpenLevel('city')}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  openLevel === 'city'
+                    ? 'text-brandPrimary'
+                    : city
+                      ? 'text-textPrimary'
+                      : 'text-textMuted'
+                }`}
+              >
+                {city || 'City'}
+              </Text>
+            </Pressable>
+            <Pressable
+              className={`flex-1 items-center py-2.5 ${
+                openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''
+              }`}
+              onPress={() => city && setOpenLevel('fns')}
+              disabled={!city}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  openLevel === 'fns'
+                    ? 'text-brandPrimary'
+                    : selectedFns.length > 0
+                      ? 'text-textPrimary'
+                      : 'text-textMuted'
+                }`}
+              >
+                {selectedFns.length > 0 ? `FNS (${selectedFns.length})` : 'FNS'}
+              </Text>
+            </Pressable>
+          </View>
+
+          {/* Options */}
+          <View style={{ maxHeight: 200 }}>
+            {openLevel === 'city' && (
+              <>
+                {allCitiesLabel && (
+                  <Pressable
+                    className="border-b border-bgSecondary px-3 py-2.5"
+                    onPress={() => {
+                      onCityChange('');
+                      setOpenLevel(null);
+                    }}
+                  >
+                    <Text className="text-sm text-textMuted">{allCitiesLabel}</Text>
+                  </Pressable>
+                )}
+                {cities.map((c) => (
+                  <Pressable
+                    key={c}
+                    className="border-b border-bgSecondary px-3 py-2.5"
+                    onPress={() => {
+                      onCityChange(c);
+                      setOpenLevel('fns');
+                    }}
+                  >
+                    <Text
+                      className={`text-sm ${
+                        city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                      }`}
+                    >
+                      {c}
+                    </Text>
+                  </Pressable>
+                ))}
+              </>
+            )}
+            {openLevel === 'fns' &&
+              fnsOptions.map((f) => {
+                const isSelected = selectedFns.includes(f);
+                return (
+                  <Pressable
+                    key={f}
+                    className="flex-row items-center gap-2 border-b border-bgSecondary px-3 py-2.5"
+                    onPress={() => onFnsToggle(f)}
+                  >
+                    <View
+                      className={
+                        isSelected
+                          ? 'h-5 w-5 items-center justify-center rounded border border-brandPrimary bg-brandPrimary'
+                          : 'h-5 w-5 rounded border border-borderLight bg-white'
+                      }
+                    >
+                      {isSelected && <Feather name="check" size={12} color="#fff" />}
+                    </View>
+                    <Text
+                      className={`text-sm ${
+                        isSelected ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                      }`}
+                    >
+                      {f}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+          </View>
+        </View>
+      )}
+
+      {/* Selected FNS chips */}
+      {selectedFns.length > 0 && (
+        <View className="flex-row flex-wrap gap-2">
+          {selectedFns.map((f) => (
+            <Pressable
+              key={f}
+              onPress={() => onRemoveFns(f)}
+              className="flex-row items-center gap-1 rounded-full bg-brandPrimary/10 px-2.5 py-1"
+            >
+              <Text className="text-xs font-medium text-brandPrimary">{f}</Text>
+              <Feather name="x" size={12} color={Colors.brandPrimary} />
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/ui/DropdownPicker.tsx
+++ b/components/ui/DropdownPicker.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export interface DropdownPickerProps {
+  label?: string;
+  placeholder?: string;
+  value: string;
+  options: string[];
+  onValueChange: (v: string) => void;
+  icon?: string;
+  /** Show an "all" / reset option at the top */
+  allLabel?: string;
+}
+
+export function DropdownPicker({
+  label,
+  placeholder = 'Select...',
+  value,
+  options,
+  onValueChange,
+  icon,
+  allLabel,
+}: DropdownPickerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View className="gap-1">
+      {label && <Text className="text-sm font-medium text-textSecondary">{label}</Text>}
+
+      <Pressable onPress={() => setOpen(!open)}>
+        <View
+          className={`min-h-[48px] flex-row items-center gap-2 rounded-xl border px-4 py-3 ${
+            open ? 'border-brandPrimary' : 'border-borderLight'
+          } bg-white`}
+        >
+          {icon && <Feather name={icon as any} size={16} color={Colors.textMuted} />}
+          <Text
+            className={`flex-1 text-base ${value ? 'text-textPrimary' : 'text-textMuted'}`}
+            numberOfLines={1}
+          >
+            {value || placeholder}
+          </Text>
+          <Feather name={open ? 'chevron-up' : 'chevron-down'} size={16} color={Colors.textMuted} />
+        </View>
+      </Pressable>
+
+      {open && (
+        <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
+          <View className="max-h-48">
+            {allLabel && (
+              <Pressable
+                className="border-b border-bgSecondary px-4 py-3"
+                onPress={() => {
+                  onValueChange('');
+                  setOpen(false);
+                }}
+              >
+                <Text className="text-base text-textMuted">{allLabel}</Text>
+              </Pressable>
+            )}
+            {options.map((opt) => (
+              <Pressable
+                key={opt}
+                className="border-b border-bgSecondary px-4 py-3"
+                onPress={() => {
+                  onValueChange(opt);
+                  setOpen(false);
+                }}
+              >
+                <Text
+                  className={`text-base ${
+                    value === opt ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                  }`}
+                >
+                  {opt}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export interface EmptyStateProps {
+  icon: string;
+  iconSize?: number;
+  title: string;
+  description?: string;
+  buttonLabel?: string;
+  onButtonPress?: () => void;
+}
+
+export function EmptyState({
+  icon,
+  iconSize = 32,
+  title,
+  description,
+  buttonLabel,
+  onButtonPress,
+}: EmptyStateProps) {
+  return (
+    <View className="items-center gap-3 py-10">
+      <View className="h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+        <Feather name={icon as any} size={iconSize} color={Colors.textMuted} />
+      </View>
+      <Text className="text-lg font-semibold text-textPrimary">{title}</Text>
+      {description && (
+        <Text className="max-w-[260px] text-center text-sm text-textMuted">{description}</Text>
+      )}
+      {buttonLabel && onButtonPress && (
+        <Pressable
+          className="mt-2 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6"
+          onPress={onButtonPress}
+        >
+          <Text className="text-sm font-semibold text-white">{buttonLabel}</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}

--- a/components/ui/FileItem.tsx
+++ b/components/ui/FileItem.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export interface FileItemProps {
+  name: string;
+  size: string;
+  onRemove: () => void;
+}
+
+export function FileItem({ name, size, onRemove }: FileItemProps) {
+  return (
+    <View className="flex-row items-center gap-3 rounded-lg border border-borderLight bg-bgSurface px-3 py-2">
+      <Feather name="file" size={16} color={Colors.brandPrimary} />
+      <View className="flex-1">
+        <Text className="text-sm text-textPrimary" numberOfLines={1}>{name}</Text>
+        <Text className="text-xs text-textMuted">{size}</Text>
+      </View>
+      <Pressable onPress={onRemove}>
+        <Feather name="x" size={16} color={Colors.textMuted} />
+      </Pressable>
+    </View>
+  );
+}

--- a/components/ui/LocationServicePicker.tsx
+++ b/components/ui/LocationServicePicker.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export interface LocationServicePickerProps {
+  city: string;
+  fns: string;
+  service: string;
+  onCityChange: (v: string) => void;
+  onFnsChange: (v: string) => void;
+  onServiceChange: (v: string) => void;
+  cities: string[];
+  fnsOptions: string[];
+  services: string[];
+  /** Placeholder for the main picker button */
+  placeholder?: string;
+  /** Label above the picker */
+  label?: string;
+}
+
+export function LocationServicePicker({
+  city,
+  fns,
+  service,
+  onCityChange,
+  onFnsChange,
+  onServiceChange,
+  cities,
+  fnsOptions,
+  services,
+  placeholder = 'Select city, FNS, and service',
+  label,
+}: LocationServicePickerProps) {
+  const [openLevel, setOpenLevel] = useState<'city' | 'fns' | 'service' | null>(null);
+
+  const summary = city ? [city, fns, service].filter(Boolean).join(' / ') : '';
+
+  return (
+    <View className="gap-1">
+      {label && <Text className="text-sm font-medium text-textSecondary">{label}</Text>}
+
+      {/* Main picker button */}
+      <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
+        <View
+          className={`min-h-[48px] flex-row items-center gap-2 rounded-xl border px-4 py-3 ${
+            openLevel ? 'border-brandPrimary' : 'border-borderLight'
+          } bg-white`}
+        >
+          <Feather name="map-pin" size={16} color={Colors.textMuted} />
+          <Text
+            className={`flex-1 text-base ${summary ? 'text-textPrimary' : 'text-textMuted'}`}
+            numberOfLines={2}
+          >
+            {summary || placeholder}
+          </Text>
+          <Feather
+            name={openLevel ? 'chevron-up' : 'chevron-down'}
+            size={16}
+            color={Colors.textMuted}
+          />
+        </View>
+      </Pressable>
+
+      {/* Cascading dropdown panel */}
+      {openLevel && (
+        <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
+          {/* Step indicator */}
+          <View className="flex-row border-b border-bgSecondary">
+            <Pressable
+              className={`flex-1 items-center py-2.5 ${
+                openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''
+              }`}
+              onPress={() => setOpenLevel('city')}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  openLevel === 'city'
+                    ? 'text-brandPrimary'
+                    : city
+                      ? 'text-textPrimary'
+                      : 'text-textMuted'
+                }`}
+              >
+                {city || 'City'}
+              </Text>
+            </Pressable>
+            <Pressable
+              className={`flex-1 items-center py-2.5 ${
+                openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''
+              }`}
+              onPress={() => city && setOpenLevel('fns')}
+              disabled={!city}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  openLevel === 'fns'
+                    ? 'text-brandPrimary'
+                    : fns
+                      ? 'text-textPrimary'
+                      : 'text-textMuted'
+                }`}
+              >
+                {fns ? fns.replace(/^FNS\s*/, '').substring(0, 20) : 'FNS'}
+              </Text>
+            </Pressable>
+            <Pressable
+              className={`flex-1 items-center py-2.5 ${
+                openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''
+              }`}
+              onPress={() => fns && setOpenLevel('service')}
+              disabled={!fns}
+            >
+              <Text
+                className={`text-xs font-semibold ${
+                  openLevel === 'service'
+                    ? 'text-brandPrimary'
+                    : service
+                      ? 'text-textPrimary'
+                      : 'text-textMuted'
+                }`}
+              >
+                {service || 'Service'}
+              </Text>
+            </Pressable>
+          </View>
+
+          {/* Options list */}
+          <View className="max-h-48">
+            {openLevel === 'city' &&
+              cities.map((c) => (
+                <Pressable
+                  key={c}
+                  className="border-b border-bgSecondary px-4 py-3"
+                  onPress={() => {
+                    onCityChange(c);
+                    onFnsChange('');
+                    onServiceChange('');
+                    setOpenLevel('fns');
+                  }}
+                >
+                  <Text
+                    className={`text-base ${
+                      city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                    }`}
+                  >
+                    {c}
+                  </Text>
+                </Pressable>
+              ))}
+            {openLevel === 'fns' &&
+              fnsOptions.map((f) => (
+                <Pressable
+                  key={f}
+                  className="border-b border-bgSecondary px-4 py-3"
+                  onPress={() => {
+                    onFnsChange(f);
+                    setOpenLevel('service');
+                  }}
+                >
+                  <Text
+                    className={`text-base ${
+                      fns === f ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                    }`}
+                  >
+                    {f}
+                  </Text>
+                </Pressable>
+              ))}
+            {openLevel === 'service' &&
+              services.map((s) => (
+                <Pressable
+                  key={s}
+                  className="border-b border-bgSecondary px-4 py-3"
+                  onPress={() => {
+                    onServiceChange(s);
+                    setOpenLevel(null);
+                  }}
+                >
+                  <Text
+                    className={`text-base ${
+                      service === s ? 'font-semibold text-brandPrimary' : 'text-textPrimary'
+                    }`}
+                  >
+                    {s}
+                  </Text>
+                </Pressable>
+              ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/ui/Stars.tsx
+++ b/components/ui/Stars.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export interface StarsProps {
+  rating: number;
+  size?: number;
+  filledColor?: string;
+  emptyColor?: string;
+}
+
+export function Stars({ rating, size = 14, filledColor = '#F59E0B', emptyColor = '#E2E8F0' }: StarsProps) {
+  return (
+    <View className="flex-row gap-0.5">
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= rating ? filledColor : emptyColor} />
+      ))}
+    </View>
+  );
+}

--- a/components/ui/StatusBadge.tsx
+++ b/components/ui/StatusBadge.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export interface StatusBadgeProps {
+  label: string;
+  bg: string;
+  fg: string;
+  icon?: string;
+}
+
+export function StatusBadge({ label, bg, fg, icon }: StatusBadgeProps) {
+  return (
+    <View className="flex-row items-center gap-1 rounded-full px-2 py-0.5" style={{ backgroundColor: bg }}>
+      {icon && <Feather name={icon as any} size={12} color={fg} />}
+      <Text className="text-xs font-medium" style={{ color: fg }}>{label}</Text>
+    </View>
+  );
+}

--- a/components/ui/Toggle.tsx
+++ b/components/ui/Toggle.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Pressable, View, Text } from 'react-native';
+import { Colors } from '../../constants/Colors';
+
+export interface ToggleProps {
+  value: boolean;
+  onValueChange: (v: boolean) => void;
+  label?: string;
+  sublabel?: string;
+  disabled?: boolean;
+}
+
+export function Toggle({ value, onValueChange, label, sublabel, disabled }: ToggleProps) {
+  const trackColor = value ? Colors.brandPrimary : '#D1D5DB';
+
+  return (
+    <Pressable
+      className="flex-row items-center justify-between"
+      onPress={() => !disabled && onValueChange(!value)}
+      style={{ opacity: disabled ? 0.5 : 1 }}
+    >
+      {(label || sublabel) ? (
+        <View className="mr-3 flex-1">
+          {label && <Text className="text-sm text-textSecondary">{label}</Text>}
+          {sublabel && <Text className="text-xs text-textMuted">{sublabel}</Text>}
+        </View>
+      ) : null}
+      <View
+        className="h-7 w-12 justify-center rounded-full px-0.5"
+        style={{ backgroundColor: trackColor }}
+      >
+        <View
+          className="h-[22px] w-[22px] rounded-full bg-white"
+          style={{
+            alignSelf: value ? 'flex-end' : 'flex-start',
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.2,
+            shadowRadius: 2,
+            elevation: 2,
+          }}
+        />
+      </View>
+    </Pressable>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,23 @@
+export { Toggle } from './Toggle';
+export type { ToggleProps } from './Toggle';
+
+export { LocationServicePicker } from './LocationServicePicker';
+export type { LocationServicePickerProps } from './LocationServicePicker';
+
+export { CityFnsPicker } from './CityFnsPicker';
+export type { CityFnsPickerProps } from './CityFnsPicker';
+
+export { DropdownPicker } from './DropdownPicker';
+export type { DropdownPickerProps } from './DropdownPicker';
+
+export { FileItem } from './FileItem';
+export type { FileItemProps } from './FileItem';
+
+export { Stars } from './Stars';
+export type { StarsProps } from './Stars';
+
+export { StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps } from './StatusBadge';
+
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps } from './EmptyState';


### PR DESCRIPTION
## Summary
- Extract 8 reusable UI components from proto pages into `components/ui/`
- Components: Toggle, LocationServicePicker, CityFnsPicker, DropdownPicker, FileItem, Stars, StatusBadge, EmptyState
- Barrel export via `components/ui/index.ts`
- All components use NativeWind className styling and Colors constants
- Proto files left untouched (migration is a separate task)

## Test plan
- [x] `npx tsc --noEmit` passes (no new errors)
- [ ] Verify components render correctly when imported in future pages

Generated with [Claude Code](https://claude.com/claude-code)