### PR TITLE
redesign: specialist settings to match prototype

### DIFF
--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
-  StyleSheet,
   SafeAreaView,
   ScrollView,
-  TouchableOpacity,
-  Switch,
+  Pressable,
   Alert,
   ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
   TextInput,
 } from 'react-native';
+import { Feather } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useRouter } from 'expo-router';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
@@ -20,7 +19,7 @@ import { useAuth } from '../../stores/authStore';
 import { api, ApiError } from '../../lib/api';
 import { isAdmin } from '../../lib/adminEmails';
 import { Header } from '../../components/Header';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors } from '../../constants/Colors';
 
 interface MyReview {
   id: string;
@@ -43,6 +42,53 @@ interface NotificationSettings {
 
 const NOTIF_KEY_RESPONSES = '@p2ptax_notif_responses';
 const NOTIF_KEY_MESSAGES = '@p2ptax_notif_messages';
+
+// ---------------------------------------------------------------------------
+// Toggle (matching proto pattern)
+// ---------------------------------------------------------------------------
+function Toggle({
+  label,
+  sublabel,
+  value,
+  onValueChange,
+  disabled,
+}: {
+  label: string;
+  sublabel?: string;
+  value: boolean;
+  onValueChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  const trackColor = value ? Colors.brandPrimary : '#D1D5DB';
+  return (
+    <Pressable
+      className="flex-row items-center justify-between"
+      onPress={() => !disabled && onValueChange(!value)}
+      style={{ opacity: disabled ? 0.5 : 1 }}
+    >
+      <View className="mr-3 flex-1">
+        <Text className="text-sm text-textSecondary">{label}</Text>
+        {sublabel ? <Text className="text-xs text-textMuted">{sublabel}</Text> : null}
+      </View>
+      <View
+        className="h-7 w-12 justify-center rounded-full px-0.5"
+        style={{ backgroundColor: trackColor }}
+      >
+        <View
+          className="h-[22px] w-[22px] rounded-full bg-white"
+          style={{
+            alignSelf: value ? 'flex-end' : 'flex-start',
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.2,
+            shadowRadius: 2,
+            elevation: 2,
+          }}
+        />
+      </View>
+    </Pressable>
+  );
+}
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -85,7 +131,6 @@ export default function SettingsScreen() {
         AsyncStorage.setItem(NOTIF_KEY_MESSAGES, String(data.new_messages)).catch(() => {});
       })
       .catch(() => {
-        // Fallback to AsyncStorage if API unavailable
         Promise.all([
           AsyncStorage.getItem(NOTIF_KEY_RESPONSES),
           AsyncStorage.getItem(NOTIF_KEY_MESSAGES),
@@ -110,7 +155,6 @@ export default function SettingsScreen() {
         await AsyncStorage.setItem(NOTIF_KEY_MESSAGES, String(value));
       }
     } catch {
-      // Revert on failure
       setNotifSettings((s) => ({ ...s, [key]: prev }));
     }
   }
@@ -181,8 +225,7 @@ export default function SettingsScreen() {
       setEmailChangeError('Введите новый email');
       return;
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(trimmed)) {
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
       setEmailChangeError('Введите корректный email');
       return;
     }
@@ -229,231 +272,230 @@ export default function SettingsScreen() {
     setEmailChangeError('');
   }
 
+  const displayEmail = user?.email ?? '\u2014';
+
   return (
-    <SafeAreaView style={styles.safe}>
+    <SafeAreaView className="flex-1 bg-white">
       {isMobile && <Header title="Настройки" showBack />}
 
       <KeyboardAvoidingView
-        style={{ flex: 1 }}
+        className="flex-1"
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-      <ScrollView
-        contentContainerStyle={styles.scroll}
-        showsVerticalScrollIndicator={false}
-        keyboardShouldPersistTaps="handled"
-      >
-        <View style={styles.container}>
-          {/* Account section */}
-          <Text style={styles.sectionTitle}>Аккаунт</Text>
-          <View style={styles.card}>
-            {/* Email row — readonly display */}
-            <View style={styles.row}>
-              <View style={styles.rowTextBlock}>
-                <Text style={styles.rowLabel}>Email</Text>
-                <Text style={styles.rowHint} numberOfLines={1}>{user?.email ?? '—'}</Text>
-              </View>
-            </View>
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ alignItems: 'center', paddingVertical: 24, paddingBottom: 48 }}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="w-full max-w-[430px] px-5 gap-5">
+            {/* Page title */}
+            <Text className="text-xl font-bold text-textPrimary">Настройки</Text>
 
-            {/* Email change flow */}
-            {emailChangeStep === 'idle' && (
-              <View style={styles.emailChangeBtnRow}>
-                <TouchableOpacity
-                  style={styles.emailChangeBtn}
+            {/* ============ Account ============ */}
+            <View className="gap-3 rounded-xl border border-borderLight p-4">
+              <Text className="text-base font-semibold text-textPrimary">Аккаунт</Text>
+
+              {/* Email — readonly */}
+              <View className="gap-1">
+                <Text className="text-sm font-medium text-textMuted">Email</Text>
+                <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
+                  <Feather name="mail" size={16} color={Colors.textMuted} />
+                  <Text className="ml-2 flex-1 text-base text-textSecondary" numberOfLines={1}>
+                    {displayEmail}
+                  </Text>
+                </View>
+              </View>
+
+              {/* Email change flow */}
+              {emailChangeStep === 'idle' && (
+                <Pressable
+                  className="h-10 items-center justify-center rounded-lg border bg-bgSecondary"
+                  style={{ borderColor: Colors.brandPrimary + '60' }}
                   onPress={handleStartEmailChange}
-                  activeOpacity={0.75}
                 >
-                  <Text style={styles.emailChangeBtnText}>Изменить email</Text>
-                </TouchableOpacity>
-              </View>
-            )}
+                  <Text className="text-sm font-medium" style={{ color: Colors.brandPrimary }}>
+                    Изменить email
+                  </Text>
+                </Pressable>
+              )}
 
-            {emailChangeStep === 'email_input' && (
-              <View style={styles.emailChangeFormBlock}>
-                <Text style={styles.emailChangeFormLabel}>Новый email</Text>
-                <TextInput
-                  style={styles.emailChangeInput}
-                  value={newEmail}
-                  onChangeText={(t) => { setNewEmail(t); setEmailChangeError(''); }}
-                  placeholder="example@email.com"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text style={styles.emailChangeErrorText}>{emailChangeError}</Text>
-                ) : null}
-                <View style={styles.emailChangeActions}>
-                  <TouchableOpacity
-                    style={[styles.emailChangeActionBtn, styles.emailChangeActionBtnSecondary]}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                    activeOpacity={0.75}
+              {emailChangeStep === 'email_input' && (
+                <View className="gap-2">
+                  <Text className="text-sm text-textSecondary">Новый email</Text>
+                  <TextInput
+                    className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-base text-textPrimary"
+                    value={newEmail}
+                    onChangeText={(t) => { setNewEmail(t); setEmailChangeError(''); }}
+                    placeholder="example@email.com"
+                    placeholderTextColor={Colors.textMuted}
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    editable={!emailChangeLoading}
+                  />
+                  {emailChangeError ? (
+                    <Text className="text-xs" style={{ color: Colors.statusError }}>
+                      {emailChangeError}
+                    </Text>
+                  ) : null}
+                  <View className="flex-row gap-2">
+                    <Pressable
+                      className="flex-1 h-10 rounded-lg items-center justify-center border border-borderLight bg-bgSecondary"
+                      onPress={handleCancelEmailChange}
+                      disabled={emailChangeLoading}
+                    >
+                      <Text className="text-sm font-medium text-textSecondary">Отмена</Text>
+                    </Pressable>
+                    <Pressable
+                      className="flex-1 h-10 rounded-lg items-center justify-center"
+                      style={{
+                        backgroundColor: Colors.brandPrimary,
+                        opacity: emailChangeLoading ? 0.6 : 1,
+                      }}
+                      onPress={handleRequestEmailChange}
+                      disabled={emailChangeLoading}
+                    >
+                      {emailChangeLoading ? (
+                        <ActivityIndicator size="small" color={Colors.white} />
+                      ) : (
+                        <Text className="text-sm font-medium text-white">Получить код</Text>
+                      )}
+                    </Pressable>
+                  </View>
+                </View>
+              )}
+
+              {emailChangeStep === 'otp_input' && (
+                <View className="gap-2">
+                  <Text className="text-sm text-textSecondary">
+                    Код отправлен на {newEmail.trim().toLowerCase()}
+                  </Text>
+                  <TextInput
+                    className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-center text-lg text-textPrimary"
+                    style={{ letterSpacing: 4 }}
+                    value={emailOtpCode}
+                    onChangeText={(t) => { setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6)); setEmailChangeError(''); }}
+                    placeholder="000000"
+                    placeholderTextColor={Colors.textMuted}
+                    keyboardType="number-pad"
+                    maxLength={6}
+                    editable={!emailChangeLoading}
+                  />
+                  {emailChangeError ? (
+                    <Text className="text-xs" style={{ color: Colors.statusError }}>
+                      {emailChangeError}
+                    </Text>
+                  ) : null}
+                  <View className="flex-row gap-2">
+                    <Pressable
+                      className="flex-1 h-10 rounded-lg items-center justify-center border border-borderLight bg-bgSecondary"
+                      onPress={handleCancelEmailChange}
+                      disabled={emailChangeLoading}
+                    >
+                      <Text className="text-sm font-medium text-textSecondary">Отмена</Text>
+                    </Pressable>
+                    <Pressable
+                      className="flex-1 h-10 rounded-lg items-center justify-center"
+                      style={{
+                        backgroundColor: Colors.brandPrimary,
+                        opacity: emailChangeLoading ? 0.6 : 1,
+                      }}
+                      onPress={handleConfirmEmailChange}
+                      disabled={emailChangeLoading}
+                    >
+                      {emailChangeLoading ? (
+                        <ActivityIndicator size="small" color={Colors.white} />
+                      ) : (
+                        <Text className="text-sm font-medium text-white">Подтвердить</Text>
+                      )}
+                    </Pressable>
+                  </View>
+                </View>
+              )}
+
+              {emailChangeStep === 'success' && (
+                <View className="gap-2">
+                  <Text
+                    className="text-base font-medium text-center py-2"
+                    style={{ color: Colors.statusSuccess }}
                   >
-                    <Text style={styles.emailChangeActionBtnSecondaryText}>Отмена</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.emailChangeActionBtn, styles.emailChangeActionBtnPrimary, emailChangeLoading && styles.emailChangeActionBtnDisabled]}
-                    onPress={handleRequestEmailChange}
-                    disabled={emailChangeLoading}
-                    activeOpacity={0.75}
+                    Email успешно изменён
+                  </Text>
+                  <Pressable
+                    className="h-10 rounded-lg items-center justify-center"
+                    style={{ backgroundColor: Colors.brandPrimary }}
+                    onPress={handleEmailChangeSuccess}
                   >
-                    {emailChangeLoading ? (
-                      <ActivityIndicator size="small" color={Colors.white} />
-                    ) : (
-                      <Text style={styles.emailChangeActionBtnPrimaryText}>Получить код</Text>
-                    )}
-                  </TouchableOpacity>
+                    <Text className="text-sm font-medium text-white">Готово</Text>
+                  </Pressable>
+                </View>
+              )}
+
+              {/* Role */}
+              <View className="gap-1">
+                <Text className="text-sm font-medium text-textMuted">Роль</Text>
+                <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
+                  <Feather name="user" size={16} color={Colors.textMuted} />
+                  <Text className="ml-2 flex-1 text-base text-textSecondary">
+                    {user?.role === 'SPECIALIST' ? 'Специалист' : 'Заказчик'}
+                  </Text>
                 </View>
               </View>
