### PR TITLE
feat: AuthContext provider and useAuth hook (#799)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, AppState, Platform, View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import Head from 'expo-router/head';
 import { AuthProvider, useAuth } from '../stores/authStore';
+import { AuthProvider as NewAuthProvider } from '../lib/auth';
 import { isAdmin } from '../lib/adminEmails';
 import { Colors } from '../constants/Colors';
 import { tryRefreshTokens } from '../lib/api';
@@ -139,9 +140,11 @@ export default function RootLayout() {
         <meta property="og:description" content="Сервис поиска налоговых специалистов" />
         <meta property="og:type" content="website" />
       </Head>
-      <AuthProvider>
-        <RootNavigator />
-      </AuthProvider>
+      <NewAuthProvider>
+        <AuthProvider>
+          <RootNavigator />
+        </AuthProvider>
+      </NewAuthProvider>
     </>
   );
 }

--- a/lib/auth/AuthContext.tsx
+++ b/lib/auth/AuthContext.tsx
@@ -1,0 +1,241 @@
+import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
+import { Platform } from 'react-native';
+import { client, onUnauthorized } from '../api/client';
+import {
+  getAccessToken,
+  setAccessToken,
+  setRefreshToken,
+  clearTokens,
+  getRefreshToken,
+} from '../api/storage';
+import { secureStorage } from '../../stores/storage';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+export interface User {
+  id: string;
+  email: string;
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  avatarUrl?: string;
+  role: 'CLIENT' | 'SPECIALIST' | 'ADMIN';
+  isNewUser?: boolean;
+}
+
+interface AuthState {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  role: User['role'] | null;
+}
+
+type AuthAction =
+  | { type: 'LOGIN'; payload: User }
+  | { type: 'LOGOUT' }
+  | { type: 'SET_LOADING'; payload: boolean }
+  | { type: 'RESTORE'; payload: User | null }
+  | { type: 'REFRESH_USER'; payload: User };
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+const USER_KEY = '@p2ptax_user';
+const IS_LOGGED_IN_KEY = 'isLoggedIn';
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+function authReducer(state: AuthState, action: AuthAction): AuthState {
+  switch (action.type) {
+    case 'LOGIN':
+      return {
+        user: action.payload,
+        isAuthenticated: true,
+        isLoading: false,
+        role: action.payload.role,
+      };
+    case 'LOGOUT':
+      return { user: null, isAuthenticated: false, isLoading: false, role: null };
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.payload };
+    case 'RESTORE':
+      return {
+        user: action.payload,
+        isAuthenticated: action.payload !== null,
+        isLoading: false,
+        role: action.payload?.role ?? null,
+      };
+    case 'REFRESH_USER':
+      return {
+        ...state,
+        user: action.payload,
+        role: action.payload.role,
+      };
+    default:
+      return state;
+  }
+}
+
+const initialState: AuthState = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: true,
+  role: null,
+};
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+interface AuthContextValue extends AuthState {
+  login: (accessToken: string, refreshToken: string, user: User) => Promise<void>;
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(authReducer, initialState);
+
+  // Restore persisted session on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    // Web cold-start: sync read of isLoggedIn to prevent login screen flash
+    if (Platform.OS === 'web') {
+      try {
+        const flag = typeof localStorage !== 'undefined' && localStorage.getItem(IS_LOGGED_IN_KEY);
+        if (flag === 'true') {
+          dispatch({ type: 'SET_LOADING', payload: true });
+        }
+      } catch {
+        // SSR or restricted context
+      }
+    }
+
+    async function restore() {
+      try {
+        const [token, userJson] = await Promise.all([
+          getAccessToken(),
+          secureStorage.getItem(USER_KEY),
+        ]);
+
+        if (cancelled) return;
+
+        if (token && userJson) {
+          const cachedUser = JSON.parse(userJson) as User;
+
+          // Validate token by fetching fresh user from API
+          try {
+            const { data: freshUser } = await client.get<User>('/users/me');
+            await secureStorage.setItem(USER_KEY, JSON.stringify(freshUser));
+            dispatch({ type: 'RESTORE', payload: freshUser });
+          } catch {
+            // Token might be expired but refresh interceptor may handle it;
+            // if we still have cached data, use it — the 401 interceptor
+            // will emit unauthorized if truly invalid
+            dispatch({ type: 'RESTORE', payload: cachedUser });
+          }
+        } else {
+          if (Platform.OS === 'web') {
+            try { localStorage.removeItem(IS_LOGGED_IN_KEY); } catch {}
+          }
+          dispatch({ type: 'RESTORE', payload: null });
+        }
+      } catch {
+        if (!cancelled) {
+          if (Platform.OS === 'web') {
+            try { localStorage.removeItem(IS_LOGGED_IN_KEY); } catch {}
+          }
+          dispatch({ type: 'RESTORE', payload: null });
+        }
+      }
+    }
+
+    restore();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Listen for 401 to auto-logout
+  useEffect(() => {
+    const unsubscribe = onUnauthorized(() => {
+      if (Platform.OS === 'web') {
+        try { localStorage.removeItem(IS_LOGGED_IN_KEY); } catch {}
+      }
+      dispatch({ type: 'LOGOUT' });
+      Promise.all([
+        clearTokens(),
+        secureStorage.removeItem(USER_KEY),
+      ]).catch(() => {});
+    });
+    return unsubscribe;
+  }, []);
+
+  const login = useCallback(async (accessToken: string, refreshToken: string, user: User) => {
+    await Promise.all([
+      setAccessToken(accessToken),
+      setRefreshToken(refreshToken),
+      secureStorage.setItem(USER_KEY, JSON.stringify(user)),
+    ]);
+    if (Platform.OS === 'web') {
+      try { localStorage.setItem(IS_LOGGED_IN_KEY, 'true'); } catch {}
+    }
+    dispatch({ type: 'LOGIN', payload: user });
+  }, []);
+
+  const logout = useCallback(async () => {
+    // Invalidate refresh token on backend
+    const rt = await getRefreshToken();
+    if (rt) {
+      try {
+        await client.post('/auth/logout', { refreshToken: rt });
+      } catch {
+        // Best-effort — clear local state regardless
+      }
+    }
+    if (Platform.OS === 'web') {
+      try { localStorage.removeItem(IS_LOGGED_IN_KEY); } catch {}
+    }
+    await Promise.all([
+      clearTokens(),
+      secureStorage.removeItem(USER_KEY),
+    ]);
+    dispatch({ type: 'LOGOUT' });
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    try {
+      const { data: freshUser } = await client.get<User>('/users/me');
+      await secureStorage.setItem(USER_KEY, JSON.stringify(freshUser));
+      dispatch({ type: 'REFRESH_USER', payload: freshUser });
+    } catch {
+      // If refresh fails, keep current state — 401 handler deals with auth issues
+    }
+  }, []);
+
+  const value: AuthContextValue = {
+    ...state,
+    login,
+    logout,
+    refreshUser,
+  };
+
+  return React.createElement(AuthContext.Provider, { value }, children);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+}

