### PR TITLE
feat: add SEO meta tags to public pages

### DIFF
--- a/app/(public)/catalog.tsx
+++ b/app/(public)/catalog.tsx
@@ -355,6 +355,7 @@ export default function CatalogScreen() {
         <meta property="og:title" content="Каталог специалистов — Налоговик" />
         <meta property="og:description" content="Каталог проверенных налоговых консультантов и юристов." />
         <meta property="og:url" content={`${APP_URL}/catalog`} />
+        <meta property="og:type" content="website" />
       </Head>
       <LandingHeader />
 

--- a/app/(public)/landing.tsx
+++ b/app/(public)/landing.tsx
@@ -525,6 +525,7 @@ export default function LandingScreen() {
         <meta property="og:title" content="Налоговик — найдите налогового специалиста" />
         <meta property="og:description" content="Подбираем специалиста по вашей ИФНС и конкретной ситуации." />
         <meta property="og:url" content={APP_URL} />
+        <meta property="og:type" content="website" />
       </Head>
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         <Header />

--- a/app/(public)/requests.tsx
+++ b/app/(public)/requests.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import Head from 'expo-router/head';
 import { Feather } from '@expo/vector-icons';
 import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../constants/Colors';
 import { requests as requestsApi, ifns as ifnsApi } from '../../lib/api/endpoints';
@@ -510,6 +511,13 @@ export default function PublicRequestsScreen() {
 
   const renderHeader = () => (
     <View style={{ gap: Spacing.lg }}>
+      <Head>
+        <title>Заявки — Налоговик</title>
+        <meta name="description" content="Активные заявки на налоговые услуги. Найдите клиента и предложите свои услуги." />
+        <meta property="og:title" content="Заявки — Налоговик" />
+        <meta property="og:description" content="Активные заявки на налоговые услуги. Найдите клиента и предложите свои услуги." />
+        <meta property="og:type" content="website" />
+      </Head>
       {/* Title */}
       <View>
         <Text style={s.pageTitle}>Заявки</Text>

--- a/app/privacy.tsx
+++ b/app/privacy.tsx
@@ -38,6 +38,10 @@ export default function PrivacyScreen() {
     <SafeAreaView style={styles.safe}>
       <Head>
         <title>Политика конфиденциальности — Налоговик</title>
+        <meta name="description" content="Политика конфиденциальности платформы Налоговик. Как мы обрабатываем и защищаем ваши данные." />
+        <meta property="og:title" content="Политика конфиденциальности — Налоговик" />
+        <meta property="og:description" content="Политика конфиденциальности платформы Налоговик." />
+        <meta property="og:type" content="website" />
       </Head>
       <Stack.Screen options={{ headerShown: false }} />
       <LandingHeader />

--- a/app/request/[id]/index.tsx
+++ b/app/request/[id]/index.tsx
@@ -11,6 +11,7 @@ import {
   Alert,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import Head from 'expo-router/head';
 import { Feather } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../../constants/Colors';
@@ -352,9 +353,20 @@ export default function RequestDetailScreen() {
   }
 
   const st = STATUS_MAP[request.status] || STATUS_MAP.OPEN;
+  const pageTitle = `${request.title} — заявка — Налоговик`;
+  const pageDescription = request.description
+    ? request.description.slice(0, 160)
+    : 'Заявка на налоговые услуги на платформе Налоговик';
 
   return (
     <View style={s.container}>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content={pageDescription} />
+        <meta property="og:type" content="website" />
+      </Head>
       {/* Header */}
       <View style={s.header}>
         <Pressable style={s.backBtn} onPress={() => router.back()}>

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -39,6 +39,10 @@ export default function TermsScreen() {
     <SafeAreaView style={styles.safe}>
       <Head>
         <title>Пользовательское соглашение — Налоговик</title>
+        <meta name="description" content="Пользовательское соглашение платформы Налоговик. Условия использования сервиса." />
+        <meta property="og:title" content="Пользовательское соглашение — Налоговик" />
+        <meta property="og:description" content="Пользовательское соглашение платформы Налоговик." />
+        <meta property="og:type" content="website" />
       </Head>
       <Stack.Screen options={{ headerShown: false }} />
       <LandingHeader />


### PR DESCRIPTION
## Summary
- Add `<Head>` with title, description, og:title, og:description, og:type meta tags to requests feed, request detail, terms, and privacy pages
- Add missing `og:type` to landing and catalog pages
- Specialist profile page already had full SEO tags — no changes needed

Closes #833

## Test plan
- [ ] Verify meta tags render in page source on landing, catalog, requests, terms, privacy, specialist/[id], request/[id]
- [ ] Check og:tags with social media preview tools

Generated with Claude Code