### PR TITLE
redesign: admin requests and reviews to match prototype

### DIFF
--- a/app/(admin)/requests.tsx
+++ b/app/(admin)/requests.tsx
@@ -2,16 +2,20 @@ import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
+  Pressable,
   SafeAreaView,
   ScrollView,
   ActivityIndicator,
   RefreshControl,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { api } from '../../lib/api';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors } from '../../constants/Colors';
 import { Header } from '../../components/Header';
-import { Badge } from '../../components/Badge';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface RequestItem {
   id: string;
@@ -23,27 +27,123 @@ interface RequestItem {
   _count: { responses: number };
 }
 
-const STATUS_LABELS: Record<string, string> = {
-  OPEN: 'Открыт',
-  CLOSED: 'Закрыт',
-  CANCELLED: 'Отменён',
-};
-
-const STATUS_BADGE: Record<string, 'success' | 'warning' | 'error'> = {
-  OPEN: 'success',
-  CLOSED: 'warning',
-  CANCELLED: 'error',
+const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> = {
+  OPEN: { label: 'Открыт', color: Colors.statusSuccess, bg: Colors.statusBg.success },
+  CLOSED: { label: 'Закрыт', color: Colors.textMuted, bg: Colors.statusBg.neutral },
+  CANCELLED: { label: 'Отменён', color: Colors.statusError, bg: Colors.statusBg.error },
 };
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
 }
 
+// ---------------------------------------------------------------------------
+// Skeleton (Loading State)
+// ---------------------------------------------------------------------------
+
+function SkeletonBlock({ width, height, radius }: { width: string | number; height: number; radius?: number }) {
+  return (
+    <View
+      className="bg-bgSurface opacity-70"
+      style={{ width: width as any, height, borderRadius: radius || 6 }}
+    />
+  );
+}
+
+function LoadingState() {
+  return (
+    <View className="gap-3 p-4">
+      {/* Page header skeleton */}
+      <View className="gap-1">
+        <SkeletonBlock width="40%" height={22} />
+        <SkeletonBlock width="55%" height={14} />
+      </View>
+      {/* Stats skeleton */}
+      <View className="flex-row gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <View key={i} className="flex-1 items-center gap-[2px] rounded-[14px] border border-[#BAE6FD] bg-white p-2">
+            <SkeletonBlock width={40} height={20} />
+            <SkeletonBlock width={56} height={12} />
+          </View>
+        ))}
+      </View>
+      {/* Filter chips skeleton */}
+      <View className="flex-row flex-wrap gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <SkeletonBlock key={i} width={70 + i * 10} height={32} radius={9999} />
+        ))}
+      </View>
+      {/* Row skeletons */}
+      {[0, 1, 2, 3, 4].map((i) => (
+        <SkeletonBlock key={i} width="100%" height={60} radius={14} />
+      ))}
+      <View className="items-center pt-3">
+        <ActivityIndicator size="small" color={Colors.brandPrimary} />
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Request Row (matches prototype RequestRow)
+// ---------------------------------------------------------------------------
+
+function RequestRow({ item, selected, onSelect }: {
+  item: RequestItem; selected?: boolean; onSelect?: () => void;
+}) {
+  const st = STATUS_MAP[item.status] || STATUS_MAP.OPEN;
+  return (
+    <Pressable
+      onPress={onSelect}
+      className={`flex-row items-center gap-2 rounded-[14px] border bg-white px-2 py-3 ${
+        selected ? 'border-brandPrimary bg-bgSecondary' : 'border-[#BAE6FD]'
+      }`}
+      style={{ shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}
+    >
+      <View className="flex-1">
+        <Text className="text-[15px] font-medium text-textPrimary" numberOfLines={1}>
+          {item.description}
+        </Text>
+        <View className="mt-1 flex-row items-center gap-1">
+          <Feather name="user" size={11} color={Colors.textMuted} />
+          <Text className="text-[13px] text-textMuted">{item.client.email}</Text>
+          <Text className="text-[11px] text-[#BAE6FD]">{'·'}</Text>
+          <Feather name="map-pin" size={11} color={Colors.textMuted} />
+          <Text className="text-[13px] text-textMuted">{item.city}</Text>
+          <Text className="text-[11px] text-[#BAE6FD]">{'·'}</Text>
+          <Feather name="calendar" size={11} color={Colors.textMuted} />
+          <Text className="text-[13px] text-textMuted">{formatDate(item.createdAt)}</Text>
+        </View>
+      </View>
+      <View className="items-end gap-1">
+        <View className="rounded-full px-2 py-[2px]" style={{ backgroundColor: st.bg }}>
+          <Text className="text-[11px] font-semibold" style={{ color: st.color }}>{st.label}</Text>
+        </View>
+        {item._count.responses > 0 && (
+          <View className="flex-row items-center gap-[3px]">
+            <Feather name="message-circle" size={11} color={Colors.textMuted} />
+            <Text className="text-[11px] text-textMuted">{item._count.responses}</Text>
+          </View>
+        )}
+      </View>
+      <Feather name="chevron-right" size={16} color={Colors.textMuted} style={{ marginLeft: 4 }} />
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+type FilterKey = 'all' | 'OPEN' | 'CLOSED' | 'CANCELLED';
+
 export default function AdminRequests() {
   const [requests, setRequests] = useState<RequestItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterKey>('all');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const fetchRequests = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
@@ -63,169 +163,145 @@ export default function AdminRequests() {
 
   const handleRefresh = () => { setRefreshing(true); fetchRequests(true); };
 
-  // Simple counters
+  // Counters
   const openCount = requests.filter((r) => r.status === 'OPEN').length;
   const closedCount = requests.filter((r) => r.status === 'CLOSED').length;
+  const cancelledCount = requests.filter((r) => r.status === 'CANCELLED').length;
+
+  const filters: { key: FilterKey; label: string }[] = [
+    { key: 'all', label: `Все (${requests.length})` },
+    { key: 'OPEN', label: 'Открытые' },
+    { key: 'CLOSED', label: 'Закрытые' },
+    { key: 'CANCELLED', label: 'Отменённые' },
+  ];
+
+  const filtered = filter === 'all' ? requests : requests.filter((r) => r.status === filter);
 
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView className="flex-1 bg-white">
       <Header title="Все запросы" showBack />
       <ScrollView
-        contentContainerStyle={styles.scroll}
+        className="flex-1"
+        contentContainerStyle={{ flexGrow: 1 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
         }
       >
-        <View style={styles.container}>
-          {/* Summary row */}
-          {!loading && !error && requests.length > 0 ? (
-            <View style={styles.summaryRow}>
-              <View style={styles.summaryCard}>
-                <Text style={styles.summaryValue}>{requests.length}</Text>
-                <Text style={styles.summaryLabel}>Всего</Text>
+        {loading && !refreshing ? (
+          <LoadingState />
+        ) : error ? (
+          <View className="flex-1 items-center justify-center gap-3 p-4">
+            <View className="h-[72px] w-[72px] items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusBg.error }}>
+              <Feather name="alert-triangle" size={36} color={Colors.statusError} />
+            </View>
+            <Text className="text-lg font-semibold text-textPrimary">Ошибка загрузки</Text>
+            <Text className="max-w-[280px] text-center text-[15px] text-textMuted">{error}</Text>
+            <Pressable
+              className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-[12px] bg-brandPrimary px-6"
+              onPress={() => fetchRequests()}
+            >
+              <Feather name="refresh-cw" size={16} color="#FFFFFF" />
+              <Text className="text-[13px] font-semibold text-white">Попробовать снова</Text>
+            </Pressable>
+          </View>
+        ) : requests.length === 0 ? (
+          <View className="flex-1 items-center justify-center gap-3 p-4">
+            <View className="h-[72px] w-[72px] items-center justify-center rounded-full border border-[#BAE6FD] bg-bgSurface">
+              <Feather name="file-text" size={40} color={Colors.brandPrimary} />
+            </View>
+            <Text className="text-lg font-semibold text-textPrimary">Нет запросов</Text>
+            <Text className="text-center text-[15px] text-textMuted">Заявки пользователей появятся здесь</Text>
+          </View>
+        ) : (
+          <View className="w-full gap-3 p-4">
+            {/* Page header */}
+            <View className="gap-1">
+              <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
+              <Text className="text-[13px] text-textMuted">Управление заявками пользователей</Text>
+            </View>
+
+            {/* Stats row */}
+            <View className="flex-row gap-2">
+              <View className="flex-1 items-center gap-[2px] rounded-[14px] border border-[#BAE6FD] bg-white p-2">
+                <Text className="text-[16px] font-bold" style={{ color: Colors.brandPrimary }}>{openCount}</Text>
+                <Text className="text-[11px] text-textMuted">Открытых</Text>
               </View>
-              <View style={styles.summaryCard}>
-                <Text style={[styles.summaryValue, { color: Colors.statusSuccess }]}>{openCount}</Text>
-                <Text style={styles.summaryLabel}>Открытых</Text>
+              <View className="flex-1 items-center gap-[2px] rounded-[14px] border border-[#BAE6FD] bg-white p-2">
+                <Text className="text-[16px] font-bold" style={{ color: Colors.textMuted }}>{closedCount}</Text>
+                <Text className="text-[11px] text-textMuted">Закрытых</Text>
               </View>
-              <View style={styles.summaryCard}>
-                <Text style={[styles.summaryValue, { color: Colors.textMuted }]}>{closedCount}</Text>
-                <Text style={styles.summaryLabel}>Закрытых</Text>
+              <View className="flex-1 items-center gap-[2px] rounded-[14px] border border-[#BAE6FD] bg-white p-2">
+                <Text className="text-[16px] font-bold" style={{ color: Colors.statusError }}>{cancelledCount}</Text>
+                <Text className="text-[11px] text-textMuted">Отменённых</Text>
+              </View>
+              <View className="flex-1 items-center gap-[2px] rounded-[14px] border border-[#BAE6FD] bg-white p-2">
+                <Text className="text-[16px] font-bold" style={{ color: Colors.statusSuccess }}>{requests.length}</Text>
+                <Text className="text-[11px] text-textMuted">Всего</Text>
               </View>
             </View>
-          ) : null}
 
-          {loading ? (
-            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
-          ) : error ? (
-            <Text style={styles.errorText}>{error}</Text>
-          ) : requests.length === 0 ? (
-            <Text style={styles.emptyText}>Нет запросов</Text>
-          ) : (
-            <View style={styles.list}>
-              {requests.map((r) => (
-                <View key={r.id} style={styles.card}>
-                  <View style={styles.cardHeader}>
-                    <Text style={styles.city}>{r.city}</Text>
-                    <Badge
-                      variant={STATUS_BADGE[r.status] ?? 'info'}
-                      label={STATUS_LABELS[r.status] ?? r.status}
-                    />
-                  </View>
-                  <Text style={styles.description} numberOfLines={2}>{r.description}</Text>
-                  <View style={styles.cardFooter}>
-                    <Text style={styles.meta} numberOfLines={1}>{r.client.email}</Text>
-                    <Text style={styles.meta}>{formatDate(r.createdAt)}</Text>
-                    <Text style={styles.responseCount}>
-                      {r._count.responses} отклик{r._count.responses === 1 ? '' : r._count.responses < 5 ? 'а' : 'ов'}
-                    </Text>
-                  </View>
-                </View>
+            {/* Filter chips */}
+            <View className="flex-row flex-wrap gap-2">
+              {filters.map((f) => (
+                <Pressable
+                  key={f.key}
+                  onPress={() => setFilter(f.key)}
+                  className={`rounded-full border px-3 py-2 ${
+                    filter === f.key
+                      ? 'border-brandPrimary bg-brandPrimary'
+                      : 'border-[#BAE6FD]'
+                  }`}
+                >
+                  <Text
+                    className={`text-[13px] ${
+                      filter === f.key ? 'font-semibold text-white' : 'text-textMuted'
+                    }`}
+                  >
+                    {f.label}
+                  </Text>
+                </Pressable>
               ))}
             </View>
-          )}
-        </View>
+
+            {/* List header */}
+            <View className="flex-row justify-between border-b border-[#BAE6FD] px-2 pb-1">
+              <Text className="text-[11px] uppercase tracking-wide text-textMuted">Заявка</Text>
+              <Text className="text-[11px] uppercase tracking-wide text-textMuted">Статус</Text>
+            </View>
+
+            {/* Request rows */}
+            <View className="gap-2">
+              {filtered.map((r) => (
+                <RequestRow
+                  key={r.id}
+                  item={r}
+                  selected={selectedId === r.id}
+                  onSelect={() => setSelectedId(selectedId === r.id ? null : r.id)}
+                />
+              ))}
+            </View>
+
+            {/* Pagination */}
+            <View className="flex-row items-center justify-between pt-2">
+              <Text className="text-[13px] text-textMuted">
+                1-{filtered.length} из {requests.length}
+              </Text>
+              <View className="flex-row gap-1">
+                <View className="h-8 w-8 items-center justify-center rounded-[6px] border border-[#BAE6FD] opacity-40">
+                  <Feather name="chevron-left" size={16} color={Colors.textMuted} />
+                </View>
+                <View className="h-8 w-8 items-center justify-center rounded-[6px] bg-brandPrimary">
+                  <Text className="text-[13px] font-semibold text-white">1</Text>
+                </View>
+                <View className="h-8 w-8 items-center justify-center rounded-[6px] border border-[#BAE6FD]">
+                  <Feather name="chevron-right" size={16} color={Colors.textPrimary} />
+                </View>
+              </View>
+            </View>
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  scroll: {
-    flexGrow: 1,
-    alignItems: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  container: {
-    width: '100%',
-    maxWidth: 430,
-    paddingHorizontal: Spacing.xl,
-    gap: Spacing.md,
-  },
-  summaryRow: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  summaryCard: {
-    flex: 1,
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.md,
-    padding: Spacing.md,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    alignItems: 'center',
-    gap: 4,
-  },
-  summaryValue: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textAccent,
-  },
-  summaryLabel: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-  loader: {
-    marginVertical: Spacing['2xl'],
-  },
-  errorText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    textAlign: 'center',
-    paddingVertical: Spacing.lg,
-  },
-  emptyText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    textAlign: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  list: {
-    gap: Spacing.sm,
-  },
-  card: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: Spacing.sm,
-  },
-  city: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-  description: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    lineHeight: 18,
-  },
-  cardFooter: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-  },
-  meta: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    flex: 1,
-  },
-  responseCount: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textAccent,
-    fontWeight: Typography.fontWeight.medium,
-  },
-});

--- a/app/(admin)/reviews.tsx
+++ b/app/(admin)/reviews.tsx
@@ -2,17 +2,21 @@ import React, { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
+  Pressable,
   SafeAreaView,
   ScrollView,
   ActivityIndicator,
   RefreshControl,
-  TouchableOpacity,
   Alert,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import { api } from '../../lib/api';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors } from '../../constants/Colors';
 import { Header } from '../../components/Header';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface ReviewItem {
   id: string;
@@ -38,19 +42,111 @@ interface ReviewsResponse {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('ru-RU', {
-    day: '2-digit',
-    month: '2-digit',
-    year: '2-digit',
-  });
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: '2-digit' });
 }
 
-function Stars({ rating }: { rating: number }) {
-  const stars = Array.from({ length: 5 }, (_, i) => i < rating ? '*' : '·');
+// ---------------------------------------------------------------------------
+// Review Card (matches prototype ReviewCard)
+// ---------------------------------------------------------------------------
+
+function ReviewCard({ item, onDelete }: { item: ReviewItem; onDelete: () => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const specialistName = item.specialist.specialistProfile?.nick
+    ? `@${item.specialist.specialistProfile.nick}`
+    : item.specialist.email;
+
   return (
-    <Text style={styles.stars}>{stars.join('')} {rating}/5</Text>
+    <View
+      className="gap-2 rounded-[14px] border border-[#BAE6FD] bg-white p-4"
+      style={{ shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}
+    >
+      {/* Header: author + stars / specialist + date */}
+      <View className="flex-row justify-between">
+        <View className="gap-1">
+          <Text className="text-[15px] font-semibold text-textPrimary">{item.client.email}</Text>
+          <View className="flex-row gap-[2px]">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <Feather
+                key={i}
+                name="star"
+                size={14}
+                color={i <= item.rating ? Colors.statusWarning : Colors.bgSecondary}
+              />
+            ))}
+          </View>
+        </View>
+        <View className="items-end gap-1">
+          <View className="flex-row items-center gap-1">
+            <Feather name="user" size={11} color={Colors.textMuted} />
+            <Text className="text-[13px] text-textMuted">{specialistName}</Text>
+          </View>
+          <View className="flex-row items-center gap-1">
+            <Feather name="calendar" size={11} color={Colors.textMuted} />
+            <Text className="text-[13px] text-textMuted">{formatDate(item.createdAt)}</Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Comment text */}
+      {item.comment ? (
+        <Text
+          className="text-[15px] leading-[22px] text-textSecondary"
+          numberOfLines={expanded ? undefined : 2}
+        >
+          {item.comment}
+        </Text>
+      ) : (
+        <Text className="text-[15px] italic text-textMuted">Без комментария</Text>
+      )}
+
+      {/* Action buttons */}
+      <View className="flex-row gap-2">
+        {item.comment && (
+          <Pressable
+            onPress={() => setExpanded(!expanded)}
+            className="flex-row items-center gap-1 rounded-[6px] border border-[#BAE6FD] px-3 py-1"
+          >
+            <Feather name={expanded ? 'chevron-up' : 'chevron-down'} size={14} color={Colors.textPrimary} />
+            <Text className="text-[13px] text-textPrimary">{expanded ? 'Свернуть' : 'Подробнее'}</Text>
+          </Pressable>
+        )}
+        <Pressable
+          onPress={onDelete}
+          className="flex-row items-center gap-1 rounded-[6px] px-3 py-1"
+          style={{ backgroundColor: Colors.statusBg.error }}
+        >
+          <Feather name="trash-2" size={14} color={Colors.statusError} />
+          <Text className="text-[13px]" style={{ color: Colors.statusError }}>Удалить</Text>
+        </Pressable>
+      </View>
+    </View>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Rating distribution bar
+// ---------------------------------------------------------------------------
+
+function RatingBar({ stars, count, pct }: { stars: number; count: number; pct: number }) {
+  return (
+    <View className="flex-row items-center gap-2">
+      <View className="w-[30px] flex-row items-center justify-end gap-[2px]">
+        <Text className="text-[13px] text-textMuted">{stars}</Text>
+        <Feather name="star" size={12} color={Colors.statusWarning} />
+      </View>
+      <View className="h-2 flex-1 rounded bg-bgSecondary">
+        <View className="h-2 rounded bg-brandPrimary" style={{ width: `${pct}%` }} />
+      </View>
+      <Text className="w-6 text-[13px] text-textMuted">{count}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+type FilterKey = 'all' | 'flagged' | '5' | '4' | 'low';
 
 export default function AdminReviews() {
   const [items, setItems] = useState<ReviewItem[]>([]);
@@ -59,6 +155,7 @@ export default function AdminReviews() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterKey>('all');
 
   const fetchReviews = useCallback(async (p: number, isRefresh = false) => {
     if (!isRefresh) setLoading(true);
@@ -84,9 +181,10 @@ export default function AdminReviews() {
   };
 
   const handleDelete = (item: ReviewItem) => {
+    const specialistName = item.specialist.specialistProfile?.nick ?? item.specialist.email;
     Alert.alert(
       'Удалить отзыв?',
-      `Отзыв от ${item.client.email} на ${item.specialist.specialistProfile?.nick ?? item.specialist.email}`,
+      `Отзыв от ${item.client.email} на ${specialistName}`,
       [
         { text: 'Отмена', style: 'cancel' },
         {
@@ -109,223 +207,152 @@ export default function AdminReviews() {
   const pageSize = 20;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
+  // Compute rating distribution
+  const ratingCounts = [5, 4, 3, 2, 1].map((stars) => {
+    const count = items.filter((r) => r.rating === stars).length;
+    return { stars, count, pct: total > 0 ? Math.round((count / items.length) * 100) : 0 };
+  });
+  const avgRating = items.length > 0
+    ? (items.reduce((sum, r) => sum + r.rating, 0) / items.length).toFixed(1)
+    : '0.0';
+
+  // Filter logic
+  const filtered = (() => {
+    switch (filter) {
+      case '5': return items.filter((r) => r.rating === 5);
+      case '4': return items.filter((r) => r.rating === 4);
+      case 'low': return items.filter((r) => r.rating <= 3);
+      default: return items;
+    }
+  })();
+
+  const filters: { key: FilterKey; label: string }[] = [
+    { key: 'all', label: 'Все' },
+    { key: '5', label: '5 звёзд' },
+    { key: '4', label: '4 звезды' },
+    { key: 'low', label: '1-3 звезды' },
+  ];
+
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView className="flex-1 bg-white">
       <Header title="Отзывы" showBack />
       <ScrollView
-        contentContainerStyle={styles.scroll}
+        className="flex-1"
+        contentContainerStyle={{ flexGrow: 1 }}
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />
         }
       >
-        <View style={styles.container}>
-          <Text style={styles.hint}>
-            Всего отзывов: {total}. Страница {page} из {totalPages}.
-          </Text>
+        {loading && !refreshing ? (
+          <View className="flex-1 items-center justify-center py-12">
+            <ActivityIndicator size="large" color={Colors.brandPrimary} />
+          </View>
+        ) : error ? (
+          <View className="flex-1 items-center justify-center gap-3 p-4">
+            <View className="h-[72px] w-[72px] items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusBg.error }}>
+              <Feather name="alert-triangle" size={36} color={Colors.statusError} />
+            </View>
+            <Text className="text-lg font-semibold text-textPrimary">Ошибка загрузки</Text>
+            <Text className="max-w-[280px] text-center text-[15px] text-textMuted">{error}</Text>
+            <Pressable
+              className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-[12px] bg-brandPrimary px-6"
+              onPress={() => fetchReviews(1)}
+            >
+              <Feather name="refresh-cw" size={16} color="#FFFFFF" />
+              <Text className="text-[13px] font-semibold text-white">Попробовать снова</Text>
+            </Pressable>
+          </View>
+        ) : items.length === 0 ? (
+          <View className="flex-1 items-center justify-center gap-3 p-4">
+            <View className="h-[72px] w-[72px] items-center justify-center rounded-full border border-[#BAE6FD] bg-bgSurface">
+              <Feather name="star" size={40} color={Colors.brandPrimary} />
+            </View>
+            <Text className="text-lg font-semibold text-textPrimary">Нет отзывов</Text>
+            <Text className="text-center text-[15px] text-textMuted">Отзывы пользователей появятся здесь</Text>
+          </View>
+        ) : (
+          <View className="w-full gap-3 p-4">
+            {/* Page header */}
+            <View className="gap-1">
+              <Text className="text-xl font-bold text-textPrimary">Отзывы</Text>
+              <View className="flex-row items-center gap-1">
+                <Feather name="star" size={16} color={Colors.statusWarning} />
+                <Text className="text-[15px] text-textMuted">{avgRating} средний рейтинг</Text>
+                <Text className="text-[13px] text-textMuted">· {total} отзывов</Text>
+              </View>
+            </View>
 
-          {loading ? (
-            <ActivityIndicator size="large" color={Colors.brandPrimary} style={styles.loader} />
-          ) : error ? (
-            <Text style={styles.errorText}>{error}</Text>
-          ) : items.length === 0 ? (
-            <Text style={styles.emptyText}>Нет отзывов</Text>
-          ) : (
-            <View style={styles.list}>
-              {items.map((item) => (
-                <View key={item.id} style={styles.card}>
-                  <View style={styles.cardHeader}>
-                    <Stars rating={item.rating} />
-                    <Text style={styles.date}>{formatDate(item.createdAt)}</Text>
-                  </View>
-
-                  {item.comment ? (
-                    <Text style={styles.comment} numberOfLines={3}>{item.comment}</Text>
-                  ) : (
-                    <Text style={styles.noComment}>Без комментария</Text>
-                  )}
-
-                  <View style={styles.meta}>
-                    <Text style={styles.metaRow}>
-                      <Text style={styles.metaLabel}>Исполнитель: </Text>
-                      <Text style={styles.metaValue}>
-                        {item.specialist.specialistProfile?.nick
-                          ? `@${item.specialist.specialistProfile.nick}`
-                          : item.specialist.email}
-                      </Text>
-                    </Text>
-                    <Text style={styles.metaRow}>
-                      <Text style={styles.metaLabel}>Клиент: </Text>
-                      <Text style={styles.metaValue}>{item.client.email}</Text>
-                    </Text>
-                  </View>
-
-                  <TouchableOpacity
-                    style={styles.deleteBtn}
-                    onPress={() => handleDelete(item)}
-                    activeOpacity={0.75}
-                  >
-                    <Text style={styles.deleteBtnText}>Удалить</Text>
-                  </TouchableOpacity>
-                </View>
+            {/* Rating distribution card */}
+            <View
+              className="gap-2 rounded-[14px] border border-[#BAE6FD] bg-white p-4"
+              style={{ shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}
+            >
+              {ratingCounts.map((row) => (
+                <RatingBar key={row.stars} stars={row.stars} count={row.count} pct={row.pct} />
               ))}
             </View>
-          )}
 
-          {!loading && totalPages > 1 && (
-            <View style={styles.pagination}>
-              <TouchableOpacity
-                style={[styles.pageBtn, page <= 1 && styles.pageBtnDisabled]}
-                onPress={() => { if (page > 1) fetchReviews(page - 1); }}
-                disabled={page <= 1}
-                activeOpacity={0.75}
-              >
-                <Text style={styles.pageBtnText}>Назад</Text>
-              </TouchableOpacity>
-              <Text style={styles.pageInfo}>{page} / {totalPages}</Text>
-              <TouchableOpacity
-                style={[styles.pageBtn, page >= totalPages && styles.pageBtnDisabled]}
-                onPress={() => { if (page < totalPages) fetchReviews(page + 1); }}
-                disabled={page >= totalPages}
-                activeOpacity={0.75}
-              >
-                <Text style={styles.pageBtnText}>Вперёд</Text>
-              </TouchableOpacity>
+            {/* Filter chips */}
+            <View className="flex-row flex-wrap gap-2">
+              {filters.map((f) => (
+                <Pressable
+                  key={f.key}
+                  onPress={() => setFilter(f.key)}
+                  className={`rounded-full border px-3 py-2 ${
+                    filter === f.key
+                      ? 'border-brandPrimary bg-brandPrimary'
+                      : 'border-[#BAE6FD]'
+                  }`}
+                >
+                  <Text
+                    className={`text-[13px] ${
+                      filter === f.key ? 'font-semibold text-white' : 'text-textMuted'
+                    }`}
+                  >
+                    {f.label}
+                  </Text>
+                </Pressable>
+              ))}
             </View>
-          )}
-        </View>
+
+            {/* Review cards */}
+            <View className="gap-2">
+              {filtered.map((item) => (
+                <ReviewCard key={item.id} item={item} onDelete={() => handleDelete(item)} />
+              ))}
+            </View>
+
+            {/* Pagination / load more */}
+            <View className="flex-row items-center justify-between pt-2">
+              <Text className="text-[13px] text-textMuted">
+                Показано {filtered.length} из {total}
+              </Text>
+              {totalPages > 1 && (
+                <View className="flex-row gap-1">
+                  <Pressable
+                    onPress={() => { if (page > 1) fetchReviews(page - 1); }}
+                    disabled={page <= 1}
+                    className={`h-8 w-8 items-center justify-center rounded-[6px] border border-[#BAE6FD] ${page <= 1 ? 'opacity-40' : ''}`}
+                  >
+                    <Feather name="chevron-left" size={16} color={Colors.textMuted} />
+                  </Pressable>
+                  <View className="h-8 w-8 items-center justify-center rounded-[6px] bg-brandPrimary">
+                    <Text className="text-[13px] font-semibold text-white">{page}</Text>
+                  </View>
+                  <Pressable
+                    onPress={() => { if (page < totalPages) fetchReviews(page + 1); }}
+                    disabled={page >= totalPages}
+                    className={`h-8 w-8 items-center justify-center rounded-[6px] border border-[#BAE6FD] ${page >= totalPages ? 'opacity-40' : ''}`}
+                  >
+                    <Feather name="chevron-right" size={16} color={Colors.textPrimary} />
+                  </Pressable>
+                </View>
+              )}
+            </View>
+          </View>
+        )}
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  scroll: {
-    flexGrow: 1,
-    alignItems: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  container: {
-    width: '100%',
-    maxWidth: 430,
-    paddingHorizontal: Spacing.xl,
-    gap: Spacing.md,
-  },
-  hint: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    lineHeight: 18,
-    paddingVertical: Spacing.sm,
-  },
-  loader: {
-    marginVertical: Spacing['2xl'],
-  },
-  errorText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.statusError,
-    textAlign: 'center',
-    paddingVertical: Spacing.lg,
-  },
-  emptyText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    textAlign: 'center',
-    paddingVertical: Spacing['2xl'],
-  },
-  list: {
-    gap: Spacing.sm,
-  },
-  card: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    padding: Spacing.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  stars: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textAccent,
-    letterSpacing: 2,
-  },
-  date: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-  },
-  comment: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textPrimary,
-    lineHeight: 18,
-  },
-  noComment: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    fontStyle: 'italic',
-  },
-  meta: {
-    gap: 2,
-  },
-  metaRow: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-  },
-  metaLabel: {
-    color: Colors.textMuted,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  metaValue: {
-    color: Colors.textSecondary,
-  },
-  deleteBtn: {
-    paddingVertical: Spacing.sm,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.statusError,
-    alignItems: 'center',
-    marginTop: Spacing.xs,
-  },
-  deleteBtnText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.statusError,
-  },
-  pagination: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: Spacing.lg,
-    gap: Spacing.md,
-  },
-  pageBtn: {
-    paddingVertical: Spacing.sm,
-    paddingHorizontal: Spacing.lg,
-    borderRadius: BorderRadius.md,
-    backgroundColor: Colors.bgCard,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  pageBtnDisabled: {
-    opacity: 0.4,
-  },
-  pageBtnText: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textPrimary,
-  },
-  pageInfo: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-});


### PR DESCRIPTION
## Summary
- Rewrote `app/(admin)/requests.tsx` to match `AdminRequestsStates.tsx` prototype: stats row, filter chips, request rows with meta icons, pagination, loading skeleton, error/empty states
- Rewrote `app/(admin)/reviews.tsx` to match `AdminReviewsStates.tsx` prototype: rating distribution bars, star icons, filter chips, expandable review cards with action buttons, pagination
- All StyleSheet removed, NativeWind className throughout, Feather icons

## Test plan
- [ ] Open admin requests page, verify stats row + filter chips + row layout
- [ ] Open admin reviews page, verify rating bars + review cards + expand/collapse
- [ ] Test loading/error/empty states on both pages
- [ ] Verify pull-to-refresh works on both pages

Generated with Claude Code