### PR TITLE
feat: file upload — avatar + chat attachment integration

### DIFF
--- a/components/AvatarPicker.tsx
+++ b/components/AvatarPicker.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Avatar, AvatarSize } from './Avatar';
+import { Colors } from '../constants/Colors';
+import { pickImage, uploadAvatar } from '../lib/upload';
+import { toast } from '../lib/toast';
+
+interface AvatarPickerProps {
+  currentUri?: string;
+  name?: string;
+  size?: AvatarSize;
+  onUploaded?: (url: string) => void;
+}
+
+export function AvatarPicker({
+  currentUri,
+  name,
+  size = 'xl',
+  onUploaded,
+}: AvatarPickerProps) {
+  const [uploading, setUploading] = useState(false);
+  const [uri, setUri] = useState(currentUri);
+
+  const handlePick = async () => {
+    if (uploading) return;
+
+    const asset = await pickImage('gallery');
+    if (!asset) return;
+
+    setUploading(true);
+    try {
+      const result = await uploadAvatar(asset);
+      setUri(result.url);
+      onUploaded?.(result.url);
+    } catch {
+      toast.error('Failed to upload avatar');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const containerSize = size === 'xl' ? 80 : size === 'lg' ? 64 : size === 'md' ? 44 : 32;
+
+  return (
+    <TouchableOpacity
+      onPress={handlePick}
+      disabled={uploading}
+      activeOpacity={0.7}
+      style={styles.container}
+    >
+      <Avatar name={name} imageUri={uri} size={size} />
+      {uploading ? (
+        <View style={[styles.overlay, { width: containerSize, height: containerSize, borderRadius: containerSize / 2 }]}>
+          <ActivityIndicator color="#fff" size="small" />
+        </View>
+      ) : (
+        <View style={styles.badge}>
+          <Ionicons name="camera" size={14} color="#fff" />
+        </View>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    alignSelf: 'center',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badge: {
+    position: 'absolute',
+    bottom: 0,
+    right: 0,
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: Colors.brandPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#fff',
+  },
+});

--- a/components/FileAttachment.tsx
+++ b/components/FileAttachment.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  Text,
+  Image,
+  ActivityIndicator,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Colors, Typography, BorderRadius, Spacing } from '../constants/Colors';
+import { pickImage, pickDocument, uploadChatAttachment, UploadResult } from '../lib/upload';
+import { toast } from '../lib/toast';
+
+interface FileAttachmentProps {
+  threadId: string;
+  onFileUploaded: (result: UploadResult) => void;
+}
+
+export function FileAttachment({ threadId, onFileUploaded }: FileAttachmentProps) {
+  const [uploading, setUploading] = useState(false);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const handlePickImage = async () => {
+    if (uploading) return;
+    const asset = await pickImage('gallery');
+    if (!asset) return;
+
+    setPreview(asset.uri);
+    setUploading(true);
+    try {
+      const result = await uploadChatAttachment(threadId, asset);
+      onFileUploaded(result);
+    } catch {
+      toast.error('Failed to upload file');
+    } finally {
+      setUploading(false);
+      setPreview(null);
+    }
+  };
+
+  const handlePickDocument = async () => {
+    if (uploading) return;
+    const asset = await pickDocument();
+    if (!asset) return;
+
+    // Show preview for images from document picker
+    if (asset.mimeType?.startsWith('image/')) {
+      setPreview(asset.uri);
+    }
+
+    setUploading(true);
+    try {
+      const result = await uploadChatAttachment(threadId, asset);
+      onFileUploaded(result);
+    } catch {
+      toast.error('Failed to upload file');
+    } finally {
+      setUploading(false);
+      setPreview(null);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {preview && (
+        <View style={styles.previewContainer}>
+          <Image source={{ uri: preview }} style={styles.preview} />
+          {uploading && (
+            <View style={styles.previewOverlay}>
+              <ActivityIndicator color="#fff" size="small" />
+            </View>
+          )}
+        </View>
+      )}
+
+      {uploading && !preview && (
+        <View style={styles.uploadingBadge}>
+          <ActivityIndicator color={Colors.brandPrimary} size="small" />
+          <Text style={styles.uploadingText}>Uploading...</Text>
+        </View>
+      )}
+
+      <View style={styles.buttons}>
+        <TouchableOpacity
+          onPress={handlePickImage}
+          disabled={uploading}
+          style={styles.btn}
+          activeOpacity={0.7}
+        >
+          <Ionicons
+            name="image-outline"
+            size={22}
+            color={uploading ? Colors.textMuted : Colors.brandPrimary}
+          />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={handlePickDocument}
+          disabled={uploading}
+          style={styles.btn}
+          activeOpacity={0.7}
+        >
+          <Ionicons
+            name="document-attach-outline"
+            size={22}
+            color={uploading ? Colors.textMuted : Colors.brandPrimary}
+          />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: Spacing.xs,
+  },
+  btn: {
+    padding: Spacing.sm,
+  },
+  previewContainer: {
+    position: 'relative',
+    width: 48,
+    height: 48,
+    borderRadius: BorderRadius.md,
+    overflow: 'hidden',
+  },
+  preview: {
+    width: 48,
+    height: 48,
+  },
+  previewOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  uploadingBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+  },
+  uploadingText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+  },
+});

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -182,3 +182,24 @@ export const stats = {
     return client.get('/stats/landing');
   },
 };