-            )}
 
-            {emailChangeStep === 'otp_input' && (
-              <View style={styles.emailChangeFormBlock}>
-                <Text style={styles.emailChangeFormLabel}>
-                  Код отправлен на {newEmail.trim().toLowerCase()}
-                </Text>
-                <TextInput
-                  style={[styles.emailChangeInput, styles.emailChangeOtpInput]}
-                  value={emailOtpCode}
-                  onChangeText={(t) => { setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6)); setEmailChangeError(''); }}
-                  placeholder="000000"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="number-pad"
-                  maxLength={6}
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text style={styles.emailChangeErrorText}>{emailChangeError}</Text>
-                ) : null}
-                <View style={styles.emailChangeActions}>
-                  <TouchableOpacity
-                    style={[styles.emailChangeActionBtn, styles.emailChangeActionBtnSecondary]}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                    activeOpacity={0.75}
-                  >
-                    <Text style={styles.emailChangeActionBtnSecondaryText}>Отмена</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.emailChangeActionBtn, styles.emailChangeActionBtnPrimary, emailChangeLoading && styles.emailChangeActionBtnDisabled]}
-                    onPress={handleConfirmEmailChange}
-                    disabled={emailChangeLoading}
-                    activeOpacity={0.75}
-                  >
-                    {emailChangeLoading ? (
-                      <ActivityIndicator size="small" color={Colors.white} />
-                    ) : (
-                      <Text style={styles.emailChangeActionBtnPrimaryText}>Подтвердить</Text>
-                    )}
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
-
-            {emailChangeStep === 'success' && (
-              <View style={styles.emailChangeFormBlock}>
-                <Text style={styles.emailChangeSuccessText}>Email успешно изменён</Text>
-                <TouchableOpacity
-                  style={[styles.emailChangeActionBtn, styles.emailChangeActionBtnPrimary]}
-                  onPress={handleEmailChangeSuccess}
-                  activeOpacity={0.75}
-                >
-                  <Text style={styles.emailChangeActionBtnPrimaryText}>Готово</Text>
-                </TouchableOpacity>
-              </View>
-            )}
-
-            <View style={styles.divider} />
-            <View style={styles.row}>
-              <Text style={styles.rowLabel}>Роль</Text>
-              <Text style={styles.rowValue}>
-                {user?.role === 'SPECIALIST' ? 'Специалист' : 'Заказчик'}
-              </Text>
-            </View>
-            {user?.role === 'SPECIALIST' && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity
-                  style={styles.row}
+              {/* Edit profile link — specialist only */}
+              {user?.role === 'SPECIALIST' && (
+                <Pressable
+                  className="h-10 flex-row items-center justify-center gap-2 rounded-lg border"
+                  style={{ borderColor: Colors.brandPrimary + '60' }}
                   onPress={() => router.push('/(dashboard)/profile')}
-                  activeOpacity={0.7}
                 >
-                  <Text style={styles.rowLabel}>Редактировать профиль</Text>
-                  <Text style={styles.rowArrow}>{'>'}</Text>
-                </TouchableOpacity>
-              </>
-            )}
-          </View>
+                  <Feather name="edit-2" size={14} color={Colors.brandPrimary} />
+                  <Text className="text-sm font-medium" style={{ color: Colors.brandPrimary }}>
+                    Редактировать профиль
+                  </Text>
+                </Pressable>
+              )}
+            </View>
 
