### PR TITLE
fix: correct table name in city migration

### DIFF
--- a/api/prisma/migrations/20260415120000_add_user_city/migration.sql
+++ b/api/prisma/migrations/20260415120000_add_user_city/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "User" ADD COLUMN "city" TEXT;
+ALTER TABLE "users" ADD COLUMN "city" TEXT;


### PR DESCRIPTION
## Summary
- Migration `20260415120000_add_user_city` referenced `"User"` (Prisma model name) instead of `"users"` (actual PostgreSQL table via `@@map("users")`)
- This caused error 42P01: `relation "User" does not exist`
- Also cleaned up the failed migration record from the server DB

## Test plan
- [ ] CI deploys successfully
- [ ] Migration runs without error on staging