### PR TITLE
fix: add service type filter to public requests feed (#909)

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -83,6 +83,7 @@ export class RequestsController {
     @Query('service') service?: string,
     @Query('maxBudget') maxBudget?: string,
     @Query('ifnsId') ifnsId?: string,
+    @Query('serviceType') serviceType?: string,
   ) {
     // 'service' is an alias for 'category' (both accepted)
     const effectiveCategory = category || service;
@@ -92,6 +93,7 @@ export class RequestsController {
       effectiveCategory,
       maxBudget ? parseInt(maxBudget, 10) : undefined,
       ifnsId,
+      serviceType,
     );
   }
 

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -150,7 +150,7 @@ export class RequestsService {
     }
   }
 
-  async findFeed(city?: string, page = 1, category?: string, maxBudget?: number, ifnsId?: string) {
+  async findFeed(city?: string, page = 1, category?: string, maxBudget?: number, ifnsId?: string, serviceType?: string) {
     // #1855: Sanitize page to prevent negative skip
     const pageNum = Math.max(1, parseInt(page as unknown as string) || 1);
 
@@ -163,6 +163,8 @@ export class RequestsService {
     if (maxBudget && maxBudget > 0) where.budget = { lte: maxBudget };
     // IFNS filter
     if (ifnsId) where.ifnsId = ifnsId;
+    // #909: Service type filter
+    if (serviceType) where.serviceType = { equals: serviceType, mode: 'insensitive' };
 
     const skip = (pageNum - 1) * PAGE_SIZE;
 

--- a/app/(public)/requests.tsx
+++ b/app/(public)/requests.tsx
@@ -85,6 +85,86 @@ function getServiceLabel(serviceType: string | null, category: string | null): s
 }
 
 // ---------------------------------------------------------------------------
+// Service Type Picker
+// ---------------------------------------------------------------------------
+
+const SERVICE_OPTIONS = [
+  'Камеральная проверка',
+  'Выездная проверка',
+  'Отдел оперативного контроля',
+];
+
+function ServicePicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View style={{ gap: 8 }}>
+      <Pressable onPress={() => setOpen((v) => !v)}>
+        <View style={[s.pickerBtn, open ? s.pickerBtnActive : null]}>
+          <Feather name="briefcase" size={16} color={Colors.textMuted} />
+          <Text
+            style={[s.pickerBtnText, !value && s.pickerBtnPlaceholder]}
+            numberOfLines={1}
+          >
+            {value || 'Тип услуги'}
+          </Text>
+          <Feather
+            name={open ? 'chevron-up' : 'chevron-down'}
+            size={14}
+            color={Colors.textMuted}
+          />
+        </View>
+      </Pressable>
+
+      {open && (
+        <View style={s.cascadePanel}>
+          <View style={{ maxHeight: 200 }}>
+            <Pressable
+              style={s.cascadeOption}
+              onPress={() => { onChange(''); setOpen(false); }}
+            >
+              <Text style={[s.cascadeOptionText, { color: Colors.textMuted }]}>Все услуги</Text>
+            </Pressable>
+            {SERVICE_OPTIONS.map((opt) => (
+              <Pressable
+                key={opt}
+                style={s.cascadeOption}
+                onPress={() => { onChange(opt); setOpen(false); }}
+              >
+                <Text
+                  style={[
+                    s.cascadeOptionText,
+                    value === opt && { fontWeight: '600', color: Colors.brandPrimary },
+                  ]}
+                >
+                  {opt}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      )}
+
+      {value ? (
+        <View style={s.chipRow}>
+          <Pressable style={s.chip} onPress={() => onChange('')}>
+            <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
+            <Text style={s.chipText}>{value}</Text>
+            <Feather name="x" size={12} color={Colors.brandPrimary} />
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // City/FNS Cascading Picker
 // ---------------------------------------------------------------------------
 
@@ -395,6 +475,7 @@ export default function PublicRequestsScreen() {
   // Filters
   const [filterCity, setFilterCity] = useState('');
   const [filterIfnsId, setFilterIfnsId] = useState('');
+  const [filterServiceType, setFilterServiceType] = useState('');
 
   // Cities + FNS options
   const [cities, setCities] = useState<string[]>([]);
@@ -452,6 +533,7 @@ export default function PublicRequestsScreen() {
       const params: Record<string, unknown> = { page: targetPage };
       if (filterCity) params.city = filterCity;
       if (filterIfnsId) params.ifnsId = filterIfnsId;
+      if (filterServiceType) params.serviceType = filterServiceType;
 
       const res = await requestsApi.getPublicFeed(params);
       const body = res.data as {
@@ -476,7 +558,7 @@ export default function PublicRequestsScreen() {
       setRefreshing(false);
       setLoadingMore(false);
     }
-  }, [filterCity, filterIfnsId]);
+  }, [filterCity, filterIfnsId, filterServiceType]);
 
   // Initial load + re-fetch on filter change
   useEffect(() => {
@@ -503,7 +585,7 @@ export default function PublicRequestsScreen() {
     router.push(`/request/${id}` as never);
   };
 
-  const hasFilters = !!(filterCity || filterIfnsId);
+  const hasFilters = !!(filterCity || filterIfnsId || filterServiceType);
 
   // ---------------------------------------------------------------------------
   // Render
@@ -532,7 +614,7 @@ export default function PublicRequestsScreen() {
           {hasFilters && (
             <Pressable
               style={s.resetBtn}
-              onPress={() => { setFilterCity(''); setFilterIfnsId(''); }}
+              onPress={() => { setFilterCity(''); setFilterIfnsId(''); setFilterServiceType(''); }}
             >
               <Feather name="x" size={14} color={Colors.textMuted} />
               <Text style={s.resetBtnText}>Сбросить</Text>
@@ -547,6 +629,10 @@ export default function PublicRequestsScreen() {
           onCityChange={handleCityChange}
           onIfnsChange={handleIfnsChange}
           loadingFns={loadingFns}
+        />
+        <ServicePicker
+          value={filterServiceType}
+          onChange={setFilterServiceType}
         />
       </View>
     </View>


### PR DESCRIPTION
Fixes #909

## Changes
- `app/(public)/requests.tsx`: added `ServicePicker` dropdown with 3 service type options. Wired to `filterServiceType` state, passes `serviceType` param to API.
- `api/src/requests/requests.controller.ts`: `getPublicFeed` now accepts `@Query('serviceType')` and forwards it to `findFeed`
- `api/src/requests/requests.service.ts`: `findFeed` accepts optional `serviceType` param with case-insensitive equals filter