### PR TITLE
fix: remove double border on all input fields

### DIFF
--- a/app/(admin)/categories.tsx
+++ b/app/(admin)/categories.tsx
@@ -125,21 +125,21 @@ export default function AdminCategories() {
           <View style={styles.card}>
             <Text style={styles.sectionTitle}>Добавить категорию</Text>
             <TextInput
-              style={styles.input}
+              style={[styles.input, { outlineStyle: 'none' } as any]}
               value={newName}
               onChangeText={setNewName}
               placeholder="Название"
               placeholderTextColor={Colors.textMuted}
             />
             <TextInput
-              style={styles.input}
+              style={[styles.input, { outlineStyle: 'none' } as any]}
               value={newIcon}
               onChangeText={setNewIcon}
               placeholder="Иконка (emoji, необязательно)"
               placeholderTextColor={Colors.textMuted}
             />
             <TextInput
-              style={styles.input}
+              style={[styles.input, { outlineStyle: 'none' } as any]}
               value={newSortOrder}
               onChangeText={setNewSortOrder}
               placeholder="Порядок сортировки (число, необязательно)"

--- a/app/(admin)/moderation.tsx
+++ b/app/(admin)/moderation.tsx
@@ -297,7 +297,7 @@ function DetailView({
             placeholderTextColor={Colors.textMuted}
             multiline
             className="min-h-[80px] rounded-[10px] border border-borderLight bg-bgPrimary p-3 text-base text-textPrimary"
-            style={{ textAlignVertical: 'top' }}
+            style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
           />
         </View>
 

--- a/app/(admin)/promotions.tsx
+++ b/app/(admin)/promotions.tsx
@@ -128,7 +128,7 @@ export default function AdminPromotions() {
             <Text style={styles.sectionTitle}>Настройка цен</Text>
             <View style={styles.priceEditor}>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { outlineStyle: 'none' } as any]}
                 placeholder="Город"
                 placeholderTextColor={Colors.textMuted}
                 value={editCity}
@@ -150,7 +150,7 @@ export default function AdminPromotions() {
                 ))}
               </View>
               <TextInput
-                style={styles.input}
+                style={[styles.input, { outlineStyle: 'none' } as any]}
                 placeholder="Цена (руб.)"
                 placeholderTextColor={Colors.textMuted}
                 value={editPrice}

