### PR TITLE
feat: skeleton screens + loading/error states (#846, #847)

### DIFF
--- a/components/skeletons/ChatSkeleton.tsx
+++ b/components/skeletons/ChatSkeleton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View } from 'react-native';
+import { SkeletonBox, SkeletonAvatar } from '../ui/Skeleton';
+
+function MessageBubble({ isOwn }: { isOwn: boolean }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        justifyContent: isOwn ? 'flex-end' : 'flex-start',
+        alignItems: 'flex-end',
+        gap: 8,
+        paddingHorizontal: 16,
+      }}
+    >
+      {!isOwn && <SkeletonAvatar size={32} />}
+      <SkeletonBox
+        width={isOwn ? 180 : 220}
+        height={isOwn ? 40 : 56}
+        borderRadius={16}
+      />
+    </View>
+  );
+}
+
+export function ChatSkeleton() {
+  return (
+    <View style={{ flex: 1, paddingVertical: 16, gap: 16 }}>
+      <MessageBubble isOwn={false} />
+      <MessageBubble isOwn={true} />
+      <MessageBubble isOwn={false} />
+      <MessageBubble isOwn={true} />
+      <MessageBubble isOwn={false} />
+    </View>
+  );
+}

--- a/components/skeletons/DashboardSkeleton.tsx
+++ b/components/skeletons/DashboardSkeleton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { View } from 'react-native';
+import { SkeletonBox, SkeletonCard } from '../ui/Skeleton';
+
+export function DashboardSkeleton() {
+  return (
+    <View style={{ padding: 16, gap: 16 }}>
+      {/* Stat cards row */}
+      <View style={{ flexDirection: 'row', gap: 12 }}>
+        {[1, 2, 3].map((i) => (
+          <View
+            key={i}
+            style={{
+              flex: 1,
+              backgroundColor: '#FFFFFF',
+              borderRadius: 14,
+              padding: 16,
+              borderWidth: 1,
+              borderColor: '#E0F2FE',
+              gap: 8,
+            }}
+          >
+            <SkeletonBox height={12} width="60%" borderRadius={4} />
+            <SkeletonBox height={28} width="40%" borderRadius={4} />
+          </View>
+        ))}
+      </View>
+
+      {/* List items */}
+      <SkeletonCard showAvatar lines={2} />
+      <SkeletonCard showAvatar lines={2} />
+    </View>
+  );
+}

--- a/components/skeletons/ProfileSkeleton.tsx
+++ b/components/skeletons/ProfileSkeleton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View } from 'react-native';
+import { SkeletonAvatar, SkeletonBox, SkeletonText } from '../ui/Skeleton';
+
+export function ProfileSkeleton() {
+  return (
+    <View style={{ padding: 16, gap: 20, alignItems: 'center' }}>
+      {/* Avatar */}
+      <SkeletonAvatar size={80} />
+
+      {/* Name + subtitle */}
+      <View style={{ alignItems: 'center', gap: 8, width: '100%' }}>
+        <SkeletonBox height={20} width="45%" borderRadius={4} />
+        <SkeletonBox height={14} width="30%" borderRadius={4} />
+      </View>
+
+      {/* Info block */}
+      <View style={{ width: '100%', gap: 16 }}>
+        <SkeletonText lines={2} lineHeight={16} />
+        <SkeletonBox height={1} width="100%" borderRadius={0} />
+        <SkeletonText lines={3} lineHeight={16} />
+      </View>
+    </View>
+  );
+}

--- a/components/skeletons/RequestListSkeleton.tsx
+++ b/components/skeletons/RequestListSkeleton.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View } from 'react-native';
+import { SkeletonCard } from '../ui/Skeleton';
+
+export function RequestListSkeleton() {
+  return (
+    <View style={{ padding: 16, gap: 12 }}>
+      {[1, 2, 3, 4].map((i) => (
+        <SkeletonCard key={i} showAvatar lines={2} />
+      ))}
+    </View>
+  );
+}

--- a/components/skeletons/index.ts
+++ b/components/skeletons/index.ts
@@ -1,0 +1,4 @@
+export { DashboardSkeleton } from './DashboardSkeleton';
+export { RequestListSkeleton } from './RequestListSkeleton';
+export { ChatSkeleton } from './ChatSkeleton';
+export { ProfileSkeleton } from './ProfileSkeleton';

