### PR TITLE
fix: add isAvailable filter to specialist catalog (#913)

### DIFF
--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -217,7 +217,7 @@ export class SpecialistsService {
     if (limit > 50) limit = 50;
     if (limit < 1) limit = 1;
     const now = new Date();
-    const profileWhere: any = { displayName: { not: null } };
+    const profileWhere: any = { displayName: { not: null }, isAvailable: true };
     if (city) {
       // Support comma-separated list of cities (multi-select)
       const cityList = city.split(',').map((c) => c.trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- Adds `isAvailable: true` filter to `profileWhere` in `getCatalog()` method
- Fixes SA gap: only specialists with `is_available=true` should appear in catalog

## Changes
- `api/src/specialists/specialists.service.ts` line 220: `profileWhere` now includes `isAvailable: true`

Closes #913