--- a/app/(admin)/users.tsx
+++ b/app/(admin)/users.tsx
@@ -393,7 +393,7 @@ export default function AdminUsers() {
               placeholder="Поиск по имени, email..."
               placeholderTextColor={Colors.textMuted}
               className="flex-1 text-[15px] text-slate-900"
-              style={{ paddingVertical: 0 }}
+              style={{ paddingVertical: 0, outlineStyle: 'none' } as any}
             />
             {search.length > 0 && (
               <Pressable onPress={() => setSearch('')}>

--- a/app/(dashboard)/city-requests.tsx
+++ b/app/(dashboard)/city-requests.tsx
@@ -527,7 +527,7 @@ export default function CityRequestsScreen() {
               multiline
               numberOfLines={4}
               maxLength={500}
-              style={styles.messageInput}
+              style={[styles.messageInput, { outlineStyle: 'none' } as any]}
               autoFocus
             />
             <Text style={styles.charCounter}>{message.length}/500</Text>

--- a/app/(dashboard)/my-requests/edit/[id].tsx
+++ b/app/(dashboard)/my-requests/edit/[id].tsx
@@ -157,6 +157,7 @@ export default function EditRequestScreen() {
                 style={[
                   styles.descriptionInput,
                   errors.description ? styles.descriptionInputError : null,
+                  { outlineStyle: 'none' } as any,
                 ]}
                 textAlignVertical="top"
               />

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -267,6 +267,7 @@ export default function CreateRequestScreen() {
                 style={[
                   styles.descriptionInput,
                   errors.description ? styles.descriptionInputError : null,
+                  { outlineStyle: 'none' } as any,
                 ]}
                 textAlignVertical="top"
               />

--- a/app/(dashboard)/profile.tsx
+++ b/app/(dashboard)/profile.tsx
@@ -514,6 +514,7 @@ export default function MySpecialistProfileScreen() {
                 autoCapitalize="words"
                 returnKeyType="done"
                 onSubmitEditing={addCity}
+                style={{ outlineStyle: 'none' } as any}
               />
               <Pressable className="w-11 h-11 bg-brandPrimary rounded-lg items-center justify-center" onPress={addCity}>
                 <Text className="text-2xl text-textPrimary leading-7">+</Text>
@@ -548,6 +549,7 @@ export default function MySpecialistProfileScreen() {
                 autoCapitalize="sentences"
                 returnKeyType="done"
                 onSubmitEditing={addService}
+                style={{ outlineStyle: 'none' } as any}
               />
               <Pressable className="w-11 h-11 bg-brandPrimary rounded-lg items-center justify-center" onPress={addService}>
                 <Text className="text-2xl text-textPrimary leading-7">+</Text>
@@ -581,6 +583,7 @@ export default function MySpecialistProfileScreen() {
                 className="flex-1 h-11 bg-white border border-border rounded-lg px-5 text-base text-textPrimary"
                 autoCapitalize="none"
                 returnKeyType="done"
+                style={{ outlineStyle: 'none' } as any}
               />
             </View>
             {fnsSearchResults.length > 0 && (() => {

--- a/app/(dashboard)/settings.tsx
+++ b/app/(dashboard)/settings.tsx
@@ -333,6 +333,7 @@ export default function SettingsScreen() {
                     autoCapitalize="none"
                     autoCorrect={false}
                     editable={!emailChangeLoading}
+                    style={{ outlineStyle: 'none' } as any}
                   />
                   {emailChangeError ? (
                     <Text className="text-xs" style={{ color: Colors.statusError }}>
@@ -373,7 +374,7 @@ export default function SettingsScreen() {
                   </Text>
                   <TextInput
                     className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-center text-lg text-textPrimary"
-                    style={{ letterSpacing: 4 }}
+                    style={{ letterSpacing: 4, outlineStyle: 'none' } as any}
                     value={emailOtpCode}
                     onChangeText={(t) => { setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6)); setEmailChangeError(''); }}
                     placeholder="000000"

--- a/app/(dashboard)/specialist-profile.tsx
+++ b/app/(dashboard)/specialist-profile.tsx
@@ -147,7 +147,7 @@ export default function SpecialistProfileSetupScreen() {
                   onChangeText={setCityInput}
                   placeholder="Добавить город..."
                   placeholderTextColor={Colors.textMuted}
-                  style={styles.addInput}
+                  style={[styles.addInput, { outlineStyle: 'none' } as any]}
                   autoCapitalize="words"
                   returnKeyType="done"
                   onSubmitEditing={addCity}
@@ -181,7 +181,7 @@ export default function SpecialistProfileSetupScreen() {
                   onChangeText={setServiceInput}
                   placeholder="Консультация — 3000 руб"
                   placeholderTextColor={Colors.textMuted}
-                  style={[styles.addInput, styles.addInputWide]}
+                  style={[styles.addInput, styles.addInputWide, { outlineStyle: 'none' } as any]}
                   autoCapitalize="sentences"
                   returnKeyType="done"
                   onSubmitEditing={addService}

--- a/app/(onboarding)/fns.tsx
+++ b/app/(onboarding)/fns.tsx
@@ -139,7 +139,7 @@ export default function FNSScreen() {
           {/* Search with dropdown */}
           <View style={styles.searchWrap}>
             <TextInput
-              style={styles.searchInput}
+              style={[styles.searchInput, { outlineStyle: 'none' } as any]}
               value={search}
               onChangeText={setSearch}
               placeholder="Поиск по номеру или городу..."

--- a/app/(public)/catalog.tsx
+++ b/app/(public)/catalog.tsx
@@ -401,6 +401,7 @@ export default function CatalogScreen() {
               placeholder="Поиск по имени, услугам..."
               placeholderTextColor="#94A3B8"
               autoCorrect={false}
+              style={{ outlineStyle: 'none' } as any}
             />
             {searchText.length > 0 && (
               <Pressable onPress={() => setSearchText('')}>
@@ -469,6 +470,7 @@ export default function CatalogScreen() {
                     placeholder={selectedFns.length > 0 ? 'Добавить ещё...' : 'Поиск ИФНС...'}
                     placeholderTextColor="#94A3B8"
                     autoCorrect={false}
+                    style={{ outlineStyle: 'none' } as any}
                   />
                 </View>
                 {fnsDropdown.length > 0 && (

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -425,6 +425,7 @@ export default function SettingsTab() {
                 autoCapitalize="none"
                 autoCorrect={false}
                 editable={!emailChangeLoading}
+                style={{ outlineStyle: 'none' } as any}
               />
               {emailChangeError ? (
                 <Text className="text-xs" style={{ color: Colors.statusError }}>
@@ -465,7 +466,7 @@ export default function SettingsTab() {
               </Text>
               <TextInput
                 className="h-11 rounded-lg border border-borderLight bg-bgSecondary px-3 text-center text-lg text-textPrimary"
-                style={{ letterSpacing: 4 }}
+                style={{ letterSpacing: 4, outlineStyle: 'none' } as any}
                 value={emailOtpCode}
                 onChangeText={(t) => {
                   setEmailOtpCode(t.replace(/\D/g, '').slice(0, 6));

--- a/app/profile/work-area-edit.tsx
+++ b/app/profile/work-area-edit.tsx
@@ -403,7 +403,7 @@ export default function WorkAreaEditScreen() {
             <View style={styles.searchRow}>
               <Feather name="search" size={18} color={Colors.textMuted} />
               <TextInput
-                style={styles.searchInput}
+                style={[styles.searchInput, { outlineStyle: 'none' } as any]}
                 value={search}
                 onChangeText={setSearch}
                 placeholder="Find city..."

--- a/app/proto/index.tsx
+++ b/app/proto/index.tsx
@@ -186,7 +186,7 @@ export default function ProtoIndex() {
             onChangeText={setSearch}
             placeholder="Поиск..."
             placeholderTextColor={Colors.textMuted}
-            style={styles.searchInput}
+            style={[styles.searchInput, { outlineStyle: 'none' } as any]}
           />
         </View>
 

--- a/app/request/[id]/index.tsx
+++ b/app/request/[id]/index.tsx
@@ -584,7 +584,7 @@ export default function RequestDetailScreen() {
                 multiline
                 placeholder="Напишите первое сообщение клиенту..."
                 placeholderTextColor={Colors.textMuted}
-                style={s.messageInput}
+                style={[s.messageInput, { outlineStyle: 'none' } as any]}
               />
               <Pressable
                 style={s.writeBtn}
@@ -619,7 +619,7 @@ export default function RequestDetailScreen() {
                 multiline
                 placeholder="Напишите первое сообщение клиенту..."
                 placeholderTextColor={Colors.textMuted}
-                style={s.messageInput}
+                style={[s.messageInput, { outlineStyle: 'none' } as any]}
               />
               <Pressable
                 style={s.writeBtn}

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -481,7 +481,7 @@ export default function RequestsFeedScreen() {
               <View style={styles.searchBar}>
                 <Text style={styles.searchIcon}>&#x1F50D;</Text>
                 <TextInput
-                  style={styles.searchInput}
+                  style={[styles.searchInput, { outlineStyle: 'none' } as any]}
                   value={cityFilter}
                   onChangeText={setCityFilter}
                   placeholder="Поиск по городу..."
@@ -587,7 +587,7 @@ export default function RequestsFeedScreen() {
                   ) : (
                     <View style={styles.ifnsInputWrapper}>
                       <TextInput
-                        style={styles.ifnsInput}
+                        style={[styles.ifnsInput, { outlineStyle: 'none' } as any]}
                         value={ifnsQuery}
                         onChangeText={setIfnsQuery}
                         placeholder="Номер или название..."
@@ -751,7 +751,7 @@ export default function RequestsFeedScreen() {
               multiline
               numberOfLines={4}
               maxLength={500}
-              style={styles.messageInput}
+              style={[styles.messageInput, { outlineStyle: 'none' } as any]}
               autoFocus
             />
             <Text style={styles.charCounter}>{respondMessage.length}/500</Text>

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -268,7 +268,7 @@ export default function SearchScreen() {
         <Ionicons name="search" size={20} color={Colors.textMuted} style={styles.searchIcon} />
         <TextInput
           ref={inputRef}
-          style={styles.searchInput}
+          style={[styles.searchInput, { outlineStyle: 'none' } as any]}
           value={query}
           onChangeText={setQuery}
           placeholder="Поиск заявок и специалистов..."

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -396,6 +396,7 @@ export default function SpecialistsCatalogScreen() {
               placeholder="Поиск по имени, услугам..."
               placeholderTextColor="#94A3B8"
               autoCorrect={false}
+              style={{ outlineStyle: 'none' } as any}
             />
             {searchText.length > 0 && (
               <Pressable onPress={() => setSearchText('')}>
@@ -464,6 +465,7 @@ export default function SpecialistsCatalogScreen() {
                     placeholder={selectedFns.length > 0 ? 'Добавить ещё...' : 'Поиск ИФНС...'}
                     placeholderTextColor="#94A3B8"
                     autoCorrect={false}
+                    style={{ outlineStyle: 'none' } as any}
                   />
                 </View>
                 {fnsDropdown.length > 0 && (

--- a/components/IfnsSearch.tsx
+++ b/components/IfnsSearch.tsx
@@ -95,7 +95,7 @@ export function IfnsSearch({ onSelect, selected, placeholder }: IfnsSearchProps)
     <View style={styles.container}>
       <View style={styles.inputRow}>
         <TextInput
-          style={styles.input}
+          style={[styles.input, { outlineStyle: 'none' } as any]}
           value={query}
           onChangeText={setQuery}
           placeholder={placeholder || 'Введите номер или название инспекции...'}

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -89,6 +89,7 @@ export function Input({
           focused && styles.inputFocused,
           error ? styles.inputError : null,
           !editable && styles.inputDisabled,
+          { outlineStyle: 'none' as any },
         ]}
       />
       {showCharCount && maxLength != null ? (

--- a/components/QuickRequestForm.tsx
+++ b/components/QuickRequestForm.tsx
@@ -137,7 +137,7 @@ export function QuickRequestForm({ style, containerStyle }: QuickRequestFormProp
       <Text style={f.label}>ОПИШИТЕ СИТУАЦИЮ</Text>
       <TextInput
         testID="quick-request-description"
-        style={f.textarea}
+        style={[f.textarea, { outlineStyle: 'none' } as any]}
         placeholder="Что произошло? С чем нужна помощь?"
         placeholderTextColor={Colors.textMuted}
         value={description}

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -119,7 +119,7 @@ export function ReportModal({ visible, onClose, targetUserId }: ReportModalProps
             {/* Comment */}
             <Text style={[styles.label, { marginTop: 16 }]}>Комментарий (необязательно)</Text>
             <TextInput
-              style={styles.textInput}
+              style={[styles.textInput, { outlineStyle: 'none' } as any]}
               value={comment}
               onChangeText={setComment}
               placeholder="Опишите ситуацию подробнее..."

--- a/components/ReviewForm.tsx
+++ b/components/ReviewForm.tsx
@@ -66,7 +66,7 @@ export function ReviewForm({ specialistNick, requestId, onSuccess, onCancel }: R
 
       <Text style={styles.label}>Комментарий (необязательно)</Text>
       <TextInput
-        style={styles.textInput}
+        style={[styles.textInput, { outlineStyle: 'none' } as any]}
         value={comment}
         onChangeText={setComment}
         placeholder="Расскажите о своём опыте..."

--- a/components/proto/states/AdminModerationStates.tsx
+++ b/components/proto/states/AdminModerationStates.tsx
@@ -245,7 +245,7 @@ function ReviewingDetailState() {
             placeholder="Укажите причину..."
             placeholderTextColor={Colors.textMuted}
             multiline
-            style={s.rejectTextarea}
+            style={[s.rejectTextarea, { outlineStyle: 'none' } as any]}
           />
         </View>
 

--- a/components/proto/states/AdminPromotionsStates.tsx
+++ b/components/proto/states/AdminPromotionsStates.tsx
@@ -173,7 +173,7 @@ function CreateFormState() {
               onChangeText={setCode}
               placeholder="SUMMER2026"
               placeholderTextColor={Colors.textMuted}
-              style={s.inputInner}
+              style={[s.inputInner, { outlineStyle: 'none' } as any]}
               autoCapitalize="characters"
             />
           </View>
@@ -189,7 +189,7 @@ function CreateFormState() {
                 placeholder="30"
                 placeholderTextColor={Colors.textMuted}
                 keyboardType="number-pad"
-                style={s.inputInner}
+                style={[s.inputInner, { outlineStyle: 'none' } as any]}
               />
               <Text style={s.inputSuffix}>%</Text>
             </View>
@@ -203,7 +203,7 @@ function CreateFormState() {
                 placeholder="100"
                 placeholderTextColor={Colors.textMuted}
                 keyboardType="number-pad"
-                style={s.inputInner}
+                style={[s.inputInner, { outlineStyle: 'none' } as any]}
               />
               <Text style={s.inputSuffix}>шт</Text>
             </View>
@@ -219,7 +219,7 @@ function CreateFormState() {
               onChangeText={setExpiry}
               placeholder="31.12.2026"
               placeholderTextColor={Colors.textMuted}
-              style={s.inputInner}
+              style={[s.inputInner, { outlineStyle: 'none' } as any]}
             />
           </View>
         </View>
@@ -232,7 +232,7 @@ function CreateFormState() {
             placeholder="Описание акции..."
             placeholderTextColor={Colors.textMuted}
             multiline
-            style={s.textarea}
+            style={[s.textarea, { outlineStyle: 'none' } as any]}
           />
         </View>
       </View>

--- a/components/proto/states/AdminUsersStates.tsx
+++ b/components/proto/states/AdminUsersStates.tsx
@@ -76,7 +76,7 @@ function UserListPopulated() {
           onChangeText={setSearch}
           placeholder="Поиск по имени, email..."
           placeholderTextColor={Colors.textMuted}
-          style={s.searchInput}
+          style={[s.searchInput, { outlineStyle: 'none' } as any]}
         />
         {search.length > 0 && (
           <Pressable onPress={() => setSearch('')}>
@@ -132,7 +132,7 @@ function UserListEmpty() {
         <TextInput
           value="несуществующий@email.com"
           editable={false}
-          style={s.searchInput}
+          style={[s.searchInput, { outlineStyle: 'none' } as any]}
         />
       </View>
 

--- a/components/proto/states/ComponentsStates.tsx
+++ b/components/proto/states/ComponentsStates.tsx
@@ -69,7 +69,7 @@ function InputsSection() {
       <View style={styles.inputGroup}>
         <Text style={styles.inputLabel}>Standard</Text>
         <TextInput
-          style={[styles.input, focused === 'std' && styles.inputFocused]}
+          style={[styles.input, focused === 'std' && styles.inputFocused, { outlineStyle: 'none' } as any]}
           placeholder="Enter text..."
           placeholderTextColor={Colors.textMuted}
           value={text}
@@ -84,7 +84,7 @@ function InputsSection() {
         <View style={[styles.inputWithIcon, focused === 'icon' && styles.inputFocused]}>
           <Feather name="search" size={16} color={Colors.textMuted} />
           <TextInput
-            style={styles.inputInner}
+            style={[styles.inputInner, { outlineStyle: 'none' } as any]}
             placeholder="Search specialist..."
             placeholderTextColor={Colors.textMuted}
             onFocus={() => setFocused('icon')}
@@ -96,7 +96,7 @@ function InputsSection() {
       <View style={styles.inputGroup}>
         <Text style={styles.inputLabel}>Error</Text>
         <TextInput
-          style={[styles.input, styles.inputError]}
+          style={[styles.input, styles.inputError, { outlineStyle: 'none' } as any]}
           value="bad-value"
           placeholderTextColor={Colors.textMuted}
         />
@@ -109,7 +109,7 @@ function InputsSection() {
       <View style={styles.inputGroup}>
         <Text style={styles.inputLabel}>Disabled</Text>
         <TextInput
-          style={[styles.input, styles.inputDisabled]}
+          style={[styles.input, styles.inputDisabled, { outlineStyle: 'none' } as any]}
           value="Disabled input"
           editable={false}
         />

--- a/components/proto/states/MessageThreadStates.tsx
+++ b/components/proto/states/MessageThreadStates.tsx
@@ -163,7 +163,7 @@ function DefaultChat() {
               onChangeText={setInputText}
               placeholder="Введите сообщение..."
               placeholderTextColor={Colors.textMuted}
-              style={s.chatInput}
+              style={[s.chatInput, { outlineStyle: 'none' } as any]}
               onSubmitEditing={handleSend}
               returnKeyType="send"
             />
@@ -240,7 +240,7 @@ function EmptyChat() {
           <TextInput
             placeholder="Введите сообщение..."
             placeholderTextColor={Colors.textMuted}
-            style={s.chatInput}
+            style={[s.chatInput, { outlineStyle: 'none' } as any]}
           />
           <Pressable style={[s.sendBtn, s.sendBtnDisabled]}>
             <Feather name="arrow-up" size={18} color={Colors.white} />

--- a/components/proto/states/MessagesStates.tsx
+++ b/components/proto/states/MessagesStates.tsx
@@ -68,7 +68,7 @@ function DefaultMessages() {
           onChangeText={setSearch}
           placeholder="Поиск по сообщениям..."
           placeholderTextColor={Colors.textMuted}
-          style={s.searchInput}
+          style={[s.searchInput, { outlineStyle: 'none' } as any]}
         />
         {search.length > 0 && (
           <Pressable onPress={() => setSearch('')}>

--- a/components/proto/states/ProfileStates.tsx
+++ b/components/proto/states/ProfileStates.tsx
@@ -68,11 +68,11 @@ function DefaultProfile() {
         <View style={s.form}>
           <View style={s.field}>
             <Text style={s.label}>Имя</Text>
-            <TextInput value={name} onChangeText={setName} style={s.input} />
+            <TextInput value={name} onChangeText={setName} style={[s.input, { outlineStyle: 'none' } as any]} />
           </View>
           <View style={s.field}>
             <Text style={s.label}>Email</Text>
-            <TextInput value="elena@mail.ru" editable={false} style={[s.input, s.inputDisabled]} />
+            <TextInput value="elena@mail.ru" editable={false} style={[s.input, s.inputDisabled, { outlineStyle: 'none' } as any]} />
             <View style={s.hintRow}>
               <Feather name="lock" size={12} color={Colors.textMuted} />
               <Text style={s.hint}>Email нельзя изменить</Text>
@@ -80,7 +80,7 @@ function DefaultProfile() {
           </View>
           <View style={s.field}>
             <Text style={s.label}>Город</Text>
-            <TextInput value={city} onChangeText={setCity} style={s.input} />
+            <TextInput value={city} onChangeText={setCity} style={[s.input, { outlineStyle: 'none' } as any]} />
           </View>
         </View>
         <View style={s.actions}>


### PR DESCRIPTION
## Summary
- Added `outlineStyle: 'none'` to every TextInput across 31 files (app pages, shared components, proto states)
- Fixed the shared `components/Input.tsx` component so all usages via `<Input>` also inherit the fix
- Prevents browser default outline from doubling with custom RN border styles on React Native Web

## Test plan
- [ ] Open any page with input fields (auth, profile, requests, chat, admin)
- [ ] Click/focus on inputs -- should see only ONE border, no double outline
- [ ] Check on both desktop and mobile viewport widths

Generated with Claude Code