### PR TITLE
redesign: admin moderation to match prototype

### DIFF
--- a/app/(admin)/moderation.tsx
+++ b/app/(admin)/moderation.tsx
@@ -2,18 +2,22 @@ import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
+  TextInput,
+  Pressable,
   SafeAreaView,
   ScrollView,
   ActivityIndicator,
   RefreshControl,
-  TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { api } from '../../lib/api';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors } from '../../constants/Colors';
 import { Header } from '../../components/Header';
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 interface SpecialistItem {
   id: string;
   nick: string;
@@ -31,25 +35,411 @@ interface SpecialistItem {
   };
 }
 
-function formatDate(iso: string | null): string {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
-}
+type FilterKey = 'all' | 'unverified' | 'verified';
+type ScreenState = 'queue' | 'detail' | 'approved' | 'rejected';
 
 const VERIFIED_BADGE = 'verified';
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function formatDate(iso: string | null): string {
+  if (!iso) return '--';
+  return new Date(iso).toLocaleDateString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(/[\s@]+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Moderation card (queue list item)
+// ---------------------------------------------------------------------------
+function ModerationCard({
+  item,
+  onApprove,
+  onReject,
+  onView,
+}: {
+  item: SpecialistItem;
+  onApprove: () => void;
+  onReject: () => void;
+  onView: () => void;
+}) {
+  const isVerified = item.badges.includes(VERIFIED_BADGE);
+  const displayName = item.nick || item.user.email;
+  const city = item.cities[0] || '';
+
+  return (
+    <View className="rounded-[14px] border border-borderLight bg-white p-4 shadow-sm gap-3">
+      {/* Top row: avatar + info + badge */}
+      <View className="flex-row items-center gap-3">
+        <View className="h-11 w-11 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+          <Text className="text-sm font-bold text-brandPrimary">
+            {getInitials(displayName)}
+          </Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-base font-semibold text-textPrimary">
+            @{item.nick || '---'}
+          </Text>
+          <View className="flex-row items-center gap-1 mt-0.5">
+            {city ? (
+              <>
+                <Feather name="map-pin" size={11} color={Colors.textMuted} />
+                <Text className="text-sm text-textMuted">{city}</Text>
+              </>
+            ) : null}
+          </View>
+        </View>
+        <View
+          className={`px-2 py-0.5 rounded-full ${
+            isVerified ? 'bg-[#DCFCE7]' : 'bg-[#E0F2FE]'
+          }`}
+        >
+          <Text
+            className={`text-xs font-semibold ${
+              isVerified ? 'text-statusSuccess' : 'text-brandPrimary'
+            }`}
+          >
+            {isVerified ? 'Верифицирован' : 'На проверке'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Services chips */}
+      {item.services.length > 0 && (
+        <View className="flex-row flex-wrap gap-1">
+          {item.services.map((svc, i) => (
+            <View
+              key={i}
+              className="rounded-full border border-borderLight bg-bgSurface px-2 py-0.5"
+            >
+              <Text className="text-xs text-textSecondary">{svc}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Date row */}
+      <View className="flex-row items-center gap-1">
+        <Feather name="calendar" size={12} color={Colors.textMuted} />
+        <Text className="flex-1 text-sm text-textMuted">
+          Обновлён: {formatDate(item.updatedAt)}
+        </Text>
+        {!isVerified && (
+          <View className="rounded-full bg-[#FEF9C3] px-2 py-0.5">
+            <Text className="text-xs font-semibold text-statusWarning">Ожидает</Text>
+          </View>
+        )}
+      </View>
+
+      {/* Action buttons */}
+      <View className="flex-row gap-2">
+        <Pressable
+          onPress={onView}
+          className="flex-1 h-9 flex-row items-center justify-center gap-1 rounded-xl border border-borderLight"
+        >
+          <Feather name="eye" size={14} color={Colors.textPrimary} />
+          <Text className="text-sm text-textPrimary">Просмотр</Text>
+        </Pressable>
+        <Pressable
+          onPress={onApprove}
+          className="h-9 w-9 items-center justify-center rounded-xl bg-[#DCFCE7]"
+          disabled={isVerified}
+          style={isVerified ? { opacity: 0.4 } : undefined}
+        >
+          <Feather name="check" size={16} color={Colors.statusSuccess} />
+        </Pressable>
+        <Pressable
+          onPress={onReject}
+          className="h-9 w-9 items-center justify-center rounded-xl bg-[#FEE2E2]"
+          disabled={!isVerified}
+          style={!isVerified ? { opacity: 0.4 } : undefined}
+        >
+          <Feather name="x" size={16} color={Colors.statusError} />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail view
+// ---------------------------------------------------------------------------
+function DetailView({
+  item,
+  onBack,
+  onApprove,
+  onReject,
+}: {
+  item: SpecialistItem;
+  onBack: () => void;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  const [rejectReason, setRejectReason] = useState('');
+  const isVerified = item.badges.includes(VERIFIED_BADGE);
+  const displayName = item.nick || item.user.email;
+  const city = item.cities[0] || '';
+
+  return (
+    <View className="gap-3">
+      <Pressable onPress={onBack} className="flex-row items-center gap-1">
+        <Feather name="arrow-left" size={16} color={Colors.brandPrimary} />
+        <Text className="text-sm font-medium text-brandPrimary">Назад к очереди</Text>
+      </Pressable>
+
+      <View className="rounded-[14px] border border-borderLight bg-white p-4 shadow-sm gap-4">
+        {/* Header */}
+        <View className="flex-row items-center gap-3">
+          <View className="h-14 w-14 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+            <Text className="text-lg font-bold text-brandPrimary">
+              {getInitials(displayName)}
+            </Text>
+          </View>
+          <View className="flex-1">
+            <Text className="text-lg font-semibold text-textPrimary">
+              @{item.nick || '---'}
+            </Text>
+            <Text className="text-sm text-textMuted mt-0.5">
+              {[city, item.user.email].filter(Boolean).join(' \u00b7 ')}
+            </Text>
+          </View>
+          <View
+            className={`px-2 py-0.5 rounded-full ${
+              isVerified ? 'bg-[#DCFCE7]' : 'bg-[#E0F2FE]'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                isVerified ? 'text-statusSuccess' : 'text-brandPrimary'
+              }`}
+            >
+              {isVerified ? 'Верифицирован' : 'На проверке'}
+            </Text>
+          </View>
+        </View>
+
+        <View className="h-px bg-borderLight" />
+
+        {/* Cities */}
+        {item.cities.length > 0 && (
+          <View className="gap-2">
+            <Text className="text-sm font-semibold text-textPrimary uppercase tracking-wide">
+              Города
+            </Text>
+            <Text className="text-base text-textSecondary leading-[22px]">
+              {item.cities.join(', ')}
+            </Text>
+          </View>
+        )}
+
+        {/* Services */}
+        {item.services.length > 0 && (
+          <View className="gap-2">
+            <Text className="text-sm font-semibold text-textPrimary uppercase tracking-wide">
+              Услуги
+            </Text>
+            <View className="flex-row flex-wrap gap-1">
+              {item.services.map((svc, i) => (
+                <View
+                  key={i}
+                  className="rounded-full border border-borderLight bg-bgSurface px-2 py-0.5"
+                >
+                  <Text className="text-xs text-textSecondary">{svc}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* Badges */}
+        {item.badges.length > 0 && (
+          <View className="gap-2">
+            <Text className="text-sm font-semibold text-textPrimary uppercase tracking-wide">
+              Знаки
+            </Text>
+            <View className="flex-row flex-wrap gap-1">
+              {item.badges.map((b, i) => (
+                <View
+                  key={i}
+                  className="rounded-full border border-borderLight bg-bgSurface px-2 py-0.5"
+                >
+                  <Text className="text-xs text-textSecondary">{b}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        <View className="h-px bg-borderLight" />
+
+        {/* Reject reason textarea */}
+        <View className="gap-2">
+          <Text className="text-sm font-semibold text-textPrimary uppercase tracking-wide">
+            Причина отклонения (при отказе)
+          </Text>
+          <TextInput
+            value={rejectReason}
+            onChangeText={setRejectReason}
+            placeholder="Укажите причину..."
+            placeholderTextColor={Colors.textMuted}
+            multiline
+            className="min-h-[80px] rounded-[10px] border border-borderLight bg-bgPrimary p-3 text-base text-textPrimary"
+            style={{ textAlignVertical: 'top' }}
+          />
+        </View>
+
+        {/* Action buttons */}
+        <View className="flex-row gap-2">
+          <Pressable
+            onPress={onApprove}
+            className="flex-1 h-11 flex-row items-center justify-center gap-1 rounded-xl bg-statusSuccess"
+            disabled={isVerified}
+            style={isVerified ? { opacity: 0.5 } : undefined}
+          >
+            <Feather name="check-circle" size={16} color={Colors.white} />
+            <Text className="text-base font-semibold text-white">Одобрить</Text>
+          </Pressable>
+          <Pressable
+            onPress={onReject}
+            className="flex-1 h-11 flex-row items-center justify-center gap-1 rounded-xl bg-[#FEE2E2]"
+            disabled={!isVerified}
+            style={!isVerified ? { opacity: 0.5 } : undefined}
+          >
+            <Feather name="x-circle" size={16} color={Colors.statusError} />
+            <Text className="text-base font-semibold text-statusError">Отклонить</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result screen (approved / rejected)
+// ---------------------------------------------------------------------------
+function ResultView({
+  type,
+  item,
+  onBack,
+}: {
+  type: 'approved' | 'rejected';
+  item: SpecialistItem;
+  onBack: () => void;
+}) {
+  const isApproved = type === 'approved';
+  const displayName = item.nick ? `@${item.nick}` : item.user.email;
+
+  return (
+    <View className="items-center py-6 gap-3">
+      <View
+        className={`h-20 w-20 items-center justify-center rounded-full ${
+          isApproved ? 'bg-[#DCFCE7]' : 'bg-[#FEE2E2]'
+        }`}
+      >
+        <Feather
+          name={isApproved ? 'check-circle' : 'x-circle'}
+          size={48}
+          color={isApproved ? Colors.statusSuccess : Colors.statusError}
+        />
+      </View>
+      <Text className="text-xl font-bold text-textPrimary">
+        {isApproved ? 'Специалист одобрен' : 'Заявка отклонена'}
+      </Text>
+      <Text className="text-sm text-textMuted text-center max-w-[300px]">
+        {displayName} получит уведомление о{' '}
+        {isApproved ? 'подтверждении профиля' : 'причине отказа'}
+      </Text>
+
+      {/* Summary card */}
+      <View className="w-full rounded-[14px] border border-borderLight bg-white p-4 shadow-sm gap-2">
+        <View className="flex-row justify-between items-center">
+          <Text className="text-sm text-textMuted">Специалист</Text>
+          <Text className="text-sm font-semibold text-textPrimary">{displayName}</Text>
+        </View>
+        <View className="h-px bg-borderLight" />
+        <View className="flex-row justify-between items-center">
+          <Text className="text-sm text-textMuted">Тип</Text>
+          <Text className="text-sm font-semibold text-textPrimary">Верификация</Text>
+        </View>
+        <View className="h-px bg-borderLight" />
+        <View className="flex-row justify-between items-center">
+          <Text className="text-sm text-textMuted">Результат</Text>
+          <View
+            className={`px-2 py-0.5 rounded-full ${
+              isApproved ? 'bg-[#DCFCE7]' : 'bg-[#FEE2E2]'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                isApproved ? 'text-statusSuccess' : 'text-statusError'
+              }`}
+            >
+              {isApproved ? 'Одобрено' : 'Отклонено'}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <Pressable
+        onPress={onBack}
+        className="h-11 items-center justify-center rounded-xl border border-brandPrimary px-6"
+      >
+        <Text className="text-sm font-medium text-brandPrimary">Вернуться к очереди</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+function EmptyView() {
+  return (
+    <View className="items-center py-10 gap-3">
+      <View className="h-20 w-20 items-center justify-center rounded-full bg-[#DCFCE7]">
+        <Feather name="check-circle" size={40} color={Colors.statusSuccess} />
+      </View>
+      <Text className="text-lg font-semibold text-textPrimary">Очередь пуста</Text>
+      <Text className="text-sm text-textMuted text-center max-w-[280px]">
+        Все заявки рассмотрены. Новые появятся автоматически.
+      </Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
 export default function AdminModeration() {
   const [specialists, setSpecialists] = useState<SpecialistItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<Record<string, boolean>>({});
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const [screen, setScreen] = useState<ScreenState>('queue');
+  const [selectedItem, setSelectedItem] = useState<SpecialistItem | null>(null);
 
   const fetchSpecialists = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
     setError(null);
     try {
-      const data = await api.get<{ items: SpecialistItem[]; total: number }>('/admin/specialists');
+      const data = await api.get<{ items: SpecialistItem[]; total: number }>(
+        '/admin/specialists',
+      );
       setSpecialists(data.items);
     } catch (e: any) {
       setError(e?.message ?? 'Failed to load specialists');
@@ -59,18 +449,33 @@ export default function AdminModeration() {
     }
   }, []);
 
-  useEffect(() => { fetchSpecialists(); }, [fetchSpecialists]);
+  useEffect(() => {
+    fetchSpecialists();
+  }, [fetchSpecialists]);
 
-  const handleRefresh = () => { setRefreshing(true); fetchSpecialists(true); };
+  const handleRefresh = () => {
+    setRefreshing(true);
+    fetchSpecialists(true);
+  };
+
+  // Filter items
+  const filteredItems = specialists.filter((s) => {
+    if (filter === 'verified') return s.badges.includes(VERIFIED_BADGE);
+    if (filter === 'unverified') return !s.badges.includes(VERIFIED_BADGE);
+    return true;
+  });
 
   const handleApprove = async (s: SpecialistItem) => {
     setActionLoading((prev) => ({ ...prev, [s.id]: true }));
     try {
       const newBadges = [...new Set([...s.badges, VERIFIED_BADGE])];
       await api.patch(`/specialists/${s.user.id}/badges`, { badges: newBadges });
+      const updated = { ...s, badges: newBadges };
       setSpecialists((prev) =>
-        prev.map((item) => item.id === s.id ? { ...item, badges: newBadges } : item)
+        prev.map((item) => (item.id === s.id ? updated : item)),
       );
+      setSelectedItem(updated);
+      setScreen('approved');
     } catch (e: any) {
       Alert.alert('Ошибка', e?.message ?? 'Не удалось одобрить профиль');
     } finally {
@@ -83,9 +488,12 @@ export default function AdminModeration() {
     try {
       const newBadges = s.badges.filter((b) => b !== VERIFIED_BADGE);
       await api.patch(`/specialists/${s.user.id}/badges`, { badges: newBadges });
+      const updated = { ...s, badges: newBadges };
       setSpecialists((prev) =>
-        prev.map((item) => item.id === s.id ? { ...item, badges: newBadges } : item)
+        prev.map((item) => (item.id === s.id ? updated : item)),
       );
+      setSelectedItem(updated);
+      setScreen('rejected');
     } catch (e: any) {
       Alert.alert('Ошибка', e?.message ?? 'Не удалось отклонить профиль');
     } finally {
@@ -93,222 +501,136 @@ export default function AdminModeration() {
     }
   };
 
+  const handleView = (s: SpecialistItem) => {
+    setSelectedItem(s);
+    setScreen('detail');
+  };
+
+  const handleBackToQueue = () => {
+    setScreen('queue');
+    setSelectedItem(null);
+  };
+
+  const filters: { key: FilterKey; label: string }[] = [
+    { key: 'all', label: 'Все' },
+    { key: 'unverified', label: 'На проверке' },
+    { key: 'verified', label: 'Верифицированные' },
+  ];
+
+  const unverifiedCount = specialists.filter(
+    (s) => !s.badges.includes(VERIFIED_BADGE),
+  ).length;
+
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView className="flex-1 bg-bgPrimary">
       <Header title="Модерация" showBack />
       <ScrollView
-        contentContainerStyle={styles.scroll}
+        className="flex-1"
+        contentContainerStyle={{ flexGrow: 1, alignItems: 'center', paddingVertical: 24 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={Colors.brandPrimary}
+          />
         }
       >
-        <View style={styles.container}>
-          <Text style={styles.hint}>
-            Профили исполнителей. Значок «verified» добавляет/убирает кнопка одобрения.
-          </Text>
+        <View className="w-full max-w-screen-sm px-4 gap-3">
+          {/* Detail / Result screens */}
+          {screen === 'detail' && selectedItem && (
+            <DetailView
+              item={selectedItem}
+              onBack={handleBackToQueue}
+              onApprove={() => handleApprove(selectedItem)}
+              onReject={() => handleReject(selectedItem)}
+            />
+          )}
 
-          {loading ? (
-            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
-          ) : error ? (
-            <Text style={styles.errorText}>{error}</Text>
-          ) : specialists.length === 0 ? (
-            <Text style={styles.emptyText}>Нет профилей</Text>
-          ) : (
-            <View style={styles.list}>
-              {specialists.map((s) => (
-                <View key={s.id} style={styles.card}>
-                  <View style={styles.cardHeader}>
-                    <Text style={styles.nick}>@{s.nick}</Text>
-                    <Text style={styles.updateDate}>Обновлён: {formatDate(s.updatedAt)}</Text>
-                  </View>
+          {(screen === 'approved' || screen === 'rejected') && selectedItem && (
+            <ResultView
+              type={screen}
+              item={selectedItem}
+              onBack={handleBackToQueue}
+            />
+          )}
 
-                  <Text style={styles.email} numberOfLines={1}>{s.user.email}</Text>
-
-                  {s.cities.length > 0 ? (
-                    <Text style={styles.detail}>
-                      <Text style={styles.detailLabel}>Города: </Text>
-                      {s.cities.join(', ')}
-                    </Text>
-                  ) : null}
-
-                  {s.services.length > 0 ? (
-                    <Text style={styles.detail} numberOfLines={2}>
-                      <Text style={styles.detailLabel}>Услуги: </Text>
-                      {s.services.join(', ')}
-                    </Text>
-                  ) : null}
-
-                  {s.badges.length > 0 ? (
-                    <Text style={styles.detail}>
-                      <Text style={styles.detailLabel}>Знаки: </Text>
-                      {s.badges.join(', ')}
-                    </Text>
-                  ) : null}
-
-                  <View style={styles.actionRow}>
-                    {actionLoading[s.id] ? (
-                      <ActivityIndicator size="small" color={Colors.brandPrimary} style={styles.cardLoader} />
-                    ) : (
-                      <>
-                        <TouchableOpacity
-                          style={[
-                            styles.approveBtn,
-                            s.badges.includes(VERIFIED_BADGE) && styles.approveBtnActive,
-                          ]}
-                          onPress={() => handleApprove(s)}
-                          activeOpacity={0.75}
-                          disabled={s.badges.includes(VERIFIED_BADGE)}
-                        >
-                          <Text style={styles.approveBtnText}>
-                            {s.badges.includes(VERIFIED_BADGE) ? 'Одобрен' : 'Одобрить'}
-                          </Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                          style={styles.rejectBtn}
-                          onPress={() => handleReject(s)}
-                          activeOpacity={0.75}
-                          disabled={!s.badges.includes(VERIFIED_BADGE)}
-                        >
-                          <Text style={[
-                            styles.rejectBtnText,
-                            !s.badges.includes(VERIFIED_BADGE) && styles.btnTextDisabled,
-                          ]}>
-                            Отклонить
-                          </Text>
-                        </TouchableOpacity>
-                      </>
-                    )}
-                  </View>
+          {/* Queue screen */}
+          {screen === 'queue' && (
+            <>
+              {/* Header row */}
+              <View className="flex-row items-center gap-2">
+                <View className="flex-1">
+                  <Text className="text-xl font-bold text-textPrimary">Модерация</Text>
+                  <Text className="text-sm text-textMuted">Заявки на рассмотрение</Text>
                 </View>
-              ))}
-            </View>
+                <View
+                  className={`min-w-[28px] h-7 items-center justify-center rounded-full px-2 ${
+                    unverifiedCount === 0 ? 'bg-statusSuccess' : 'bg-statusWarning'
+                  }`}
+                >
+                  <Text className="text-sm font-bold text-white">{unverifiedCount}</Text>
+                </View>
+              </View>
+
+              {/* Filter chips */}
+              <View className="flex-row flex-wrap gap-2">
+                {filters.map((f) => (
+                  <Pressable
+                    key={f.key}
+                    onPress={() => setFilter(f.key)}
+                    className={`px-3 py-2 rounded-full border ${
+                      filter === f.key
+                        ? 'bg-brandPrimary border-brandPrimary'
+                        : 'border-borderLight'
+                    }`}
+                  >
+                    <Text
+                      className={`text-sm ${
+                        filter === f.key
+                          ? 'text-white font-semibold'
+                          : 'text-textMuted'
+                      }`}
+                    >
+                      {f.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              {/* Content */}
+              {loading ? (
+                <View className="py-6 items-center">
+                  <ActivityIndicator size="large" color={Colors.brandPrimary} />
+                </View>
+              ) : error ? (
+                <Text className="text-sm text-statusError text-center py-4">{error}</Text>
+              ) : filteredItems.length === 0 ? (
+                <EmptyView />
+              ) : (
+                <View className="gap-3">
+                  {filteredItems.map((item) => (
+                    <View key={item.id}>
+                      {actionLoading[item.id] ? (
+                        <View className="rounded-[14px] border border-borderLight bg-white p-4 items-center py-6">
+                          <ActivityIndicator size="small" color={Colors.brandPrimary} />
+                        </View>
+                      ) : (
+                        <ModerationCard
+                          item={item}
+                          onView={() => handleView(item)}
+                          onApprove={() => handleApprove(item)}
+                          onReject={() => handleReject(item)}
+                        />
+                      )}
+                    </View>
+                  ))}
+                </View>
+              )}
+            </>
           )}
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  scroll: {
-    flexGrow: 1,
-    alignItems: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  container: {
-    width: '100%',
-    maxWidth: 430,
-    paddingHorizontal: Spacing.xl,
-    gap: Spacing.md,
-  },
-  hint: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    lineHeight: 18,
-    paddingVertical: Spacing.sm,
-  },
-  loader: {
-    marginVertical: Spacing['2xl'],
-  },
-  errorText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    textAlign: 'center',
-    paddingVertical: Spacing.lg,
-  },
-  emptyText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    textAlign: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  list: {
-    gap: Spacing.sm,
-  },
-  card: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  nick: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textAccent,
-  },
-  updateDate: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-  email: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-  },
-  detail: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    lineHeight: 18,
-  },
-  detailLabel: {
-    color: Colors.textMuted,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  actionRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.sm,
-  },
-  approveBtn: {
-    flex: 1,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.statusSuccess,
-    alignItems: 'center',
-  },
-  approveBtnText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.statusSuccess,
-  },
-  rejectBtn: {
-    flex: 1,
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.statusError,
-    alignItems: 'center',
-  },
-  rejectBtnText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.statusError,
-  },
-  approveBtnActive: {
-    backgroundColor: Colors.statusSuccess,
-    borderColor: Colors.statusSuccess,
-    opacity: 0.7,
-  },
-  btnTextDisabled: {
-    opacity: 0.35,
-  },
-  cardLoader: {
-    flex: 1,
-    paddingVertical: Spacing.sm,
-  },
-});


### PR DESCRIPTION
## Summary
- Rewrite admin moderation page (`app/(admin)/moderation.tsx`) to match prototype from `AdminModerationStates.tsx`
- Replace all StyleSheet with NativeWind className, use Feather icons
- Add multi-state UI: queue list with filter chips, detail view with reject reason, approved/rejected confirmation screens
- Preserve real API calls (GET /admin/specialists, PATCH /specialists/:id/badges)

## Test plan
- [ ] Open admin moderation page, verify card layout matches prototype (avatar initials, service chips, status badge, date row, action buttons)
- [ ] Test filter chips (Все / На проверке / Верифицированные)
- [ ] Click "Просмотр" to open detail view, verify back navigation
- [ ] Approve/reject a specialist, verify result screen shows correctly
- [ ] Verify empty state when all items filtered out

Generated with Claude Code