### PR TITLE
feat: E2E auth flow tests with Playwright (#843)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,8 @@ api/uploads/
 .idea/
 worktrees/
 tests/__pycache__/
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/

--- a/e2e/auth.test.ts
+++ b/e2e/auth.test.ts
@@ -1,0 +1,144 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * E2E tests for the auth flow: email -> OTP -> dashboard.
+ *
+ * Requires:
+ *  - Frontend running on localhost:8081 (Expo web)
+ *  - API running on localhost:3812 (NestJS)
+ *  - Dev mode enabled (OTP code is always 000000)
+ */
+
+const TEST_EMAIL = 'e2e-auth-test@p2ptax.test';
+const DEV_OTP = '000000';
+const WRONG_OTP = '111111';
+
+// Helper: navigate to the email auth page
+async function goToEmailPage(page: Page) {
+  await page.goto('/(auth)/email');
+  await page.waitForSelector('text=email', { timeout: 10_000 });
+}
+
+// Helper: fill email and submit as CLIENT
+async function submitEmailAsClient(page: Page, email: string) {
+  const emailInput = page.locator('input[type="email"], input[placeholder="you@example.com"]').first();
+  await emailInput.fill(email);
+  // Click the "client" role button
+  await page.getByRole('button', { name: /ищу специалиста/i }).click();
+}
+
+// Helper: fill OTP digits
+async function fillOtp(page: Page, code: string) {
+  const digits = code.split('');
+  // OTP inputs are individual TextInput fields in a row
+  const otpInputs = page.locator('input[inputmode="numeric"], input[maxlength="6"]');
+  const count = await otpInputs.count();
+
+  if (count >= 6) {
+    // Individual digit inputs
+    for (let i = 0; i < 6; i++) {
+      await otpInputs.nth(i).fill(digits[i]);
+    }
+  } else if (count >= 1) {
+    // Single input or paste-capable — type the full code into the first one
+    await otpInputs.first().fill(code);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Email page -> enter valid email -> navigate to OTP page
+// ---------------------------------------------------------------------------
+test('valid email navigates to OTP page', async ({ page }) => {
+  await goToEmailPage(page);
+  await submitEmailAsClient(page, TEST_EMAIL);
+
+  // Should navigate to OTP page — look for "Введите код" header
+  await expect(page.getByText('Введите код')).toBeVisible({ timeout: 10_000 });
+  // Email should be displayed on OTP page
+  await expect(page.getByText(TEST_EMAIL)).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: OTP page -> enter valid code (000000) -> navigate to dashboard
+// ---------------------------------------------------------------------------
+test('valid OTP code navigates to dashboard', async ({ page }) => {
+  await goToEmailPage(page);
+  await submitEmailAsClient(page, TEST_EMAIL);
+  await expect(page.getByText('Введите код')).toBeVisible({ timeout: 10_000 });
+
+  // Fill dev OTP
+  await fillOtp(page, DEV_OTP);
+
+  // Auto-submit should trigger; wait for navigation away from OTP page.
+  // Dashboard or onboarding should appear (depends on whether user is new).
+  await page.waitForURL(/\/(dashboard|onboarding)/, { timeout: 15_000 });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Invalid email shows error
+// ---------------------------------------------------------------------------
+test('invalid email shows error message', async ({ page }) => {
+  await goToEmailPage(page);
+
+  const emailInput = page.locator('input[type="email"], input[placeholder="you@example.com"]').first();
+  await emailInput.fill('not-an-email');
+  await page.getByRole('button', { name: /ищу специалиста/i }).click();
+
+  // Should show validation error — not navigate away
+  await expect(page.getByText(/корректный email/i)).toBeVisible({ timeout: 5_000 });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Wrong OTP shows error
+// ---------------------------------------------------------------------------
+test('wrong OTP shows error message', async ({ page }) => {
+  await goToEmailPage(page);
+  await submitEmailAsClient(page, TEST_EMAIL);
+  await expect(page.getByText('Введите код')).toBeVisible({ timeout: 10_000 });
+
+  await fillOtp(page, WRONG_OTP);
+
+  // Should show error on the same OTP page
+  await expect(page.getByText(/неверный код|ошибка|Попытка/i)).toBeVisible({ timeout: 10_000 });
+  // Should still be on OTP page
+  await expect(page.getByText('Введите код')).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Resend button appears after timer expires
+// ---------------------------------------------------------------------------
+test('resend button appears after countdown', async ({ page }) => {
+  await goToEmailPage(page);
+  await submitEmailAsClient(page, TEST_EMAIL);
+  await expect(page.getByText('Введите код')).toBeVisible({ timeout: 10_000 });
+
+  // Initially, should show countdown text
+  await expect(page.getByText(/повторно через/i)).toBeVisible();
+
+  // The resend link should NOT be visible yet
+  await expect(page.getByText(/отправить код повторно/i)).not.toBeVisible();
+
+  // Note: waiting the full 60s in E2E is not practical.
+  // We validate the timer text is present, which proves the timer mechanism exists.
+  // Full timer expiration can be tested by mocking timers in unit tests.
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: Auth state persists after page reload
+// ---------------------------------------------------------------------------
+test('auth state persists after page reload', async ({ page }) => {
+  await goToEmailPage(page);
+  await submitEmailAsClient(page, TEST_EMAIL);
+  await expect(page.getByText('Введите код')).toBeVisible({ timeout: 10_000 });
+
+  await fillOtp(page, DEV_OTP);
+  await page.waitForURL(/\/(dashboard|onboarding)/, { timeout: 15_000 });
+
+  // Reload the page
+  await page.reload();
+
+  // After reload, should NOT be redirected back to auth
+  await page.waitForTimeout(3_000);
+  const url = page.url();
+  expect(url).not.toMatch(/\(auth\)/);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@types/react": "~19.1.0",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
@@ -3018,6 +3019,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -10210,6 +10227,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write '**/*.{ts,tsx,json,md}'",
     "format:check": "prettier --check '**/*.{ts,tsx,json,md}'",
-    "typecheck": "cd api && npx tsc --noEmit"
+    "typecheck": "cd api && npx tsc --noEmit",
+    "test:e2e": "npx playwright test",
+    "test:e2e:headed": "npx playwright test --headed"
   },
   "dependencies": {
     "@expo/metro-runtime": "~6.1.2",
@@ -48,6 +50,7 @@
     "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/react": "~19.1.0",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:8081',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  // Expo web dev server
+  webServer: {
+    command: 'doppler run -- npx expo start --web --port 8081',
+    port: 8081,
+    timeout: 60_000,
+    reuseExistingServer: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Set up Playwright E2E test infrastructure (`playwright.config.ts`, `e2e/` directory)
- Created 6 auth flow tests: valid email -> OTP navigation, valid OTP -> dashboard, invalid email error, wrong OTP error, resend timer visibility, auth persistence after reload
- Added `test:e2e` and `test:e2e:headed` npm scripts
- Updated `.gitignore` for Playwright artifacts

Closes #843

## Test plan
- [ ] Start API: `cd api && doppler run -- npm run dev`
- [ ] Start frontend: `doppler run -- npx expo start --web`
- [ ] Run tests: `npm run test:e2e`
- [ ] All 6 tests should pass against local dev environment (OTP=000000)

Generated with [Claude Code](https://claude.com/claude-code)