### PR TITLE
feat: in-app notification center (#852)

### DIFF
--- a/api/prisma/migrations/20260415000000_add_notifications/migration.sql
+++ b/api/prisma/migrations/20260415000000_add_notifications/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('NEW_MESSAGE', 'NEW_RESPONSE', 'REQUEST_UPDATE', 'REVIEW', 'SYSTEM');
+
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "data" JSONB,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_isRead_idx" ON "notifications"("userId", "isRead");
+
+-- CreateIndex
+CREATE INDEX "notifications_userId_createdAt_idx" ON "notifications"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -64,6 +64,7 @@ model User {
   complaintsGiven     Complaint[]       @relation("ComplaintReporter")
   complaintsReceived  Complaint[]       @relation("ComplaintTarget")
   paymentRecords      PaymentRecord[]
+  notifications       Notification[]
 
   @@map("users")
 }
@@ -440,5 +441,29 @@ model Setting {
   value String
 
   @@map("settings")
+}
+
+enum NotificationType {
+  NEW_MESSAGE
+  NEW_RESPONSE
+  REQUEST_UPDATE
+  REVIEW
+  SYSTEM
+}
+
+model Notification {
+  id        String           @id @default(cuid())
+  userId    String
+  user      User             @relation(fields: [userId], references: [id])
+  type      NotificationType
+  title     String
+  body      String
+  data      Json?
+  isRead    Boolean          @default(false)
+  createdAt DateTime         @default(now())
+
+  @@index([userId, isRead])
+  @@index([userId, createdAt])
+  @@map("notifications")
 }
 

--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -18,6 +18,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { randomUUID } from 'crypto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { StorageService } from '../storage/storage.service';
+import { InAppNotificationService } from '../notifications/in-app-notification.service';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
 import { StartThreadDto } from './dto/start-thread.dto';
@@ -42,6 +43,7 @@ export class ChatController {
     private readonly chatService: ChatService,
     private readonly chatGateway: ChatGateway,
     private readonly storageService: StorageService,
+    private readonly inAppNotifService: InAppNotificationService,
   ) {}
 
   @Get()
@@ -171,6 +173,15 @@ export class ChatController {
     if (!recipientOnline) {
       this.chatGateway.notifyRecipientAsync(recipientId, req.user.email, threadId).catch(() => {});
     }
+
+    // In-app notification for the recipient
+    this.inAppNotifService.create({
+      userId: recipientId,
+      type: 'NEW_MESSAGE',
+      title: 'Новое сообщение',
+      body: dto.content?.trim()?.slice(0, 100) || 'Вложение',
+      data: { threadId },
+    }).catch(() => {});
 
     return message;
   }

--- a/api/src/notifications/in-app-notification.service.ts
+++ b/api/src/notifications/in-app-notification.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationType, Prisma } from '@prisma/client';
+
+const PAGE_SIZE = 20;
+
+@Injectable()
+export class InAppNotificationService {
+  constructor(private prisma: PrismaService) {}
+
+  /** List user notifications, paginated, newest first */
+  async list(userId: string, page = 1) {
+    const skip = (page - 1) * PAGE_SIZE;
+    const [items, total] = await Promise.all([
+      this.prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: PAGE_SIZE,
+      }),
+      this.prisma.notification.count({ where: { userId } }),
+    ]);
+    return { items, total, page, pageSize: PAGE_SIZE };
+  }
+
+  /** Get unread count */
+  async unreadCount(userId: string) {
+    const count = await this.prisma.notification.count({
+      where: { userId, isRead: false },
+    });
+    return { count };
+  }
+
+  /** Mark single notification as read */
+  async markRead(userId: string, notificationId: string) {
+    return this.prisma.notification.updateMany({
+      where: { id: notificationId, userId },
+      data: { isRead: true },
+    });
+  }
+
+  /** Mark all notifications as read */
+  async markAllRead(userId: string) {
+    return this.prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
+  }
+
+  /** Create a notification entry */
+  async create(input: {
+    userId: string;
+    type: NotificationType;
+    title: string;
+    body: string;
+    data?: Prisma.InputJsonValue;
+  }) {
+    return this.prisma.notification.create({ data: input });
+  }
+}

