### PR TITLE
Fix issue #915: QA follow-up #763: Notification preferences UI still uses single toggle, not per-event

### DIFF
--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -36,14 +36,23 @@ interface MyReview {
 
 type EmailChangeStep = 'idle' | 'email_input' | 'otp_input' | 'success';
 
-const NOTIF_KEY = '@p2ptax_email_notif';
+interface NotificationSettings {
+  new_responses: boolean;
+  new_messages: boolean;
+}
+
+const NOTIF_KEY_RESPONSES = '@p2ptax_notif_responses';
+const NOTIF_KEY_MESSAGES = '@p2ptax_notif_messages';
 
 export default function SettingsScreen() {
   const router = useRouter();
   const { isMobile } = useBreakpoints();
   const { user, logout, updateEmail } = useAuth();
 
-  const [emailNotif, setEmailNotif] = useState(true);
+  const [notifSettings, setNotifSettings] = useState<NotificationSettings>({
+    new_responses: true,
+    new_messages: true,
+  });
   const [notifLoading, setNotifLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
   const [myReviews, setMyReviews] = useState<MyReview[]>([]);
@@ -67,32 +76,42 @@ export default function SettingsScreen() {
     }
   }, [user?.role]);
 
-  // Load notification preference from API, fallback to AsyncStorage
+  // Load notification preferences from API, fallback to AsyncStorage
   useEffect(() => {
-    api.get('/users/me/settings')
-      .then((data: any) => {
-        setEmailNotif(data.emailNotifications);
-        AsyncStorage.setItem(NOTIF_KEY, String(data.emailNotifications)).catch(() => {});
+    api.get<NotificationSettings>('/users/me/notification-settings')
+      .then((data) => {
+        setNotifSettings(data);
+        AsyncStorage.setItem(NOTIF_KEY_RESPONSES, String(data.new_responses)).catch(() => {});
+        AsyncStorage.setItem(NOTIF_KEY_MESSAGES, String(data.new_messages)).catch(() => {});
       })
       .catch(() => {
         // Fallback to AsyncStorage if API unavailable
-        AsyncStorage.getItem(NOTIF_KEY)
-          .then((val) => {
-            if (val !== null) setEmailNotif(val === 'true');
-          })
-          .catch(() => {});
+        Promise.all([
+          AsyncStorage.getItem(NOTIF_KEY_RESPONSES),
+          AsyncStorage.getItem(NOTIF_KEY_MESSAGES),
+        ]).then(([responses, messages]) => {
+          setNotifSettings({
+            new_responses: responses !== null ? responses === 'true' : true,
+            new_messages: messages !== null ? messages === 'true' : true,
+          });
+        }).catch(() => {});
       })
       .finally(() => setNotifLoading(false));
   }, []);
 
-  async function handleNotifToggle(value: boolean) {
-    setEmailNotif(value);
+  async function handleNotifToggle(key: keyof NotificationSettings, value: boolean) {
+    const prev = notifSettings[key];
+    setNotifSettings((s) => ({ ...s, [key]: value }));
     try {
-      await api.patch('/users/me/settings', { emailNotifications: value });
-      await AsyncStorage.setItem(NOTIF_KEY, String(value));
+      await api.patch('/users/me/notification-settings', { [key]: value });
+      if (key === 'new_responses') {
+        await AsyncStorage.setItem(NOTIF_KEY_RESPONSES, String(value));
+      } else {
+        await AsyncStorage.setItem(NOTIF_KEY_MESSAGES, String(value));
+      }
     } catch {
       // Revert on failure
-      setEmailNotif(!value);
+      setNotifSettings((s) => ({ ...s, [key]: prev }));
     }
   }
 
@@ -373,24 +392,52 @@ export default function SettingsScreen() {
           <View style={styles.card}>
             <View style={styles.row}>
               <View style={styles.rowTextBlock}>
-                <Text style={styles.rowLabel}>Email-уведомления</Text>
-                <Text style={styles.rowHint}>
-                  {user?.role === 'SPECIALIST'
-                    ? 'Новые запросы в ваших городах и сообщения'
-                    : 'Отклики специалистов и сообщения'}
-                </Text>
+                <Text style={styles.rowLabel}>Новые отклики</Text>
+                <Text style={styles.rowHint}>Уведомления о новых откликах на ваши запросы</Text>
               </View>
               {notifLoading ? (
                 <ActivityIndicator size="small" color={Colors.brandPrimary} />
               ) : (
                 <Switch
-                  value={emailNotif}
-                  onValueChange={handleNotifToggle}
+                  value={notifSettings.new_responses}
+                  onValueChange={(v) => handleNotifToggle('new_responses', v)}
                   trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
                   thumbColor={Colors.textPrimary}
-                  accessibilityLabel="Email-уведомления"
+                  accessibilityLabel="Новые отклики"
                 />
               )}
+            </View>
+            <View style={styles.divider} />
+            <View style={styles.row}>
+              <View style={styles.rowTextBlock}>
+                <Text style={styles.rowLabel}>Новые сообщения</Text>
+                <Text style={styles.rowHint}>Уведомления о новых сообщениях в чатах</Text>
+              </View>
+              {notifLoading ? (
+                <ActivityIndicator size="small" color={Colors.brandPrimary} />
+              ) : (
+                <Switch
+                  value={notifSettings.new_messages}
+                  onValueChange={(v) => handleNotifToggle('new_messages', v)}
+                  trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
+                  thumbColor={Colors.textPrimary}
+                  accessibilityLabel="Новые сообщения"
+                />
+              )}
+            </View>
+            <View style={styles.divider} />
+            <View style={styles.row}>
+              <View style={styles.rowTextBlock}>
+                <Text style={styles.rowLabel}>Автозакрытие</Text>
+                <Text style={styles.rowHint}>Уведомления об автоматическом закрытии запросов</Text>
+              </View>
+              <Switch
+                value={true}
+                disabled={true}
+                trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
+                thumbColor={Colors.textPrimary}
+                accessibilityLabel="Автозакрытие"
+              />
             </View>
           </View>
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -184,8 +184,10 @@ export default function SettingsTab() {
   const isSpecialist = user?.role === 'SPECIALIST';
 
   // Notification toggles
-  const [emailNotif, setEmailNotif] = useState(true);
-  const [pushNotif, setPushNotif] = useState(false);
+  const [notifSettings, setNotifSettings] = useState<{ new_responses: boolean; new_messages: boolean }>({
+    new_responses: true,
+    new_messages: true,
+  });
 
   // Confirm modals
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
@@ -219,13 +221,13 @@ export default function SettingsTab() {
       // Load notification settings
       promises.push(
         users
-          .getSettings()
-          .then((res: { data: Record<string, unknown> }) => {
+          .getNotificationSettings()
+          .then((res: { data: { new_responses: boolean; new_messages: boolean } }) => {
             if (res.data) {
-              if (typeof res.data.emailNotifications === 'boolean')
-                setEmailNotif(res.data.emailNotifications);
-              if (typeof res.data.pushNotifications === 'boolean')
-                setPushNotif(res.data.pushNotifications);
+              setNotifSettings({
+                new_responses: typeof res.data.new_responses === 'boolean' ? res.data.new_responses : true,
+                new_messages: typeof res.data.new_messages === 'boolean' ? res.data.new_messages : true,
+              });
             }
           })
           .catch(() => {}),
@@ -270,23 +272,15 @@ export default function SettingsTab() {
   }, [fetchData]);
 
   // ---- Notification toggles ----
-  const handleToggleEmail = useCallback(async (v: boolean) => {
-    setEmailNotif(v);
+  const handleNotifToggle = useCallback(async (key: 'new_responses' | 'new_messages', v: boolean) => {
+    const prev = notifSettings[key];
+    setNotifSettings((s) => ({ ...s, [key]: v }));
     try {
-      await users.updateSettings({ emailNotifications: v });
+      await users.updateNotificationSettings({ [key]: v });
     } catch {
-      setEmailNotif(!v);
+      setNotifSettings((s) => ({ ...s, [key]: prev }));
     }
-  }, []);
-
-  const handleTogglePush = useCallback(async (v: boolean) => {
-    setPushNotif(v);
-    try {
-      await users.updateSettings({ pushNotifications: v });
-    } catch {
-      setPushNotif(!v);
-    }
-  }, []);
+  }, [notifSettings]);
 
   // ---- Availability toggle (specialist) ----
   const handleToggleAvailability = useCallback(async (val: boolean) => {
@@ -524,21 +518,26 @@ export default function SettingsTab() {
           <Text style={s.sectionTitle}>Уведомления</Text>
           <SectionCard>
             <ToggleRow
-              label="Email-уведомления"
-              sublabel={
-                isSpecialist
-                  ? 'Новые запросы в ваших городах'
-                  : 'Отклики специалистов и сообщения'
-              }
+              label="Новые отклики"
+              sublabel="Уведомления о новых откликах на ваши запросы"
               icon="mail"
-              value={emailNotif}
-              onToggle={handleToggleEmail}
+              value={notifSettings.new_responses}
+              onToggle={(v) => handleNotifToggle('new_responses', v)}
             />
             <ToggleRow
-              label="Push-уведомления"
-              icon="bell"
-              value={pushNotif}
-              onToggle={handleTogglePush}
+              label="Новые сообщения"
+              sublabel="Уведомления о новых сообщениях в чатах"
+              icon="message-square"
+              value={notifSettings.new_messages}
+              onToggle={(v) => handleNotifToggle('new_messages', v)}
+            />
+            <ToggleRow
+              label="Автозакрытие"
+              sublabel="Уведомления об автоматическом закрытии запросов"
+              icon="clock"
+              value={true}
+              onToggle={() => {}}
+              disabled
               last
             />
           </SectionCard>

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -76,6 +76,14 @@ export const users = {
     return client.patch('/users/me/settings', data);
   },
 
+  getNotificationSettings() {
+    return client.get<{ new_responses: boolean; new_messages: boolean }>('/users/me/notification-settings');
+  },
+
+  updateNotificationSettings(data: { new_responses?: boolean; new_messages?: boolean }) {
+    return client.patch<{ new_responses: boolean; new_messages: boolean }>('/users/me/notification-settings', data);
+  },
+
   /** Step 1: send OTP to the new email address */
   requestEmailChange(newEmail: string) {
     return client.post<{ message: string }>('/users/me/change-email/request', { newEmail });

--- a/tests/test_notification_preferences.py
+++ b/tests/test_notification_preferences.py
@@ -1,0 +1,151 @@
+"""
+Tests for per-event notification preferences UI.
+
+Validates that issue #763 requirements are met:
+- Dashboard settings uses per-event notification toggles (new_responses, new_messages)
+- Tabs settings uses per-event notification toggles (new_responses, new_messages)
+- Both files call /users/me/notification-settings endpoint
+- Autoclose toggle is present and always ON (disabled)
+- Old single emailNotifications toggle is removed
+- Endpoints file has getNotificationSettings/updateNotificationSettings
+"""
+
+import re
+import unittest
+
+class TestDashboardSettingsNotificationPreferences(unittest.TestCase):
+    """Validate app/(dashboard)/settings.tsx has per-event notification toggles."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/settings.tsx") as f:
+            self.source = f.read()
+
+    def test_no_single_email_notifications_toggle(self):
+        """Old single emailNotifications toggle must be removed."""
+        self.assertNotIn("emailNotifications", self.source)
+
+    def test_no_old_notif_key(self):
+        """Old NOTIF_KEY constant must be removed."""
+        # Should not have the old single key, only the per-event keys
+        self.assertNotIn("@p2ptax_email_notif'", self.source)
+
+    def test_uses_notification_settings_endpoint(self):
+        """Must call /users/me/notification-settings endpoint."""
+        self.assertIn("/users/me/notification-settings", self.source)
+
+    def test_new_responses_toggle_exists(self):
+        """new_responses toggle must exist."""
+        self.assertIn("new_responses", self.source)
+
+    def test_new_messages_toggle_exists(self):
+        """new_messages toggle must exist."""
+        self.assertIn("new_messages", self.source)
+
+    def test_new_responses_label(self):
+        """Must show 'Новые отклики' label."""
+        self.assertIn("Новые отклики", self.source)
+
+    def test_new_messages_label(self):
+        """Must show 'Новые сообщения' label."""
+        self.assertIn("Новые сообщения", self.source)
+
+    def test_autoclose_toggle_exists(self):
+        """Autoclose toggle must exist."""
+        self.assertIn("Автозакрытие", self.source)
+
+    def test_autoclose_is_disabled(self):
+        """Autoclose toggle must be disabled (always ON)."""
+        # The Switch for autoclose should have disabled={true}
+        self.assertIn("disabled={true}", self.source)
+
+    def test_notif_settings_state(self):
+        """Must use notifSettings state with new_responses and new_messages."""
+        self.assertIn("notifSettings", self.source)
+        self.assertIn("setNotifSettings", self.source)
+
+    def test_no_old_email_notif_state(self):
+        """Old emailNotif state must be removed."""
+        self.assertNotIn("setEmailNotif", self.source)
+        # Check there's no useState(true) for emailNotif
+        self.assertNotRegex(self.source, r"emailNotif.*useState")
+
+class TestTabsSettingsNotificationPreferences(unittest.TestCase):
+    """Validate app/(tabs)/settings.tsx has per-event notification toggles."""
+
+    def setUp(self):
+        with open("/workspace/app/(tabs)/settings.tsx") as f:
+            self.source = f.read()
+
+    def test_no_single_email_notifications_toggle(self):
+        """Old single emailNotifications toggle must be removed."""
+        self.assertNotIn("emailNotifications", self.source)
+
+    def test_uses_notification_settings_endpoint(self):
+        """Must call getNotificationSettings from endpoints."""
+        self.assertIn("getNotificationSettings", self.source)
+
+    def test_new_responses_toggle_exists(self):
+        """new_responses toggle must exist."""
+        self.assertIn("new_responses", self.source)
+
+    def test_new_messages_toggle_exists(self):
+        """new_messages toggle must exist."""
+        self.assertIn("new_messages", self.source)
+
+    def test_new_responses_label(self):
+        """Must show 'Новые отклики' label."""
+        self.assertIn("Новые отклики", self.source)
+
+    def test_new_messages_label(self):
+        """Must show 'Новые сообщения' label."""
+        self.assertIn("Новые сообщения", self.source)
+
+    def test_autoclose_toggle_exists(self):
+        """Autoclose toggle must exist."""
+        self.assertIn("Автозакрытие", self.source)
+
+    def test_autoclose_is_disabled(self):
+        """Autoclose toggle must be disabled."""
+        self.assertIn('disabled', self.source)
+
+    def test_no_old_email_notif_state(self):
+        """Old emailNotif/pushNotif state must be removed."""
+        self.assertNotIn("setEmailNotif", self.source)
+        self.assertNotIn("setPushNotif", self.source)
+        self.assertNotIn("handleToggleEmail", self.source)
+        self.assertNotIn("handleTogglePush", self.source)
+
+    def test_notif_settings_state(self):
+        """Must use notifSettings state."""
+        self.assertIn("notifSettings", self.source)
+        self.assertIn("setNotifSettings", self.source)
+
+class TestEndpointsNotificationSettings(unittest.TestCase):
+    """Validate lib/api/endpoints.ts has notification-settings methods."""
+
+    def setUp(self):
+        with open("/workspace/lib/api/endpoints.ts") as f:
+            self.source = f.read()
+
+    def test_get_notification_settings_exists(self):
+        """getNotificationSettings method must exist."""
+        self.assertIn("getNotificationSettings", self.source)
+
+    def test_update_notification_settings_exists(self):
+        """updateNotificationSettings method must exist."""
+        self.assertIn("updateNotificationSettings", self.source)
+
+    def test_notification_settings_endpoint(self):
+        """Must use /users/me/notification-settings endpoint."""
+        self.assertIn("/users/me/notification-settings", self.source)
+
+    def test_new_responses_param(self):
+        """Must reference new_responses parameter."""
+        self.assertIn("new_responses", self.source)
+
+    def test_new_messages_param(self):
+        """Must reference new_messages parameter."""
+        self.assertIn("new_messages", self.source)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #915.

The changes fully address all requirements specified in the issue:

1. **Per-event notification toggles replace the single toggle**: Both `app/(dashboard)/settings.tsx` and `app/(tabs)/settings.tsx` now use a `notifSettings` state object with `new_responses` and `new_messages` booleans instead of the old single `emailNotif` boolean.

2. **Correct API endpoint usage**: Both settings screens now call `GET /users/me/notification-settings` to load preferences and `PATCH /users/me/notification-settings` to update them, replacing the old `/users/me/settings` calls with `emailNotifications`.

3. **Three toggles as specified**:
   - **Новые отклики** (new_responses) — toggleable ON/OFF
   - **Новые сообщения** (new_messages) — toggleable ON/OFF
   - **Автозакрытие** — always ON with `disabled={true}`, visual-only as required

4. **Endpoints layer updated**: `lib/api/endpoints.ts` now exposes `getNotificationSettings()` and `updateNotificationSettings()` methods targeting the correct backend endpoint.

5. **Proper error handling preserved**: The optimistic update pattern with revert-on-failure is maintained for both toggle handlers, using the previous value of the specific key being toggled.

6. **AsyncStorage fallback updated** (dashboard): The fallback caching now stores per-key values (`@p2ptax_notif_responses`, `@p2ptax_notif_messages`) instead of the old single `@p2ptax_email_notif` key.

7. **Old code fully removed**: No references to `emailNotifications`, `setEmailNotif`, `pushNotif`, `setPushNotif`, `handleToggleEmail`, or `handleTogglePush` remain. The old single toggle UI is completely replaced.

The 26 tests in the added test file validate all these structural requirements by checking the source files for the presence/absence of expected patterns, and they all pass.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