### PR TITLE
fix: align complaint migration with actual DB column names

### DIFF
--- a/api/prisma/migrations/20260414160000_add_complaint_status/migration.sql
+++ b/api/prisma/migrations/20260414160000_add_complaint_status/migration.sql
@@ -5,4 +5,4 @@ CREATE TYPE "ComplaintStatus" AS ENUM ('PENDING', 'REVIEWED', 'DISMISSED');
 ALTER TABLE "complaints" ADD COLUMN "status" "ComplaintStatus" NOT NULL DEFAULT 'PENDING';
 
 -- CreateIndex (unique: one complaint per user per target)
-CREATE UNIQUE INDEX "complaints_reporterId_targetId_key" ON "complaints"("reporterId", "targetId");
+CREATE UNIQUE INDEX "complaints_reporterId_targetUserId_key" ON "complaints"("reporterId", "targetUserId");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -423,10 +423,10 @@ model Complaint {
   id         String           @id @default(cuid())
   reporterId String
   reporter   User             @relation("ComplaintReporter", fields: [reporterId], references: [id])
-  targetId   String
+  targetId   String           @map("targetUserId")
   target     User             @relation("ComplaintTarget", fields: [targetId], references: [id])
   reason     ComplaintReason
-  comment    String?
+  comment    String?          @map("description")
   status     ComplaintStatus  @default(PENDING)
   createdAt  DateTime         @default(now())
 


### PR DESCRIPTION
## Summary
- Fixed migration `20260414160000_add_complaint_status`: index referenced `targetId` but DB column is `targetUserId`
- Added `@map("targetUserId")` and `@map("description")` to Prisma schema to align field names with actual DB columns
- Deleted failed migration record from production DB so it can re-run cleanly
- Verified all 3 pending migrations (complaint_status, notifications, push_tokens) — only the complaint one had issues

## Test plan
- [ ] CI passes migration deploy
- [ ] All 3 pending migrations apply successfully

Generated with [Claude Code](https://claude.com/claude-code)