--- a/api/src/notifications/notifications.controller.ts
+++ b/api/src/notifications/notifications.controller.ts
@@ -1,0 +1,38 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { InAppNotificationService } from './in-app-notification.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationsController {
+  constructor(private readonly notifService: InAppNotificationService) {}
+
+  @Get()
+  list(@Request() req: any, @Query('page') page?: string) {
+    return this.notifService.list(req.user.id, page ? parseInt(page, 10) : 1);
+  }
+
+  @Get('unread-count')
+  unreadCount(@Request() req: any) {
+    return this.notifService.unreadCount(req.user.id);
+  }
+
+  @Patch(':id/read')
+  markRead(@Request() req: any, @Param('id') id: string) {
+    return this.notifService.markRead(req.user.id, id);
+  }
+
+  @Post('read-all')
+  markAllRead(@Request() req: any) {
+    return this.notifService.markAllRead(req.user.id);
+  }
+}

--- a/api/src/notifications/notifications.module.ts
+++ b/api/src/notifications/notifications.module.ts
@@ -1,9 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { EmailService } from './email.service';
+import { InAppNotificationService } from './in-app-notification.service';
+import { NotificationsController } from './notifications.controller';
 
 @Global()
 @Module({
-  providers: [EmailService],
-  exports: [EmailService],
+  controllers: [NotificationsController],
+  providers: [EmailService, InAppNotificationService],
+  exports: [EmailService, InAppNotificationService],
 })
 export class NotificationsModule {}

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -10,6 +10,7 @@ import {
 import { Cron } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../notifications/email.service';
+import { InAppNotificationService } from '../notifications/in-app-notification.service';
 import { CreateRequestDto } from './dto/create-request.dto';
 import { CreateQuickRequestDto } from './dto/create-quick-request.dto';
 import { RespondRequestDto } from './dto/respond-request.dto';
@@ -28,6 +29,7 @@ export class RequestsService {
   constructor(
     private prisma: PrismaService,
     private emailService: EmailService,
+    private inAppNotifService: InAppNotificationService,
   ) {}
 
   async findRecent(limit = 5) {
@@ -402,6 +404,15 @@ export class RequestsService {
     if (request.client.notifyNewResponses) {
       this.emailService.notifyNewResponse(request.client.email, requestId, specialistId, request.client.id);
     }
+
+    // In-app notification for the client
+    this.inAppNotifService.create({
+      userId: request.client.id,
+      type: 'NEW_RESPONSE',
+      title: 'Новый отклик',
+      body: `Специалист откликнулся на заявку "${request.title}"`,
+      data: { requestId, responseId: result.response.id },
+    }).catch(() => {});
 
     return result;
   }

--- a/api/src/reviews/reviews.service.ts
+++ b/api/src/reviews/reviews.service.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { InAppNotificationService } from '../notifications/in-app-notification.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { RequestStatus } from '@prisma/client';
 
@@ -13,7 +14,10 @@ const PAGE_SIZE = 20;
 
 @Injectable()
 export class ReviewsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private inAppNotifService: InAppNotificationService,
+  ) {}
 
   async create(clientId: string, dto: CreateReviewDto) {
     // Resolve specialist by nick
@@ -66,7 +70,7 @@ export class ReviewsService {
       throw new ConflictException('You have already reviewed this specialist for this request');
     }
 
-    return this.prisma.review.create({
+    const review = await this.prisma.review.create({
       data: {
         clientId,
         specialistId,
@@ -75,6 +79,17 @@ export class ReviewsService {
         comment: dto.comment ?? null,
       },
     });
+
+    // In-app notification for the specialist
+    this.inAppNotifService.create({
+      userId: specialistId,
+      type: 'REVIEW',
+      title: 'Новый отзыв',
+      body: `Клиент оставил отзыв: ${dto.rating} из 5`,
+      data: { reviewId: review.id, requestId: dto.requestId },
+    }).catch(() => {});
+
+    return review;
   }
 
   async listByClient(clientId: string) {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { Tabs, useRouter } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '../../constants/Colors';
 import { useAuth } from '../../stores/authStore';
 import { useResponsive } from '../../lib/hooks/useResponsive';
+import { useUnreadNotifications } from '../../lib/hooks/useUnreadNotifications';
 import { Sidebar, NavGroup } from '../../components/Sidebar';
 
 type FeatherIcon = React.ComponentProps<typeof Feather>['name'];
@@ -33,39 +34,45 @@ const SPECIALIST_TABS: TabConfig[] = [
 
 const ALL_TAB_NAMES = ['dashboard', 'requests', 'messages', 'settings', 'feed', 'my-responses'];
 
-// Sidebar nav groups for desktop view
-const CLIENT_SIDEBAR_NAV: NavGroup[] = [
-  {
-    items: [
-      { label: 'Главная', icon: 'home-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
-      { label: 'Заявки', icon: 'document-text-outline', route: '/(tabs)/requests', segment: 'requests' },
-    ],
-  },
-  {
-    label: 'Личное',
-    items: [
-      { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
-      { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
-    ],
-  },
-];
+// Sidebar nav groups for desktop view (built dynamically for badge counts)
+function buildClientSidebarNav(unreadNotifs: number): NavGroup[] {
+  return [
+    {
+      items: [
+        { label: 'Главная', icon: 'home-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
+        { label: 'Заявки', icon: 'document-text-outline', route: '/(tabs)/requests', segment: 'requests' },
+      ],
+    },
+    {
+      label: 'Личное',
+      items: [
+        { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
+        { label: 'Уведомления', icon: 'notifications-outline', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
+        { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
+      ],
+    },
+  ];
+}
 
-const SPECIALIST_SIDEBAR_NAV: NavGroup[] = [
-  {
-    items: [
-      { label: 'Лента', icon: 'list-outline', route: '/(tabs)/feed', segment: 'feed' },
-      { label: 'Мои отклики', icon: 'send-outline', route: '/(tabs)/my-responses', segment: 'my-responses' },
-    ],
-  },
-  {
-    label: 'Личное',
-    items: [
-      { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
-      { label: 'Профиль', icon: 'person-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
-      { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
-    ],
-  },
-];
+function buildSpecialistSidebarNav(unreadNotifs: number): NavGroup[] {
+  return [
+    {
+      items: [
+        { label: 'Лента', icon: 'list-outline', route: '/(tabs)/feed', segment: 'feed' },
+        { label: 'Мои отклики', icon: 'send-outline', route: '/(tabs)/my-responses', segment: 'my-responses' },
+      ],
+    },
+    {
+      label: 'Личное',
+      items: [
+        { label: 'Сообщения', icon: 'chatbubble-outline', route: '/(tabs)/messages', segment: 'messages' },
+        { label: 'Уведомления', icon: 'notifications-outline', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
+        { label: 'Профиль', icon: 'person-outline', route: '/(tabs)/dashboard', segment: 'dashboard' },
+        { label: 'Настройки', icon: 'settings-outline', route: '/(tabs)/settings', segment: 'settings' },
+      ],
+    },
+  ];
+}
 
 const SIDEBAR_WIDTH = 240;
 
@@ -73,6 +80,7 @@ export default function TabsLayout() {
   const { user, logout } = useAuth();
   const { isMobile } = useResponsive();
   const router = useRouter();
+  const { unreadCount } = useUnreadNotifications();
   const isSpecialist = user?.role === 'SPECIALIST';
   const activeTabs = isSpecialist ? SPECIALIST_TABS : CLIENT_TABS;
   const activeNames = new Set(activeTabs.map((t) => t.name));
@@ -82,7 +90,9 @@ export default function TabsLayout() {
     router.replace('/');
   }, [logout, router]);
 
-  const sidebarNav = isSpecialist ? SPECIALIST_SIDEBAR_NAV : CLIENT_SIDEBAR_NAV;
+  const sidebarNav = isSpecialist
+    ? buildSpecialistSidebarNav(unreadCount)
+    : buildClientSidebarNav(unreadCount);
 
   const tabs = (
     <Tabs

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -15,6 +15,7 @@ import { dashboard, requests, threads } from '../../lib/api/endpoints';
 import { Colors, Typography, Spacing, Shadows, BorderRadius } from '../../constants/Colors';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { StatusBadge } from '../../components/ui/StatusBadge';
+import { NotificationBell } from '../../components/NotificationBell';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -274,9 +275,12 @@ export default function DashboardTab() {
     >
       {/* Welcome */}
       <View style={styles.welcomeSection}>
-        <Text style={styles.welcomeTitle}>
-          {'\u{1F44B}'} {userName ? `${userName}` : 'Добро пожаловать'}
-        </Text>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text style={styles.welcomeTitle}>
+            {'\u{1F44B}'} {userName ? `${userName}` : 'Добро пожаловать'}
+          </Text>
+          <NotificationBell />
+        </View>
         <Text style={styles.welcomeSubtitle}>Ваш личный кабинет</Text>
       </View>
 

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -14,6 +14,7 @@ import { Feather } from '@expo/vector-icons';
 import { useAuth } from '../../stores/authStore';
 import { threads as threadsApi } from '../../lib/api/endpoints';
 import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../constants/Colors';
+import { NotificationBell } from '../../components/NotificationBell';
 
 // ---------------------------------------------------------------------------
 // Types matching backend response (ChatService.getThreads)
@@ -233,7 +234,10 @@ export default function MessagesTab() {
   return (
     <View style={s.container}>
       {/* Header */}
-      <Text style={s.pageTitle}>Сообщения</Text>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: Spacing.lg, marginBottom: Spacing.sm }}>
+        <Text style={[s.pageTitle, { marginBottom: 0, paddingHorizontal: 0 }]}>Сообщения</Text>
+        <NotificationBell />
+      </View>
 
       {/* Search bar */}
       <View style={s.searchWrap}>

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -13,6 +13,7 @@ import { Feather } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../constants/Colors';
 import { requests as requestsApi } from '../../lib/api/endpoints';
+import { NotificationBell } from '../../components/NotificationBell';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -217,10 +218,13 @@ export default function RequestsTab() {
       {/* Header */}
       <View style={s.topBar}>
         <Text style={s.pageTitle}>Мои заявки</Text>
-        <Pressable style={s.addBtn} onPress={goToCreate}>
-          <Feather name="plus" size={16} color={Colors.white} />
-          <Text style={s.addBtnText}>Новая</Text>
-        </Pressable>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+          <NotificationBell />
+          <Pressable style={s.addBtn} onPress={goToCreate}>
+            <Feather name="plus" size={16} color={Colors.white} />
+            <Text style={s.addBtnText}>Новая</Text>
+          </Pressable>
+        </View>
       </View>
 
       {/* Tabs */}

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,0 +1,417 @@
+import React, { useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  FlatList,
+  ActivityIndicator,
+  RefreshControl,
+  StyleSheet,
+} from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { Feather } from '@expo/vector-icons';
+import { notifications as notifApi } from '../lib/api/endpoints';
+import { Colors, Typography, Spacing, BorderRadius } from '../constants/Colors';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+interface Notification {
+  id: string;
+  type: 'NEW_MESSAGE' | 'NEW_RESPONSE' | 'REQUEST_UPDATE' | 'REVIEW' | 'SYSTEM';
+  title: string;
+  body: string;
+  data: Record<string, unknown> | null;
+  isRead: boolean;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const TYPE_ICONS: Record<Notification['type'], React.ComponentProps<typeof Feather>['name']> = {
+  NEW_MESSAGE: 'message-circle',
+  NEW_RESPONSE: 'user-check',
+  REQUEST_UPDATE: 'file-text',
+  REVIEW: 'star',
+  SYSTEM: 'bell',
+};
+
+const TYPE_COLORS: Record<Notification['type'], string> = {
+  NEW_MESSAGE: Colors.brandPrimary,
+  NEW_RESPONSE: Colors.statusSuccess,
+  REQUEST_UPDATE: Colors.statusWarning,
+  REVIEW: '#F59E0B',
+  SYSTEM: Colors.textMuted,
+};
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'Только что';
+  if (diffMin < 60) return `${diffMin} мин назад`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours} ч назад`;
+  return d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' });
+}
+
+function groupKey(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const itemDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diff = today.getTime() - itemDay.getTime();
+  if (diff === 0) return 'Сегодня';
+  if (diff <= 86400000) return 'Вчера';
+  return d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long' });
+}
+
+// ---------------------------------------------------------------------------
+// Notification Item
+// ---------------------------------------------------------------------------
+function NotificationItem({
+  item,
+  onPress,
+}: {
+  item: Notification;
+  onPress: () => void;
+}) {
+  const iconName = TYPE_ICONS[item.type] || 'bell';
+  const iconColor = TYPE_COLORS[item.type] || Colors.textMuted;
+
+  return (
+    <Pressable onPress={onPress} style={[s.item, !item.isRead && s.itemUnread]}>
+      <View style={[s.iconWrap, { backgroundColor: iconColor + '18' }]}>
+        <Feather name={iconName} size={18} color={iconColor} />
+      </View>
+      <View style={s.itemBody}>
+        <View style={s.itemTop}>
+          <Text style={[s.itemTitle, !item.isRead && s.itemTitleBold]} numberOfLines={1}>
+            {item.title}
+          </Text>
+          <Text style={s.itemTime}>{formatDate(item.createdAt)}</Text>
+        </View>
+        <Text style={s.itemText} numberOfLines={2}>
+          {item.body}
+        </Text>
+      </View>
+      {!item.isRead && <View style={s.unreadDot} />}
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Screen
+// ---------------------------------------------------------------------------
+export default function NotificationsScreen() {
+  const router = useRouter();
+  const [items, setItems] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const fetchNotifications = useCallback(async (p = 1, append = false) => {
+    try {
+      const res = await notifApi.list(p);
+      const data = res.data as { items: Notification[]; total: number };
+      if (append) {
+        setItems((prev) => [...prev, ...data.items]);
+      } else {
+        setItems(data.items);
+      }
+      setTotal(data.total);
+      setPage(p);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+      setLoadingMore(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      setLoading(true);
+      fetchNotifications(1);
+    }, [fetchNotifications]),
+  );
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchNotifications(1);
+  }, [fetchNotifications]);
+
+  const onEndReached = useCallback(() => {
+    if (loadingMore || items.length >= total) return;
+    setLoadingMore(true);
+    fetchNotifications(page + 1, true);
+  }, [loadingMore, items.length, total, page, fetchNotifications]);
+
+  const markAllRead = useCallback(async () => {
+    try {
+      await notifApi.markAllRead();
+      setItems((prev) => prev.map((n) => ({ ...n, isRead: true })));
+    } catch {
+      // silent
+    }
+  }, []);
+
+  const handlePress = useCallback(
+    async (item: Notification) => {
+      // Mark as read
+      if (!item.isRead) {
+        notifApi.markRead(item.id).catch(() => {});
+        setItems((prev) =>
+          prev.map((n) => (n.id === item.id ? { ...n, isRead: true } : n)),
+        );
+      }
+      // Navigate based on type
+      const data = item.data || {};
+      if (item.type === 'NEW_MESSAGE' && data.threadId) {
+        router.push(`/chat/${data.threadId}`);
+      } else if (
+        (item.type === 'NEW_RESPONSE' || item.type === 'REQUEST_UPDATE') &&
+        data.requestId
+      ) {
+        router.push(`/request/${data.requestId}`);
+      } else if (item.type === 'REVIEW') {
+        router.push('/(tabs)/dashboard');
+      }
+    },
+    [router],
+  );
+
+  // Group items by date
+  const sections: { title: string; data: Notification[] }[] = [];
+  let currentGroup = '';
+  for (const item of items) {
+    const g = groupKey(item.createdAt);
+    if (g !== currentGroup) {
+      currentGroup = g;
+      sections.push({ title: g, data: [] });
+    }
+    sections[sections.length - 1].data.push(item);
+  }
+
+  // Flatten with section headers for FlatList
+  type ListItem = { type: 'header'; title: string; key: string } | { type: 'item'; item: Notification; key: string };
+  const flatData: ListItem[] = [];
+  for (const section of sections) {
+    flatData.push({ type: 'header', title: section.title, key: `h-${section.title}` });
+    for (const item of section.data) {
+      flatData.push({ type: 'item', item, key: item.id });
+    }
+  }
+
+  const hasUnread = items.some((n) => !n.isRead);
+
+  if (loading) {
+    return (
+      <View style={s.centered}>
+        <ActivityIndicator size="large" color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <View style={s.container}>
+        <View style={s.header}>
+          <Pressable onPress={() => router.back()} hitSlop={8}>
+            <Feather name="arrow-left" size={22} color={Colors.textPrimary} />
+          </Pressable>
+          <Text style={s.pageTitle}>Уведомления</Text>
+          <View style={{ width: 22 }} />
+        </View>
+        <View style={s.centered}>
+          <View style={s.emptyIconWrap}>
+            <Feather name="bell-off" size={36} color={Colors.textMuted} />
+          </View>
+          <Text style={s.emptyTitle}>Нет уведомлений</Text>
+          <Text style={s.emptyText}>
+            Здесь будут появляться уведомления о новых сообщениях, откликах и отзывах
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={s.container}>
+      {/* Header */}
+      <View style={s.header}>
+        <Pressable onPress={() => router.back()} hitSlop={8}>
+          <Feather name="arrow-left" size={22} color={Colors.textPrimary} />
+        </Pressable>
+        <Text style={s.pageTitle}>Уведомления</Text>
+        {hasUnread ? (
+          <Pressable onPress={markAllRead} hitSlop={8}>
+            <Text style={s.markAllText}>Прочитать все</Text>
+          </Pressable>
+        ) : (
+          <View style={{ width: 22 }} />
+        )}
+      </View>
+
+      <FlatList
+        data={flatData}
+        keyExtractor={(d) => d.key}
+        renderItem={({ item: d }) => {
+          if (d.type === 'header') {
+            return <Text style={s.sectionHeader}>{d.title}</Text>;
+          }
+          return <NotificationItem item={d.item} onPress={() => handlePress(d.item)} />;
+        }}
+        contentContainerStyle={s.list}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.brandPrimary}
+          />
+        }
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.3}
+        ListFooterComponent={
+          loadingMore ? (
+            <ActivityIndicator
+              size="small"
+              color={Colors.brandPrimary}
+              style={{ paddingVertical: Spacing.lg }}
+            />
+          ) : null
+        }
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+const s = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+  },
+  centered: {
+    flex: 1,
+    backgroundColor: Colors.bgPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing.xl,
+    gap: Spacing.md,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.xl,
+    paddingBottom: Spacing.md,
+  },
+  pageTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.textPrimary,
+  },
+  markAllText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.brandPrimary,
+  },
+  list: {
+    paddingHorizontal: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+  },
+  sectionHeader: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: Spacing.lg,
+    marginBottom: Spacing.sm,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.borderLight,
+  },
+  itemUnread: {
+    backgroundColor: Colors.bgSecondary,
+    marginHorizontal: -Spacing.lg,
+    paddingHorizontal: Spacing.lg,
+    borderRadius: BorderRadius.md,
+  },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  itemBody: {
+    flex: 1,
+    gap: 2,
+  },
+  itemTop: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  itemTitle: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.medium,
+    color: Colors.textPrimary,
+    flex: 1,
+    marginRight: Spacing.sm,
+  },
+  itemTitleBold: {
+    fontWeight: Typography.fontWeight.bold,
+  },
+  itemTime: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  itemText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    lineHeight: Typography.fontSize.sm * Typography.lineHeight.normal,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.brandPrimary,
+  },
+  emptyIconWrap: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: Colors.bgSurface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  emptyTitle: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  emptyText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    textAlign: 'center',
+    maxWidth: 280,
+  },
+});

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Pressable, Text, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Feather } from '@expo/vector-icons';
+import { Colors, Typography } from '../constants/Colors';
+import { useUnreadNotifications } from '../lib/hooks/useUnreadNotifications';
+
+export function NotificationBell() {
+  const router = useRouter();
+  const { unreadCount } = useUnreadNotifications();
+
+  return (
+    <Pressable
+      onPress={() => router.push('/notifications')}
+      hitSlop={8}
+      style={styles.wrap}
+      accessibilityLabel={`Уведомления${unreadCount > 0 ? `, ${unreadCount} непрочитанных` : ''}`}
+    >
+      <Feather name="bell" size={20} color={Colors.textSecondary} />
+      {unreadCount > 0 && (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: 'relative',
+    padding: 4,
+  },
+  badge: {
+    position: 'absolute',
+    top: 0,
+    right: -2,
+    backgroundColor: Colors.statusError,
+    borderRadius: 10,
+    minWidth: 16,
+    height: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 3,
+    borderWidth: 1.5,
+    borderColor: Colors.bgPrimary,
+  },
+  badgeText: {
+    color: Colors.white,
+    fontSize: 9,
+    fontWeight: '700',
+    lineHeight: 11,
+  },
+});

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -235,6 +235,27 @@ export const complaints = {
 };
 
 // ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+export const notifications = {
+  list(page = 1) {
+    return client.get('/notifications', { params: { page } });
+  },
+
+  unreadCount() {
+    return client.get<{ count: number }>('/notifications/unread-count');
+  },
+
+  markRead(id: string) {
+    return client.patch(`/notifications/${id}/read`);
+  },
+
+  markAllRead() {
+    return client.post('/notifications/read-all');
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Upload
 // ---------------------------------------------------------------------------
 export const upload = {

--- a/lib/hooks/useUnreadNotifications.ts
+++ b/lib/hooks/useUnreadNotifications.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useFocusEffect } from 'expo-router';
+import { notifications as notifApi } from '../api/endpoints';
+
+const POLL_INTERVAL = 60_000; // 1 minute
+
+export function useUnreadNotifications() {
+  const [count, setCount] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetch = useCallback(async () => {
+    try {
+      const res = await notifApi.unreadCount();
+      setCount(res.data.count);
+    } catch {
+      // silent
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetch();
+      intervalRef.current = setInterval(fetch, POLL_INTERVAL);
+      return () => {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+      };
+    }, [fetch]),
+  );
+
+  return { unreadCount: count, refresh: fetch };
+}


### PR DESCRIPTION
## Summary
- Notification model with 5 types (NEW_MESSAGE, NEW_RESPONSE, REQUEST_UPDATE, REVIEW, SYSTEM)
- REST endpoints: list, unread-count, mark-read, mark-all-read
- Auto-creates notifications on chat messages, specialist responses, and reviews
- Notifications page: grouped by date, tap navigates to relevant screen, pull-to-refresh, pagination
- NotificationBell component with unread badge in dashboard/requests/messages headers
- Desktop sidebar: notification link with live badge count

## Test plan
- [ ] Run `prisma migrate deploy` on staging DB
- [ ] Send a chat message -> verify notification created for recipient
- [ ] Create a response to a request -> verify notification for client
- [ ] Leave a review -> verify notification for specialist
- [ ] Open /notifications page -> see grouped list
- [ ] Tap notification -> navigates to correct screen (chat/request)
- [ ] "Прочитать все" marks all as read
- [ ] Bell badge shows correct unread count

Closes #852