### PR TITLE
fix: 5 critical bugs — DTO, endpoints, double provider, toast

### DIFF
--- a/api/src/requests/dto/respond-request.dto.ts
+++ b/api/src/requests/dto/respond-request.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, MaxLength, IsInt, Min, IsDateString } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsInt, Min, IsDateString, IsOptional } from 'class-validator';
 
 export class RespondRequestDto {
   @IsString()
@@ -6,10 +6,12 @@ export class RespondRequestDto {
   @MaxLength(500)
   comment!: string;
 
+  @IsOptional()
   @IsInt()
   @Min(0)
-  price!: number;
+  price?: number;
 
+  @IsOptional()
   @IsDateString()
-  deadline!: string;
+  deadline?: string;
 }

--- a/app/(admin)/moderation.tsx
+++ b/app/(admin)/moderation.tsx
@@ -469,7 +469,7 @@ export default function AdminModeration() {
     setActionLoading((prev) => ({ ...prev, [s.id]: true }));
     try {
       const newBadges = [...new Set([...s.badges, VERIFIED_BADGE])];
-      await api.patch(`/specialists/${s.user.id}/badges`, { badges: newBadges });
+      await api.patch(`/admin/specialists/${s.user.id}/badges`, { badges: newBadges });
       const updated = { ...s, badges: newBadges };
       setSpecialists((prev) =>
         prev.map((item) => (item.id === s.id ? updated : item)),
@@ -487,7 +487,7 @@ export default function AdminModeration() {
     setActionLoading((prev) => ({ ...prev, [s.id]: true }));
     try {
       const newBadges = s.badges.filter((b) => b !== VERIFIED_BADGE);
-      await api.patch(`/specialists/${s.user.id}/badges`, { badges: newBadges });
+      await api.patch(`/admin/specialists/${s.user.id}/badges`, { badges: newBadges });
       const updated = { ...s, badges: newBadges };
       setSpecialists((prev) =>
         prev.map((item) => (item.id === s.id ? updated : item)),

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -87,7 +87,7 @@ export default function ResponsesScreen() {
     if (!isRefresh) setLoading(true);
     setError('');
     try {
-      const requests = await api.get<RequestFromAPI[]>('/requests/mine');
+      const requests = await api.get<RequestFromAPI[]>('/requests/my');
       // Flatten: collect all non-deactivated responses across all requests
       const flat: ResponseListItem[] = [];
       for (const req of requests) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,7 +4,6 @@ import { ActivityIndicator, AppState, Platform, View } from 'react-native';
 import { Stack, useRouter, useSegments } from 'expo-router';
 import Head from 'expo-router/head';
 import { AuthProvider, useAuth } from '../stores/authStore';
-import { AuthProvider as NewAuthProvider } from '../lib/auth';
 import { isAdmin } from '../lib/adminEmails';
 import { Colors } from '../constants/Colors';
 import { tryRefreshTokens } from '../lib/api';
@@ -146,12 +145,10 @@ export default function RootLayout() {
         <meta property="og:type" content="website" />
       </Head>
       <ErrorBoundary>
-        <NewAuthProvider>
-          <AuthProvider>
-            <RootNavigator />
-            <ToastContainer />
-          </AuthProvider>
-        </NewAuthProvider>
+        <AuthProvider>
+          <RootNavigator />
+          <ToastContainer />
+        </AuthProvider>
       </ErrorBoundary>
     </>
   );

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -96,6 +96,8 @@ client.interceptors.response.use(
         const message = data?.message || 'Произошла ошибка запроса';
         toast.error(message);
       }
+    } else if (status === 401) {
+      // 401 is handled by the refresh interceptor below — skip toast
     } else if (!error.response && error.message !== 'canceled') {
       // Network error (no response at all)
       toast.error('Нет соединения с сервером');


### PR DESCRIPTION
## Summary
- **BUG #1**: `respond-request.dto.ts` — made `price` and `deadline` optional (`@IsOptional()`) since form sends only `comment`
- **BUG #2**: `responses.tsx` — fixed endpoint `/requests/mine` → `/requests/my`
- **BUG #3**: `moderation.tsx` — fixed endpoint `/specialists/.../badges` → `/admin/specialists/.../badges`
- **BUG #4**: `_layout.tsx` — removed unused `NewAuthProvider` that caused double token refresh
- **BUG #5**: `client.ts` — toast interceptor now skips 401 responses (handled by refresh interceptor)

## Test plan
- [ ] Specialist respond form submits successfully with only a comment
- [ ] Responses page loads client's requests
- [ ] Admin moderation approve/reject works
- [ ] No double auth provider in React tree
- [ ] No spurious error toast on 401 during token refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)