### PR TITLE
feat: onboarding profile page — avatar, phone, telegram, bio

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -95,6 +95,18 @@ class SetupSpecialistProfileDto {
   /** Structured FNS-service bindings: array of { fnsId, serviceNames[] } */
   @IsOptional()
   fnsServices?: Array<{ fnsId: string; serviceNames: string[] }>;
+
+  @IsOptional()
+  @IsString()
+  displayName?: string;
+
+  @IsOptional()
+  @IsString()
+  bio?: string;
+
+  @IsOptional()
+  @IsString()
+  telegram?: string;
 }
 
 class ChangeEmailRequestDto {
@@ -230,7 +242,11 @@ export class UsersController {
     @Request() req: { user: { id: string } },
     @Body() body: SetupSpecialistProfileDto,
   ) {
-    return this.usersService.setupSpecialistProfile(req.user.id, body.cities, body.services, body.fnsOffices, body.fnsServices);
+    return this.usersService.setupSpecialistProfile(req.user.id, body.cities, body.services, body.fnsOffices, body.fnsServices, {
+      displayName: body.displayName,
+      bio: body.bio,
+      telegram: body.telegram,
+    });
   }
 
   /** GET /users/me/settings — return user settings */

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -135,6 +135,7 @@ export class UsersService {
     services: string[],
     fnsOffices?: string[],
     fnsServices?: Array<{ fnsId: string; serviceNames: string[] }>,
+    profileFields?: { displayName?: string; bio?: string; telegram?: string },
   ): Promise<{ ok: true }> {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found');
@@ -157,6 +158,12 @@ export class UsersService {
 
     const trimmedFnsOffices = (fnsOffices ?? []).map((f) => f.trim()).filter(Boolean);
 
+    // Optional profile fields (displayName, bio, telegram) from onboarding step 3
+    const extraFields: Record<string, string> = {};
+    if (profileFields?.displayName) extraFields.displayName = profileFields.displayName.trim();
+    if (profileFields?.bio) extraFields.bio = profileFields.bio.trim();
+    if (profileFields?.telegram) extraFields.telegram = profileFields.telegram.trim();
+
     if (existing) {
       // Update existing profile and ensure role is SPECIALIST
       await this.prisma.$transaction([
@@ -166,6 +173,7 @@ export class UsersService {
             cities: trimmedCities,
             services: trimmedServices,
             ...(trimmedFnsOffices.length > 0 && { fnsOffices: trimmedFnsOffices }),
+            ...extraFields,
             profileComplete,
           },
         }),
@@ -193,6 +201,7 @@ export class UsersService {
             services: trimmedServices,
             fnsOffices: trimmedFnsOffices,
             badges: [],
+            ...extraFields,
             profileComplete,
           },
         }),

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -7,69 +7,125 @@ import {
   KeyboardAvoidingView,
   Platform,
   ScrollView,
-  TouchableOpacity,
+  Pressable,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Feather } from '@expo/vector-icons';
 import { Button } from '../../components/Button';
 import { Input } from '../../components/Input';
-import { Colors, Spacing, Typography } from '../../constants/Colors';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { OnboardingProgress } from '../../components/OnboardingProgress';
 import { api, ApiError, tryRefreshTokens, getToken } from '../../lib/api';
-import { useAuth } from '../../stores/authStore';
-import { AuthUser } from '../../stores/authStore';
+import { useAuth, AuthUser } from '../../stores/authStore';
+
+// Phone mask: +7 (XXX) XXX-XX-XX
+function formatPhone(raw: string): string {
+  // Keep only digits
+  const digits = raw.replace(/\D/g, '');
+
+  // Ensure starts with 7
+  let d = digits;
+  if (d.startsWith('8')) d = '7' + d.slice(1);
+  if (!d.startsWith('7') && d.length > 0) d = '7' + d;
+
+  if (d.length === 0) return '';
+  if (d.length <= 1) return '+7';
+  if (d.length <= 4) return `+7 (${d.slice(1)}`;
+  if (d.length <= 7) return `+7 (${d.slice(1, 4)}) ${d.slice(4)}`;
+  if (d.length <= 9) return `+7 (${d.slice(1, 4)}) ${d.slice(4, 7)}-${d.slice(7)}`;
+  return `+7 (${d.slice(1, 4)}) ${d.slice(4, 7)}-${d.slice(7, 9)}-${d.slice(9, 11)}`;
+}
+
+function unformatPhone(formatted: string): string {
+  return formatted.replace(/\D/g, '');
+}
 
 export default function ProfileScreen() {
   const router = useRouter();
   const { completeOnboarding, login, user } = useAuth();
 
-  const [displayName, setDisplayName] = useState('');
-  const [headline, setHeadline] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [telegram, setTelegram] = useState('');
   const [bio, setBio] = useState('');
-  const [contacts, setContacts] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  const isSpecialist = user?.role === 'SPECIALIST';
+
+  function handlePhoneChange(text: string) {
+    const formatted = formatPhone(text);
+    setPhone(formatted);
+  }
+
+  function handleTelegramChange(text: string) {
+    // Auto-prefix @ if not present
+    if (text.length > 0 && !text.startsWith('@')) {
+      setTelegram('@' + text);
+    } else {
+      setTelegram(text);
+    }
+  }
 
   async function handleSubmit() {
     setError('');
     setLoading(true);
     try {
+      // Save firstName, lastName, phone to User model
+      const profileData: Record<string, string> = {};
+      const trimmedFirstName = firstName.trim();
+      const trimmedLastName = lastName.trim();
+      const rawPhone = unformatPhone(phone);
+
+      if (trimmedFirstName) profileData.firstName = trimmedFirstName;
+      if (trimmedLastName) profileData.lastName = trimmedLastName;
+      if (rawPhone.length > 1) profileData.phone = '+' + rawPhone;
+
+      if (Object.keys(profileData).length > 0) {
+        await api.patch('/users/me/profile', profileData);
+      }
+
       // Read all previously saved onboarding data
-      const [citiesRaw, fnsRaw, fnsDataRaw, servicesRaw] = await Promise.all([
+      const [citiesRaw, fnsRaw, servicesRaw] = await Promise.all([
         AsyncStorage.getItem('onboarding_cities'),
         AsyncStorage.getItem('onboarding_fns'),
-        AsyncStorage.getItem('onboarding_fns_data'),
         AsyncStorage.getItem('onboarding_services'),
       ]);
 
       const cities: string[] = citiesRaw ? JSON.parse(citiesRaw) : [];
-      const fnsOffices: string[] = fnsRaw ? JSON.parse(fnsRaw) : [];
       const services: string[] = servicesRaw ? JSON.parse(servicesRaw) : [];
+      const fnsOffices: string[] = fnsRaw ? JSON.parse(fnsRaw) : [];
 
-      const patchBody: Record<string, unknown> = {
+      const specialistBody: Record<string, unknown> = {
         cities,
-        fnsOffices,
         services,
       };
 
-      const trimmedDisplayName = displayName.trim();
-      const trimmedHeadline = headline.trim();
+      if (fnsOffices.length > 0) specialistBody.fnsOffices = fnsOffices;
+
+      // Build display name from first + last name
+      const displayName = [trimmedFirstName, trimmedLastName].filter(Boolean).join(' ');
+      if (displayName) specialistBody.displayName = displayName;
+
       const trimmedBio = bio.trim();
-      const trimmedContacts = contacts.trim();
+      const trimmedTelegram = telegram.trim();
+      if (trimmedBio) specialistBody.bio = trimmedBio;
+      if (trimmedTelegram) specialistBody.telegram = trimmedTelegram;
 
-      if (trimmedDisplayName) patchBody.displayName = trimmedDisplayName;
-      if (trimmedHeadline) patchBody.headline = trimmedHeadline;
-      if (trimmedBio) patchBody.bio = trimmedBio;
-      if (trimmedContacts) patchBody.contacts = trimmedContacts;
+      await api.patch('/users/me/specialist-profile', specialistBody);
 
-      await api.patch('/users/me/specialist-profile', patchBody);
-
-      // Refresh JWT so the new token carries SPECIALIST role (not CLIENT)
+      // Refresh JWT so the new token carries SPECIALIST role
       await tryRefreshTokens();
       const freshToken = await getToken();
       if (freshToken) {
-        // Fetch updated user profile (role is now SPECIALIST in DB)
-        const freshUser = await api.get<{ id: string; email: string; role: string; username: string | null }>('/users/me');
+        const freshUser = await api.get<{
+          id: string;
+          email: string;
+          role: string;
+          username: string | null;
+        }>('/users/me');
         await login(freshToken, {
           userId: freshUser.id,
           email: freshUser.email,
@@ -79,7 +135,7 @@ export default function ProfileScreen() {
         } as AuthUser);
       }
 
-      // Mark onboarding complete — sets isNewUser=false in store + AsyncStorage
+      // Mark onboarding complete
       await completeOnboarding(user?.username ?? '');
 
       // Clean up AsyncStorage onboarding keys
@@ -116,63 +172,86 @@ export default function ProfileScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <View style={styles.container}>
-            <OnboardingProgress currentStep={5} />
+            <OnboardingProgress currentStep={3} totalSteps={3} />
+
+            {/* Progress text */}
+            <View style={styles.progressBar}>
+              <View style={styles.progressTrack}>
+                <View style={[styles.progressFill, { width: '100%' }]} />
+              </View>
+              <Text style={styles.stepText}>Шаг 3 из 3</Text>
+            </View>
 
             {/* Header */}
             <View style={styles.header}>
-              <Text style={styles.step}>Шаг 5 из 5 — Расскажите о себе</Text>
-              <Text style={styles.title}>Ваш профиль</Text>
+              <Text style={styles.title}>Заполните профиль</Text>
               <Text style={styles.subtitle}>
-                Все поля необязательны. Заполните то, что хотите показать клиентам.
+                Эта информация поможет клиентам выбрать вас
               </Text>
+            </View>
+
+            {/* Avatar placeholder */}
+            <View style={styles.avatarRow}>
+              <View style={styles.avatarCircle}>
+                <Feather name="user" size={28} color={Colors.brandPrimary} />
+              </View>
+              <View>
+                <Pressable style={styles.avatarBtn}>
+                  <Feather name="camera" size={14} color={Colors.brandPrimary} />
+                  <Text style={styles.avatarBtnText}>Загрузить фото</Text>
+                </Pressable>
+                <Text style={styles.avatarHint}>JPG или PNG, до 5 МБ</Text>
+              </View>
             </View>
 
             {/* Form */}
             <View style={styles.form}>
-              {/* displayName */}
               <Input
-                label="Отображаемое имя"
-                value={displayName}
-                onChangeText={setDisplayName}
-                placeholder="Иван Петров"
+                label="Имя"
+                value={firstName}
+                onChangeText={setFirstName}
+                placeholder="Иван"
                 autoCapitalize="words"
               />
 
-              {/* headline */}
               <Input
-                label="Слоган / заголовок"
-                value={headline}
-                onChangeText={setHeadline}
-                placeholder="Решу ваш вопрос с ФНС быстро"
-                autoCapitalize="sentences"
-                maxLength={150}
-                showCharCount
+                label="Фамилия"
+                value={lastName}
+                onChangeText={setLastName}
+                placeholder="Иванов"
+                autoCapitalize="words"
               />
 
-              {/* bio */}
               <Input
-                label="О себе"
-                value={bio}
-                onChangeText={setBio}
-                placeholder="Опыт работы, специализация..."
-                autoCapitalize="sentences"
-                multiline
-                numberOfLines={5}
-                minHeight={120}
-                maxLength={1000}
-                showCharCount
+                label="Телефон"
+                value={phone}
+                onChangeText={handlePhoneChange}
+                placeholder="+7 (XXX) XXX-XX-XX"
+                keyboardType="phone-pad"
               />
 
-              {/* contacts */}
               <Input
-                label="Контакты / ссылки"
-                value={contacts}
-                onChangeText={setContacts}
-                placeholder="Telegram: @username"
+                label="Telegram"
+                value={telegram}
+                onChangeText={handleTelegramChange}
+                placeholder="@username"
                 autoCapitalize="none"
-                maxLength={200}
-                showCharCount
               />
+
+              {isSpecialist && (
+                <Input
+                  label="О себе"
+                  value={bio}
+                  onChangeText={setBio}
+                  placeholder="Расскажите о вашем опыте..."
+                  autoCapitalize="sentences"
+                  multiline
+                  numberOfLines={4}
+                  minHeight={100}
+                  maxLength={1000}
+                  showCharCount
+                />
+              )}
 
               {!!error && <Text style={styles.errorText}>{error}</Text>}
 
@@ -182,17 +261,8 @@ export default function ProfileScreen() {
                 disabled={loading}
                 style={styles.btn}
               >
-                Завершить регистрацию
+                Завершить
               </Button>
-
-              <TouchableOpacity
-                onPress={handleSubmit}
-                disabled={loading}
-                style={styles.skipBtn}
-                activeOpacity={0.7}
-              >
-                <Text style={styles.skipBtnText}>Пропустить</Text>
-              </TouchableOpacity>
             </View>
           </View>
         </ScrollView>
@@ -213,21 +283,34 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     alignItems: 'center',
     paddingVertical: Spacing['2xl'],
-    justifyContent: 'center',
   },
   container: {
     width: '100%',
-    maxWidth: 430,
+    maxWidth: 480,
     paddingHorizontal: Spacing.xl,
-    gap: Spacing['2xl'],
+    gap: Spacing.lg,
+  },
+  progressBar: {
+    gap: Spacing.xs,
+  },
+  progressTrack: {
+    height: 4,
+    borderRadius: BorderRadius.sm,
+    backgroundColor: Colors.bgSecondary,
+  },
+  progressFill: {
+    height: 4,
+    borderRadius: BorderRadius.sm,
+    backgroundColor: Colors.statusSuccess,
+  },
+  stepText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
   },
   header: {
     gap: Spacing.xs,
-  },
-  step: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    fontWeight: Typography.fontWeight.medium,
   },
   title: {
     fontSize: Typography.fontSize['2xl'],
@@ -238,6 +321,37 @@ const styles = StyleSheet.create({
     fontSize: Typography.fontSize.base,
     color: Colors.textSecondary,
     lineHeight: 22,
+  },
+  avatarRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.lg,
+  },
+  avatarCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderColor: Colors.textMuted,
+    backgroundColor: Colors.bgSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  avatarBtnText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.brandPrimary,
+  },
+  avatarHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+    marginTop: 2,
   },
   form: {
     gap: Spacing.lg,
@@ -250,13 +364,5 @@ const styles = StyleSheet.create({
   btn: {
     width: '100%',
     marginTop: Spacing.sm,
-  },
-  skipBtn: {
-    alignItems: 'center',
-    paddingVertical: Spacing.sm,
-  },
-  skipBtnText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
   },
 });


### PR DESCRIPTION
## Summary
- Rewrites `app/(onboarding)/profile.tsx` as step 3/3 with: avatar placeholder, firstName, lastName, phone (+7 mask), telegram (@username), bio (specialist only)
- Expands `SetupSpecialistProfileDto` to accept optional `displayName`, `bio`, `telegram` during onboarding
- Saves user fields via `PATCH /users/me/profile`, specialist fields via `PATCH /users/me/specialist-profile`

## Test plan
- [ ] Navigate through onboarding flow: username -> work-area -> profile
- [ ] Verify phone mask formats correctly as +7 (XXX) XXX-XX-XX
- [ ] Verify telegram auto-prefixes @
- [ ] Bio field only shows for SPECIALIST role
- [ ] Submit saves profile and redirects to dashboard
- [ ] tsc --noEmit passes (no new errors)

Closes #808