### PR TITLE
feat: start chat from request detail and specialist profile

### DIFF
--- a/api/prisma/migrations/20260414140000_add_request_id_to_thread/migration.sql
+++ b/api/prisma/migrations/20260414140000_add_request_id_to_thread/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "threads" ADD COLUMN "requestId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "threads" ADD CONSTRAINT "threads_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "requests"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -182,6 +182,7 @@ model Request {
 
   responses   Response[]
   reviews     Review[]
+  threads     Thread[]
 
   @@index([clientId])
   @@index([city, status])
@@ -214,6 +215,8 @@ model Thread {
   participant1   User     @relation("ThreadParticipant1", fields: [participant1Id], references: [id])
   participant2Id String
   participant2   User     @relation("ThreadParticipant2", fields: [participant2Id], references: [id])
+  requestId      String?
+  request        Request? @relation(fields: [requestId], references: [id])
   createdAt      DateTime @default(now())
 
   messages       Message[]

--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -55,7 +55,7 @@ export class ChatController {
     @Request() req: { user: { id: string } },
     @Body() dto: StartThreadDto,
   ) {
-    return this.chatService.startThread(req.user.id, dto.otherUserId);
+    return this.chatService.startThread(req.user.id, dto.otherUserId, dto.requestId);
   }
 
   // POST /threads/start — upsert thread (legacy alias)
@@ -64,7 +64,7 @@ export class ChatController {
     @Request() req: { user: { id: string } },
     @Body() dto: StartThreadDto,
   ) {
-    return this.chatService.startThread(req.user.id, dto.otherUserId);
+    return this.chatService.startThread(req.user.id, dto.otherUserId, dto.requestId);
   }
 
   @Get(':id/messages')

--- a/api/src/chat/chat.service.ts
+++ b/api/src/chat/chat.service.ts
@@ -112,7 +112,7 @@ export class ChatService {
   }
 
   /** Upsert thread between two users. Returns { threadId } */
-  async startThread(userId: string, otherUserId: string) {
+  async startThread(userId: string, otherUserId: string, requestId?: string) {
     if (userId === otherUserId) {
       throw new BadRequestException('Cannot start a thread with yourself');
     }
@@ -121,13 +121,19 @@ export class ChatService {
     const other = await this.prisma.user.findUnique({ where: { id: otherUserId } });
     if (!other) throw new NotFoundException('User not found');
 
+    // Verify request exists if provided
+    if (requestId) {
+      const request = await this.prisma.request.findUnique({ where: { id: requestId } });
+      if (!request) throw new NotFoundException('Request not found');
+    }
+
     // Sort IDs to enforce unique constraint invariant: participant1Id < participant2Id
     const [p1, p2] = [userId, otherUserId].sort();
 
     const thread = await this.prisma.thread.upsert({
       where: { participant1Id_participant2Id: { participant1Id: p1, participant2Id: p2 } },
-      create: { participant1Id: p1, participant2Id: p2 },
-      update: {},
+      create: { participant1Id: p1, participant2Id: p2, ...(requestId && { requestId }) },
+      update: { ...(requestId && { requestId }) },
       select: { id: true },
     });
 

--- a/api/src/chat/dto/start-thread.dto.ts
+++ b/api/src/chat/dto/start-thread.dto.ts
@@ -1,7 +1,11 @@
-import { IsString, IsNotEmpty } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class StartThreadDto {
   @IsString()
   @IsNotEmpty()
   otherUserId!: string;
+
+  @IsString()
+  @IsOptional()
+  requestId?: string;
 }

--- a/app/request/[id].tsx
+++ b/app/request/[id].tsx
@@ -289,12 +289,12 @@ export default function RequestDetailScreen() {
   }, [id, fetchData]);
 
   const handleStartThread = useCallback(
-    async (otherUserId: string) => {
+    async (otherUserId: string, requestId?: string) => {
       try {
         setStartingThread(true);
-        const res = await threadsApi.startThread(otherUserId);
-        const thread = res.data as { id: string };
-        router.push(`/chat/${thread.id}` as never);
+        const res = await threadsApi.startThread(otherUserId, requestId);
+        const thread = res.data as { threadId: string };
+        router.push(`/(dashboard)/messages/${thread.threadId}` as never);
       } catch {
         Alert.alert('Ошибка', 'Не удалось начать чат');
       } finally {
@@ -306,16 +306,17 @@ export default function RequestDetailScreen() {
 
   const handleResponsePress = useCallback(
     (item: ResponseItem) => {
-      handleStartThread(item.specialist.id);
+      // Navigate to chat with this specialist, linked to this request
+      handleStartThread(item.specialist.id, id);
     },
-    [handleStartThread],
+    [handleStartThread, id],
   );
 
   // Specialist writes to client (request owner)
   const handleSpecialistRespond = useCallback(() => {
     if (!request?.clientId) return;
-    handleStartThread(request.clientId);
-  }, [request, handleStartThread]);
+    handleStartThread(request.clientId, id);
+  }, [request, handleStartThread, id]);
 
   // Non-authenticated user: redirect to auth with return URL
   const handleAuthRedirect = useCallback(() => {

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -143,8 +143,8 @@ export const threads = {
     return client.post(`/threads/${threadId}/messages`, data);
   },
 
-  startThread(otherUserId: string) {
-    return client.post('/threads/start', { otherUserId });
+  startThread(otherUserId: string, requestId?: string) {
+    return client.post('/threads/start', { otherUserId, ...(requestId && { requestId }) });
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `requestId` optional field to Thread model with migration
- Backend `POST /threads/start` accepts optional `requestId` to link thread to a request
- Request detail page: specialist "Написать" and client response clicks pass `requestId` and navigate to `/(dashboard)/messages/[threadId]`
- Frontend `threads.startThread` endpoint supports optional `requestId` param

Closes #816

## Test plan
- [ ] Specialist views request detail, clicks "Написать" -> thread created with requestId, navigates to messages
- [ ] Client clicks on specialist response card -> thread created with requestId, navigates to messages
- [ ] Specialist profile "Написать специалисту" -> thread created without requestId (unchanged)
- [ ] Existing threads reused (no duplicates) — upsert logic preserved
- [ ] Migration applies cleanly on staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)