### PR TITLE
fix: use jsonb_array_elements in migration

### DIFF
--- a/api/prisma/migrations/20260413140000_add_specialist_fns_services/migration.sql
+++ b/api/prisma/migrations/20260413140000_add_specialist_fns_services/migration.sql
@@ -64,7 +64,7 @@ SELECT
     sp."id",
     i."id"
 FROM "specialist_profiles" sp,
-     json_array_elements(sp."fnsDepartmentsData") AS fns_entry,
+     jsonb_array_elements(sp."fnsDepartmentsData") AS fns_entry,
      "ifns" i
 WHERE sp."fnsDepartmentsData" IS NOT NULL
   AND i."name" = fns_entry->>'office'
@@ -79,11 +79,11 @@ SELECT DISTINCT
     i."id",
     s."id"
 FROM "specialist_profiles" sp,
-     json_array_elements(sp."fnsDepartmentsData") AS fns_entry,
-     json_array_elements(fns_entry->'departments') AS dept_name,
+     jsonb_array_elements(sp."fnsDepartmentsData") AS fns_entry,
+     jsonb_array_elements(fns_entry->'departments') AS dept_name,
      "ifns" i,
      "services" s
 WHERE sp."fnsDepartmentsData" IS NOT NULL
   AND i."name" = fns_entry->>'office'
-  AND s."name" = dept_name
+  AND s."name" = dept_name#>>'{}'
 ON CONFLICT ("specialistId", "fnsId", "serviceId") DO NOTHING;


### PR DESCRIPTION
## Summary
- Replace `json_array_elements()` with `jsonb_array_elements()` in migration `20260413140000_add_specialist_fns_services`
- The `fnsDepartmentsData` column is `jsonb` type — PostgreSQL requires `jsonb_array_elements()` for jsonb columns
- Also added text cast (`#>>'{}'`) for dept_name comparison since `jsonb_array_elements` returns jsonb values

## Server
- Failed migration record already deleted from `_prisma_migrations` on production DB
- No partial tables left (transaction rolled back cleanly)

## Test plan
- [ ] CI passes on development
- [ ] Migration applies successfully on production deploy