### PR TITLE
fix(responses): client-facing accept/decline UI matching proto

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -14,6 +14,7 @@ const CLIENT_NAV_GROUPS: NavGroup[] = [
     items: [
       { label: 'Glavnaya', icon: 'home', route: '/(dashboard)', segment: 'index' },
       { label: 'Moi zayavki', icon: 'file-text', route: '/(dashboard)/my-requests', segment: 'my-requests' },
+      { label: 'Otkliki', icon: 'inbox', route: '/(dashboard)/responses', segment: 'responses' },
       { label: 'Lenta zayavok', icon: 'list', route: '/requests', segment: 'feed' },
     ],
   },
@@ -60,6 +61,7 @@ const SPECIALIST_NAV_GROUPS: NavGroup[] = [
 const CLIENT_TAB_ITEMS: BottomTabItem[] = [
   { label: 'Glavnaya', icon: 'home', route: '/(dashboard)', segment: 'index' },
   { label: 'Zayavki', icon: 'file-text', route: '/(dashboard)/my-requests', segment: 'my-requests' },
+  { label: 'Otkliki', icon: 'inbox', route: '/(dashboard)/responses', segment: 'responses' },
   { label: 'Soobscheniya', icon: 'message-circle', route: '/(dashboard)/messages', segment: 'messages' },
   { label: 'Profil', icon: 'user', route: '/(dashboard)/settings', segment: 'settings' },
 ];

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -7,47 +7,114 @@ import {
   FlatList,
   ActivityIndicator,
   RefreshControl,
-  TouchableOpacity,
+  Pressable,
   Alert,
+  Platform,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { Feather } from '@expo/vector-icons';
 import { useBreakpoints } from '../../hooks/useBreakpoints';
 import { api, ApiError } from '../../lib/api';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { Header } from '../../components/Header';
-import { Card } from '../../components/Card';
-import { Button } from '../../components/Button';
 import { EmptyState } from '../../components/EmptyState';
 
-interface ResponseItem {
-  id: string;
-  message: string;
-  createdAt: string;
-  request: {
-    id: string;
-    description: string;
-    city: string;
-    status: string;
-    createdAt: string;
-    clientId?: string;
-  };
+// --- Types matching API shape from GET /requests/mine ---
+
+interface SpecialistProfile {
+  nick?: string;
+  displayName?: string;
+  avatarUrl?: string;
 }
 
-export default function MyResponsesScreen() {
+interface ResponseFromAPI {
+  id: string;
+  comment: string;
+  price: number;
+  status: string;
+  specialist: {
+    id: string;
+    email: string;
+    specialistProfile?: SpecialistProfile | null;
+  };
+  createdAt: string;
+}
+
+interface RequestFromAPI {
+  id: string;
+  description: string;
+  city: string;
+  category?: string | null;
+  status: string;
+  _count: { responses: number };
+  responses: ResponseFromAPI[];
+}
+
+// Flattened item for the list
+interface ResponseListItem {
+  id: string;
+  responseId: string;
+  requestId: string;
+  requestTitle: string;
+  specialistName: string;
+  specialistId: string;
+  price: number;
+  message: string;
+  status: string;
+  createdAt: string;
+}
+
+function getInitials(name: string) {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase();
+}
+
+function formatPrice(price: number) {
+  return price.toLocaleString('ru-RU') + ' \u20BD';
+}
+
+export default function ResponsesScreen() {
   const router = useRouter();
   const { isMobile } = useBreakpoints();
-  const [responses, setResponses] = useState<ResponseItem[]>([]);
+  const [items, setItems] = useState<ResponseListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
-  const [startingDialogId, setStartingDialogId] = useState<string | null>(null);
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
 
-  const fetchResponses = useCallback(async (isRefresh = false) => {
+  const fetchData = useCallback(async (isRefresh = false) => {
     if (!isRefresh) setLoading(true);
     setError('');
     try {
-      const data = await api.get<ResponseItem[]>('/requests/my-responses');
-      setResponses(data);
+      const requests = await api.get<RequestFromAPI[]>('/requests/mine');
+      // Flatten: collect all non-deactivated responses across all requests
+      const flat: ResponseListItem[] = [];
+      for (const req of requests) {
+        for (const resp of req.responses) {
+          if (resp.status === 'deactivated') continue;
+          const displayName =
+            resp.specialist?.specialistProfile?.displayName
+            || resp.specialist?.specialistProfile?.nick
+            || resp.specialist?.email?.split('@')[0]
+            || '??';
+          flat.push({
+            id: resp.id,
+            responseId: resp.id,
+            requestId: req.id,
+            requestTitle: req.category || req.description.slice(0, 60),
+            specialistName: displayName,
+            specialistId: resp.specialist.id,
+            price: resp.price,
+            message: resp.comment,
+            status: resp.status,
+            createdAt: resp.createdAt,
+          });
+        }
+      }
+      // Sort by price ascending (cheapest first)
+      flat.sort((a, b) => a.price - b.price);
+      setItems(flat);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Не удалось загрузить отклики');
     } finally {
@@ -57,98 +124,119 @@ export default function MyResponsesScreen() {
   }, []);
 
   useEffect(() => {
-    fetchResponses();
-  }, [fetchResponses]);
+    fetchData();
+  }, [fetchData]);
 
   function handleRefresh() {
     setRefreshing(true);
-    fetchResponses(true);
+    fetchData(true);
   }
 
-  async function handleStartDialog(clientId: string) {
-    if (startingDialogId) return;
-    setStartingDialogId(clientId);
+  async function handleAccept(responseId: string) {
+    if (acceptingId) return;
+    setAcceptingId(responseId);
     try {
-      const resp = await api.post<{ threadId: string }>('/threads/start', { otherUserId: clientId });
-      router.push(`/(dashboard)/messages/${resp.threadId}`);
+      await api.put(`/responses/${responseId}/accept`);
+      // Update local state
+      setItems((prev) =>
+        prev.map((item) =>
+          item.responseId === responseId ? { ...item, status: 'accepted' } : item,
+        ),
+      );
+      const msg = 'Отклик принят. Вы можете написать специалисту в сообщениях.';
+      if (Platform.OS === 'web') {
+        alert(msg);
+      } else {
+        Alert.alert('Принято', msg);
+      }
     } catch (err) {
-      const msg = err instanceof ApiError ? err.message : 'Не удалось открыть диалог';
-      Alert.alert('Ошибка', msg);
+      const msg = err instanceof ApiError ? err.message : 'Не удалось принять отклик';
+      if (Platform.OS === 'web') {
+        alert(msg);
+      } else {
+        Alert.alert('Ошибка', msg);
+      }
     } finally {
-      setStartingDialogId(null);
+      setAcceptingId(null);
     }
   }
 
-  function formatDate(iso: string) {
-    const d = new Date(iso);
-    return d.toLocaleDateString('ru-RU', {
-      day: 'numeric',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+  function handleDecline(responseId: string) {
+    // Remove from local list (no server endpoint for client decline)
+    setItems((prev) => prev.filter((item) => item.responseId !== responseId));
   }
 
-  function renderItem({ item }: { item: ResponseItem }) {
-    const req = item.request;
-    const isOpen = req.status === 'OPEN';
+  // Find cheapest among pending (non-accepted) items
+  const pending = items.filter((i) => i.status !== 'accepted');
+  const cheapest = pending.length > 0 ? pending[0] : null; // already sorted by price
+
+  function renderItem({ item }: { item: ResponseListItem }) {
+    const initials = getInitials(item.specialistName);
+    const isAccepted = item.status === 'accepted';
+    const isAccepting = acceptingId === item.responseId;
+
     return (
-      <TouchableOpacity style={styles.cardWrapper} activeOpacity={0.8} onPress={() => router.push(`/(dashboard)/my-requests/${item.request.id}`)}>
-        <Card padding={Spacing.lg}>
-          {/* Request meta */}
-          <View style={styles.metaRow}>
-            <View style={styles.cityChip}>
-              <Text style={styles.cityText}>{req.city}</Text>
-            </View>
-            <View style={[styles.statusChip, !isOpen && styles.statusChipClosed]}>
-              <Text style={[styles.statusText, !isOpen && styles.statusTextClosed]}>
-                {isOpen ? 'Открыт' : 'Закрыт'}
-              </Text>
-            </View>
+      <View style={styles.card}>
+        {/* Top row: avatar + name + price */}
+        <View style={styles.cardTop}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarText}>{initials}</Text>
           </View>
-
-          {/* Request description */}
-          <Text style={styles.requestDesc} numberOfLines={3}>
-            {req.description}
-          </Text>
-
-          {/* Divider */}
-          <View style={styles.divider} />
-
-          {/* My response */}
-          <Text style={styles.responseLabel}>Мой отклик:</Text>
-          <Text style={styles.responseText} numberOfLines={3}>
-            {item.message}
-          </Text>
-
-          {/* Dates */}
-          <View style={styles.datesRow}>
-            <Text style={styles.dateText}>{'Отклик: '}{formatDate(item.createdAt)}</Text>
-            <Text style={styles.dateText}>{'Запрос: '}{formatDate(req.createdAt)}</Text>
+          <View style={styles.info}>
+            <Text style={styles.name}>{item.specialistName}</Text>
+            <Text style={styles.requestRef} numberOfLines={1}>
+              {item.requestTitle}
+            </Text>
           </View>
+          <Text style={styles.price}>{formatPrice(item.price)}</Text>
+        </View>
 
-          {/* Write to client button */}
-          {item.request.clientId && (
-            <Button
-              onPress={() => handleStartDialog(item.request.clientId!)}
-              variant="secondary"
-              loading={startingDialogId === item.request.clientId}
-              disabled={startingDialogId !== null}
-              style={styles.writeBtn}
+        {/* Message */}
+        <Text style={styles.message} numberOfLines={2}>
+          {item.message}
+        </Text>
+
+        {/* Action buttons */}
+        {isAccepted ? (
+          <View style={styles.acceptedBadge}>
+            <Feather name="check-circle" size={14} color={Colors.statusSuccess} />
+            <Text style={styles.acceptedText}>Принято</Text>
+          </View>
+        ) : (
+          <View style={styles.actions}>
+            <Pressable
+              onPress={() => handleAccept(item.responseId)}
+              style={styles.btnAccept}
+              disabled={isAccepting}
             >
-              Написать
-            </Button>
-          )}
-        </Card>
-      </TouchableOpacity>
+              {isAccepting ? (
+                <ActivityIndicator size="small" color={Colors.white} />
+              ) : (
+                <>
+                  <Feather name="check" size={16} color={Colors.white} />
+                  <Text style={styles.btnAcceptText}>Принять</Text>
+                </>
+              )}
+            </Pressable>
+            <Pressable
+              onPress={() => handleDecline(item.responseId)}
+              style={styles.btnDecline}
+              disabled={isAccepting}
+            >
+              <Feather name="x" size={16} color={Colors.textMuted} />
+              <Text style={styles.btnDeclineText}>Отклонить</Text>
+            </Pressable>
+          </View>
+        )}
+      </View>
     );
   }
 
   return (
     <SafeAreaView style={styles.safe}>
-      {isMobile && <Header title="Мои отклики" showBack />}
+      {isMobile && <Header title="Отклики" showBack />}
       <FlatList
-        data={responses}
+        data={items}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
         contentContainerStyle={styles.listContent}
@@ -159,6 +247,31 @@ export default function MyResponsesScreen() {
             onRefresh={handleRefresh}
             tintColor={Colors.brandPrimary}
           />
+        }
+        ListHeaderComponent={
+          items.length > 0 ? (
+            <View style={styles.headerSection}>
+              {/* Title + count badge */}
+              <View style={styles.topBar}>
+                <Text style={styles.pageTitle}>Отклики</Text>
+                <View style={styles.countBadge}>
+                  <Text style={styles.countText}>{items.length}</Text>
+                </View>
+              </View>
+
+              {/* Price comparison bar */}
+              {cheapest && pending.length > 1 && (
+                <View style={styles.priceBar}>
+                  <Feather name="trending-down" size={14} color={Colors.statusSuccess} />
+                  <Text style={styles.priceBarText}>
+                    Лучшая цена:{' '}
+                    <Text style={styles.priceBarValue}>{formatPrice(cheapest.price)}</Text>
+                    {' '}от {cheapest.specialistName}
+                  </Text>
+                </View>
+              )}
+            </View>
+          ) : null
         }
         ListEmptyComponent={
           loading ? (
@@ -171,13 +284,13 @@ export default function MyResponsesScreen() {
               title="Ошибка загрузки"
               subtitle={error}
               ctaLabel="Повторить"
-              onCtaPress={() => fetchResponses()}
+              onCtaPress={() => fetchData()}
             />
           ) : (
             <EmptyState
               icon="mail-outline"
-              title="Нет откликов"
-              subtitle="Вы ещё не откликались ни на один запрос"
+              title="Пока нет откликов"
+              subtitle="Специалисты рассматривают ваши заявки. Первые отклики обычно приходят в течение часа."
             />
           )
         }
@@ -197,87 +310,170 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingTop: Spacing.md,
   },
-  cardWrapper: {
+  headerSection: {
     width: '100%',
-    maxWidth: 430,
+    maxWidth: 640,
+    gap: Spacing.md,
     marginBottom: Spacing.md,
   },
-  metaRow: {
+  topBar: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: Spacing.sm,
+    gap: Spacing.sm,
   },
-  cityChip: {
-    backgroundColor: Colors.bgSecondary,
-    paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
-    borderRadius: BorderRadius.full,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-  },
-  cityText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.textSecondary,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  statusChip: {
-    backgroundColor: Colors.statusBg.success,
-    paddingHorizontal: Spacing.sm,
-    paddingVertical: 3,
-    borderRadius: BorderRadius.full,
-  },
-  statusChipClosed: {
-    backgroundColor: Colors.statusBg.warning,
-  },
-  statusText: {
-    fontSize: Typography.fontSize.xs,
-    color: Colors.statusSuccess,
-    fontWeight: Typography.fontWeight.medium,
-  },
-  statusTextClosed: {
-    color: Colors.textMuted,
-  },
-  requestDesc: {
-    fontSize: Typography.fontSize.base,
+  pageTitle: {
+    fontSize: Typography.fontSize.xl,
+    fontWeight: Typography.fontWeight.bold,
     color: Colors.textPrimary,
-    lineHeight: 22,
-    marginBottom: Spacing.md,
   },
-  divider: {
-    height: 1,
-    backgroundColor: Colors.border,
-    marginVertical: Spacing.md,
+  countBadge: {
+    backgroundColor: Colors.brandPrimary,
+    minWidth: 24,
+    height: 24,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 6,
   },
-  responseLabel: {
+  countText: {
     fontSize: Typography.fontSize.xs,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textMuted,
-    marginBottom: Spacing.xs,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.white,
   },
-  responseText: {
+
+  // Price comparison bar
+  priceBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    backgroundColor: Colors.statusBg.success,
+    padding: Spacing.md,
+    borderRadius: BorderRadius.card,
+  },
+  priceBarText: {
     fontSize: Typography.fontSize.sm,
     color: Colors.textSecondary,
-    lineHeight: 20,
-    fontStyle: 'italic',
-    marginBottom: Spacing.md,
+    flex: 1,
   },
-  datesRow: {
+  priceBarValue: {
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.statusSuccess,
+  },
+
+  // Card
+  card: {
+    width: '100%',
+    maxWidth: 640,
+    backgroundColor: Colors.bgCard,
+    borderRadius: BorderRadius.card,
+    padding: Spacing.lg,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    gap: Spacing.sm,
+    marginBottom: Spacing.md,
+    ...Shadows.sm,
+  },
+  cardTop: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: Colors.bgSecondary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  avatarText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.textPrimary,
+  },
+  requestRef: {
+    fontSize: Typography.fontSize.sm,
+    color: Colors.textMuted,
+    marginTop: 2,
+  },
+  price: {
+    fontSize: Typography.fontSize.lg,
+    fontWeight: Typography.fontWeight.bold,
+    color: Colors.brandPrimary,
+  },
+  message: {
+    fontSize: Typography.fontSize.base,
+    color: Colors.textSecondary,
+    lineHeight: 22,
+  },
+
+  // Actions
+  actions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  btnAccept: {
+    flex: 1,
+    height: 40,
+    backgroundColor: Colors.brandPrimary,
+    borderRadius: BorderRadius.btn,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: Spacing.xs,
+    ...Shadows.sm,
+  },
+  btnAcceptText: {
+    fontSize: Typography.fontSize.base,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.white,
+  },
+  btnDecline: {
+    flex: 1,
+    height: 40,
+    borderRadius: BorderRadius.btn,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: Colors.border,
+    flexDirection: 'row',
     gap: Spacing.xs,
   },
-  dateText: {
-    fontSize: Typography.fontSize.xs,
+  btnDeclineText: {
+    fontSize: Typography.fontSize.base,
     color: Colors.textMuted,
   },
-  writeBtn: {
-    marginTop: Spacing.md,
-    width: '100%',
+
+  // Accepted badge
+  acceptedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    marginTop: Spacing.xs,
+    paddingVertical: Spacing.xs,
+    paddingHorizontal: Spacing.sm,
+    backgroundColor: Colors.statusBg.success,
+    borderRadius: BorderRadius.full,
+    alignSelf: 'flex-start',
   },
+  acceptedText: {
+    fontSize: Typography.fontSize.sm,
+    fontWeight: Typography.fontWeight.semibold,
+    color: Colors.statusSuccess,
+  },
+
+  // Loading
   loadingBox: {
     paddingTop: Spacing['4xl'],
     alignItems: 'center',

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -278,6 +278,9 @@ export const api = {
   post<T>(path: string, body?: unknown): Promise<T> {
     return request<T>('POST', path, body);
   },
+  put<T>(path: string, body?: unknown): Promise<T> {
+    return request<T>('PUT', path, body);
+  },
   patch<T>(path: string, body?: unknown): Promise<T> {
     return request<T>('PATCH', path, body);
   },


### PR DESCRIPTION
## Summary
- Rewrote `app/(dashboard)/responses.tsx` from specialist-facing "my responses" to client-facing responses page matching `ResponsesStates` proto
- Cards show avatar initials, specialist name, price, message with accept/decline buttons
- Price comparison bar highlights best offer
- Accept calls `PUT /responses/:id/accept`, decline removes from local view
- Added responses page to client sidebar and bottom tab navigation
- Added `api.put()` method to API client

## Test plan
- [ ] Login as client with requests that have responses
- [ ] Verify responses page shows specialist cards with price and accept/decline
- [ ] Accept a response and verify status changes
- [ ] Decline removes card from view
- [ ] Empty state shows when no responses exist
- [ ] Price comparison bar visible with 2+ pending responses