### PR TITLE
feat: email change flow — endpoints in API client (#837)

### DIFF
--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -75,6 +75,19 @@ export const users = {
   updateSettings(data: Record<string, unknown>) {
     return client.patch('/users/me/settings', data);
   },
+
+  /** Step 1: send OTP to the new email address */
+  requestEmailChange(newEmail: string) {
+    return client.post<{ message: string }>('/users/me/change-email/request', { newEmail });
+  },
+
+  /** Step 2: verify OTP, update email, return new tokens */
+  confirmEmailChange(newEmail: string, code: string) {
+    return client.post<{ accessToken: string; refreshToken: string; email: string }>(
+      '/users/me/change-email/confirm',
+      { newEmail, code },
+    );
+  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Backend email change flow (request OTP + confirm OTP) was already implemented in `users.service.ts` and `users.controller.ts`
- Frontend email change UI was already implemented in `settings.tsx` with inline `api.post()` calls
- Auth store already had `updateEmail` method with `SET_EMAIL` reducer action
- Added typed `requestEmailChange()` and `confirmEmailChange()` endpoint methods to `lib/api/endpoints.ts` for API client consistency

## Test plan
- [ ] Open settings page, click "Изменить email"
- [ ] Enter new email, receive OTP code
- [ ] Enter 6-digit OTP, confirm — email updates in UI and tokens refresh
- [ ] Verify duplicate email is rejected with error message

Generated with Claude Code