### PR TITLE
fix: add ScrollView to email auth page

### DIFF
--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable, TextInput, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, Pressable, TextInput, KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import { api, ApiError } from '../../lib/api';
@@ -48,7 +48,12 @@ export default function EmailScreen() {
       className="flex-1 bg-white"
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <View className="flex-1 items-center justify-center px-4 py-8">
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+      <View className="flex-1 items-center px-4 py-8">
         {/* Logo */}
         <View className="mb-8 items-center gap-2">
           <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
@@ -122,6 +127,7 @@ export default function EmailScreen() {
           {'Нажимая кнопку, вы соглашаетесь с\nусловиями использования'}
         </Text>
       </View>
+      </ScrollView>
     </KeyboardAvoidingView>
   );
 }


### PR DESCRIPTION
## Summary
- Email auth page (`app/(auth)/email.tsx`) lacked ScrollView — content overflowed on small screens/zoomed browsers with no way to scroll
- Wrapped inner content in ScrollView with `flexGrow: 1, justifyContent: 'center'` — scrolls when needed, centers when there's space
- Matches the existing pattern already used on the OTP page

## Findings
- OTP page (`otp.tsx`) already has ScrollView — no fix needed
- Auth header (`_layout.tsx`) renders correctly with inline styles (shield + "Nalogovik", height: 56)
- Landing page has its own inline Header component — public layout is fine
- Pre-existing TS errors (missing deps: axios, playwright, expo-document-picker) — not related to this change

## Test plan
- [ ] Open email auth page on small screen / zoomed browser — content should scroll
- [ ] On normal screen — content should remain centered
- [ ] Auth header (shield + "Nalogovik") visible above the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)