-          {/* Notifications section */}
-          <Text style={styles.sectionTitle}>Уведомления</Text>
-          <View style={styles.card}>
-            <View style={styles.row}>
-              <View style={styles.rowTextBlock}>
-                <Text style={styles.rowLabel}>Новые отклики</Text>
-                <Text style={styles.rowHint}>Уведомления о новых откликах на ваши запросы</Text>
-              </View>
+            {/* ============ Notifications ============ */}
+            <View className="gap-3 rounded-xl border border-borderLight p-4">
+              <Text className="text-base font-semibold text-textPrimary">Уведомления</Text>
               {notifLoading ? (
                 <ActivityIndicator size="small" color={Colors.brandPrimary} />
               ) : (
-                <Switch
-                  value={notifSettings.new_responses}
-                  onValueChange={(v) => handleNotifToggle('new_responses', v)}
-                  trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
-                  thumbColor={Colors.textPrimary}
-                  accessibilityLabel="Новые отклики"
-                />
+                <>
+                  <Toggle
+                    label="Новые отклики"
+                    sublabel="Уведомления о новых откликах на ваши запросы"
+                    value={notifSettings.new_responses}
+                    onValueChange={(v) => handleNotifToggle('new_responses', v)}
+                  />
+                  <Toggle
+                    label="Новые сообщения"
+                    sublabel="Уведомления о новых сообщениях в чатах"
+                    value={notifSettings.new_messages}
+                    onValueChange={(v) => handleNotifToggle('new_messages', v)}
+                  />
+                  <Toggle
+                    label="Автозакрытие"
+                    sublabel="Уведомления об автоматическом закрытии запросов"
+                    value={true}
+                    onValueChange={() => {}}
+                    disabled
+                  />
+                </>
               )}
             </View>
-            <View style={styles.divider} />
-            <View style={styles.row}>
-              <View style={styles.rowTextBlock}>
-                <Text style={styles.rowLabel}>Новые сообщения</Text>
-                <Text style={styles.rowHint}>Уведомления о новых сообщениях в чатах</Text>
-              </View>
-              {notifLoading ? (
-                <ActivityIndicator size="small" color={Colors.brandPrimary} />
-              ) : (
-                <Switch
-                  value={notifSettings.new_messages}
-                  onValueChange={(v) => handleNotifToggle('new_messages', v)}
-                  trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
-                  thumbColor={Colors.textPrimary}
-                  accessibilityLabel="Новые сообщения"
-                />
-              )}
-            </View>
-            <View style={styles.divider} />
-            <View style={styles.row}>
-              <View style={styles.rowTextBlock}>
-                <Text style={styles.rowLabel}>Автозакрытие</Text>
-                <Text style={styles.rowHint}>Уведомления об автоматическом закрытии запросов</Text>
-              </View>
-              <Switch
-                value={true}
-                disabled={true}
-                trackColor={{ false: Colors.border, true: Colors.brandPrimary }}
-                thumbColor={Colors.textPrimary}
-                accessibilityLabel="Автозакрытие"
-              />
-            </View>
-          </View>
 
