### PR TITLE
redesign: specialist dashboard to match prototype

### DIFF
--- a/app/specialist/dashboard.tsx
+++ b/app/specialist/dashboard.tsx
@@ -2,67 +2,211 @@ import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
-  SafeAreaView,
+  TextInput,
   ScrollView,
-  TouchableOpacity,
+  Pressable,
   ActivityIndicator,
   RefreshControl,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Ionicons } from '@expo/vector-icons';
+import { Feather } from '@expo/vector-icons';
 import { useAuth } from '../../stores/authStore';
 import { api, ApiError } from '../../lib/api';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
-import { Header } from '../../components/Header';
-import { useBreakpoints } from '../../hooks/useBreakpoints';
+import { threads } from '../../lib/api/endpoints';
+import { Colors } from '../../constants/Colors';
 
-interface ResponseItem {
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+interface RequestItem {
   id: string;
+  description: string;
+  title?: string;
+  city: string;
+  category: string | null;
+  service?: string;
+  fnsName?: string;
+  status: string;
+  createdAt: string;
+  client: { id: string; username?: string; firstName?: string };
+  _count: { responses: number };
 }
 
-interface ThreadItem {
-  id: string;
+interface FeedResponse {
+  items: RequestItem[];
+  total: number;
+  page: number;
+  pageSize: number;
 }
 
 interface SpecialistProfile {
-  id: string;
-  displayName?: string;
+  cities: string[];
 }
 
-function getDisplayName(user: { email: string; username?: string | null } | null): string {
-  if (!user) return '';
-  if (user.username) return user.username;
-  const local = user.email.split('@')[0] ?? '';
-  return local.charAt(0).toUpperCase() + local.slice(1);
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
+function getAuthorName(client: RequestItem['client']): string {
+  if (client.firstName) return client.firstName;
+  if (client.username) return client.username;
+  return 'Клиент';
+}
+
+function getRequestTitle(r: RequestItem): string {
+  if (r.title) return r.title;
+  if (r.description) return r.description.slice(0, 80);
+  return 'Заявка';
+}
+
+// ---------------------------------------------------------------------------
+// Request Card (matches prototype)
+// ---------------------------------------------------------------------------
+function RequestCard({
+  r,
+  onMessage,
+  onDetails,
+}: {
+  r: RequestItem;
+  onMessage: () => void;
+  onDetails: () => void;
+}) {
+  return (
+    <View className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+      <View className="flex-row items-start justify-between gap-2">
+        <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>
+          {getRequestTitle(r)}
+        </Text>
+        <Text className="text-xs text-textMuted">{formatDate(r.createdAt)}</Text>
+      </View>
+
+      <Text className="text-sm leading-5 text-textSecondary" numberOfLines={2}>
+        {r.description}
+      </Text>
+
+      <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
+        <View className="flex-row items-center gap-1">
+          <Feather name="map-pin" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{r.city}</Text>
+        </View>
+        {r.fnsName && (
+          <View className="flex-row items-center gap-1">
+            <Feather name="home" size={12} color={Colors.textMuted} />
+            <Text className="text-xs text-textMuted">{r.fnsName}</Text>
+          </View>
+        )}
+        {(r.service || r.category) && (
+          <View className="flex-row items-center gap-1">
+            <Feather name="briefcase" size={12} color={Colors.textMuted} />
+            <Text className="text-xs text-textMuted">{r.service || r.category}</Text>
+          </View>
+        )}
+        <View className="flex-row items-center gap-1">
+          <Feather name="user" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{getAuthorName(r.client)}</Text>
+        </View>
+      </View>
+
+      <View className="mt-1 flex-row gap-2">
+        <Pressable
+          className="h-10 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary"
+          onPress={onMessage}
+        >
+          <Feather name="send" size={14} color={Colors.white} />
+          <Text className="text-sm font-semibold text-white">Написать по заявке</Text>
+        </Pressable>
+        <Pressable
+          className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-borderLight px-4"
+          onPress={onDetails}
+        >
+          <Feather name="eye" size={14} color={Colors.textPrimary} />
+          <Text className="text-sm font-medium text-textPrimary">Подробнее</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+function EmptyState({ onSettings }: { onSettings: () => void }) {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
+      <View className="items-center gap-3 py-10">
+        <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSecondary">
+          <Feather name="inbox" size={32} color={Colors.brandPrimary} />
+        </View>
+        <Text className="text-lg font-semibold text-textPrimary">Новых заявок пока нет</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">
+          Настройте город и ФНС в настройках, чтобы видеть больше заявок
+        </Text>
+        <Pressable
+          className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg border border-brandPrimary px-6"
+          onPress={onSettings}
+        >
+          <Feather name="settings" size={16} color={Colors.brandPrimary} />
+          <Text className="text-sm font-semibold text-brandPrimary">Настройки</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+function LoadingSkeleton() {
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="gap-1">
+        <View className="h-6 w-24 rounded-md bg-bgSurface" />
+        <View className="h-4 w-40 rounded-md bg-bgSurface" />
+      </View>
+      <View className="h-11 w-full rounded-xl bg-bgSurface" />
+      {[1, 2, 3].map((i) => (
+        <View key={i} className="gap-2 rounded-xl border border-borderLight p-4">
+          <View className="h-4 w-4/5 rounded bg-bgSurface" />
+          <View className="h-3 w-full rounded bg-bgSurface" />
+          <View className="h-3 w-3/5 rounded bg-bgSurface" />
+          <View className="h-10 w-full rounded-lg bg-bgSurface" />
+        </View>
+      ))}
+      <View className="items-center pt-2">
+        <ActivityIndicator size="small" color={Colors.brandPrimary} />
+      </View>
+    </ScrollView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
 export default function SpecialistDashboard() {
   const router = useRouter();
-  const { user, logout } = useAuth();
-  const { isMobile } = useBreakpoints();
-  const [responseCount, setResponseCount] = useState(0);
-  const [threadCount, setThreadCount] = useState(0);
-  const [hasProfile, setHasProfile] = useState<boolean | null>(null);
+  const { user } = useAuth();
+  const [requestsList, setRequestsList] = useState<RequestItem[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [loadError, setLoadError] = useState('');
+  const [error, setError] = useState('');
+  const [search, setSearch] = useState('');
+  const [hasProfile, setHasProfile] = useState<boolean | null>(null);
 
   const fetchData = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
-    setLoadError('');
+    setError('');
     try {
-      const [responses, threads] = await Promise.all([
-        api.get<ResponseItem[]>('/requests/my-responses').catch(() => [] as ResponseItem[]),
-        api.get<ThreadItem[]>('/threads').catch(() => [] as ThreadItem[]),
-      ]);
-
-      setResponseCount(Array.isArray(responses) ? responses.length : 0);
-      setThreadCount(Array.isArray(threads) ? threads.length : 0);
-
-      // Check specialist profile
+      // Check specialist profile and get cities
+      let cities: string[] = [];
       try {
-        await api.get<SpecialistProfile>('/specialists/me');
+        const profile = await api.get<SpecialistProfile>('/specialists/me');
+        cities = profile.cities || [];
         setHasProfile(true);
       } catch (err) {
         if (err instanceof ApiError && err.status === 404) {
@@ -71,9 +215,44 @@ export default function SpecialistDashboard() {
           setHasProfile(false);
         }
       }
+
+      if (cities.length === 0) {
+        setRequestsList([]);
+        setTotalCount(0);
+        return;
+      }
+
+      // Fetch open requests for specialist's cities
+      const results = await Promise.all(
+        cities.map((city) =>
+          api
+            .get<FeedResponse>(`/requests?city=${encodeURIComponent(city)}&page=1`)
+            .catch(() => ({ items: [], total: 0, page: 1, pageSize: 20 }) as FeedResponse),
+        ),
+      );
+
+      // Merge and deduplicate
+      const seen = new Set<string>();
+      const allItems: RequestItem[] = [];
+      let total = 0;
+      for (const res of results) {
+        total += res.total;
+        for (const item of res.items) {
+          if (!seen.has(item.id)) {
+            seen.add(item.id);
+            allItems.push(item);
+          }
+        }
+      }
+
+      // Sort by newest first
+      allItems.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+      setRequestsList(allItems);
+      setTotalCount(total);
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : 'Не удалось загрузить данные. Проверьте соединение.';
-      setLoadError(msg);
+      const msg = err instanceof ApiError ? err.message : 'Не удалось загрузить данные';
+      setError(msg);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -84,410 +263,116 @@ export default function SpecialistDashboard() {
     fetchData();
   }, [fetchData]);
 
-  // No longer auto-redirect — show CTA instead (see #361)
-
   function handleRefresh() {
     setRefreshing(true);
     fetchData(true);
   }
 
-  async function handleLogout() {
-    await logout();
-    router.replace('/');
+  async function handleStartThread(request: RequestItem) {
+    try {
+      const res = await threads.startThread(request.client.id, request.id);
+      const threadId = (res.data as { id: string }).id;
+      router.push(`/chat/${threadId}`);
+    } catch {
+      // If thread already exists, navigate to messages
+      router.push('/(dashboard)/messages');
+    }
   }
 
-  const displayName = getDisplayName(user);
+  // Filter by search
+  const filtered = search
+    ? requestsList.filter(
+        (r) =>
+          getRequestTitle(r).toLowerCase().includes(search.toLowerCase()) ||
+          (r.service || r.category || '').toLowerCase().includes(search.toLowerCase()) ||
+          r.city.toLowerCase().includes(search.toLowerCase()),
+      )
+    : requestsList;
 
-  // Profile status chip
-  const profileChip = hasProfile !== null ? (
-    <TouchableOpacity
-      style={[styles.profileChip, hasProfile ? styles.profileChipFilled : styles.profileChipEmpty]}
-      onPress={() => router.push('/(dashboard)/profile')}
-      activeOpacity={0.7}
-    >
-      <Ionicons
-        name={hasProfile ? 'checkmark-circle' : 'alert-circle'}
-        size={16}
-        color={hasProfile ? Colors.statusSuccess : Colors.statusWarning}
-      />
-      <Text style={[styles.profileChipText, hasProfile ? styles.profileChipTextFilled : styles.profileChipTextEmpty]}>
-        {hasProfile ? 'Профиль заполнен' : 'Заполните профиль'}
-      </Text>
-      {!hasProfile && (
-        <Ionicons name="chevron-forward" size={14} color={Colors.statusWarning} />
-      )}
-    </TouchableOpacity>
-  ) : null;
+  // Loading
+  if (loading) return <LoadingSkeleton />;
 
-  const statsSection = (
-    <View style={styles.statsRow}>
-      <TouchableOpacity
-        style={styles.statCard}
-        onPress={() => router.push('/(dashboard)/responses')}
-        activeOpacity={0.7}
-      >
-        <Text style={styles.statValue}>{responseCount}</Text>
-        <Text style={styles.statLabel}>Мои ответы</Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={styles.statCard}
-        onPress={() => router.push('/(dashboard)/messages')}
-        activeOpacity={0.7}
-      >
-        <Text style={styles.statValue}>{threadCount}</Text>
-        <Text style={styles.statLabel}>Активные диалоги</Text>
-      </TouchableOpacity>
-    </View>
-  );
+  // Empty — no profile or no requests
+  if (hasProfile === false || (requestsList.length === 0 && !error)) {
+    return <EmptyState onSettings={() => router.push('/(dashboard)/profile')} />;
+  }
 
-  const quickActions = (
-    <View style={styles.section}>
-      <Text style={styles.sectionTitle}>Быстрые действия</Text>
-      <View style={styles.actionsRow}>
-        <TouchableOpacity
-          style={styles.actionCard}
-          onPress={() => router.push('/(dashboard)/city-requests')}
-          activeOpacity={0.7}
-        >
-          <View style={styles.actionIconWrap}>
-            <Ionicons name="search-outline" size={22} color={Colors.brandPrimary} />
-          </View>
-          <Text style={styles.actionLabel}>Смотреть запросы</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.actionCard}
-          onPress={() => router.push('/(dashboard)/profile')}
-          activeOpacity={0.7}
-        >
-          <View style={styles.actionIconWrap}>
-            <Ionicons name="person-outline" size={22} color={Colors.brandPrimary} />
-          </View>
-          <Text style={styles.actionLabel}>Мой профиль</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.actionCard}
-          onPress={() => router.push('/specialist/my-responses')}
-          activeOpacity={0.7}
-        >
-          <View style={styles.actionIconWrap}>
-            <Ionicons name="document-text-outline" size={22} color={Colors.brandPrimary} />
-          </View>
-          <Text style={styles.actionLabel}>Мои отклики</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.actionCard}
-          onPress={() => router.push('/(dashboard)/messages')}
-          activeOpacity={0.7}
-        >
-          <View style={styles.actionIconWrap}>
-            <Ionicons name="chatbubble-outline" size={22} color={Colors.brandPrimary} />
-          </View>
-          <Text style={styles.actionLabel}>Мои диалоги</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.actionCard}
-          onPress={() => router.push('/(dashboard)/promotion')}
-          activeOpacity={0.7}
-        >
-          <View style={styles.actionIconWrap}>
-            <Ionicons name="rocket-outline" size={22} color={Colors.brandPrimary} />
-          </View>
-          <Text style={styles.actionLabel}>Продвижение</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-  );
-
-  const noProfileCta = hasProfile === false ? (
-    <View style={styles.noProfileCta}>
-      <Ionicons name="person-add-outline" size={36} color={Colors.brandPrimary} />
-      <Text style={styles.noProfileCtaTitle}>Создайте профиль специалиста</Text>
-      <Text style={styles.noProfileCtaSubtitle}>
-        Заполните профиль, чтобы клиенты могли вас найти и отправить запрос
-      </Text>
-      <TouchableOpacity
-        style={styles.noProfileCtaBtn}
-        onPress={() => router.push('/(onboarding)/username')}
-        activeOpacity={0.8}
-      >
-        <Text style={styles.noProfileCtaBtnText}>Создать профиль</Text>
-      </TouchableOpacity>
-    </View>
-  ) : null;
-
-  const content = loading ? (
-    <ActivityIndicator size="large" color={Colors.brandPrimary} style={{ marginTop: Spacing['3xl'] }} />
-  ) : loadError ? (
-    <View style={styles.errorBox}>
-      <Text style={styles.errorBoxText}>{loadError}</Text>
-      <TouchableOpacity onPress={() => fetchData()} style={styles.retryBtn}>
-        <Text style={styles.retryBtnText}>Повторить</Text>
-      </TouchableOpacity>
-    </View>
-  ) : (
-    <>
-      {noProfileCta}
-      {profileChip}
-      {statsSection}
-      {quickActions}
-    </>
-  );
-
-  // Desktop/tablet
-  if (!isMobile) {
+  // Error
+  if (error && requestsList.length === 0) {
     return (
-      <SafeAreaView style={styles.safe}>
-        <ScrollView
-          contentContainerStyle={styles.scrollWide}
-          showsVerticalScrollIndicator={false}
-          refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
-          }
-        >
-          <View style={styles.wideContainer}>
-            <Text style={styles.wideGreeting}>
-              {`Кабинет специалиста`}
-            </Text>
-            <Text style={styles.wideSubGreeting}>
-              {`Добро пожаловать, ${displayName}`}
-            </Text>
-            {content}
-          </View>
-        </ScrollView>
-      </SafeAreaView>
-    );
-  }
-
-  // Mobile
-  return (
-    <SafeAreaView style={styles.safe}>
-      <Header
-        title="Кабинет специалиста"
-        rightAction={
-          <TouchableOpacity onPress={handleLogout} hitSlop={12}>
-            <Text style={styles.logoutText}>Выйти</Text>
-          </TouchableOpacity>
-        }
-      />
       <ScrollView
-        contentContainerStyle={styles.scroll}
-        showsVerticalScrollIndicator={false}
+        className="flex-1 bg-white"
+        contentContainerStyle={{ padding: 16, gap: 16, flex: 1, justifyContent: 'center', alignItems: 'center' }}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
         }
       >
-        <View style={styles.container}>
-          <Text style={styles.welcome}>
-            {`Добро пожаловать, ${displayName}`}
-          </Text>
-          {content}
-        </View>
+        <Feather name="wifi-off" size={48} color={Colors.textMuted} />
+        <Text className="text-lg font-semibold text-textPrimary">Ошибка загрузки</Text>
+        <Text className="max-w-[280px] text-center text-sm text-textMuted">{error}</Text>
+        <Pressable
+          className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary px-6"
+          onPress={() => fetchData()}
+        >
+          <Text className="text-sm font-semibold text-white">Повторить</Text>
+        </Pressable>
       </ScrollView>
-    </SafeAreaView>
+    );
+  }
+
+  // Populated — requests feed with search
+  return (
+    <ScrollView
+      className="flex-1 bg-white"
+      contentContainerStyle={{ padding: 16, gap: 16 }}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+      }
+    >
+      {/* Header */}
+      <View>
+        <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
+        <Text className="text-sm text-textMuted">{totalCount} заявок в вашем регионе</Text>
+      </View>
+
+      {/* Search */}
+      <View className="flex-row items-center gap-2 rounded-xl border border-borderLight bg-white px-3">
+        <Feather name="search" size={18} color={Colors.textMuted} />
+        <TextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Поиск по заявкам..."
+          placeholderTextColor={Colors.textMuted}
+          className="h-11 flex-1 text-base text-textPrimary"
+          style={{ outlineStyle: 'none' } as any}
+        />
+        {search ? (
+          <Pressable onPress={() => setSearch('')}>
+            <Feather name="x" size={18} color={Colors.textMuted} />
+          </Pressable>
+        ) : null}
+      </View>
+
+      {/* Results */}
+      {filtered.length > 0 ? (
+        <View className="gap-3">
+          {filtered.map((r) => (
+            <RequestCard
+              key={r.id}
+              r={r}
+              onMessage={() => handleStartThread(r)}
+              onDetails={() => router.push(`/request/${r.id}`)}
+            />
+          ))}
+        </View>
+      ) : (
+        <View className="items-center gap-2 py-8">
+          <Feather name="search" size={32} color={Colors.textMuted} />
+          <Text className="text-sm text-textMuted">Ничего не найдено</Text>
+        </View>
+      )}
+
+      <View className="h-8" />
+    </ScrollView>
   );
 }
-
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  // Mobile
-  scroll: {
-    flexGrow: 1,
-    alignItems: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  container: {
-    width: '100%',
-    maxWidth: 430,
-    paddingHorizontal: Spacing.xl,
-    gap: Spacing.lg,
-  },
-  welcome: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  // Profile chip
-  profileChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    alignSelf: 'flex-start',
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.full,
-    gap: Spacing.xs,
-  },
-  profileChipFilled: {
-    backgroundColor: Colors.statusBg.success,
-  },
-  profileChipEmpty: {
-    backgroundColor: Colors.statusBg.warning,
-  },
-  profileChipText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  profileChipTextFilled: {
-    color: Colors.statusSuccess,
-  },
-  profileChipTextEmpty: {
-    color: Colors.textPrimary,
-  },
-  // Sections
-  section: {
-    gap: Spacing.md,
-  },
-  sectionTitle: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  // Stats
-  statsRow: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-    flexWrap: 'wrap',
-  },
-  statCard: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    padding: Spacing.xl,
-    minWidth: 100,
-    flex: 1,
-    alignItems: 'center',
-    gap: Spacing.xs,
-    ...Shadows.sm,
-  },
-  statValue: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.brandPrimary,
-  },
-  statLabel: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    textAlign: 'center',
-  },
-  // Quick actions
-  actionsRow: {
-    flexDirection: 'row',
-    gap: Spacing.md,
-    flexWrap: 'wrap',
-  },
-  actionCard: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    padding: Spacing.lg,
-    flex: 1,
-    minWidth: 100,
-    alignItems: 'center',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  actionIconWrap: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: Colors.statusBg.info,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  actionLabel: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  logoutText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  errorBox: {
-    marginTop: Spacing['2xl'],
-    padding: Spacing.xl,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.md,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    alignItems: 'center',
-    gap: Spacing.md,
-  },
-  errorBoxText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.statusError,
-    textAlign: 'center',
-  },
-  retryBtn: {
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.xl,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.md,
-  },
-  retryBtnText: {
-    fontSize: Typography.fontSize.sm,
-    color: '#FFFFFF',
-    fontWeight: Typography.fontWeight.semibold,
-  },
-  // Desktop / tablet
-  scrollWide: {
-    flexGrow: 1,
-    paddingVertical: Spacing['4xl'],
-    paddingHorizontal: Spacing['3xl'],
-  },
-  wideContainer: {
-    gap: Spacing['2xl'],
-    maxWidth: 800,
-  },
-  wideGreeting: {
-    fontSize: Typography.fontSize['2xl'],
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  wideSubGreeting: {
-    fontSize: Typography.fontSize.md,
-    color: Colors.textSecondary,
-    marginTop: -Spacing.lg,
-  },
-  // No profile CTA
-  noProfileCta: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 2,
-    borderColor: Colors.brandPrimary,
-    padding: Spacing['2xl'],
-    alignItems: 'center',
-    gap: Spacing.md,
-    ...Shadows.md,
-  },
-  noProfileCtaTitle: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    textAlign: 'center',
-  },
-  noProfileCtaSubtitle: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    textAlign: 'center',
-    lineHeight: 22,
-  },
-  noProfileCtaBtn: {
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.md,
-    paddingVertical: Spacing.md,
-    paddingHorizontal: Spacing['2xl'],
-    marginTop: Spacing.sm,
-  },
-  noProfileCtaBtnText: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.white,
-  },
-});


### PR DESCRIPTION
## Summary
- Rewrote specialist dashboard to match `SpecialistDashboardStates.tsx` prototype exactly
- Replaced StyleSheet + Ionicons with NativeWind className + Feather icons
- New design: requests feed with search bar, request cards with metadata (city, FNS, service, author), action buttons (message + details)
- Empty state with settings CTA, loading skeleton, error state with retry
- Kept real API: fetches specialist profile cities, loads requests per city, deduplicates and sorts

## Test plan
- [ ] Specialist with profile sees requests feed from their cities
- [ ] Search filters by title, service, city
- [ ] "Napisat po zayavke" starts thread and navigates to chat
- [ ] "Podrobnee" navigates to request detail
- [ ] Empty state shows when no profile or no requests
- [ ] Pull-to-refresh works

Generated with Claude Code