--- a/components/ui/PageStates.tsx
+++ b/components/ui/PageStates.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ActivityIndicator, Pressable, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+// --- LoadingState ---
+
+export interface LoadingStateProps {
+  text?: string;
+}
+
+export function LoadingState({ text }: LoadingStateProps) {
+  return (
+    <View className="flex-1 items-center justify-center py-20">
+      <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      {text && (
+        <Text className="mt-4 text-sm text-textMuted">{text}</Text>
+      )}
+    </View>
+  );
+}
+
+// --- ErrorState ---
+
+export interface ErrorStateProps {
+  title?: string;
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorState({
+  title = 'Произошла ошибка',
+  message = 'Не удалось загрузить данные. Попробуйте ещё раз.',
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <View className="flex-1 items-center justify-center gap-3 py-20">
+      <View className="h-16 w-16 items-center justify-center rounded-full bg-[#FEE2E2]">
+        <Feather name="alert-circle" size={32} color={Colors.statusError} />
+      </View>
+      <Text className="text-lg font-semibold text-textPrimary">{title}</Text>
+      <Text className="max-w-[280px] text-center text-sm text-textMuted">
+        {message}
+      </Text>
+      {onRetry && (
+        <Pressable
+          className="mt-2 h-10 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6"
+          onPress={onRetry}
+        >
+          <Feather name="refresh-cw" size={16} color="#FFFFFF" />
+          <Text className="text-sm font-semibold text-white">
+            Попробовать снова
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+// --- NetworkErrorState ---
+
+export interface NetworkErrorStateProps {
+  onRetry?: () => void;
+}
+
+export function NetworkErrorState({ onRetry }: NetworkErrorStateProps) {
+  return (
+    <ErrorState
+      title="Нет соединения"
+      message="Проверьте подключение к интернету и попробуйте снова."
+      onRetry={onRetry}
+    />
+  );
+}

--- a/components/ui/Skeleton.tsx
+++ b/components/ui/Skeleton.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View, ViewStyle } from 'react-native';
+import { Colors } from '../../constants/Colors';
+
+const PULSE_DURATION = 1200;
+
+function usePulse() {
+  const opacity = useRef(new Animated.Value(0.4)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: PULSE_DURATION / 2,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 0.4,
+          duration: PULSE_DURATION / 2,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [opacity]);
+
+  return opacity;
+}
+
+// --- SkeletonBox ---
+
+export interface SkeletonBoxProps {
+  width?: number | string;
+  height?: number | string;
+  borderRadius?: number;
+  style?: ViewStyle;
+}
+
+export function SkeletonBox({
+  width = '100%',
+  height = 16,
+  borderRadius = 6,
+  style,
+}: SkeletonBoxProps) {
+  const opacity = usePulse();
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width: width as any,
+          height: height as any,
+          borderRadius,
+          backgroundColor: Colors.borderLight,
+          opacity,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+// --- SkeletonText ---
+
+export interface SkeletonTextProps {
+  lines?: number;
+  lineHeight?: number;
+  lastLineWidth?: string;
+  style?: ViewStyle;
+}
+
+export function SkeletonText({
+  lines = 3,
+  lineHeight = 14,
+  lastLineWidth = '60%',
+  style,
+}: SkeletonTextProps) {
+  return (
+    <View style={[{ gap: 10 }, style]}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <SkeletonBox
+          key={i}
+          height={lineHeight}
+          width={i === lines - 1 && lines > 1 ? lastLineWidth : '100%'}
+          borderRadius={4}
+        />
+      ))}
+    </View>
+  );
+}
+
+// --- SkeletonAvatar ---
+
+export interface SkeletonAvatarProps {
+  size?: number;
+  style?: ViewStyle;
+}
+
+export function SkeletonAvatar({ size = 48, style }: SkeletonAvatarProps) {
+  return (
+    <SkeletonBox
+      width={size}
+      height={size}
+      borderRadius={size / 2}
+      style={style}
+    />
+  );
+}
+
+// --- SkeletonCard ---
+
+export interface SkeletonCardProps {
+  showAvatar?: boolean;
+  lines?: number;
+  style?: ViewStyle;
+}
+
+export function SkeletonCard({
+  showAvatar = false,
+  lines = 3,
+  style,
+}: SkeletonCardProps) {
+  return (
+    <View
+      style={[
+        {
+          backgroundColor: Colors.bgCard,
+          borderRadius: 14,
+          padding: 16,
+          borderWidth: 1,
+          borderColor: Colors.borderLight,
+          gap: 12,
+        },
+        style,
+      ]}
+    >
+      {showAvatar && (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <SkeletonAvatar size={40} />
+          <View style={{ flex: 1, gap: 8 }}>
+            <SkeletonBox height={14} width="50%" borderRadius={4} />
+            <SkeletonBox height={12} width="30%" borderRadius={4} />
+          </View>
+        </View>
+      )}
+      <SkeletonText lines={lines} />
+    </View>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -21,3 +21,18 @@ export type { StatusBadgeProps } from './StatusBadge';
 
 export { EmptyState } from './EmptyState';
 export type { EmptyStateProps } from './EmptyState';
+
+export { SkeletonBox, SkeletonText, SkeletonAvatar, SkeletonCard } from './Skeleton';
+export type {
+  SkeletonBoxProps,
+  SkeletonTextProps,
+  SkeletonAvatarProps,
+  SkeletonCardProps,
+} from './Skeleton';
+
+export { LoadingState, ErrorState, NetworkErrorState } from './PageStates';
+export type {
+  LoadingStateProps,
+  ErrorStateProps,
+  NetworkErrorStateProps,
+} from './PageStates';


### PR DESCRIPTION
## Summary
- Reusable `Skeleton` primitives: `SkeletonBox`, `SkeletonText`, `SkeletonAvatar`, `SkeletonCard` with animated pulse effect
- Page state components: `LoadingState`, `ErrorState`, `NetworkErrorState` (Russian UI text)
- Page-specific skeletons: `DashboardSkeleton`, `RequestListSkeleton`, `ChatSkeleton`, `ProfileSkeleton`
- All exported from `components/ui/index.ts` and `components/skeletons/index.ts`

Closes #846, closes #847

## Test plan
- [ ] Import skeletons into pages and verify pulse animation renders
- [ ] Verify ErrorState retry button triggers callback
- [ ] tsc --noEmit passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)