### PR TITLE
fix: use structured contact fields on specialist profile (#912)

### DIFF
--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -186,11 +186,10 @@ export class SpecialistsService {
     const activity = await this.computeActivity(profile.userId);
     const fnsGroupedByCity = this.groupFnsByCity(profile.specialistFns, profile.specialistServices);
 
-    // Strip internal IDs from public profile response; contacts only for authenticated users
-    const { id: _id, userId: _userId, contacts, specialistFns: _sf, specialistServices: _ss, ...publicProfile } = profile;
+    // Strip internal IDs from public profile response; structured contact fields are public
+    const { id: _id, userId: _userId, specialistFns: _sf, specialistServices: _ss, ...publicProfile } = profile;
     return {
       ...publicProfile,
-      ...(requestingUser ? { contacts } : {}),
       activity,
       rating: activity.avgRating,
       reviewCount: activity.reviewCount,

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { StyleSheet, View, Text, ScrollView, TouchableOpacity, ActivityIndicator, SafeAreaView, Image, Platform, Alert, Share, TextInput, FlatList } from 'react-native';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, ActivityIndicator, SafeAreaView, Image, Platform, Alert, Share, TextInput, FlatList, Linking } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import Head from 'expo-router/head';
 import { api, ApiError } from '../../lib/api';
@@ -41,6 +41,11 @@ interface SpecialistProfile {
   services: string[];
   badges: string[];
   contacts: string | null;
+  phone: string | null;
+  telegram: string | null;
+  whatsapp: string | null;
+  officeAddress: string | null;
+  workingHours: string | null;
   promoted: boolean;
   promotionTier: number;
   activity: { responseCount: number; avgRating: number | null; reviewCount: number };
@@ -607,20 +612,61 @@ export default function PublicSpecialistProfileScreen() {
         </View>
       )}
 
-      {profile.contacts && user?.role !== 'SPECIALIST' && (
+      {(profile.phone || profile.telegram || profile.whatsapp || profile.officeAddress || profile.workingHours) && (
         <View style={styles.section}>
           <Text style={styles.sectionLabel}>Связаться</Text>
-          {user ? (
-            <Text style={styles.bodyText}>{profile.contacts}</Text>
-          ) : (
-            <TouchableOpacity
-              onPress={() => router.push(`/(auth)/email?redirectTo=/specialists/${profile.nick}` as any)}
-              activeOpacity={0.8}
-              style={styles.ghostBtn}
-            >
-              <Text style={styles.ghostBtnText}>Войдите чтобы увидеть контакты</Text>
-            </TouchableOpacity>
-          )}
+          <View style={styles.contactsList}>
+            {profile.phone && (
+              <TouchableOpacity
+                style={styles.contactRow}
+                onPress={() => Linking.openURL(`tel:${profile.phone}`)}
+                activeOpacity={0.7}
+              >
+                <Ionicons name="call-outline" size={18} color={B.action} />
+                <Text style={styles.contactLink}>{profile.phone}</Text>
+              </TouchableOpacity>
+            )}
+            {profile.telegram && (
+              <TouchableOpacity
+                style={styles.contactRow}
+                onPress={() => {
+                  const handle = profile.telegram!.replace(/^@/, '');
+                  Linking.openURL(`https://t.me/${handle}`);
+                }}
+                activeOpacity={0.7}
+              >
+                <Ionicons name="paper-plane-outline" size={18} color={B.action} />
+                <Text style={styles.contactLink}>
+                  {profile.telegram.startsWith('@') ? profile.telegram : `@${profile.telegram}`}
+                </Text>
+              </TouchableOpacity>
+            )}
+            {profile.whatsapp && (
+              <TouchableOpacity
+                style={styles.contactRow}
+                onPress={() => {
+                  const num = profile.whatsapp!.replace(/\D/g, '');
+                  Linking.openURL(`https://wa.me/${num}`);
+                }}
+                activeOpacity={0.7}
+              >
+                <Ionicons name="logo-whatsapp" size={18} color={B.action} />
+                <Text style={styles.contactLink}>{profile.whatsapp}</Text>
+              </TouchableOpacity>
+            )}
+            {profile.officeAddress && (
+              <View style={styles.contactRow}>
+                <Ionicons name="location-outline" size={18} color={B.muted} />
+                <Text style={styles.contactText}>{profile.officeAddress}</Text>
+              </View>
+            )}
+            {profile.workingHours && (
+              <View style={styles.contactRow}>
+                <Ionicons name="time-outline" size={18} color={B.muted} />
+                <Text style={styles.contactText}>{profile.workingHours}</Text>
+              </View>
+            )}
+          </View>
         </View>
       )}
 
@@ -933,6 +979,12 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
   },
   ghostBtnText: { fontSize: 13, color: B.action, fontWeight: '500' },
+
+  // Contacts
+  contactsList: { gap: 12 },
+  contactRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  contactLink: { fontSize: 15, color: B.action, lineHeight: 22, flex: 1 },
+  contactText: { fontSize: 15, color: B.primary, lineHeight: 22, flex: 1 },
 
   // Reviews header
   reviewsHeaderRow: {


### PR DESCRIPTION
## Summary
- **Backend**: removed auth restriction on contact fields — `phone`, `telegram`, `whatsapp`, `officeAddress`, `workingHours` are now returned publicly (SA says contacts section is PUBLIC for everyone including guests)
- **Frontend**: updated `SpecialistProfile` interface with individual contact fields; replaced single `contacts` string render with structured display using action links (`tel:`, `t.me/`, `wa.me/`) and Ionicons icons
- Contacts section now visible to guests (removed `user` auth check)

## Test plan
- [ ] Visit specialist profile as guest — contacts section visible with structured fields
- [ ] Phone taps open dialer
- [ ] Telegram link opens t.me/username
- [ ] WhatsApp link opens wa.me/number
- [ ] Office address and working hours show as plain text
- [ ] Section hidden when all contact fields are null

Closes #912