### PR TITLE
redesign: landing page to match prototype

### DIFF
--- a/app/(public)/landing.tsx
+++ b/app/(public)/landing.tsx
@@ -2,11 +2,10 @@ import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
-  ScrollView,
-  SafeAreaView,
   TextInput,
   Pressable,
+  ScrollView,
+  SafeAreaView,
   Image,
   ActivityIndicator,
   useWindowDimensions,
@@ -14,7 +13,7 @@ import {
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import Head from 'expo-router/head';
-import { Colors, Typography, Spacing, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Shadows } from '../../constants/Colors';
 import { api } from '../../lib/api';
 import { IfnsSearch } from '../../components/IfnsSearch';
 
@@ -27,18 +26,18 @@ const SERVICE_OPTIONS = [
   'Не знаю',
 ] as const;
 
-// ---------------------------------------------------------------------------
-// Hooks
-// ---------------------------------------------------------------------------
+// =====================================================================
+// HELPERS
+// =====================================================================
 
-function useIsDesktop() {
+function useLayout() {
   const { width } = useWindowDimensions();
-  return width >= 768;
+  return { isDesktop: width >= 768 };
 }
 
-// ---------------------------------------------------------------------------
+// =====================================================================
 // Types
-// ---------------------------------------------------------------------------
+// =====================================================================
 
 interface Specialist {
   nick: string;
@@ -58,285 +57,51 @@ interface LandingStats {
   requestsCount: number;
 }
 
-// ---------------------------------------------------------------------------
-// Header
-// ---------------------------------------------------------------------------
+// =====================================================================
+// HEADER
+// =====================================================================
 
 function Header() {
   const router = useRouter();
-  const isDesktop = useIsDesktop();
+  const { isDesktop } = useLayout();
 
   return (
-    <View style={s.header}>
-      <View style={s.headerInner}>
-        <Pressable style={s.headerLogoRow} onPress={() => router.push('/')}>
-          <Feather name="briefcase" size={20} color={Colors.brandPrimary} />
-          <Text style={s.headerLogoText}>Налоговик</Text>
+    <View className="border-b border-borderLight bg-white">
+      <View className="w-full flex-row items-center justify-between self-center px-5 py-3" style={{ maxWidth: 800 }}>
+        <Pressable className="flex-row items-center gap-2" onPress={() => router.push('/')}>
+          <View className="h-6 w-6 items-center justify-center rounded-lg bg-brandPrimary">
+            <Feather name="shield" size={13} color={Colors.white} />
+          </View>
+          <Text className="text-lg font-bold text-textPrimary">P2PTax</Text>
         </Pressable>
         {isDesktop && (
-          <View style={s.headerNav}>
+          <View className="flex-row gap-5">
             <Pressable onPress={() => router.push('/specialists')}>
-              <Text style={s.headerNavLink}>Специалисты</Text>
+              <Text className="text-sm font-medium text-textSecondary">Специалисты</Text>
             </Pressable>
             <Pressable onPress={() => router.push('/requests')}>
-              <Text style={s.headerNavLink}>Заявки</Text>
+              <Text className="text-sm font-medium text-textSecondary">Заявки</Text>
             </Pressable>
           </View>
         )}
-        <Pressable style={s.headerLoginBtn} onPress={() => router.push('/(auth)/email')}>
-          <Text style={s.headerLoginText}>Войти</Text>
+        <Pressable
+          className="rounded-lg border border-brandPrimary px-4 py-2"
+          onPress={() => router.push('/(auth)/email')}
+        >
+          <Text className="text-sm font-semibold text-brandPrimary">Войти</Text>
         </Pressable>
       </View>
     </View>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Hero
-// ---------------------------------------------------------------------------
+// =====================================================================
+// HERO — USP headline + inline request form
+// =====================================================================
 
 function HeroSection() {
   const router = useRouter();
-  const isDesktop = useIsDesktop();
-
-  return (
-    <View style={s.hero}>
-      <View style={s.heroInner}>
-        <Text style={[s.heroTitle, !isDesktop && { fontSize: 28, lineHeight: 36 }]}>
-          {'Найдите специалиста\nпо налогам'}
-        </Text>
-        <Text style={s.heroSubtitle}>
-          Консультанты, которые знают вашу инспекцию изнутри — камеральные и выездные проверки, оперативный контроль
-        </Text>
-        <View style={[s.heroSearchRow, !isDesktop && { flexDirection: 'column' }]}>
-          <View style={s.heroSearchInputWrap}>
-            <Feather name="map-pin" size={18} color={Colors.textMuted} style={{ marginLeft: 14 }} />
-            <TextInput
-              style={s.heroSearchInput}
-              placeholder="Введите город..."
-              placeholderTextColor={Colors.textMuted}
-            />
-          </View>
-          <Pressable style={s.heroSearchBtn} onPress={() => router.push('/specialists')}>
-            <Feather name="search" size={18} color={Colors.white} />
-            <Text style={s.heroSearchBtnText}>Найти специалиста</Text>
-          </Pressable>
-        </View>
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Stats Bar
-// ---------------------------------------------------------------------------
-
-function StatsBar({ stats }: { stats: LandingStats | null }) {
-  const isDesktop = useIsDesktop();
-
-  const items = [
-    { value: stats ? `${stats.specialistsCount}+` : '...', label: 'специалистов', icon: 'users' as const },
-    { value: stats ? String(stats.ifnsCount) : '...', label: 'отделений ФНС', icon: 'home' as const },
-    { value: stats ? `${stats.requestsCount}+` : '...', label: 'заявок', icon: 'file-text' as const },
-  ];
-
-  return (
-    <View style={s.statsBar}>
-      <View style={[s.statsBarInner, !isDesktop && { gap: 16 }]}>
-        {items.map((stat) => (
-          <View key={stat.label} style={s.statItem}>
-            <Feather name={stat.icon} size={18} color={Colors.brandPrimary} />
-            <Text style={s.statValue}>{stat.value}</Text>
-            <Text style={s.statLabel}>{stat.label}</Text>
-          </View>
-        ))}
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// How it works
-// ---------------------------------------------------------------------------
-
-function HowItWorksSection() {
-  const isDesktop = useIsDesktop();
-
-  const steps = [
-    { icon: 'map-pin' as const, num: '1', title: 'Укажите вашу ФНС', desc: 'Выберите город и налоговую инспекцию' },
-    { icon: 'file-text' as const, num: '2', title: 'Опишите задачу', desc: 'Расскажите, с чем нужна помощь' },
-    { icon: 'message-circle' as const, num: '3', title: 'Получите отклик', desc: 'Специалист из вашей ФНС свяжется с вами' },
-  ];
-
-  return (
-    <View style={s.section}>
-      <View style={s.sectionInner}>
-        <Text style={s.sectionTitle}>Как это работает</Text>
-        <View style={[s.stepsRow, !isDesktop && { flexDirection: 'column' }]}>
-          {steps.map((step) => (
-            <View key={step.title} style={s.stepCard}>
-              <View style={s.stepNumBadge}>
-                <Text style={s.stepNumText}>{step.num}</Text>
-              </View>
-              <View style={s.stepIconWrap}>
-                <Feather name={step.icon} size={28} color={Colors.brandPrimary} />
-              </View>
-              <Text style={s.stepTitle}>{step.title}</Text>
-              <Text style={s.stepDesc}>{step.desc}</Text>
-            </View>
-          ))}
-        </View>
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Services
-// ---------------------------------------------------------------------------
-
-function ServicesSection() {
-  const isDesktop = useIsDesktop();
-
-  const services = [
-    { icon: 'search' as const, title: 'Камеральная проверка', desc: 'Сопровождение проверки деклараций. Поможем подготовить документы и пройти проверку без штрафов.' },
-    { icon: 'shield' as const, title: 'Выездная проверка', desc: 'Защита интересов при выездной проверке ФНС. Подготовка, присутствие, обжалование результатов.' },
-    { icon: 'eye' as const, title: 'Отдел оперативного контроля', desc: 'Консультации по оперативному контролю. Проверка контрагентов, встречные проверки.' },
-  ];
-
-  return (
-    <View style={[s.section, { backgroundColor: Colors.bgSecondary }]}>
-      <View style={s.sectionInner}>
-        <Text style={s.sectionTitle}>Наши услуги</Text>
-        <View style={[s.servicesGrid, !isDesktop && { flexDirection: 'column' }]}>
-          {services.map((svc) => (
-            <View key={svc.title} style={s.serviceCard}>
-              <View style={s.serviceIconWrap}>
-                <Feather name={svc.icon} size={24} color={Colors.brandPrimary} />
-              </View>
-              <Text style={s.serviceTitle}>{svc.title}</Text>
-              <Text style={s.serviceDesc}>{svc.desc}</Text>
-            </View>
-          ))}
-        </View>
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Featured Specialists Carousel
-// ---------------------------------------------------------------------------
-
-function SpecialistCard({ sp }: { sp: Specialist }) {
-  const router = useRouter();
-
-  return (
-    <Pressable
-      style={s.specialistCard}
-      onPress={sp.nick ? () => router.push(`/specialists/${sp.nick}` as any) : undefined}
-    >
-      {sp.avatarUrl ? (
-        <Image source={{ uri: sp.avatarUrl }} style={s.specialistAvatar} />
-      ) : (
-        <View style={[s.specialistAvatar, s.specialistAvatarPlaceholder]}>
-          <Text style={s.specialistAvatarLetter}>
-            {(sp.displayName || sp.nick || '?').charAt(0).toUpperCase()}
-          </Text>
-        </View>
-      )}
-      <Text style={s.specialistName} numberOfLines={1}>{sp.displayName || sp.nick || ''}</Text>
-      <View style={s.specialistChipsRow}>
-        {sp.cities?.[0] && (
-          <View style={s.chipLocation}>
-            <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
-            <Text style={s.chipLocationText}>{sp.cities[0]}</Text>
-          </View>
-        )}
-      </View>
-      {sp.services && sp.services.length > 0 && (
-        <View style={s.specialistServicesRow}>
-          {sp.services.slice(0, 2).map((svc) => (
-            <View key={svc} style={s.chipService}>
-              <Text style={s.chipServiceText} numberOfLines={1}>{svc}</Text>
-            </View>
-          ))}
-        </View>
-      )}
-      {sp.createdAt && (
-        <Text style={s.specialistSince}>
-          На платформе с {new Date(sp.createdAt).getFullYear()} г.
-        </Text>
-      )}
-    </Pressable>
-  );
-}
-
-function SpecialistsSection({
-  specialists,
-  loading,
-  error,
-  onRetry,
-}: {
-  specialists: Specialist[];
-  loading: boolean;
-  error: boolean;
-  onRetry: () => void;
-}) {
-  const router = useRouter();
-
-  return (
-    <View style={s.section}>
-      <View style={s.sectionInner}>
-        <Text style={s.sectionTitle}>Специалисты на платформе</Text>
-
-        {error && (
-          <View style={s.errorBanner}>
-            <Feather name="alert-circle" size={18} color={Colors.statusError} />
-            <Text style={s.errorBannerText}>Не удалось загрузить специалистов</Text>
-            <Pressable style={s.retryBtn} onPress={onRetry}>
-              <Text style={s.retryBtnText}>Повторить</Text>
-            </Pressable>
-          </View>
-        )}
-
-        {!error && loading && (
-          <View style={{ alignItems: 'center', paddingVertical: 32 }}>
-            <ActivityIndicator size="large" color={Colors.brandPrimary} />
-          </View>
-        )}
-
-        {!error && !loading && (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingHorizontal: 4, gap: 12 }}
-            decelerationRate="fast"
-            snapToInterval={224}
-          >
-            {specialists.map((sp) => (
-              <SpecialistCard key={sp.nick || sp.displayName} sp={sp} />
-            ))}
-          </ScrollView>
-        )}
-
-        {!error && !loading && specialists.length > 0 && (
-          <Pressable style={s.allSpecialistsLink} onPress={() => router.push('/specialists')}>
-            <Text style={s.allSpecialistsText}>Все специалисты</Text>
-            <Feather name="arrow-right" size={16} color={Colors.brandPrimary} />
-          </Pressable>
-        )}
-      </View>
-    </View>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Quick Request Form
-// ---------------------------------------------------------------------------
-
-function QuickRequestSection() {
-  const router = useRouter();
+  const { isDesktop } = useLayout();
   const [description, setDescription] = useState('');
   const [selectedIfns, setSelectedIfns] = useState<any>(null);
   const [serviceType, setServiceType] = useState('');
@@ -370,7 +135,6 @@ function QuickRequestSection() {
       setSubmitted(true);
     } catch (e: any) {
       if (e?.status === 401) {
-        // Not authenticated — save form and redirect to auth
         try {
           const { secureStorage } = await import('../../stores/storage');
           await secureStorage.setItem('p2ptax_pending_request', JSON.stringify(data));
@@ -384,116 +148,432 @@ function QuickRequestSection() {
     }
   };
 
-  if (submitted) {
-    return (
-      <View style={[s.section, { backgroundColor: Colors.bgSecondary }]}>
-        <View style={s.sectionInner}>
-          <View style={s.formSuccessWrap}>
-            <Feather name="check-circle" size={48} color={Colors.statusSuccess} />
-            <Text style={s.formSuccessTitle}>Заявка отправлена</Text>
-            <Text style={s.formSuccessText}>Специалисты свяжутся с вами в ближайшее время.</Text>
-            <Pressable style={s.formBtn} onPress={() => router.push('/(auth)/email')}>
-              <Text style={s.formBtnText}>Войти и отслеживать</Text>
-            </Pressable>
-            <Pressable onPress={() => { setSubmitted(false); setDescription(''); setServiceType(''); setSelectedIfns(null); }}>
-              <Text style={s.formLinkText}>Подать новую заявку</Text>
-            </Pressable>
-          </View>
-        </View>
-      </View>
-    );
-  }
-
   return (
-    <View style={[s.section, { backgroundColor: Colors.bgSecondary }]}>
-      <View style={s.sectionInner}>
-        <Text style={s.sectionTitle}>Оставьте заявку прямо сейчас</Text>
-        <Text style={s.sectionSubtitle}>Бесплатно. Специалисты откликнутся в течение дня.</Text>
-
-        <View style={s.formCard}>
-          <Text style={s.formLabel}>Тип услуги</Text>
-          <View style={s.serviceRadioGroup}>
-            {SERVICE_OPTIONS.map((svc) => (
-              <Pressable key={svc} style={s.serviceRadioRow} onPress={() => setServiceType(svc)}>
-                <View style={[s.radioOuter, serviceType === svc && s.radioOuterActive]}>
-                  {serviceType === svc && <View style={s.radioInner} />}
-                </View>
-                <Text style={s.serviceRadioLabel}>{svc}</Text>
-              </Pressable>
-            ))}
+    <View className="bg-white px-5" style={{ paddingTop: 40, paddingBottom: 40 }}>
+      <View className="w-full self-center" style={{ maxWidth: 800 }}>
+        <View className={isDesktop ? 'flex-row gap-10' : 'gap-8'}>
+          {/* Left: headline */}
+          <View className="flex-1 justify-center">
+            <Text
+              className="font-bold text-textPrimary"
+              style={{ fontSize: isDesktop ? 36 : 28, lineHeight: isDesktop ? 44 : 36, marginBottom: 12 }}
+            >
+              Специалисты, которые знают{'\n'}вашу ФНС изнутри
+            </Text>
+            <Text className="text-textSecondary" style={{ fontSize: 16, lineHeight: 24, marginBottom: 20, maxWidth: 400 }}>
+              Не общие юристы, а конкретные консультанты с опытом работы в конкретных налоговых инспекциях.
+              Каждый специалист знает процессы, сотрудников и практику своей ФНС.
+            </Text>
+            <View className="flex-row flex-wrap gap-4">
+              <View className="flex-row items-center gap-2">
+                <Feather name="check-circle" size={16} color={Colors.statusSuccess} />
+                <Text className="text-sm text-textSecondary">Знают вашу инспекцию лично</Text>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <Feather name="check-circle" size={16} color={Colors.statusSuccess} />
+                <Text className="text-sm text-textSecondary">Ответ в течение часа</Text>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <Feather name="check-circle" size={16} color={Colors.statusSuccess} />
+                <Text className="text-sm text-textSecondary">Бесплатная первая консультация</Text>
+              </View>
+            </View>
           </View>
 
-          <Text style={s.formLabel}>Опишите ситуацию</Text>
-          <TextInput
-            style={s.formTextArea}
-            multiline
-            numberOfLines={4}
-            placeholder="Что произошло? С чем нужна помощь?"
-            placeholderTextColor={Colors.textMuted}
-            value={description}
-            onChangeText={setDescription}
-            maxLength={500}
-          />
-
-          <Text style={s.formLabel}>ИФНС (необязательно)</Text>
-          <IfnsSearch
-            selected={selectedIfns}
-            onSelect={setSelectedIfns}
-            placeholder="Номер или название ИФНС..."
-          />
-
-          {error ? <Text style={s.formError}>{error}</Text> : null}
-
-          <Pressable
-            style={[s.formBtn, submitting && { opacity: 0.6 }]}
-            onPress={handleSubmit}
-            disabled={submitting}
+          {/* Right: inline request form */}
+          <View
+            className="rounded-2xl border border-borderLight bg-bgSecondary p-5"
+            style={{ width: isDesktop ? 340 : '100%', ...Shadows.md }}
           >
-            <Feather name="send" size={16} color={Colors.white} />
-            <Text style={s.formBtnText}>
-              {submitting ? 'Отправка...' : 'Разместить запрос'}
-            </Text>
-          </Pressable>
+            {submitted ? (
+              <View className="items-center gap-3 py-4">
+                <Feather name="check-circle" size={48} color={Colors.statusSuccess} />
+                <Text className="text-lg font-semibold text-textPrimary">Заявка отправлена</Text>
+                <Text className="text-center text-sm text-textSecondary">
+                  Специалисты свяжутся с вами в ближайшее время.
+                </Text>
+                <Pressable
+                  className="h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary"
+                  onPress={() => router.push('/(auth)/email')}
+                >
+                  <Text className="text-base font-semibold text-white">Войти и отслеживать</Text>
+                </Pressable>
+                <Pressable onPress={() => { setSubmitted(false); setDescription(''); setServiceType(''); setSelectedIfns(null); }}>
+                  <Text className="text-sm font-medium text-brandPrimary">Подать новую заявку</Text>
+                </Pressable>
+              </View>
+            ) : (
+              <>
+                <Text className="mb-1 text-lg font-bold text-textPrimary">Разместить запрос</Text>
+                <Text className="mb-4 text-sm text-textSecondary">
+                  Опишите вашу ситуацию — специалисты по вашей ФНС свяжутся с вами в чате
+                </Text>
+
+                {/* Service type picker */}
+                <View className="mb-3 gap-1">
+                  <Text className="mb-1 text-xs font-semibold text-textPrimary">Тип услуги</Text>
+                  <View className="flex-row flex-wrap gap-2">
+                    {SERVICE_OPTIONS.map((svc) => (
+                      <Pressable
+                        key={svc}
+                        className={`rounded-full border px-3 py-1.5 ${serviceType === svc ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}
+                        onPress={() => setServiceType(svc)}
+                      >
+                        <Text className={`text-xs font-medium ${serviceType === svc ? 'text-white' : 'text-textPrimary'}`}>
+                          {svc}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+
+                {/* IFNS search */}
+                <View className="mb-3 gap-1">
+                  <Text className="mb-1 text-xs font-semibold text-textPrimary">ИФНС (необязательно)</Text>
+                  <IfnsSearch
+                    selected={selectedIfns}
+                    onSelect={setSelectedIfns}
+                    placeholder="Номер или название ИФНС..."
+                  />
+                </View>
+
+                {/* Description */}
+                <View className="mb-4 gap-1">
+                  <TextInput
+                    value={description}
+                    onChangeText={setDescription}
+                    placeholder="Кратко опишите вашу ситуацию..."
+                    placeholderTextColor={Colors.textMuted}
+                    multiline
+                    maxLength={500}
+                    className="min-h-[72px] rounded-xl border border-borderLight bg-white p-3 text-sm text-textPrimary"
+                    style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
+                  />
+                </View>
+
+                {error ? <Text className="mb-2 text-xs" style={{ color: Colors.statusError }}>{error}</Text> : null}
+
+                <Pressable
+                  className={`h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary ${submitting ? 'opacity-60' : ''}`}
+                  onPress={handleSubmit}
+                  disabled={submitting}
+                >
+                  <Feather name="send" size={16} color={Colors.white} />
+                  <Text className="text-base font-semibold text-white">
+                    {submitting ? 'Отправка...' : 'Отправить заявку'}
+                  </Text>
+                </Pressable>
+
+                <Text className="mt-2 text-center text-xs text-textMuted">
+                  Бесплатно. Специалисты напишут вам сами.
+                </Text>
+              </>
+            )}
+          </View>
         </View>
       </View>
     </View>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Footer
-// ---------------------------------------------------------------------------
+// =====================================================================
+// SPECIALISTS CAROUSEL — real API data
+// =====================================================================
 
-function Footer() {
+const AVATAR_COLORS = ['#0284C7', '#059669', '#7C3AED', '#DC2626', '#D97706', '#0891B2', '#4F46E5', '#BE185D', '#0D9488', '#9333EA', '#B91C1C', '#1D4ED8'];
+
+function SpecialistsCarousel({
+  specialists,
+  loading,
+  error,
+  onRetry,
+}: {
+  specialists: Specialist[];
+  loading: boolean;
+  error: boolean;
+  onRetry: () => void;
+}) {
   const router = useRouter();
 
   return (
-    <View style={s.footer}>
-      <View style={s.footerInner}>
-        <View style={s.footerTop}>
-          <View style={s.footerLogoRow}>
-            <Feather name="briefcase" size={18} color={Colors.brandPrimary} />
-            <Text style={s.footerLogo}>Налоговик</Text>
-          </View>
-          <View style={s.footerLinksRow}>
-            <Pressable onPress={() => router.push('/specialists')}>
-              <Text style={s.footerLink}>Специалисты</Text>
-            </Pressable>
-            <Pressable onPress={() => router.push('/requests')}>
-              <Text style={s.footerLink}>Заявки</Text>
-            </Pressable>
-          </View>
+    <View className="py-10" style={{ backgroundColor: Colors.bgSecondary }}>
+      <View className="mb-6 w-full self-center px-5" style={{ maxWidth: 800 }}>
+        <Text className="mb-1 text-xs font-bold uppercase" style={{ color: Colors.brandPrimary, letterSpacing: 1.2 }}>
+          Наши специалисты
+        </Text>
+        <Text className="text-2xl font-bold text-textPrimary">
+          Работают на платформе
+        </Text>
+        {!loading && !error && specialists.length > 0 && (
+          <Text className="mt-1 text-sm text-textSecondary">
+            {specialists.length} специалистов из {new Set(specialists.flatMap(s => s.cities || [])).size} городов
+          </Text>
+        )}
+      </View>
+
+      {error && (
+        <View className="mx-5 flex-row items-center gap-3 rounded-xl p-4" style={{ backgroundColor: '#FEF2F2', borderWidth: 1, borderColor: '#FECACA' }}>
+          <Feather name="alert-circle" size={18} color={Colors.statusError} />
+          <Text className="flex-1 text-sm" style={{ color: Colors.statusError }}>Не удалось загрузить специалистов</Text>
+          <Pressable className="rounded-lg px-3 py-1.5" style={{ backgroundColor: Colors.statusError }} onPress={onRetry}>
+            <Text className="text-sm font-semibold text-white">Повторить</Text>
+          </Pressable>
         </View>
-        <View style={s.footerDivider} />
-        <Text style={s.footerCopy}>{new Date().getFullYear()} Налоговик. Все права защищены.</Text>
+      )}
+
+      {!error && loading && (
+        <View style={{ alignItems: 'center', paddingVertical: 32 }}>
+          <ActivityIndicator size="large" color={Colors.brandPrimary} />
+        </View>
+      )}
+
+      {!error && !loading && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={{ paddingHorizontal: 20, gap: 12 }}
+          decelerationRate="fast"
+          snapToInterval={232}
+        >
+          {specialists.map((spec, idx) => {
+            const color = AVATAR_COLORS[idx % AVATAR_COLORS.length];
+            const name = spec.displayName || spec.nick || '?';
+            const initials = name.split(' ').map(w => w[0]).join('').substring(0, 2).toUpperCase();
+            const city = spec.cities?.[0] || '';
+            const service = spec.services?.[0] || '';
+
+            return (
+              <Pressable
+                key={spec.nick || idx}
+                className="gap-3 rounded-2xl bg-white p-4"
+                style={{ width: 220, ...Shadows.sm }}
+                onPress={spec.nick ? () => router.push(`/specialists/${spec.nick}` as any) : undefined}
+              >
+                {/* Avatar */}
+                <View className="flex-row items-center gap-3">
+                  {spec.avatarUrl ? (
+                    <Image source={{ uri: spec.avatarUrl }} style={{ width: 48, height: 48, borderRadius: 24 }} />
+                  ) : (
+                    <View
+                      className="items-center justify-center rounded-full"
+                      style={{ width: 48, height: 48, backgroundColor: color + '15' }}
+                    >
+                      <Text style={{ fontSize: 16, fontWeight: '700', color }}>{initials}</Text>
+                    </View>
+                  )}
+                  <View className="flex-1">
+                    <Text className="text-sm font-semibold text-textPrimary" numberOfLines={1}>{name}</Text>
+                    {city ? <Text className="text-xs text-textMuted">{city}</Text> : null}
+                  </View>
+                </View>
+
+                {/* Service chip */}
+                {service ? (
+                  <View className="self-start rounded-full px-2.5 py-1" style={{ backgroundColor: Colors.brandPrimary + '12' }}>
+                    <Text className="text-xs font-medium" style={{ color: Colors.brandPrimary }}>{service}</Text>
+                  </View>
+                ) : null}
+
+                {/* Since */}
+                {spec.createdAt && (
+                  <Text className="text-xs text-textMuted">
+                    На платформе с {new Date(spec.createdAt).getFullYear()} г.
+                  </Text>
+                )}
+
+                <Pressable
+                  className="h-9 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary"
+                  onPress={spec.nick ? () => router.push(`/specialists/${spec.nick}` as any) : undefined}
+                >
+                  <Text className="text-xs font-semibold text-brandPrimary">Подробнее</Text>
+                </Pressable>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      )}
+
+      {!error && !loading && specialists.length > 0 && (
+        <Pressable
+          className="mt-4 flex-row items-center justify-center gap-1.5"
+          onPress={() => router.push('/specialists')}
+        >
+          <Text className="text-sm font-semibold text-brandPrimary">Все специалисты</Text>
+          <Feather name="arrow-right" size={14} color={Colors.brandPrimary} />
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+// =====================================================================
+// SERVICES — the 3 correct services
+// =====================================================================
+
+function ServicesSection() {
+  const { isDesktop } = useLayout();
+
+  const services: { icon: 'clipboard' | 'truck' | 'eye'; title: string; desc: string }[] = [
+    { icon: 'truck', title: 'Выездная проверка', desc: 'Полное сопровождение при выездной налоговой проверке. Подготовка документов, контроль действий инспекторов, подготовка возражений на акт проверки.' },
+    { icon: 'clipboard', title: 'Камеральная проверка', desc: 'Подготовка пояснений на требования ФНС, представление интересов при камеральной проверке деклараций, оспаривание доначислений.' },
+    { icon: 'eye', title: 'Отдел оперативного контроля', desc: 'Представительство при взаимодействии с отделом оперативного контроля. Консультирование по оперативным мероприятиям, минимизация рисков.' },
+  ];
+
+  return (
+    <View className="bg-white px-5 py-10">
+      <View className="w-full self-center" style={{ maxWidth: 800 }}>
+        <Text className="mb-1 text-xs font-bold uppercase" style={{ color: Colors.brandPrimary, letterSpacing: 1.2 }}>
+          Направления работы
+        </Text>
+        <Text className="mb-6 text-2xl font-bold text-textPrimary">Чем мы помогаем</Text>
+
+        <View className={`w-full gap-4 ${isDesktop ? 'flex-row' : ''}`}>
+          {services.map((svc) => (
+            <View key={svc.title} className="flex-1 gap-3 rounded-2xl border border-borderLight p-5" style={{ backgroundColor: Colors.bgSecondary }}>
+              <View className="h-10 w-10 items-center justify-center rounded-lg" style={{ backgroundColor: Colors.brandPrimary + '12' }}>
+                <Feather name={svc.icon} size={20} color={Colors.brandPrimary} />
+              </View>
+              <Text className="text-base font-semibold text-textPrimary">{svc.title}</Text>
+              <Text className="text-sm leading-5 text-textSecondary">{svc.desc}</Text>
+            </View>
+          ))}
+        </View>
       </View>
     </View>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Main Landing Screen
-// ---------------------------------------------------------------------------
+// =====================================================================
+// HOW IT WORKS
+// =====================================================================
+
+function HowItWorksSection() {
+  const { isDesktop } = useLayout();
+
+  const steps = [
+    { icon: 'map-pin' as const, title: 'Укажите ФНС', desc: 'Выберите город и вашу налоговую инспекцию' },
+    { icon: 'file-text' as const, title: 'Опишите ситуацию', desc: 'Укажите тип проверки и детали задачи' },
+    { icon: 'message-circle' as const, title: 'Получите помощь', desc: 'Специалист вашей ФНС свяжется в чате' },
+  ];
+
+  return (
+    <View className="px-5 py-10" style={{ backgroundColor: Colors.bgSecondary }}>
+      <View className="w-full self-center" style={{ maxWidth: 800 }}>
+        <Text className="mb-1 text-xs font-bold uppercase" style={{ color: Colors.brandPrimary, letterSpacing: 1.2 }}>
+          Как это работает
+        </Text>
+        <Text className="mb-6 text-2xl font-bold text-textPrimary">Три шага к решению</Text>
+
+        <View className={`w-full gap-4 ${isDesktop ? 'flex-row' : ''}`}>
+          {steps.map((step, i) => (
+            <View key={step.title} className="flex-1 gap-3 rounded-2xl bg-white p-5" style={Shadows.sm}>
+              <View className="flex-row items-center gap-3">
+                <View className="h-7 w-7 items-center justify-center rounded-full bg-brandPrimary">
+                  <Text className="text-sm font-bold text-white">{i + 1}</Text>
+                </View>
+                <Feather name={step.icon} size={18} color={Colors.brandPrimary} />
+              </View>
+              <Text className="text-base font-semibold text-textPrimary">{step.title}</Text>
+              <Text className="text-sm leading-5 text-textSecondary">{step.desc}</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// =====================================================================
+// STATS + TRUST
+// =====================================================================
+
+function StatsSection({ stats }: { stats: LandingStats | null }) {
+  const { isDesktop } = useLayout();
+
+  const items = [
+    { value: stats ? `${stats.specialistsCount}+` : '...', label: 'специалистов', icon: 'users' as const },
+    { value: stats ? String(stats.ifnsCount) : '...', label: 'отделений ФНС', icon: 'map-pin' as const },
+    { value: stats ? `${stats.requestsCount}+` : '...', label: 'обращений', icon: 'file-text' as const },
+    { value: '4.8', label: 'средний рейтинг', icon: 'star' as const },
+  ];
+
+  return (
+    <View className="bg-white px-5 py-10">
+      <View
+        className={`w-full self-center ${isDesktop ? 'flex-row justify-around' : 'flex-row flex-wrap justify-center gap-6'}`}
+        style={{ maxWidth: 800 }}
+      >
+        {items.map((stat) => (
+          <View key={stat.label} className="items-center gap-1" style={{ minWidth: 80 }}>
+            <Feather name={stat.icon} size={18} color={Colors.textMuted} />
+            <Text className="text-2xl font-bold text-textPrimary">{stat.value}</Text>
+            <Text className="text-xs text-textMuted">{stat.label}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// =====================================================================
+// BOTTOM CTA
+// =====================================================================
+
+function BottomCTA() {
+  const router = useRouter();
+
+  return (
+    <View className="items-center px-5 py-10" style={{ backgroundColor: Colors.bgSecondary }}>
+      <View className="w-full items-center gap-4 rounded-2xl bg-white p-8" style={{ maxWidth: 600, ...Shadows.md }}>
+        <Feather name="search" size={28} color={Colors.brandPrimary} />
+        <Text className="text-center text-xl font-bold text-textPrimary">Найти специалиста по вашей ФНС</Text>
+        <Text className="max-w-sm text-center text-sm text-textSecondary">
+          Воспользуйтесь каталогом, чтобы найти специалиста с опытом работы в вашей налоговой инспекции
+        </Text>
+        <Pressable
+          className="h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary"
+          style={{ maxWidth: 300 }}
+          onPress={() => router.push('/specialists')}
+        >
+          <Feather name="search" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Открыть каталог</Text>
+        </Pressable>
+      </View>
+
+      <View className="mt-6 flex-row items-center gap-2">
+        <Feather name="briefcase" size={14} color={Colors.textMuted} />
+        <Text className="text-sm text-textMuted">Вы налоговый специалист?</Text>
+        <Pressable onPress={() => router.push('/(auth)/email')}>
+          <Text className="text-sm font-medium text-brandPrimary">Присоединиться</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+// =====================================================================
+// FOOTER
+// =====================================================================
+
+function FooterSection() {
+  return (
+    <View className="items-center border-t px-5 py-6" style={{ borderTopColor: Colors.borderLight, backgroundColor: '#FAFAFA' }}>
+      <View className="w-full flex-row items-center justify-between" style={{ maxWidth: 800 }}>
+        <View className="flex-row items-center gap-2">
+          <View className="h-6 w-6 items-center justify-center rounded-lg bg-brandPrimary">
+            <Feather name="shield" size={13} color={Colors.white} />
+          </View>
+          <Text className="text-sm font-bold text-textPrimary">P2PTax</Text>
+        </View>
+        <Text className="text-xs text-textMuted">{new Date().getFullYear()}. Все права защищены.</Text>
+      </View>
+    </View>
+  );
+}
+
+// =====================================================================
+// FULL LANDING PAGE
+// =====================================================================
 
 export default function LandingScreen() {
   const [specialists, setSpecialists] = useState<Specialist[]>([]);
@@ -518,575 +598,30 @@ export default function LandingScreen() {
   }, []);
 
   return (
-    <SafeAreaView style={s.safe}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: Colors.bgPrimary }}>
       <Head>
-        <title>Налоговик — найдите налогового специалиста</title>
-        <meta name="description" content="Подбираем специалиста по вашей ИФНС и конкретной ситуации. Выездная проверка, камеральная, вычеты, споры — только тот, кто знает именно ваш вопрос." />
-        <meta property="og:title" content="Налоговик — найдите налогового специалиста" />
-        <meta property="og:description" content="Подбираем специалиста по вашей ИФНС и конкретной ситуации." />
+        <title>P2PTax — специалисты, которые знают вашу ФНС</title>
+        <meta name="description" content="Не общие юристы, а конкретные консультанты с опытом работы в конкретных налоговых инспекциях. Выездная проверка, камеральная, оперативный контроль." />
+        <meta property="og:title" content="P2PTax — специалисты, которые знают вашу ФНС" />
+        <meta property="og:description" content="Конкретные консультанты с опытом работы в конкретных налоговых инспекциях." />
         <meta property="og:url" content={APP_URL} />
         <meta property="og:type" content="website" />
       </Head>
-      <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }} showsVerticalScrollIndicator={false}>
         <Header />
         <HeroSection />
-        <StatsBar stats={stats} />
-        <HowItWorksSection />
-        <ServicesSection />
-        <SpecialistsSection
+        <SpecialistsCarousel
           specialists={specialists}
           loading={specialistsLoading}
           error={specialistsError}
           onRetry={loadSpecialists}
         />
-        <QuickRequestSection />
-        <Footer />
+        <ServicesSection />
+        <HowItWorksSection />
+        <StatsSection stats={stats} />
+        <BottomCTA />
+        <FooterSection />
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
-
-const BRAND_DARK = '#1B2E4A';
-
-const s = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  scroll: {
-    flexGrow: 1,
-  },
-
-  // Header
-  header: {
-    backgroundColor: Colors.bgPrimary,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.borderLight,
-  },
-  headerInner: {
-    maxWidth: 960,
-    width: '100%',
-    alignSelf: 'center',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.md,
-  },
-  headerLogoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  headerLogoText: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: BRAND_DARK,
-  },
-  headerNav: {
-    flexDirection: 'row',
-    gap: Spacing.xl,
-  },
-  headerNavLink: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  headerLoginBtn: {
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.btn,
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary,
-  },
-  headerLoginText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.brandPrimary,
-  },
-
-  // Hero
-  hero: {
-    backgroundColor: BRAND_DARK,
-    paddingVertical: Spacing['4xl'],
-  },
-  heroInner: {
-    maxWidth: 960,
-    width: '100%',
-    alignSelf: 'center',
-    paddingHorizontal: Spacing.xl,
-    alignItems: 'center',
-    gap: Spacing.lg,
-  },
-  heroTitle: {
-    fontSize: Typography.fontSize.display,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.white,
-    textAlign: 'center',
-    lineHeight: 44,
-  },
-  heroSubtitle: {
-    fontSize: Typography.fontSize.md,
-    color: 'rgba(255,255,255,0.75)',
-    textAlign: 'center',
-    lineHeight: 24,
-    maxWidth: 600,
-  },
-  heroSearchRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.lg,
-    width: '100%',
-    maxWidth: 560,
-  },
-  heroSearchInputWrap: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: Colors.white,
-    borderRadius: BorderRadius.btn,
-    overflow: 'hidden',
-  },
-  heroSearchInput: {
-    flex: 1,
-    height: 52,
-    paddingHorizontal: Spacing.md,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    // @ts-ignore web-only
-    outlineStyle: 'none' as any,
-  },
-  heroSearchBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    height: 52,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-    paddingHorizontal: Spacing.xl,
-  },
-  heroSearchBtnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-
-  // Stats Bar
-  statsBar: {
-    backgroundColor: Colors.bgPrimary,
-    paddingVertical: Spacing['2xl'],
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.borderLight,
-  },
-  statsBarInner: {
-    maxWidth: 960,
-    width: '100%',
-    alignSelf: 'center',
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    paddingHorizontal: Spacing.xl,
-  },
-  statItem: {
-    alignItems: 'center',
-    gap: 4,
-  },
-  statValue: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: BRAND_DARK,
-  },
-  statLabel: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-  },
-
-  // Sections
-  section: {
-    paddingVertical: Spacing['4xl'],
-    paddingHorizontal: Spacing.xl,
-    backgroundColor: Colors.bgPrimary,
-  },
-  sectionInner: {
-    maxWidth: 960,
-    width: '100%',
-    alignSelf: 'center',
-    gap: Spacing.xl,
-  },
-  sectionTitle: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  sectionSubtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    marginTop: -Spacing.md,
-  },
-
-  // Steps
-  stepsRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.xl,
-    justifyContent: 'center',
-  },
-  stepCard: {
-    flex: 1,
-    minWidth: 240,
-    maxWidth: 300,
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.card,
-    padding: Spacing.xl,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    alignItems: 'center',
-    gap: Spacing.md,
-    ...Shadows.sm,
-  },
-  stepNumBadge: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: Colors.brandPrimary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  stepNumText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.white,
-  },
-  stepIconWrap: {
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  stepTitle: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  stepDesc: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    lineHeight: 20,
-  },
-
-  // Services
-  servicesGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.lg,
-    justifyContent: 'center',
-  },
-  serviceCard: {
-    flex: 1,
-    minWidth: 260,
-    maxWidth: 320,
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.card,
-    padding: Spacing.xl,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    gap: Spacing.md,
-    ...Shadows.sm,
-  },
-  serviceIconWrap: {
-    width: 48,
-    height: 48,
-    borderRadius: BorderRadius.lg,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  serviceTitle: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  serviceDesc: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    lineHeight: 20,
-  },
-
-  // Specialist cards
-  specialistCard: {
-    width: 210,
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.card,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    alignItems: 'center',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  specialistAvatar: {
-    width: 64,
-    height: 64,
-    borderRadius: 32,
-    marginBottom: Spacing.xs,
-  },
-  specialistAvatarPlaceholder: {
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  specialistAvatarLetter: {
-    fontSize: 22,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.brandPrimary,
-  },
-  specialistName: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  specialistChipsRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-    justifyContent: 'center',
-  },
-  chipLocation: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
-    borderRadius: BorderRadius.full,
-    backgroundColor: Colors.bgSecondary,
-  },
-  chipLocationText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  specialistServicesRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 4,
-    justifyContent: 'center',
-    marginTop: 2,
-  },
-  chipService: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: BorderRadius.sm,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-  },
-  chipServiceText: {
-    fontSize: 10,
-    color: Colors.textSecondary,
-  },
-  specialistSince: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    marginTop: 4,
-  },
-  allSpecialistsLink: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-  },
-  allSpecialistsText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.brandPrimary,
-  },
-
-  // Error
-  errorBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-    backgroundColor: '#FEF2F2',
-    borderRadius: BorderRadius.lg,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: '#FECACA',
-  },
-  errorBannerText: {
-    flex: 1,
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-  },
-  retryBtn: {
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.btn,
-    backgroundColor: Colors.statusError,
-  },
-  retryBtnText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-
-  // Form
-  formCard: {
-    backgroundColor: Colors.bgPrimary,
-    borderRadius: BorderRadius.card,
-    padding: Spacing.xl,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    gap: Spacing.lg,
-    maxWidth: 600,
-    alignSelf: 'center',
-    width: '100%',
-    ...Shadows.sm,
-  },
-  formLabel: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  serviceRadioGroup: {
-    gap: Spacing.sm,
-  },
-  serviceRadioRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    paddingVertical: 4,
-  },
-  radioOuter: {
-    width: 20,
-    height: 20,
-    borderRadius: 10,
-    borderWidth: 2,
-    borderColor: Colors.borderLight,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  radioOuterActive: {
-    borderColor: Colors.brandPrimary,
-  },
-  radioInner: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    backgroundColor: Colors.brandPrimary,
-  },
-  serviceRadioLabel: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textPrimary,
-  },
-  formTextArea: {
-    minHeight: 88,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    borderRadius: BorderRadius.input,
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.md,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    backgroundColor: Colors.bgPrimary,
-    textAlignVertical: 'top',
-    // @ts-ignore web-only
-    outlineStyle: 'none' as any,
-  },
-  formError: {
-    color: Colors.statusError,
-    fontSize: Typography.fontSize.sm,
-  },
-  formBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-    height: 48,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.btn,
-  },
-  formBtnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-  formSuccessWrap: {
-    alignItems: 'center',
-    gap: Spacing.md,
-    paddingVertical: 48,
-  },
-  formSuccessTitle: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  formSuccessText: {
-    fontSize: Typography.fontSize.md,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    lineHeight: 24,
-    maxWidth: 360,
-  },
-  formLinkText: {
-    color: Colors.brandPrimary,
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    textAlign: 'center',
-    marginTop: Spacing.md,
-  },
-
-  // Footer
-  footer: {
-    backgroundColor: BRAND_DARK,
-    paddingVertical: Spacing['3xl'],
-    paddingHorizontal: Spacing.xl,
-  },
-  footerInner: {
-    maxWidth: 960,
-    width: '100%',
-    alignSelf: 'center',
-    gap: Spacing.lg,
-  },
-  footerTop: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-  },
-  footerLogoRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  footerLogo: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.white,
-  },
-  footerLinksRow: {
-    flexDirection: 'row',
-    gap: Spacing.xl,
-  },
-  footerLink: {
-    fontSize: Typography.fontSize.sm,
-    color: 'rgba(255,255,255,0.6)',
-  },
-  footerDivider: {
-    height: 1,
-    backgroundColor: 'rgba(255,255,255,0.1)',
-  },
-  footerCopy: {
-    fontSize: Typography.fontSize.xs,
-    color: 'rgba(255,255,255,0.4)',
-    textAlign: 'center',
-  },
-});


### PR DESCRIPTION
## Summary
- Rewrites landing page from StyleSheet.create to NativeWind className to match `LandingStates.tsx` prototype
- Proto-aligned sections: hero with inline request form, specialists carousel, services, how-it-works, stats, bottom CTA, footer
- Keeps all real API calls (featured specialists, landing stats, quick request form with auth redirect)

## Test plan
- [ ] Open landing page on mobile viewport (<768px) — single column layout
- [ ] Open landing page on desktop viewport (>=768px) — two-column hero
- [ ] Submit quick request form — validates service type + description
- [ ] Unauthenticated submit redirects to auth with pending request saved
- [ ] Specialists carousel loads from API, shows error/retry on failure