-          {/* My Reviews — CLIENT only */}
-          {user?.role === 'CLIENT' && (
-            <>
-              <Text style={styles.sectionTitle}>Мои отзывы</Text>
-              <View style={styles.card}>
+            {/* ============ My Reviews — CLIENT only ============ */}
+            {user?.role === 'CLIENT' && (
+              <View className="gap-3 rounded-xl border border-borderLight p-4">
+                <Text className="text-base font-semibold text-textPrimary">Мои отзывы</Text>
                 {reviewsLoading ? (
-                  <View style={styles.row}>
-                    <ActivityIndicator size="small" color={Colors.brandPrimary} />
-                  </View>
+                  <ActivityIndicator size="small" color={Colors.brandPrimary} />
                 ) : myReviews.length === 0 ? (
-                  <View style={styles.row}>
-                    <Text style={styles.rowLabel}>Вы пока не оставляли отзывов</Text>
-                  </View>
+                  <Text className="text-sm text-textMuted">Вы пока не оставляли отзывов</Text>
                 ) : (
                   myReviews.map((review, idx) => {
                     const specName =
@@ -463,16 +505,20 @@ export default function SettingsScreen() {
                     const stars = Array.from({ length: 5 }, (_, i) => (i < review.rating ? '\u2605' : '\u2606')).join('');
                     return (
                       <View key={review.id}>
-                        {idx > 0 && <View style={styles.divider} />}
-                        <View style={styles.reviewRow}>
-                          <View style={styles.reviewHeader}>
-                            <Text style={styles.reviewSpecialist} numberOfLines={1}>{specName}</Text>
-                            <Text style={styles.reviewRating}>{stars} {review.rating}/5</Text>
+                        {idx > 0 && <View className="h-px bg-borderLight" />}
+                        <View className="gap-1">
+                          <View className="flex-row justify-between items-center">
+                            <Text className="text-base font-medium flex-1 text-textPrimary" numberOfLines={1}>
+                              {specName}
+                            </Text>
+                            <Text className="text-sm font-medium ml-2" style={{ color: Colors.brandPrimary }}>
+                              {stars} {review.rating}/5
+                            </Text>
                           </View>
                           {review.comment ? (
-                            <Text style={styles.reviewComment} numberOfLines={3}>{review.comment}</Text>
+                            <Text className="text-sm text-textSecondary" numberOfLines={3}>{review.comment}</Text>
                           ) : null}
-                          <Text style={styles.reviewDate}>
+                          <Text className="text-xs text-textMuted">
                             {new Date(review.createdAt).toLocaleDateString('ru-RU', {
                               day: 'numeric', month: 'short', year: 'numeric',
                             })}
@@ -483,268 +529,59 @@ export default function SettingsScreen() {
                   })
                 )}
               </View>
-            </>
-          )}
+            )}
 
-          {/* Admin section — visible only for admin emails */}
-          {isAdmin(user?.email) ? (
-            <>
-              <Text style={styles.sectionTitle}>Администрирование</Text>
-              <View style={styles.card}>
-                <TouchableOpacity
-                  style={styles.row}
+            {/* ============ Admin ============ */}
+            {isAdmin(user?.email) && (
+              <View className="gap-3 rounded-xl border border-borderLight p-4">
+                <Text className="text-base font-semibold text-textPrimary">Администрирование</Text>
+                <Pressable
+                  className="h-10 flex-row items-center justify-center gap-2 rounded-lg border border-borderLight"
                   onPress={() => router.push('/(admin)')}
-                  activeOpacity={0.7}
                 >
-                  <Text style={styles.rowLabel}>Панель администратора</Text>
-                  <Text style={styles.rowArrow}>{'>'}</Text>
-                </TouchableOpacity>
+                  <Feather name="shield" size={16} color={Colors.textMuted} />
+                  <Text className="text-sm font-medium text-textPrimary">Панель администратора</Text>
+                  <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+                </Pressable>
               </View>
-            </>
-          ) : null}
+            )}
 
-          {/* Actions section */}
-          <Text style={styles.sectionTitle}>Действия</Text>
-          <View style={styles.card}>
-            <TouchableOpacity style={styles.row} onPress={handleLogout} activeOpacity={0.7}>
-              <Text style={styles.rowLabel}>Выйти из аккаунта</Text>
-              <Text style={styles.rowArrow}>{'>'}</Text>
-            </TouchableOpacity>
-          </View>
+            {/* ============ Logout ============ */}
+            <Pressable
+              className="h-12 flex-row items-center justify-center gap-2 rounded-xl"
+              style={{ backgroundColor: Colors.statusBg.error }}
+              onPress={handleLogout}
+            >
+              <Feather name="log-out" size={18} color={Colors.statusError} />
+              <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
+                Выйти из аккаунта
+              </Text>
+            </Pressable>
 
-          {/* Danger zone */}
-          <Text style={[styles.sectionTitle, styles.dangerTitle]}>Опасная зона</Text>
-          <View style={[styles.card, styles.cardDanger]}>
-            <TouchableOpacity
-              style={styles.row}
+            {/* ============ Delete account ============ */}
+            <Pressable
+              className="h-12 flex-row items-center justify-center gap-2 rounded-xl border"
+              style={{ borderColor: Colors.statusBg.error }}
               onPress={handleDeleteAccount}
-              activeOpacity={0.7}
               disabled={deleting}
             >
               {deleting ? (
                 <ActivityIndicator size="small" color={Colors.statusError} />
               ) : (
                 <>
-                  <Text style={styles.deleteText}>Удалить аккаунт</Text>
-                  <Text style={styles.rowArrow}>{'>'}</Text>
+                  <Feather name="trash-2" size={18} color={Colors.statusError} />
+                  <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
+                    Удалить аккаунт
+                  </Text>
                 </>
               )}
-            </TouchableOpacity>
+            </Pressable>
+            <Text className="text-xs text-textMuted px-1">
+              Удаление аккаунта необратимо. Все данные будут удалены.
+            </Text>
           </View>
-          <Text style={styles.deleteHint}>
-            Удаление аккаунта необратимо. Все данные будут удалены.
-          </Text>
-        </View>
-      </ScrollView>
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  safe: {
-    flex: 1,
-    backgroundColor: Colors.bgPrimary,
-  },
-  scroll: {
-    alignItems: 'center',
-    paddingVertical: Spacing['2xl'],
-    paddingBottom: Spacing['4xl'],
-  },
-  container: {
-    width: '100%',
-    maxWidth: 430,
-    paddingHorizontal: Spacing.xl,
-    gap: Spacing.sm,
-  },
-  sectionTitle: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textMuted,
-    textTransform: 'uppercase',
-    letterSpacing: 0.8,
-    marginTop: Spacing.lg,
-    marginBottom: Spacing.xs,
-    paddingHorizontal: Spacing.xs,
-  },
-  dangerTitle: {
-    color: Colors.statusError,
-  },
-  card: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.lg,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    overflow: 'hidden',
-    ...Shadows.sm,
-  },
-  cardDanger: {
-    borderColor: Colors.statusError + '40',
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.lg,
-    minHeight: 52,
-  },
-  divider: {
-    height: 1,
-    backgroundColor: Colors.border,
-    marginHorizontal: Spacing.xl,
-  },
-  rowTextBlock: {
-    flex: 1,
-    gap: 2,
-  },
-  rowLabel: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    flex: 1,
-  },
-  rowHint: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  rowValue: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textMuted,
-    maxWidth: '55%',
-    textAlign: 'right',
-  },
-  rowArrow: {
-    fontSize: Typography.fontSize.md,
-    color: Colors.textMuted,
-    marginLeft: Spacing.sm,
-  },
-  deleteText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.statusError,
-    flex: 1,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  deleteHint: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    paddingHorizontal: Spacing.xs,
-    marginTop: Spacing.xs,
-  },
-  reviewRow: {
-    paddingHorizontal: Spacing.xl,
-    paddingVertical: Spacing.lg,
-    gap: 4,
-  },
-  reviewHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  reviewSpecialist: {
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.medium,
-    color: Colors.textPrimary,
-    flex: 1,
-  },
-  reviewRating: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-    marginLeft: Spacing.sm,
-  },
-  reviewComment: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    marginTop: 2,
-  },
-  reviewDate: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textMuted,
-    marginTop: 2,
-  },
-  // Email change styles
-  emailChangeBtnRow: {
-    paddingHorizontal: Spacing.xl,
-    paddingBottom: Spacing.lg,
-  },
-  emailChangeBtn: {
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.brandPrimary + '60',
-    borderRadius: BorderRadius.md,
-    paddingVertical: Spacing.sm,
-    alignItems: 'center',
-  },
-  emailChangeBtnText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  emailChangeFormBlock: {
-    paddingHorizontal: Spacing.xl,
-    paddingBottom: Spacing.lg,
-    gap: Spacing.sm,
-  },
-  emailChangeFormLabel: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-  },
-  emailChangeInput: {
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.sm,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-  },
-  emailChangeOtpInput: {
-    letterSpacing: 4,
-    textAlign: 'center',
-    fontSize: Typography.fontSize.lg,
-  },
-  emailChangeErrorText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.statusError,
-  },
-  emailChangeSuccessText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.statusSuccess,
-    fontWeight: Typography.fontWeight.medium,
-    textAlign: 'center',
-    paddingVertical: Spacing.sm,
-  },
-  emailChangeActions: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-  },
-  emailChangeActionBtn: {
-    flex: 1,
-    borderRadius: BorderRadius.md,
-    paddingVertical: Spacing.sm,
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 40,
-  },
-  emailChangeActionBtnPrimary: {
-    backgroundColor: Colors.brandPrimary,
-  },
-  emailChangeActionBtnSecondary: {
-    backgroundColor: Colors.bgSecondary,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  emailChangeActionBtnDisabled: {
-    opacity: 0.6,
-  },
-  emailChangeActionBtnPrimaryText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.white,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  emailChangeActionBtnSecondaryText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -10,7 +10,6 @@ import {
   Platform,
   TextInput,
   KeyboardAvoidingView,
-  Switch,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
@@ -55,79 +54,44 @@ type EmailChangeStep = 'idle' | 'email_input' | 'otp_input' | 'success';
 const APP_VERSION = '1.0.0';
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// Sub-components (matching proto Toggle pattern)
 // ---------------------------------------------------------------------------
-function SettingRow({
+function Toggle({
   label,
   value,
-  icon,
-  danger,
-  onPress,
-}: {
-  label: string;
-  value?: string;
-  icon?: string;
-  danger?: boolean;
-  onPress?: () => void;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      className="flex-row items-center gap-3 px-4 py-3 border-b border-sky-50"
-    >
-      {icon && (
-        <Feather
-          name={icon as any}
-          size={18}
-          color={danger ? Colors.statusError : Colors.textMuted}
-        />
-      )}
-      <Text
-        className="flex-1 text-[13px]"
-        style={{ color: danger ? Colors.statusError : Colors.textPrimary }}
-      >
-        {label}
-      </Text>
-      {value && (
-        <Text className="text-[13px] mr-2" style={{ color: Colors.textMuted }}>
-          {value}
-        </Text>
-      )}
-      <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-    </Pressable>
-  );
-}
-
-function ToggleRow({
-  label,
-  icon,
-  enabled,
-  onToggle,
+  onValueChange,
   disabled,
 }: {
   label: string;
-  icon: string;
-  enabled: boolean;
-  onToggle: (v: boolean) => void;
+  value: boolean;
+  onValueChange: (v: boolean) => void;
   disabled?: boolean;
 }) {
+  const trackColor = value ? Colors.brandPrimary : '#D1D5DB';
   return (
-    <View
-      className="flex-row items-center gap-3 px-4 py-3 border-b border-sky-50"
+    <Pressable
+      className="flex-row items-center justify-between"
+      onPress={() => !disabled && onValueChange(!value)}
       style={{ opacity: disabled ? 0.5 : 1 }}
     >
-      <Feather name={icon as any} size={18} color={Colors.textMuted} />
-      <Text className="flex-1 text-[13px]" style={{ color: Colors.textPrimary }}>
-        {label}
-      </Text>
-      <Switch
-        value={enabled}
-        onValueChange={(v) => { if (!disabled) onToggle(v); }}
-        trackColor={{ false: '#D1D5DB', true: '#0284C7' }}
-        thumbColor="#fff"
-        disabled={disabled}
-      />
-    </View>
+      <Text className="mr-3 flex-1 text-sm text-textSecondary">{label}</Text>
+      <View
+        className="h-7 w-12 justify-center rounded-full px-0.5"
+        style={{ backgroundColor: trackColor }}
+      >
+        <View
+          className="h-[22px] w-[22px] rounded-full bg-white"
+          style={{
+            alignSelf: value ? 'flex-end' : 'flex-start',
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.2,
+            shadowRadius: 2,
+            elevation: 2,
+          }}
+        />
+      </View>
+    </Pressable>
   );
 }
 
@@ -145,36 +109,26 @@ function ConfirmCard({
   loading?: boolean;
 }) {
   return (
-    <View
-      className="bg-white rounded-[14px] p-4 gap-3 shadow-sm"
-      style={{ borderWidth: 1, borderColor: Colors.statusBg.error }}
-    >
-      <Text className="text-[13px] text-center" style={{ color: Colors.textSecondary }}>
-        {message}
-      </Text>
+    <View className="rounded-xl border border-borderLight bg-white p-4 gap-3">
+      <Text className="text-sm text-center text-textSecondary">{message}</Text>
       <View className="flex-row gap-2">
         <Pressable
           onPress={onCancel}
           disabled={loading}
-          className="flex-1 h-10 rounded-[12px] items-center justify-center"
-          style={{ borderWidth: 1, borderColor: Colors.border }}
+          className="flex-1 h-10 rounded-xl items-center justify-center border border-borderLight"
         >
-          <Text className="text-[13px]" style={{ color: Colors.textMuted }}>
-            Отмена
-          </Text>
+          <Text className="text-sm text-textMuted">Отмена</Text>
         </Pressable>
         <Pressable
           onPress={onConfirm}
           disabled={loading}
-          className="flex-1 h-10 rounded-[12px] items-center justify-center"
+          className="flex-1 h-10 rounded-xl items-center justify-center"
           style={{ backgroundColor: Colors.statusError }}
         >
           {loading ? (
             <ActivityIndicator size="small" color={Colors.white} />
           ) : (
-            <Text className="text-[13px] font-semibold" style={{ color: Colors.white }}>
-              {confirmLabel}
-            </Text>
+            <Text className="text-sm font-semibold text-white">{confirmLabel}</Text>
           )}
         </Pressable>
       </View>
@@ -405,9 +359,7 @@ export default function SettingsTab() {
     }
   }, [logout, router]);
 
-  const displayName = user?.username || user?.email || '';
   const displayEmail = user?.email || '';
-  const initials = (user?.username || user?.email || '?')[0].toUpperCase();
 
   return (
     <KeyboardAvoidingView
@@ -416,7 +368,7 @@ export default function SettingsTab() {
     >
       <ScrollView
         className="flex-1 bg-white"
-        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 16 }}
+        contentContainerStyle={{ padding: 16, gap: 20 }}
         keyboardShouldPersistTaps="handled"
         refreshControl={
           <RefreshControl
@@ -427,506 +379,314 @@ export default function SettingsTab() {
         }
       >
         {/* Page title */}
-        <Text
-          className="text-[20px] font-bold"
-          style={{ color: Colors.textPrimary }}
-        >
-          Настройки
-        </Text>
+        <Text className="text-xl font-bold text-textPrimary">Настройки</Text>
 
-        {/* ============ Profile card ============ */}
-        <View
-          className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-          style={{ borderWidth: 1, borderColor: Colors.border }}
-        >
-          <View className="flex-row items-center gap-3 p-4">
-            <View
-              className="w-12 h-12 rounded-full items-center justify-center"
-              style={{ backgroundColor: Colors.brandPrimary }}
-            >
-              <Text className="text-[18px] font-bold text-white">{initials}</Text>
-            </View>
-            <View className="flex-1">
-              <Text
-                className="text-[15px] font-semibold"
-                style={{ color: Colors.textPrimary }}
-              >
-                {displayName}
-              </Text>
-              <Text className="text-[13px] mt-0.5" style={{ color: Colors.textMuted }}>
-                {displayEmail}
+        {/* ============ Account card ============ */}
+        <View className="gap-3 rounded-xl border border-borderLight p-4">
+          <Text className="text-base font-semibold text-textPrimary">Аккаунт</Text>
+
+          {/* Email — readonly */}
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textMuted">Email</Text>
+            <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
+              <Feather name="mail" size={16} color={Colors.textMuted} />
+              <Text className="ml-2 flex-1 text-base text-textSecondary" numberOfLines={1}>
+                {displayEmail || '\u2014'}
               </Text>
             </View>
           </View>
-        </View>
 
-        {/* ============ Specialist: Work area ============ */}
-        {isSpecialist && profile && (
-          <View className="gap-2">
-            <Text
-              className="text-[11px] font-semibold uppercase"
-              style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
+          {/* Email change flow */}
+          {emailChangeStep === 'idle' && (
+            <Pressable
+              className="h-10 items-center justify-center rounded-lg border bg-bgSecondary"
+              style={{ borderColor: Colors.brandPrimary + '60' }}
+              onPress={handleStartEmailChange}
             >
-              Рабочая зона
-            </Text>
-            <View
-              className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-              style={{ borderWidth: 1, borderColor: Colors.border }}
-            >
-              <Pressable
-                className="flex-row items-center gap-3 px-4 py-3"
-                onPress={() => router.push('/profile/edit')}
-              >
-                <Feather name="edit-2" size={18} color={Colors.brandPrimary} />
-                <Text className="flex-1 text-[13px]" style={{ color: Colors.brandPrimary }}>
-                  Редактировать профиль
-                </Text>
-                <Feather name="chevron-right" size={16} color={Colors.brandPrimary} />
-              </Pressable>
-            </View>
-            <View className="gap-1 px-1">
-              {profile.cities.length > 0 && (
-                <View className="flex-row items-center gap-2">
-                  <Feather name="map-pin" size={14} color={Colors.textMuted} />
-                  <Text className="text-[13px] flex-1" style={{ color: Colors.textSecondary }}>
-                    {profile.cities.join(', ')}
-                  </Text>
-                </View>
-              )}
-              {profile.fnsOffices.length > 0 && (
-                <View className="flex-row items-center gap-2">
-                  <Feather name="briefcase" size={14} color={Colors.textMuted} />
-                  <Text className="text-[13px]" style={{ color: Colors.textSecondary }}>
-                    {profile.fnsOffices.length} ИФНС
-                  </Text>
-                </View>
-              )}
-              {profile.services.length > 0 && (
-                <View className="flex-row items-center gap-2">
-                  <Feather name="check-circle" size={14} color={Colors.textMuted} />
-                  <Text className="text-[13px] flex-1" style={{ color: Colors.textSecondary }}>
-                    {profile.services.join(', ')}
-                  </Text>
-                </View>
-              )}
-              {profile.cities.length === 0 &&
-                profile.fnsOffices.length === 0 &&
-                profile.services.length === 0 && (
-                  <Text className="text-[13px] italic" style={{ color: Colors.textMuted }}>
-                    Профиль не заполнен
-                  </Text>
-                )}
-            </View>
-          </View>
-        )}
+              <Text className="text-sm font-medium" style={{ color: Colors.brandPrimary }}>
+                Изменить email
+              </Text>
+            </Pressable>
+          )}
 
-        {/* ============ Specialist: Public profile toggle ============ */}
-        {isSpecialist && (
-          <View className="gap-2">
-            <Text
-              className="text-[11px] font-semibold uppercase"
-              style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
-            >
-              Публичный профиль
-            </Text>
-            <View
-              className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-              style={{ borderWidth: 1, borderColor: Colors.border }}
-            >
-              <ToggleRow
-                label="Принимаю заявки"
-                icon="eye"
-                enabled={isAvailable}
-                onToggle={handleToggleAvailability}
-                disabled={savingAvailability}
+          {emailChangeStep === 'email_input' && (
+            <View className="gap-2">
+              <Text className="text-sm text-textSecondary">Новый email</Text>
+              <TextInput
+                className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-base text-textPrimary"
+                value={newEmail}
+                onChangeText={(t) => {
+                  setNewEmail(t);
+                  setEmailChangeError('');
+                }}
+                placeholder="example@email.com"
+                placeholderTextColor={Colors.textMuted}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoCorrect={false}
+                editable={!emailChangeLoading}
               />
-            </View>
-          </View>
-        )}
-
-        {/* ============ Notifications ============ */}
-        <View className="gap-2">
-          <Text
-            className="text-[11px] font-semibold uppercase"
-            style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
-          >
-            Уведомления
-          </Text>
-          <View
-            className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-            style={{ borderWidth: 1, borderColor: Colors.border }}
-          >
-            <ToggleRow
-              label="Email-уведомления"
-              icon="mail"
-              enabled={notifSettings.new_responses}
-              onToggle={(v) => handleNotifToggle('new_responses', v)}
-            />
-            <ToggleRow
-              label="Push-уведомления"
-              icon="bell"
-              enabled={false}
-              onToggle={() => {}}
-              disabled
-            />
-            <ToggleRow
-              label="Новые отклики"
-              icon="message-circle"
-              enabled={notifSettings.new_messages}
-              onToggle={(v) => handleNotifToggle('new_messages', v)}
-            />
-          </View>
-        </View>
-
-        {/* ============ Account ============ */}
-        <View className="gap-2">
-          <Text
-            className="text-[11px] font-semibold uppercase"
-            style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
-          >
-            Аккаунт
-          </Text>
-          <View
-            className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-            style={{ borderWidth: 1, borderColor: Colors.border }}
-          >
-            {emailChangeStep === 'idle' && (
-              <SettingRow
-                label="Изменить email"
-                icon="mail"
-                onPress={handleStartEmailChange}
-              />
-            )}
-
-            {emailChangeStep === 'email_input' && (
-              <View className="p-4 gap-2">
-                <Text className="text-[13px]" style={{ color: Colors.textSecondary }}>
-                  Новый email
+              {emailChangeError ? (
+                <Text className="text-xs" style={{ color: Colors.statusError }}>
+                  {emailChangeError}
                 </Text>
-                <TextInput
-                  className="rounded-[6px] px-4 py-2 text-[15px]"
-                  style={{
-                    backgroundColor: Colors.bgSecondary,
-                    borderWidth: 1,
-                    borderColor: Colors.border,
-                    color: Colors.textPrimary,
-                  }}
-                  value={newEmail}
-                  onChangeText={(t) => {
-                    setNewEmail(t);
-                    setEmailChangeError('');
-                  }}
-                  placeholder="example@email.com"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text className="text-[11px]" style={{ color: Colors.statusError }}>
-                    {emailChangeError}
-                  </Text>
-                ) : null}
-                <View className="flex-row gap-2">
-                  <Pressable
-                    className="flex-1 rounded-[6px] py-2 items-center justify-center min-h-[40px]"
-                    style={{
-                      backgroundColor: Colors.bgSecondary,
-                      borderWidth: 1,
-                      borderColor: Colors.border,
-                    }}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    <Text className="text-[13px] font-medium" style={{ color: Colors.textSecondary }}>
-                      Отмена
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    className="flex-1 rounded-[6px] py-2 items-center justify-center min-h-[40px]"
-                    style={{
-                      backgroundColor: Colors.brandPrimary,
-                      opacity: emailChangeLoading ? 0.6 : 1,
-                    }}
-                    onPress={handleRequestEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    {emailChangeLoading ? (
-                      <ActivityIndicator size="small" color={Colors.white} />
-                    ) : (
-                      <Text className="text-[13px] font-medium text-white">
-                        Получить код
-                      </Text>
-                    )}
-                  </Pressable>
-                </View>
-              </View>
-            )}
-
-            {emailChangeStep === 'otp_input' && (
-              <View className="p-4 gap-2">
-                <Text className="text-[13px]" style={{ color: Colors.textSecondary }}>
-                  Код отправлен на {newEmail.trim().toLowerCase()}
-                </Text>
-                <TextInput
-                  className="rounded-[6px] px-4 py-2 text-[18px] text-center"
-                  style={{
-                    backgroundColor: Colors.bgSecondary,
-                    borderWidth: 1,
-                    borderColor: Colors.border,
-                    color: Colors.textPrimary,
-                    letterSpacing: 4,
-                  }}
-                  value={emailOtpCode}
-                  onChangeText={(t) => {
-                    setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6));
-                    setEmailChangeError('');
-                  }}
-                  placeholder="000000"
-                  placeholderTextColor={Colors.textMuted}
-                  keyboardType="number-pad"
-                  maxLength={6}
-                  editable={!emailChangeLoading}
-                />
-                {emailChangeError ? (
-                  <Text className="text-[11px]" style={{ color: Colors.statusError }}>
-                    {emailChangeError}
-                  </Text>
-                ) : null}
-                <View className="flex-row gap-2">
-                  <Pressable
-                    className="flex-1 rounded-[6px] py-2 items-center justify-center min-h-[40px]"
-                    style={{
-                      backgroundColor: Colors.bgSecondary,
-                      borderWidth: 1,
-                      borderColor: Colors.border,
-                    }}
-                    onPress={handleCancelEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    <Text className="text-[13px] font-medium" style={{ color: Colors.textSecondary }}>
-                      Отмена
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    className="flex-1 rounded-[6px] py-2 items-center justify-center min-h-[40px]"
-                    style={{
-                      backgroundColor: Colors.brandPrimary,
-                      opacity: emailChangeLoading ? 0.6 : 1,
-                    }}
-                    onPress={handleConfirmEmailChange}
-                    disabled={emailChangeLoading}
-                  >
-                    {emailChangeLoading ? (
-                      <ActivityIndicator size="small" color={Colors.white} />
-                    ) : (
-                      <Text className="text-[13px] font-medium text-white">
-                        Подтвердить
-                      </Text>
-                    )}
-                  </Pressable>
-                </View>
-              </View>
-            )}
-
-            {emailChangeStep === 'success' && (
-              <View className="p-4 gap-2">
-                <Text
-                  className="text-[15px] font-medium text-center py-2"
-                  style={{ color: Colors.statusSuccess }}
-                >
-                  Email успешно изменён
-                </Text>
+              ) : null}
+              <View className="flex-row gap-2">
                 <Pressable
-                  className="flex-1 rounded-[6px] py-2 items-center justify-center min-h-[40px]"
-                  style={{ backgroundColor: Colors.brandPrimary }}
-                  onPress={() => {
-                    setEmailChangeStep('idle');
-                    setNewEmail('');
-                    setEmailOtpCode('');
-                    setEmailChangeError('');
-                  }}
+                  className="flex-1 h-10 rounded-lg items-center justify-center border border-borderLight bg-bgSecondary"
+                  onPress={handleCancelEmailChange}
+                  disabled={emailChangeLoading}
                 >
-                  <Text className="text-[13px] font-medium text-white">Готово</Text>
+                  <Text className="text-sm font-medium text-textSecondary">Отмена</Text>
+                </Pressable>
+                <Pressable
+                  className="flex-1 h-10 rounded-lg items-center justify-center"
+                  style={{
+                    backgroundColor: Colors.brandPrimary,
+                    opacity: emailChangeLoading ? 0.6 : 1,
+                  }}
+                  onPress={handleRequestEmailChange}
+                  disabled={emailChangeLoading}
+                >
+                  {emailChangeLoading ? (
+                    <ActivityIndicator size="small" color={Colors.white} />
+                  ) : (
+                    <Text className="text-sm font-medium text-white">Получить код</Text>
+                  )}
                 </Pressable>
               </View>
-            )}
+            </View>
+          )}
 
-            <SettingRow label="Язык" value="Русский" icon="globe" />
-            <SettingRow label="Тема" value="Светлая" icon="sun" />
-          </View>
+          {emailChangeStep === 'otp_input' && (
+            <View className="gap-2">
+              <Text className="text-sm text-textSecondary">
+                Код отправлен на {newEmail.trim().toLowerCase()}
+              </Text>
+              <TextInput
+                className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-center text-lg text-textPrimary"
+                style={{ letterSpacing: 4 }}
+                value={emailOtpCode}
+                onChangeText={(t) => {
+                  setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6));
+                  setEmailChangeError('');
+                }}
+                placeholder="000000"
+                placeholderTextColor={Colors.textMuted}
+                keyboardType="number-pad"
+                maxLength={6}
+                editable={!emailChangeLoading}
+              />
+              {emailChangeError ? (
+                <Text className="text-xs" style={{ color: Colors.statusError }}>
+                  {emailChangeError}
+                </Text>
+              ) : null}
+              <View className="flex-row gap-2">
+                <Pressable
+                  className="flex-1 h-10 rounded-lg items-center justify-center border border-borderLight bg-bgSecondary"
+                  onPress={handleCancelEmailChange}
+                  disabled={emailChangeLoading}
+                >
+                  <Text className="text-sm font-medium text-textSecondary">Отмена</Text>
+                </Pressable>
+                <Pressable
+                  className="flex-1 h-10 rounded-lg items-center justify-center"
+                  style={{
+                    backgroundColor: Colors.brandPrimary,
+                    opacity: emailChangeLoading ? 0.6 : 1,
+                  }}
+                  onPress={handleConfirmEmailChange}
+                  disabled={emailChangeLoading}
+                >
+                  {emailChangeLoading ? (
+                    <ActivityIndicator size="small" color={Colors.white} />
+                  ) : (
+                    <Text className="text-sm font-medium text-white">Подтвердить</Text>
+                  )}
+                </Pressable>
+              </View>
+            </View>
+          )}
+
+          {emailChangeStep === 'success' && (
+            <View className="gap-2">
+              <Text
+                className="text-base font-medium text-center py-2"
+                style={{ color: Colors.statusSuccess }}
+              >
+                Email успешно изменён
+              </Text>
+              <Pressable
+                className="h-10 rounded-lg items-center justify-center"
+                style={{ backgroundColor: Colors.brandPrimary }}
+                onPress={() => {
+                  setEmailChangeStep('idle');
+                  setNewEmail('');
+                  setEmailOtpCode('');
+                  setEmailChangeError('');
+                }}
+              >
+                <Text className="text-sm font-medium text-white">Готово</Text>
+              </Pressable>
+            </View>
+          )}
+
+          {/* Phone — specialist, matching prototype */}
+          {isSpecialist && (
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-textMuted">Телефон</Text>
+              <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
+                <Feather name="phone" size={16} color={Colors.textMuted} />
+                <Text className="ml-2 flex-1 text-base text-textSecondary">
+                  {'\u2014'}
+                </Text>
+                <Pressable hitSlop={8} onPress={() => router.push('/profile/edit')}>
+                  <Feather name="edit-2" size={16} color={Colors.brandPrimary} />
+                </Pressable>
+              </View>
+            </View>
+          )}
         </View>
+
+        {/* ============ Notifications ============ */}
+        <View className="gap-3 rounded-xl border border-borderLight p-4">
+          <Text className="text-base font-semibold text-textPrimary">Уведомления</Text>
+          <Toggle
+            label="Email-уведомления"
+            value={notifSettings.new_responses}
+            onValueChange={(v) => handleNotifToggle('new_responses', v)}
+          />
+          <Toggle
+            label="Push-уведомления"
+            value={notifSettings.new_messages}
+            onValueChange={(v) => handleNotifToggle('new_messages', v)}
+          />
+        </View>
+
+        {/* ============ Public profile — specialist ============ */}
+        {isSpecialist && (
+          <View className="gap-3 rounded-xl border border-borderLight p-4">
+            <Text className="text-base font-semibold text-textPrimary">Публичный профиль</Text>
+            <Toggle
+              label="Профиль виден всем"
+              value={isAvailable}
+              onValueChange={handleToggleAvailability}
+              disabled={savingAvailability}
+            />
+          </View>
+        )}
 
         {/* ============ Client reviews ============ */}
         {!isSpecialist && myReviews.length > 0 && (
-          <View className="gap-2">
-            <Text
-              className="text-[11px] font-semibold uppercase"
-              style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
-            >
-              Мои отзывы
-            </Text>
-            <View
-              className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-              style={{ borderWidth: 1, borderColor: Colors.border }}
-            >
-              {myReviews.map((review, idx) => {
-                const specName =
-                  review.specialist.specialistProfile?.displayName ??
-                  review.specialist.specialistProfile?.nick ??
-                  review.specialist.email.split('@')[0];
-                const stars = Array.from({ length: 5 }, (_, i) =>
-                  i < review.rating ? '\u2605' : '\u2606',
-                ).join('');
-                return (
-                  <View key={review.id}>
-                    {idx > 0 && (
-                      <View className="h-px mx-4" style={{ backgroundColor: Colors.border }} />
-                    )}
-                    <View className="px-4 py-3 gap-1">
-                      <View className="flex-row justify-between items-center">
-                        <Text
-                          className="text-[15px] font-medium flex-1"
-                          style={{ color: Colors.textPrimary }}
-                          numberOfLines={1}
-                        >
-                          {specName}
-                        </Text>
-                        <Text
-                          className="text-[13px] font-medium ml-2"
-                          style={{ color: Colors.brandPrimary }}
-                        >
-                          {stars} {review.rating}/5
-                        </Text>
-                      </View>
-                      {review.comment ? (
-                        <Text
-                          className="text-[13px] mt-0.5"
-                          style={{ color: Colors.textSecondary }}
-                          numberOfLines={3}
-                        >
-                          {review.comment}
-                        </Text>
-                      ) : null}
+          <View className="gap-3 rounded-xl border border-borderLight p-4">
+            <Text className="text-base font-semibold text-textPrimary">Мои отзывы</Text>
+            {myReviews.map((review, idx) => {
+              const specName =
+                review.specialist.specialistProfile?.displayName ??
+                review.specialist.specialistProfile?.nick ??
+                review.specialist.email.split('@')[0];
+              const stars = Array.from({ length: 5 }, (_, i) =>
+                i < review.rating ? '\u2605' : '\u2606',
+              ).join('');
+              return (
+                <View key={review.id}>
+                  {idx > 0 && <View className="h-px bg-borderLight" />}
+                  <View className="gap-1">
+                    <View className="flex-row justify-between items-center">
                       <Text
-                        className="text-[11px] mt-0.5"
-                        style={{ color: Colors.textMuted }}
+                        className="text-base font-medium flex-1 text-textPrimary"
+                        numberOfLines={1}
                       >
-                        {new Date(review.createdAt).toLocaleDateString('ru-RU', {
-                          day: 'numeric',
-                          month: 'short',
-                          year: 'numeric',
-                        })}
+                        {specName}
+                      </Text>
+                      <Text
+                        className="text-sm font-medium ml-2"
+                        style={{ color: Colors.brandPrimary }}
+                      >
+                        {stars} {review.rating}/5
                       </Text>
                     </View>
+                    {review.comment ? (
+                      <Text className="text-sm text-textSecondary" numberOfLines={3}>
+                        {review.comment}
+                      </Text>
+                    ) : null}
+                    <Text className="text-xs text-textMuted">
+                      {new Date(review.createdAt).toLocaleDateString('ru-RU', {
+                        day: 'numeric',
+                        month: 'short',
+                        year: 'numeric',
+                      })}
+                    </Text>
                   </View>
-                );
-              })}
-            </View>
+                </View>
+              );
+            })}
           </View>
         )}
-
-        {/* ============ Information ============ */}
-        <View className="gap-2">
-          <Text
-            className="text-[11px] font-semibold uppercase"
-            style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
-          >
-            Информация
-          </Text>
-          <View
-            className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-            style={{ borderWidth: 1, borderColor: Colors.border }}
-          >
-            <SettingRow label="Политика конфиденциальности" icon="shield" />
-            <SettingRow label="Условия использования" icon="file-text" />
-            <SettingRow label="Версия" value={APP_VERSION} icon="info" />
-          </View>
-        </View>
 
         {/* ============ Admin ============ */}
         {isAdmin(user?.email) && (
-          <View className="gap-2">
-            <Text
-              className="text-[11px] font-semibold uppercase"
-              style={{ color: Colors.textMuted, letterSpacing: 0.5 }}
+          <View className="gap-3 rounded-xl border border-borderLight p-4">
+            <Text className="text-base font-semibold text-textPrimary">Администрирование</Text>
+            <Pressable
+              className="h-10 flex-row items-center justify-center gap-2 rounded-lg border border-borderLight"
+              onPress={() => router.push('/(admin)')}
             >
-              Администрирование
-            </Text>
-            <View
-              className="bg-white rounded-[14px] overflow-hidden shadow-sm"
-              style={{ borderWidth: 1, borderColor: Colors.border }}
-            >
-              <SettingRow
-                label="Панель администратора"
-                icon="shield"
-                onPress={() => router.push('/(admin)')}
-              />
-            </View>
+              <Feather name="shield" size={16} color={Colors.textMuted} />
+              <Text className="text-sm font-medium text-textPrimary">Панель администратора</Text>
+              <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+            </Pressable>
           </View>
         )}
 
-        {/* ============ Danger zone ============ */}
-        <View className="gap-2">
-          <Pressable
-            onPress={() => setShowLogoutConfirm(true)}
-            className="flex-row items-center justify-center gap-2 h-12 rounded-[12px]"
-            style={{ backgroundColor: Colors.statusBg.error }}
-          >
-            <Feather name="log-out" size={18} color={Colors.statusError} />
-            <Text
-              className="text-[13px] font-semibold"
-              style={{ color: Colors.statusError }}
-            >
-              Выйти из аккаунта
-            </Text>
-          </Pressable>
-
-          {showLogoutConfirm && (
-            <ConfirmCard
-              message="Вы уверены, что хотите выйти?"
-              confirmLabel="Выйти"
-              onCancel={() => setShowLogoutConfirm(false)}
-              onConfirm={handleLogout}
-              loading={logoutLoading}
-            />
-          )}
-
-          <Pressable
-            onPress={() => setShowDeleteConfirm(true)}
-            className="flex-row items-center justify-center gap-2 h-12 rounded-[12px]"
-            style={{
-              backgroundColor: 'transparent',
-              borderWidth: 1,
-              borderColor: Colors.statusBg.error,
-            }}
-          >
-            <Feather name="trash-2" size={18} color={Colors.statusError} />
-            <Text
-              className="text-[13px] font-semibold"
-              style={{ color: Colors.statusError }}
-            >
-              Удалить аккаунт
-            </Text>
-          </Pressable>
-
-          {showDeleteConfirm && (
-            <ConfirmCard
-              message="Это действие необратимо. Все ваши данные будут удалены."
-              confirmLabel="Удалить"
-              onCancel={() => setShowDeleteConfirm(false)}
-              onConfirm={handleDeleteAccount}
-              loading={deleteLoading}
-            />
-          )}
-        </View>
-
-        {/* ============ Version ============ */}
-        <Text
-          className="text-[11px] text-center mt-2"
-          style={{ color: Colors.textMuted }}
+        {/* ============ Logout ============ */}
+        <Pressable
+          className="h-12 flex-row items-center justify-center gap-2 rounded-xl"
+          style={{ backgroundColor: Colors.statusBg.error }}
+          onPress={() => setShowLogoutConfirm(true)}
         >
+          <Feather name="log-out" size={18} color={Colors.statusError} />
+          <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
+            Выйти из аккаунта
+          </Text>
+        </Pressable>
+
+        {showLogoutConfirm && (
+          <ConfirmCard
+            message="Вы уверены, что хотите выйти?"
+            confirmLabel="Выйти"
+            onCancel={() => setShowLogoutConfirm(false)}
+            onConfirm={handleLogout}
+            loading={logoutLoading}
+          />
+        )}
+
+        {/* ============ Delete account ============ */}
+        <Pressable
+          className="h-12 flex-row items-center justify-center gap-2 rounded-xl border"
+          style={{ borderColor: Colors.statusBg.error }}
+          onPress={() => setShowDeleteConfirm(true)}
+        >
+          <Feather name="trash-2" size={18} color={Colors.statusError} />
+          <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
+            Удалить аккаунт
+          </Text>
+        </Pressable>
+
+        {showDeleteConfirm && (
+          <ConfirmCard
+            message="Это действие необратимо. Все ваши данные будут удалены."
+            confirmLabel="Удалить"
+            onCancel={() => setShowDeleteConfirm(false)}
+            onConfirm={handleDeleteAccount}
+            loading={deleteLoading}
+          />
+        )}
+
+        {/* Version */}
+        <Text className="text-xs text-center text-textMuted">
           Версия {APP_VERSION}
         </Text>
       </ScrollView>


### PR DESCRIPTION
## Summary
- Rewrote `app/(tabs)/settings.tsx` and `app/(dashboard)/settings.tsx` to match `SpecialistSettingsStates` prototype
- Replaced all StyleSheet with NativeWind classes
- Switched from Switch to proto Toggle component pattern
- Restructured layout into bordered card sections (Account, Notifications, Public profile)
- All business logic preserved (email change, notifications, reviews, admin, logout, delete)

## Test plan
- [ ] Verify settings page renders correctly for SPECIALIST role
- [ ] Verify settings page renders correctly for CLIENT role
- [ ] Test email change flow
- [ ] Test notification toggles
- [ ] Test logout and delete account flows