### PR TITLE
Fix issue #914: QA follow-up #762: Request file upload PR only modified module.ts, no frontend file picker

### DIFF
--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -12,6 +12,8 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
+import * as DocumentPicker from 'expo-document-picker';
+import * as ImagePicker from 'expo-image-picker';
 import { api, ApiError } from '../../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius } from '../../../constants/Colors';
 import { Header } from '../../../components/Header';
@@ -19,6 +21,18 @@ import { Button } from '../../../components/Button';
 import { Input } from '../../../components/Input';
 import { IfnsSearch } from '../../../components/IfnsSearch';
 import { useBreakpoints } from '../../../hooks/useBreakpoints';
+
+const MAX_FILES = 5;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
+const ALLOWED_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png'];
+
+interface SelectedFile {
+  uri: string;
+  name: string;
+  mimeType: string;
+  size: number;
+}
 
 const TAX_CATEGORIES = [
   'НДС',
@@ -44,9 +58,92 @@ export default function CreateRequestScreen() {
   const [selectedIfns, setSelectedIfns] = useState<any>(null);
   const [budget, setBudget] = useState('');
   const [category, setCategory] = useState('');
+  const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
+  const [fileError, setFileError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
   const [errors, setErrors] = useState<{ title?: string; description?: string; city?: string; budget?: string }>({});
   const scrollViewRef = useRef<ScrollView>(null);
+
+  function addFiles(files: SelectedFile[]) {
+    setFileError(undefined);
+    const remaining = MAX_FILES - selectedFiles.length;
+    if (remaining <= 0) {
+      setFileError(`Максимум ${MAX_FILES} файлов`);
+      return;
+    }
+    const toAdd: SelectedFile[] = [];
+    for (const f of files) {
+      if (toAdd.length >= remaining) {
+        setFileError(`Максимум ${MAX_FILES} файлов`);
+        break;
+      }
+      const ext = f.name.split('.').pop()?.toLowerCase() ?? '';
+      if (!ALLOWED_MIME_TYPES.includes(f.mimeType) && !ALLOWED_EXTENSIONS.includes(ext)) {
+        setFileError('Допустимые форматы: PDF, JPG, PNG');
+        continue;
+      }
+      if (f.size > MAX_FILE_SIZE) {
+        setFileError('Максимальный размер файла — 10 МБ');
+        continue;
+      }
+      toAdd.push(f);
+    }
+    if (toAdd.length > 0) {
+      setSelectedFiles((prev) => [...prev, ...toAdd]);
+    }
+  }
+
+  function removeFile(index: number) {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+    setFileError(undefined);
+  }
+
+  async function pickDocument() {
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ['application/pdf'],
+        multiple: true,
+        copyToCacheDirectory: true,
+      });
+      if (result.canceled) return;
+      const files: SelectedFile[] = result.assets.map((a) => ({
+        uri: a.uri,
+        name: a.name ?? 'document.pdf',
+        mimeType: a.mimeType ?? 'application/pdf',
+        size: a.size ?? 0,
+      }));
+      addFiles(files);
+    } catch {
+      Alert.alert('Ошибка', 'Не удалось выбрать документ');
+    }
+  }
+
+  async function pickImage() {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        allowsMultipleSelection: true,
+        quality: 0.8,
+      });
+      if (result.canceled) return;
+      const files: SelectedFile[] = result.assets.map((a) => {
+        const uriParts = a.uri.split('/');
+        const fileName = a.fileName ?? uriParts[uriParts.length - 1] ?? 'image.jpg';
+        const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+        let mimeType = 'image/jpeg';
+        if (ext === 'png') mimeType = 'image/png';
+        return {
+          uri: a.uri,
+          name: fileName,
+          mimeType,
+          size: a.fileSize ?? 0,
+        };
+      });
+      addFiles(files);
+    } catch {
+      Alert.alert('Ошибка', 'Не удалось выбрать изображение');
+    }
+  }
 
   function validate(): boolean {
     const e: typeof errors = {};
@@ -71,6 +168,19 @@ export default function CreateRequestScreen() {
     return Object.keys(e).length === 0;
   }
 
+  async function uploadFiles(requestId: string) {
+    if (selectedFiles.length === 0) return;
+    const formData = new FormData();
+    for (const file of selectedFiles) {
+      formData.append('files', {
+        uri: file.uri,
+        name: file.name,
+        type: file.mimeType,
+      } as any);
+    }
+    await api.upload(`/requests/${requestId}/documents`, formData);
+  }
+
   async function handleSubmit() {
     if (!validate()) return;
     setLoading(true);
@@ -87,7 +197,13 @@ export default function CreateRequestScreen() {
       }
       if (budget.trim()) body.budget = Number(budget.trim());
       if (category) body.category = category;
-      await api.post('/requests', body);
+      const created = await api.post<{ id: string }>('/requests', body);
+      try {
+        await uploadFiles(created.id);
+      } catch (uploadErr) {
+        const msg = uploadErr instanceof ApiError ? uploadErr.message : 'Файлы не удалось загрузить';
+        Alert.alert('Запрос создан', `Но файлы не загружены: ${msg}`);
+      }
       router.replace('/(dashboard)/my-requests');
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : 'Не удалось создать запрос';
@@ -220,6 +336,47 @@ export default function CreateRequestScreen() {
               </View>
             </View>
 
+            <View style={styles.field}>
+              <Text style={styles.label}>Документы (необязательно, до {MAX_FILES} файлов)</Text>
+              <Text style={styles.fileHint}>PDF, JPG, PNG — макс. 10 МБ каждый</Text>
+              <View style={styles.fileButtonsRow}>
+                <TouchableOpacity
+                  style={styles.fileButton}
+                  onPress={pickDocument}
+                  activeOpacity={0.7}
+                  disabled={selectedFiles.length >= MAX_FILES}
+                >
+                  <Text style={styles.fileButtonText}>📄 PDF</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.fileButton}
+                  onPress={pickImage}
+                  activeOpacity={0.7}
+                  disabled={selectedFiles.length >= MAX_FILES}
+                >
+                  <Text style={styles.fileButtonText}>🖼 Фото</Text>
+                </TouchableOpacity>
+              </View>
+              {selectedFiles.length > 0 && (
+                <View style={styles.fileChipsRow}>
+                  {selectedFiles.map((file, index) => (
+                    <View key={`${file.name}-${index}`} style={styles.fileChip}>
+                      <Text style={styles.fileChipText} numberOfLines={1}>
+                        {file.name}
+                      </Text>
+                      <TouchableOpacity
+                        onPress={() => removeFile(index)}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      >
+                        <Text style={styles.fileChipRemove}>✕</Text>
+                      </TouchableOpacity>
+                    </View>
+                  ))}
+                </View>
+              )}
+              {fileError && <Text style={styles.errorText}>{fileError}</Text>}
+            </View>
+
           </View>
         </ScrollView>
         <View style={styles.stickyBottom}>
@@ -344,5 +501,56 @@ const styles = StyleSheet.create({
   },
   chipTextActive: {
     color: '#FFFFFF',
+  },
+  fileHint: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textMuted,
+  },
+  fileButtonsRow: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+  },
+  fileButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.sm,
+    borderRadius: BorderRadius.md,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  fileButtonText: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textSecondary,
+    fontWeight: Typography.fontWeight.medium,
+  },
+  fileChipsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  fileChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.xs,
+    borderRadius: BorderRadius.full,
+    backgroundColor: Colors.bgCard,
+    borderWidth: 1,
+    borderColor: Colors.brandPrimary,
+    maxWidth: 220,
+  },
+  fileChipText: {
+    fontSize: Typography.fontSize.xs,
+    color: Colors.textPrimary,
+    flexShrink: 1,
+  },
+  fileChipRemove: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.statusError,
+    fontWeight: Typography.fontWeight.bold,
   },
 });

