### PR TITLE
feat: global error boundary + API error toasts

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,8 @@ import { AuthProvider as NewAuthProvider } from '../lib/auth';
 import { isAdmin } from '../lib/adminEmails';
 import { Colors } from '../constants/Colors';
 import { tryRefreshTokens } from '../lib/api';
+import { ErrorBoundary } from '../components/ErrorBoundary';
+import { ToastContainer } from '../components/Toast';
 
 const PROACTIVE_INTERVAL_MS = 20 * 60 * 1000; // 20 minutes
 const VISIBILITY_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
@@ -143,11 +145,14 @@ export default function RootLayout() {
         <meta property="og:description" content="Сервис поиска налоговых специалистов" />
         <meta property="og:type" content="website" />
       </Head>
-      <NewAuthProvider>
-        <AuthProvider>
-          <RootNavigator />
-        </AuthProvider>
-      </NewAuthProvider>
+      <ErrorBoundary>
+        <NewAuthProvider>
+          <AuthProvider>
+            <RootNavigator />
+            <ToastContainer />
+          </AuthProvider>
+        </NewAuthProvider>
+      </ErrorBoundary>
     </>
   );
 }

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,94 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Colors, BorderRadius, Typography, Spacing } from '../constants/Colors';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <View style={styles.container}>
+          <Text style={styles.title}>Что-то пошло не так</Text>
+          <Text style={styles.message}>
+            Произошла непредвиденная ошибка. Попробуйте обновить страницу.
+          </Text>
+          {__DEV__ && this.state.error && (
+            <Text style={styles.debug}>{this.state.error.message}</Text>
+          )}
+          <Pressable style={styles.button} onPress={this.handleRetry}>
+            <Text style={styles.buttonText}>Попробовать снова</Text>
+          </Pressable>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing['3xl'],
+  },
+  title: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+    marginBottom: Spacing.md,
+  },
+  message: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    textAlign: 'center',
+    marginBottom: Spacing.lg,
+    maxWidth: 360,
+  },
+  debug: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.statusError,
+    textAlign: 'center',
+    marginBottom: Spacing.lg,
+    maxWidth: 480,
+    fontFamily: 'monospace',
+  },
+  button: {
+    backgroundColor: Colors.brandPrimary,
+    paddingHorizontal: Spacing['2xl'],
+    paddingVertical: Spacing.md,
+    borderRadius: BorderRadius.btn,
+  },
+  buttonText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.white,
+  },
+});

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Colors, BorderRadius, Typography } from '../constants/Colors';
+import { toast, ToastMessage } from '../lib/toast';
+
+const AUTO_DISMISS_MS = 3000;
+
+const TYPE_STYLES: Record<ToastMessage['type'], { bg: string; text: string }> = {
+  success: { bg: Colors.statusBg.success, text: Colors.statusSuccess },
+  error: { bg: Colors.statusBg.error, text: Colors.statusError },
+  info: { bg: Colors.statusBg.info, text: Colors.statusInfo },
+};
+
+function ToastItem({ item, onDismiss }: { item: ToastMessage; onDismiss: (id: string) => void }) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 200,
+      useNativeDriver: Platform.OS !== 'web',
+    }).start();
+
+    timerRef.current = setTimeout(() => {
+      fadeOut();
+    }, AUTO_DISMISS_MS);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const fadeOut = useCallback(() => {
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: Platform.OS !== 'web',
+    }).start(() => onDismiss(item.id));
+  }, [item.id, onDismiss, opacity]);
+
+  const colors = TYPE_STYLES[item.type];
+
+  return (
+    <Animated.View style={[styles.item, { backgroundColor: colors.bg, opacity }]}>
+      <Pressable onPress={fadeOut} style={styles.itemInner}>
+        <Text style={[styles.text, { color: colors.text }]}>{item.message}</Text>
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+/**
+ * ToastContainer — renders active toasts.
+ * Place once at app root, above all other content.
+ */
+export function ToastContainer() {
+  const [items, setItems] = useState<ToastMessage[]>([]);
+
+  const handleDismiss = useCallback((id: string) => {
+    setItems((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  useEffect(() => {
+    const unsubShow = toast.onShow((msg) => {
+      setItems((prev) => [...prev, msg]);
+    });
+    const unsubDismiss = toast.onDismiss((id) => {
+      handleDismiss(id);
+    });
+    return () => {
+      unsubShow();
+      unsubDismiss();
+    };
+  }, [handleDismiss]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      {items.map((item) => (
+        <ToastItem key={item.id} item={item} onDismiss={handleDismiss} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: Platform.OS === 'web' ? 16 : 56,
+    left: 0,
+    right: 0,
+    zIndex: 9999,
+    alignItems: 'center',
+    pointerEvents: 'box-none',
+  },
+  item: {
+    marginBottom: 8,
+    borderRadius: BorderRadius.lg,
+    maxWidth: 480,
+    width: '90%',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  itemInner: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  text: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.medium,
+    lineHeight: Typography.fontSize.sm * Typography.lineHeight.normal,
+  },
+});

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -11,6 +11,7 @@ import {
   setRefreshToken,
   clearTokens,
 } from './storage';
+import { toast } from '../toast';
 
 // ---------------------------------------------------------------------------
 // Base URL
@@ -79,8 +80,36 @@ function processQueue(error: unknown, token: string | null = null) {
   failedQueue = [];
 }
 
+// ---------------------------------------------------------------------------
+// Response interceptor — error toasts for non-401 errors
+// ---------------------------------------------------------------------------
 client.interceptors.response.use(
-  (response) => response,
+  undefined,
+  (error: AxiosError) => {
+    const status = error.response?.status;
+
+    if (status && status !== 401) {
+      if (status >= 500) {
+        toast.error('Ошибка сервера, попробуйте позже');
+      } else if (status >= 400) {
+        const data = error.response?.data as { message?: string } | undefined;
+        const message = data?.message || 'Произошла ошибка запроса';
+        toast.error(message);
+      }
+    } else if (!error.response && error.message !== 'canceled') {
+      // Network error (no response at all)
+      toast.error('Нет соединения с сервером');
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Response interceptor — 401 refresh + retry with queue
+// ---------------------------------------------------------------------------
+client.interceptors.response.use(
+  undefined,
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,52 @@
+// Toast notification system — event-based, no external deps
+// Usage: import { toast } from '@/lib/toast'; toast.error('msg');
+
+type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastMessage {
+  id: string;
+  type: ToastType;
+  message: string;
+}
+
+type ToastListener = (msg: ToastMessage) => void;
+type DismissListener = (id: string) => void;
+
+const showListeners: ToastListener[] = [];
+const dismissListeners: DismissListener[] = [];
+
+let counter = 0;
+
+function show(type: ToastType, message: string): string {
+  const id = `toast-${++counter}-${Date.now()}`;
+  const msg: ToastMessage = { id, type, message };
+  showListeners.forEach((l) => l(msg));
+  return id;
+}
+
+function dismiss(id: string) {
+  dismissListeners.forEach((l) => l(id));
+}
+
+export const toast = {
+  success: (message: string) => show('success', message),
+  error: (message: string) => show('error', message),
+  info: (message: string) => show('info', message),
+  dismiss,
+  /** @internal */
+  onShow(listener: ToastListener): () => void {
+    showListeners.push(listener);
+    return () => {
+      const idx = showListeners.indexOf(listener);
+      if (idx !== -1) showListeners.splice(idx, 1);
+    };
+  },
+  /** @internal */
+  onDismiss(listener: DismissListener): () => void {
+    dismissListeners.push(listener);
+    return () => {
+      const idx = dismissListeners.indexOf(listener);
+      if (idx !== -1) dismissListeners.splice(idx, 1);
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- React ErrorBoundary wraps app root — catches render crashes, shows fallback UI with retry button
- Toast notification system (no external deps) — success/error/info types, auto-dismiss 3s, top-of-screen overlay
- API client interceptor shows user-friendly toasts on 4xx/5xx/network errors, skips 401 (handled by auth refresh)

Closes #802

## Test plan
- [ ] Trigger a render error (e.g. throw in a component) — ErrorBoundary fallback shown
- [ ] Call API with bad data — toast appears with error message
- [ ] Kill API server — "Нет соединения с сервером" toast appears
- [ ] 401 errors — no toast (auth refresh handles it)
- [ ] Toast auto-dismisses after 3 seconds
- [ ] Tap toast to dismiss early