--- a/lib/auth/ProtectedRoute.tsx
+++ b/lib/auth/ProtectedRoute.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { Redirect } from 'expo-router';
+import { useAuth, User } from './AuthContext';
+import { Colors } from '../../constants/Colors';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  /** If set, only users with this role can access the route */
+  allowedRoles?: User['role'][];
+  /** Where to redirect if role doesn't match (defaults to /(dashboard)) */
+  roleFallback?: string;
+}
+
+export function ProtectedRoute({
+  children,
+  allowedRoles,
+  roleFallback = '/(dashboard)',
+}: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading, role } = useAuth();
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, backgroundColor: Colors.bgPrimary, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Redirect href="/(auth)/email" />;
+  }
+
+  if (allowedRoles && role && !allowedRoles.includes(role)) {
+    return <Redirect href={roleFallback as never} />;
+  }
+
+  return <>{children}</>;
+}

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,0 +1,3 @@
+export { AuthProvider, useAuth } from './AuthContext';
+export type { User } from './AuthContext';
+export { ProtectedRoute } from './ProtectedRoute';


### PR DESCRIPTION
## Summary
- Created `lib/auth/AuthContext.tsx` with `AuthProvider` and `useAuth()` hook using the new `lib/api/client` (axios-based, from #798)
- On mount: validates stored tokens via `GET /users/me`, restores user state
- Exposes `login(accessToken, refreshToken, user)`, `logout()`, `refreshUser()`
- Created `lib/auth/ProtectedRoute.tsx` — guards routes by auth state and role, redirects unauthenticated users to `/(auth)/email`
- Wrapped app layout with `NewAuthProvider` alongside existing store-based `AuthProvider` for gradual migration

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (no new errors)
- [ ] Verify app loads without errors with both providers active
- [ ] Test `useAuth()` from `lib/auth` returns correct context values

Generated with [Claude Code](https://claude.com/claude-code)