--- a/tests/test_request_file_upload.py
+++ b/tests/test_request_file_upload.py
@@ -1,0 +1,276 @@
+"""
+Tests for Request file upload feature:
+- Frontend has file picker UI (DocumentPicker + ImagePicker)
+- Selected files shown as chips with remove button
+- Files uploaded after request creation via POST /requests/:id/documents
+- Validation: max 5 files, pdf/jpg/png only, max 10MB each
+"""
+
+import re
+import unittest
+
+class TestFrontendFilePickerImports(unittest.TestCase):
+    """Validate new.tsx imports DocumentPicker and ImagePicker."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_document_picker_imported(self):
+        """Must import expo-document-picker."""
+        self.assertIn("import * as DocumentPicker from 'expo-document-picker'", self.form)
+
+    def test_image_picker_imported(self):
+        """Must import expo-image-picker."""
+        self.assertIn("import * as ImagePicker from 'expo-image-picker'", self.form)
+
+class TestFrontendFilePickerConstants(unittest.TestCase):
+    """Validate file upload constants are defined."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_max_files_constant(self):
+        """MAX_FILES must be 5."""
+        self.assertIn("const MAX_FILES = 5", self.form)
+
+    def test_max_file_size_constant(self):
+        """MAX_FILE_SIZE must be 10 MB."""
+        self.assertIn("const MAX_FILE_SIZE = 10 * 1024 * 1024", self.form)
+
+    def test_allowed_mime_types(self):
+        """ALLOWED_MIME_TYPES must include pdf, jpeg, png."""
+        self.assertIn("'application/pdf'", self.form)
+        self.assertIn("'image/jpeg'", self.form)
+        self.assertIn("'image/png'", self.form)
+
+    def test_allowed_extensions(self):
+        """ALLOWED_EXTENSIONS must include pdf, jpg, jpeg, png."""
+        self.assertIn("'pdf'", self.form)
+        self.assertIn("'jpg'", self.form)
+        self.assertIn("'png'", self.form)
+
+class TestFrontendFilePickerState(unittest.TestCase):
+    """Validate file picker state management."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_selected_files_state(self):
+        """Must have selectedFiles state."""
+        self.assertIn("const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([])", self.form)
+
+    def test_file_error_state(self):
+        """Must have fileError state."""
+        self.assertIn("const [fileError, setFileError] = useState", self.form)
+
+    def test_selected_file_interface(self):
+        """Must define SelectedFile interface with uri, name, mimeType, size."""
+        self.assertIn("interface SelectedFile", self.form)
+        self.assertIn("uri: string", self.form)
+        self.assertIn("name: string", self.form)
+        self.assertIn("mimeType: string", self.form)
+        self.assertIn("size: number", self.form)
+
+class TestFrontendFilePickerFunctions(unittest.TestCase):
+    """Validate file picker functions exist."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_pick_document_function(self):
+        """Must have pickDocument function using DocumentPicker."""
+        self.assertIn("async function pickDocument()", self.form)
+        self.assertIn("DocumentPicker.getDocumentAsync", self.form)
+
+    def test_pick_image_function(self):
+        """Must have pickImage function using ImagePicker."""
+        self.assertIn("async function pickImage()", self.form)
+        self.assertIn("ImagePicker.launchImageLibraryAsync", self.form)
+
+    def test_add_files_function(self):
+        """Must have addFiles function with validation."""
+        self.assertIn("function addFiles(", self.form)
+
+    def test_remove_file_function(self):
+        """Must have removeFile function."""
+        self.assertIn("function removeFile(", self.form)
+
+    def test_add_files_validates_max_count(self):
+        """addFiles must check MAX_FILES limit."""
+        # Find addFiles function body
+        idx = self.form.index("function addFiles(")
+        section = self.form[idx:idx + 600]
+        self.assertIn("MAX_FILES", section)
+
+    def test_add_files_validates_mime_type(self):
+        """addFiles must validate MIME types."""
+        idx = self.form.index("function addFiles(")
+        section = self.form[idx:idx + 600]
+        self.assertIn("ALLOWED_MIME_TYPES", section)
+
+    def test_add_files_validates_file_size(self):
+        """addFiles must validate file size."""
+        idx = self.form.index("function addFiles(")
+        section = self.form[idx:idx + 900]
+        self.assertIn("MAX_FILE_SIZE", section)
+
+class TestFrontendFileUploadOnSubmit(unittest.TestCase):
+    """Validate files are uploaded after request creation."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_upload_files_function(self):
+        """Must have uploadFiles function."""
+        self.assertIn("async function uploadFiles(requestId: string)", self.form)
+
+    def test_upload_uses_form_data(self):
+        """uploadFiles must use FormData."""
+        idx = self.form.index("async function uploadFiles(")
+        section = self.form[idx:idx + 400]
+        self.assertIn("new FormData()", section)
+
+    def test_upload_calls_api_upload(self):
+        """uploadFiles must call api.upload with /requests/:id/documents."""
+        idx = self.form.index("async function uploadFiles(")
+        section = self.form[idx:idx + 400]
+        self.assertIn("api.upload", section)
+        self.assertIn("/documents", section)
+
+    def test_submit_calls_upload_files(self):
+        """handleSubmit must call uploadFiles after creating request."""
+        idx = self.form.index("async function handleSubmit()")
+        section = self.form[idx:idx + 800]
+        self.assertIn("uploadFiles(", section)
+
+    def test_submit_gets_request_id(self):
+        """handleSubmit must capture created request id."""
+        idx = self.form.index("async function handleSubmit()")
+        section = self.form[idx:idx + 800]
+        self.assertIn("api.post<{ id: string }>", section)
+
+    def test_upload_error_does_not_block_navigation(self):
+        """Upload failure should not prevent navigation."""
+        idx = self.form.index("async function handleSubmit()")
+        section = self.form[idx:idx + 1200]
+        # Should have try/catch around uploadFiles
+        self.assertIn("catch (uploadErr)", section)
+        self.assertIn("router.replace", section)
+
+class TestFrontendFilePickerUI(unittest.TestCase):
+    """Validate file picker UI elements exist."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_pdf_button_exists(self):
+        """Must have a button to pick PDF documents."""
+        self.assertIn("onPress={pickDocument}", self.form)
+        self.assertIn("PDF", self.form)
+
+    def test_image_button_exists(self):
+        """Must have a button to pick images."""
+        self.assertIn("onPress={pickImage}", self.form)
+
+    def test_file_chips_rendered(self):
+        """Selected files must be rendered as chips."""
+        self.assertIn("fileChip", self.form)
+        self.assertIn("fileChipText", self.form)
+
+    def test_remove_button_on_chips(self):
+        """Each file chip must have a remove button."""
+        self.assertIn("removeFile(index)", self.form)
+        self.assertIn("fileChipRemove", self.form)
+
+    def test_file_error_displayed(self):
+        """File error must be displayed."""
+        self.assertIn("fileError", self.form)
+
+    def test_documents_label_exists(self):
+        """Must have a label for the documents section."""
+        self.assertIn("Документы", self.form)
+
+    def test_file_hint_exists(self):
+        """Must show allowed formats hint."""
+        self.assertIn("PDF, JPG, PNG", self.form)
+        self.assertIn("10 МБ", self.form)
+
+    def test_buttons_disabled_at_max(self):
+        """File picker buttons must be disabled when MAX_FILES reached."""
+        self.assertIn("disabled={selectedFiles.length >= MAX_FILES}", self.form)
+
+class TestFrontendFilePickerStyles(unittest.TestCase):
+    """Validate file picker styles are defined."""
+
+    def setUp(self):
+        with open("/workspace/app/(dashboard)/my-requests/new.tsx") as f:
+            self.form = f.read()
+
+    def test_file_button_style(self):
+        self.assertIn("fileButton:", self.form)
+
+    def test_file_button_text_style(self):
+        self.assertIn("fileButtonText:", self.form)
+
+    def test_file_chips_row_style(self):
+        self.assertIn("fileChipsRow:", self.form)
+
+    def test_file_chip_style(self):
+        self.assertIn("fileChip:", self.form)
+
+    def test_file_chip_text_style(self):
+        self.assertIn("fileChipText:", self.form)
+
+    def test_file_chip_remove_style(self):
+        self.assertIn("fileChipRemove:", self.form)
+
+class TestBackendUploadEndpoint(unittest.TestCase):
+    """Validate backend has the upload endpoint."""
+
+    def setUp(self):
+        with open("/workspace/api/src/requests/requests.controller.ts") as f:
+            self.controller = f.read()
+
+    def test_upload_endpoint_exists(self):
+        """POST /requests/:id/documents endpoint must exist."""
+        self.assertIn("@Post(':id/documents')", self.controller)
+
+    def test_upload_uses_file_interceptor(self):
+        """Upload endpoint must use file interceptor."""
+        self.assertIn("AnyFilesInterceptor", self.controller)
+
+    def test_max_file_size_10mb(self):
+        """Max file size must be 10 MB."""
+        self.assertIn("10 * 1024 * 1024", self.controller)
+
+    def test_max_files_5(self):
+        """Max files must be 5."""
+        self.assertIn("MAX_REQUEST_DOCUMENTS = 5", self.controller)
+
+    def test_allowed_mime_types(self):
+        """Must validate PDF, JPG, PNG MIME types."""
+        self.assertIn("application/pdf", self.controller)
+        self.assertIn("image/jpeg", self.controller)
+        self.assertIn("image/png", self.controller)
+
+class TestPackageDependencies(unittest.TestCase):
+    """Validate required packages are in package.json."""
+
+    def setUp(self):
+        with open("/workspace/package.json") as f:
+            self.pkg = f.read()
+
+    def test_expo_document_picker_installed(self):
+        self.assertIn("expo-document-picker", self.pkg)
+
+    def test_expo_image_picker_installed(self):
+        self.assertIn("expo-image-picker", self.pkg)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #914.

