### PR TITLE
feat: promotions frontend — badges, endpoints, profile

### DIFF
--- a/app/(public)/catalog.tsx
+++ b/app/(public)/catalog.tsx
@@ -124,19 +124,41 @@ function DropdownSelect({ label, icon, value, options, onSelect, placeholder, di
 // ---------------------------------------------------------------------------
 // Specialist Card
 // ---------------------------------------------------------------------------
+const TIER_BADGE_CONFIG: Record<number, { bg: string; border: string; color: string; label: string }> = {
+  3: { bg: '#FFF7ED', border: '#F59E0B', color: '#D97706', label: 'TOP' },
+  2: { bg: '#F3F0FF', border: '#8B5CF6', color: '#7C3AED', label: 'Featured' },
+  1: { bg: '#EFF6FF', border: '#3B82F6', color: '#2563EB', label: 'PRO' },
+};
+
 function SpecialistCard({ specialist, onPress }: {
   specialist: SpecialistItem;
   onPress: () => void;
 }) {
   const displayName = specialist.displayName || `@${specialist.nick}`;
   const isVerified = specialist.badges.includes('verified');
+  const tierCfg = specialist.promoted ? TIER_BADGE_CONFIG[specialist.promotionTier] : null;
 
   return (
     <Pressable
       onPress={onPress}
-      className="bg-white rounded-xl p-4 border border-sky-100 gap-3"
-      style={{ minWidth: 280, shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}
+      className={`bg-white rounded-xl p-4 gap-3 ${specialist.promoted ? 'border-2' : 'border border-sky-100'}`}
+      style={{
+        minWidth: 280,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: specialist.promoted ? 0.1 : 0.06,
+        shadowRadius: specialist.promoted ? 4 : 2,
+        elevation: specialist.promoted ? 4 : 2,
+        ...(tierCfg ? { borderColor: tierCfg.border } : {}),
+      }}
     >
+      {/* Promoted badge */}
+      {specialist.promoted && tierCfg && (
+        <View className="flex-row items-center gap-1 self-start px-2 py-0.5 rounded-full border" style={{ backgroundColor: tierCfg.bg, borderColor: tierCfg.border }}>
+          <Feather name="zap" size={11} color={tierCfg.color} />
+          <Text style={{ fontSize: 10, fontWeight: '600', color: tierCfg.color }}>{tierCfg.label}</Text>
+        </View>
+      )}
       {/* Header: avatar + info */}
       <View className="flex-row gap-3">
         <Avatar name={displayName} imageUri={specialist.avatarUrl || undefined} size="lg" />

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -325,6 +325,21 @@ export default function PublicSpecialistProfileScreen() {
 
       {/* Badges row */}
       <View style={styles.badgesRow}>
+        {profile.promoted && (
+          <View style={[styles.badge, {
+            backgroundColor: profile.promotionTier === 3 ? '#FFF7ED' : profile.promotionTier === 2 ? '#F3F0FF' : '#EFF6FF',
+            borderColor: profile.promotionTier === 3 ? '#F59E0B' : profile.promotionTier === 2 ? '#8B5CF6' : '#3B82F6',
+          }]}>
+            <Ionicons name="rocket" size={14} color={profile.promotionTier === 3 ? '#D97706' : profile.promotionTier === 2 ? '#7C3AED' : '#2563EB'} />
+            <Text style={{
+              fontSize: 12,
+              fontWeight: '600',
+              color: profile.promotionTier === 3 ? '#D97706' : profile.promotionTier === 2 ? '#7C3AED' : '#2563EB',
+            }}>
+              {profile.promotionTier === 3 ? 'TOP' : profile.promotionTier === 2 ? 'Featured' : 'PRO'}
+            </Text>
+          </View>
+        )}
         {isVerified && (
           <View style={[styles.badge, styles.badgeSuccess]}>
             <Ionicons name="shield-checkmark" size={14} color={B.success} />

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -141,9 +141,16 @@ export default function SpecialistsCatalogScreen() {
 
   const specialists = items;
 
+  const TIER_BADGE_STYLES: Record<number, { bg: string; border: string; color: string; label: string }> = {
+    3: { bg: '#FFF7ED', border: '#F59E0B', color: '#D97706', label: 'TOP' },
+    2: { bg: '#F3F0FF', border: '#8B5CF6', color: '#7C3AED', label: 'Featured' },
+    1: { bg: '#EFF6FF', border: '#3B82F6', color: '#2563EB', label: 'PRO' },
+  };
+
   function renderSpecialist({ item }: { item: SpecialistItem }) {
     const isVerified = item.badges.includes('verified');
     const displayName = item.displayName || `@${item.nick}`;
+    const tierStyle = item.promoted ? TIER_BADGE_STYLES[item.promotionTier] : null;
 
     return (
       <TouchableOpacity
@@ -151,7 +158,14 @@ export default function SpecialistsCatalogScreen() {
         activeOpacity={0.8}
         style={isMobile ? styles.cardWrapperMobile : styles.cardWrapperGrid}
       >
-        <View style={[styles.card, isMobile && styles.cardMobile]}>
+        <View style={[styles.card, isMobile && styles.cardMobile, item.promoted && styles.cardPromoted, item.promoted && tierStyle && { borderColor: tierStyle.border }]}>
+          {/* Promoted badge */}
+          {item.promoted && tierStyle && (
+            <View style={[styles.promotedBadge, { backgroundColor: tierStyle.bg, borderColor: tierStyle.border }]}>
+              <Ionicons name="rocket" size={11} color={tierStyle.color} />
+              <Text style={[styles.promotedBadgeText, { color: tierStyle.color }]}>{tierStyle.label}</Text>
+            </View>
+          )}
           {/* Top row: avatar + name/headline/city */}
           <View style={styles.cardHeader}>
             <Avatar name={displayName} imageUri={item.avatarUrl || undefined} size="lg" />
@@ -542,6 +556,25 @@ const styles = StyleSheet.create({
   cardMobile: {
     borderLeftWidth: 4,
     borderLeftColor: Colors.brandPrimary,
+  },
+  cardPromoted: {
+    borderWidth: 1.5,
+    borderLeftWidth: 4,
+  },
+  promotedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: 4,
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    marginBottom: Spacing.xs,
+  },
+  promotedBadgeText: {
+    fontSize: 10,
+    fontWeight: Typography.fontWeight.semibold,
   },
   cardHeader: {
     flexDirection: 'row',

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -318,6 +318,26 @@ export const notifications = {
 };
 
 // ---------------------------------------------------------------------------
+// Promotions
+// ---------------------------------------------------------------------------
+export const promotions = {
+  /** Get available promotion prices (public, no auth) */
+  getPrices(city?: string) {
+    return client.get('/promotions/prices', { params: city ? { city } : undefined });
+  },
+
+  /** Purchase a promotion (specialist only) */
+  purchase(data: { city: string; tier: string; periodMonths?: number; idempotencyKey?: string }) {
+    return client.post('/promotions/purchase', data);
+  },
+
+  /** Get my promotions */
+  getMyPromotions() {
+    return client.get('/promotions/my');
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Search
 // ---------------------------------------------------------------------------
 export const search = {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -6,4 +6,4 @@ export {
   setRefreshToken,
   clearTokens,
 } from './storage';
-export { auth, users, requests, specialists, threads, ifns, stats, reviews, admin, search } from './endpoints';
+export { auth, users, requests, specialists, threads, ifns, stats, reviews, admin, search, promotions } from './endpoints';


### PR DESCRIPTION
## Summary
- Add `promotions` API endpoints to `lib/api/endpoints.ts` (purchase, getMyPromotions, getPrices)
- Export `promotions` from `lib/api/index.ts`
- Add promoted badge/highlight to specialist cards in both catalog pages (`specialists/index.tsx`, `(public)/catalog.tsx`)
- Add promoted tier badge to specialist profile page (`specialists/[nick].tsx`)
- Promoted specialists get colored border (gold/purple/blue) and tier label (TOP/Featured/PRO)

Backend was already fully implemented (Promotion model, purchase endpoint, cron cleanup, prices).

Closes #836

## Test plan
- [ ] Open `/specialists` catalog — promoted specialists should show colored border + tier badge
- [ ] Open `/catalog` (public) — same promoted visual treatment
- [ ] Open individual specialist profile — promoted badge appears in badges row
- [ ] As specialist, navigate to Promotion page from sidebar — purchase flow works

Generated with [Claude Code](https://claude.com/claude-code)