### PR TITLE
feat: responsive layout — sidebar desktop, bottom tabs mobile

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,8 +1,12 @@
-import React from 'react';
-import { Tabs } from 'expo-router';
+import React, { useCallback } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Tabs, useRouter } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '../../constants/Colors';
 import { useAuth } from '../../stores/authStore';
+import { useResponsive } from '../../lib/hooks/useResponsive';
+import { Sidebar, NavGroup } from '../../components/Sidebar';
 
 type FeatherIcon = React.ComponentProps<typeof Feather>['name'];
 
@@ -29,23 +33,70 @@ const SPECIALIST_TABS: TabConfig[] = [
 
 const ALL_TAB_NAMES = ['dashboard', 'requests', 'messages', 'settings', 'feed'];
 
+// Sidebar nav groups for desktop view
+const CLIENT_SIDEBAR_NAV: NavGroup[] = [
+  {
+    items: [
+      { label: 'Главная', icon: 'home-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
+      { label: 'Заявки', icon: 'document-text-outline', route: '/(tabs)/requests', segment: 'requests' },
+    ],
+  },
+  {
+    label: 'Личное',
+    items: [
+      { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
+      { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
+    ],
+  },
+];
+
+const SPECIALIST_SIDEBAR_NAV: NavGroup[] = [
+  {
+    items: [
+      { label: 'Лента', icon: 'list-outline', route: '/(tabs)/feed', segment: 'feed' },
+      { label: 'Заявки', icon: 'document-text-outline', route: '/(tabs)/requests', segment: 'requests' },
+    ],
+  },
+  {
+    label: 'Личное',
+    items: [
+      { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
+      { label: 'Профиль', icon: 'person-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
+      { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
+    ],
+  },
+];
+
+const SIDEBAR_WIDTH = 240;
+
 export default function TabsLayout() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
+  const { isMobile } = useResponsive();
+  const router = useRouter();
   const isSpecialist = user?.role === 'SPECIALIST';
   const activeTabs = isSpecialist ? SPECIALIST_TABS : CLIENT_TABS;
   const activeNames = new Set(activeTabs.map((t) => t.name));
 
-  return (
+  const handleLogout = useCallback(async () => {
+    await logout();
+    router.replace('/');
+  }, [logout, router]);
+
+  const sidebarNav = isSpecialist ? SPECIALIST_SIDEBAR_NAV : CLIENT_SIDEBAR_NAV;
+
+  const tabs = (
     <Tabs
       screenOptions={{
         headerShown: false,
         tabBarActiveTintColor: Colors.brandPrimary,
         tabBarInactiveTintColor: Colors.textMuted,
-        tabBarStyle: {
-          backgroundColor: Colors.bgPrimary,
-          borderTopColor: Colors.borderLight,
-          borderTopWidth: 1,
-        },
+        tabBarStyle: isMobile
+          ? {
+              backgroundColor: Colors.bgPrimary,
+              borderTopColor: Colors.borderLight,
+              borderTopWidth: 1,
+            }
+          : { display: 'none' },
         tabBarLabelStyle: {
           fontSize: 11,
           fontWeight: '600',
@@ -71,4 +122,34 @@ export default function TabsLayout() {
       })}
     </Tabs>
   );
+
+  // Desktop: sidebar + content
+  if (!isMobile) {
+    return (
+      <View style={styles.desktopContainer}>
+        <Sidebar
+          items={sidebarNav}
+          userEmail={user?.username || user?.email?.split('@')[0]}
+          onLogout={handleLogout}
+          width={SIDEBAR_WIDTH}
+        />
+        <View style={styles.desktopContent}>{tabs}</View>
+      </View>
+    );
+  }
+
+  // Mobile: regular bottom tabs
+  return tabs;
 }
+
+const styles = StyleSheet.create({
+  desktopContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: Colors.bgPrimary,
+  },
+  desktopContent: {
+    flex: 1,
+    overflow: 'hidden' as any,
+  },
+});

--- a/components/layouts/PageContainer.tsx
+++ b/components/layouts/PageContainer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, StyleSheet, ViewStyle } from 'react-native';
+import { useResponsive } from '../../lib/hooks/useResponsive';
+import { Spacing } from '../../constants/Colors';
+
+interface PageContainerProps {
+  children: React.ReactNode;
+  /** Override max width on desktop (default 960) */
+  maxWidth?: number;
+  /** Additional style applied to the outer wrapper */
+  style?: ViewStyle;
+  /** Remove default horizontal padding */
+  noPadding?: boolean;
+}
+
+/**
+ * Centers page content with max-width constraint on desktop.
+ * On mobile, fills full width with horizontal padding.
+ */
+export function PageContainer({
+  children,
+  maxWidth = 960,
+  style,
+  noPadding,
+}: PageContainerProps) {
+  const { isDesktop } = useResponsive();
+
+  return (
+    <View
+      style={[
+        styles.container,
+        isDesktop && { maxWidth, alignSelf: 'center' as const },
+        !noPadding && styles.padding,
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+  },
+  padding: {
+    paddingHorizontal: Spacing.lg,
+  },
+});

--- a/components/layouts/SidebarLayout.tsx
+++ b/components/layouts/SidebarLayout.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { useResponsive } from '../../lib/hooks/useResponsive';
+import { Sidebar, SidebarNavItem, NavGroup } from '../Sidebar';
+import { Colors } from '../../constants/Colors';
+
+const SIDEBAR_WIDTH = 240;
+
+interface SidebarLayoutProps {
+  children: React.ReactNode;
+  /** Navigation items for the sidebar */
+  navItems: SidebarNavItem[] | NavGroup[];
+  /** User email shown in sidebar footer */
+  userEmail?: string;
+  /** Logout handler */
+  onLogout?: () => void;
+}
+
+/**
+ * Desktop: sidebar navigation + content area.
+ * Mobile/tablet: renders children only (bottom tabs handled by parent).
+ */
+export function SidebarLayout({
+  children,
+  navItems,
+  userEmail,
+  onLogout,
+}: SidebarLayoutProps) {
+  const { isMobile } = useResponsive();
+
+  if (isMobile) {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={styles.container}>
+      <Sidebar
+        items={navItems}
+        userEmail={userEmail}
+        onLogout={onLogout}
+        width={SIDEBAR_WIDTH}
+      />
+      <View style={styles.content}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: Colors.bgPrimary,
+  },
+  content: {
+    flex: 1,
+    overflow: 'hidden' as any,
+  },
+});

--- a/lib/hooks/useResponsive.ts
+++ b/lib/hooks/useResponsive.ts
@@ -1,0 +1,27 @@
+import { useWindowDimensions } from 'react-native';
+
+const BREAKPOINTS = {
+  mobile: 640,
+  tablet: 1024,
+} as const;
+
+export interface ResponsiveValues {
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+  width: number;
+}
+
+/**
+ * Returns responsive breakpoint flags based on window width.
+ * mobile: <640, tablet: 640-1024, desktop: >1024
+ */
+export function useResponsive(): ResponsiveValues {
+  const { width } = useWindowDimensions();
+
+  const isDesktop = width > BREAKPOINTS.tablet;
+  const isTablet = !isDesktop && width >= BREAKPOINTS.mobile;
+  const isMobile = !isDesktop && !isTablet;
+
+  return { isMobile, isTablet, isDesktop, width };
+}


### PR DESCRIPTION
## Summary
- Add `useResponsive` hook (`lib/hooks/useResponsive.ts`) — breakpoints: mobile <640, tablet 640-1024, desktop >1024
- Add `PageContainer` component (`components/layouts/PageContainer.tsx`) — centers content with max-width on desktop
- Add `SidebarLayout` component (`components/layouts/SidebarLayout.tsx`) — sidebar + content area on desktop, passthrough on mobile
- Update `app/(tabs)/_layout.tsx` — desktop shows sidebar navigation with hidden bottom tabs, mobile keeps bottom tabs

Infrastructure only. Individual pages can adopt `PageContainer` gradually.

Closes #832

## Test plan
- [ ] Open on mobile viewport (<640px) — bottom tabs visible, no sidebar
- [ ] Open on desktop viewport (>1024px) — sidebar visible, bottom tabs hidden
- [ ] Navigation links in sidebar work correctly for both client and specialist roles
- [ ] Logout button in sidebar works

🤖 Generated with [Claude Code](https://claude.com/claude-code)