The changes directly address all requirements specified in the issue:

1. **File picker added to new request form**: Both `expo-document-picker` (for PDFs) and `expo-image-picker` (for images) are imported and used via `pickDocument()` and `pickImage()` functions.

2. **Selected files shown as chips with remove button**: The UI renders `fileChip` components for each selected file, displaying the filename with a `✕` remove button that calls `removeFile(index)`.

3. **Upload files after request creation**: The `handleSubmit()` function now captures the created request's ID via `api.post<{ id: string }>('/requests', body)`, then calls `uploadFiles(requestId)` which constructs a `FormData` and posts to `POST /requests/:id/documents`. Upload failure is handled gracefully — it shows an alert but still navigates away, so the request creation isn't lost.

4. **Validation implemented correctly**:
   - **Max 5 files**: `MAX_FILES = 5` constant, checked in `addFiles()`, and buttons are disabled when limit is reached (`disabled={selectedFiles.length >= MAX_FILES}`).
   - **PDF/JPG/PNG only**: Validated against both MIME types (`application/pdf`, `image/jpeg`, `image/png`) and file extensions (`pdf`, `jpg`, `jpeg`, `png`).
   - **Max 10MB each**: `MAX_FILE_SIZE = 10 * 1024 * 1024`, checked per file in `addFiles()`.

The implementation is complete and well-structured. The `addFiles` function properly validates each file individually, skipping invalid ones while adding valid ones, and setting appropriate Russian-language error messages. The UI includes helpful hints about allowed formats and size limits. The only file modified is the one specified in the issue (`app/(dashboard)/my-requests/new.tsx`), plus a test file was added.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