+
+// ---------------------------------------------------------------------------
+// Upload
+// ---------------------------------------------------------------------------
+export const upload = {
+  /** Upload avatar for current user. Returns updated user profile with avatarUrl. */
+  avatar(formData: FormData) {
+    return client.post('/users/me/avatar', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  },
+
+  /** Upload file attachment in a chat thread. Returns { url, signedUrl, type, name }. */
+  chatAttachment(threadId: string, formData: FormData) {
+    return client.post<{ url: string; signedUrl: string; type: string; name: string }>(
+      `/threads/${threadId}/upload`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    );
+  },
+};

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,0 +1,133 @@
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import { Platform } from 'react-native';
+import { client } from './api/client';
+
+export interface UploadResult {
+  url: string;
+  signedUrl?: string;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+// ---------------------------------------------------------------------------
+// Image picker (camera / gallery)
+// ---------------------------------------------------------------------------
+export async function pickImage(
+  source: 'camera' | 'gallery' = 'gallery',
+): Promise<ImagePicker.ImagePickerAsset | null> {
+  if (source === 'camera') {
+    const perm = await ImagePicker.requestCameraPermissionsAsync();
+    if (!perm.granted) return null;
+  }
+
+  const launcher =
+    source === 'camera'
+      ? ImagePicker.launchCameraAsync
+      : ImagePicker.launchImageLibraryAsync;
+
+  const result = await launcher({
+    mediaTypes: ['images'],
+    allowsEditing: true,
+    quality: 0.8,
+  });
+
+  if (result.canceled || !result.assets?.[0]) return null;
+  return result.assets[0];
+}
+
+// ---------------------------------------------------------------------------
+// Document picker
+// ---------------------------------------------------------------------------
+export async function pickDocument(): Promise<DocumentPicker.DocumentPickerAsset | null> {
+  const result = await DocumentPicker.getDocumentAsync({
+    type: [
+      'application/pdf',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'image/*',
+    ],
+    copyToCacheDirectory: true,
+  });
+
+  if (result.canceled || !result.assets?.[0]) return null;
+  return result.assets[0];
+}
+
+// ---------------------------------------------------------------------------
+// Upload avatar (POST /users/me/avatar)
+// ---------------------------------------------------------------------------
+export async function uploadAvatar(
+  asset: ImagePicker.ImagePickerAsset,
+): Promise<UploadResult> {
+  const formData = new FormData();
+
+  const uri = asset.uri;
+  const filename = uri.split('/').pop() || 'avatar.jpg';
+  const mimeType = asset.mimeType || 'image/jpeg';
+
+  if (Platform.OS === 'web') {
+    const blob = await fetch(uri).then((r) => r.blob());
+    formData.append('file', blob, filename);
+  } else {
+    formData.append('file', {
+      uri,
+      name: filename,
+      type: mimeType,
+    } as unknown as Blob);
+  }
+
+  const res = await client.post('/users/me/avatar', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+
+  return {
+    url: res.data.avatarUrl,
+    filename,
+    size: asset.fileSize || 0,
+    mimeType,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Upload chat attachment (POST /threads/:threadId/upload)
+// ---------------------------------------------------------------------------
+export async function uploadChatAttachment(
+  threadId: string,
+  asset: ImagePicker.ImagePickerAsset | DocumentPicker.DocumentPickerAsset,
+): Promise<UploadResult> {
+  const formData = new FormData();
+
+  const uri = asset.uri;
+  const filename =
+    'fileName' in asset
+      ? (asset.fileName ?? uri.split('/').pop() ?? 'file')
+      : (uri.split('/').pop() ?? 'file');
+  const mimeType =
+    asset.mimeType || 'application/octet-stream';
+  const size = 'fileSize' in asset ? (asset.fileSize ?? 0) : ('size' in asset ? (asset.size ?? 0) : 0);
+
+  if (Platform.OS === 'web') {
+    const blob = await fetch(uri).then((r) => r.blob());
+    formData.append('file', blob, filename);
+  } else {
+    formData.append('file', {
+      uri,
+      name: filename,
+      type: mimeType,
+    } as unknown as Blob);
+  }
+
+  const res = await client.post(`/threads/${threadId}/upload`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+
+  return {
+    url: res.data.url,
+    signedUrl: res.data.signedUrl,
+    filename: res.data.name || filename,
+    size,
+    mimeType,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo": "~54.0.33",
         "expo-auth-session": "^55.0.13",
         "expo-constants": "~18.0.13",
+        "expo-document-picker": "~14.0.8",
         "expo-image-picker": "~17.0.10",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
@@ -6353,6 +6354,15 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-14.0.8.tgz",
+      "integrity": "sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-font": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo": "~54.0.33",
     "expo-auth-session": "^55.0.13",
     "expo-constants": "~18.0.13",
+    "expo-document-picker": "~14.0.8",
     "expo-image-picker": "~17.0.10",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",


### PR DESCRIPTION
## Summary
- Added `lib/upload.ts` — `pickImage()`, `pickDocument()`, `uploadAvatar()`, `uploadChatAttachment()` utilities
- Added `components/AvatarPicker.tsx` — circular avatar with camera icon, tap to upload, loading state
- Added `components/FileAttachment.tsx` — image/document picker buttons for chat, upload progress, preview thumbnail
- Updated `lib/api/endpoints.ts` with `upload.avatar()` and `upload.chatAttachment()` endpoint helpers
- Installed `expo-document-picker`

Backend endpoints already exist: `POST /users/me/avatar` and `POST /threads/:id/upload`.

Closes #827

## Test plan
- [ ] Import AvatarPicker in onboarding/profile screen, verify image pick + upload works
- [ ] Import FileAttachment in chat input, verify image and document upload works
- [ ] Verify tsc --noEmit passes (no new errors)