### PR TITLE
fix: resolve 7 HIGH-severity bugs

### DIFF
--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -35,22 +35,36 @@ export class SpecialistsService {
     await this.prisma.specialistService.deleteMany({ where: { specialistId: specialistProfileId } });
     await this.prisma.specialistFns.deleteMany({ where: { specialistId: specialistProfileId } });
 
-    for (const entry of fnsServices) {
-      await this.prisma.specialistFns.create({
-        data: { specialistId: specialistProfileId, fnsId: entry.fnsId },
-      }).catch(() => { /* ignore duplicate */ });
+    // Batch create FNS links
+    const uniqueFnsIds = [...new Set(fnsServices.map((e) => e.fnsId))];
+    if (uniqueFnsIds.length > 0) {
+      await this.prisma.specialistFns.createMany({
+        data: uniqueFnsIds.map((fnsId) => ({ specialistId: specialistProfileId, fnsId })),
+        skipDuplicates: true,
+      });
+    }
 
+    // Collect all unique service names and resolve them in one query
+    const allServiceNames = [...new Set(fnsServices.flatMap((e) => e.serviceNames))];
+    const serviceRecords = allServiceNames.length > 0
+      ? await this.prisma.service.findMany({ where: { name: { in: allServiceNames } } })
+      : [];
+    const serviceMap = new Map(serviceRecords.map((s) => [s.name, s.id]));
+
+    // Batch create service links
+    const serviceLinks: Array<{ specialistId: string; fnsId: string; serviceId: string }> = [];
+    for (const entry of fnsServices) {
       for (const svcName of entry.serviceNames) {
-        const svc = await this.prisma.service.findUnique({ where: { name: svcName } });
-        if (!svc) continue;
-        await this.prisma.specialistService.create({
-          data: {
-            specialistId: specialistProfileId,
-            fnsId: entry.fnsId,
-            serviceId: svc.id,
-          },
-        }).catch(() => { /* ignore duplicate */ });
+        const serviceId = serviceMap.get(svcName);
+        if (!serviceId) continue;
+        serviceLinks.push({ specialistId: specialistProfileId, fnsId: entry.fnsId, serviceId });
       }
+    }
+    if (serviceLinks.length > 0) {
+      await this.prisma.specialistService.createMany({
+        data: serviceLinks,
+        skipDuplicates: true,
+      });
     }
   }
 

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -26,7 +26,7 @@ interface SpecialistProfile {
 
 interface ResponseItem {
   id: string;
-  message: string;
+  comment: string;
   specialist: {
     id: string;
     email: string;
@@ -55,15 +55,27 @@ function formatShortDate(iso: string) {
 }
 
 function getStatusLabel(status: string) {
-  if (status === 'OPEN') return 'Активная';
-  if (status === 'CLOSED') return 'Закрыта';
-  return status;
+  switch (status) {
+    case 'OPEN': return 'Активная';
+    case 'NEW': return 'Новая';
+    case 'IN_PROGRESS': return 'В работе';
+    case 'CLOSING_SOON': return 'Скоро закроется';
+    case 'CLOSED': return 'Закрыта';
+    case 'CANCELLED': return 'Отменена';
+    default: return status;
+  }
 }
 
 function getStatusColor(status: string) {
-  if (status === 'OPEN') return Colors.statusSuccess;
-  if (status === 'CLOSED') return Colors.textMuted;
-  return Colors.statusWarning;
+  switch (status) {
+    case 'OPEN': return Colors.statusSuccess;
+    case 'NEW': return Colors.brandPrimary;
+    case 'IN_PROGRESS': return Colors.statusWarning;
+    case 'CLOSING_SOON': return Colors.statusWarning;
+    case 'CLOSED': return Colors.textMuted;
+    case 'CANCELLED': return Colors.statusError;
+    default: return Colors.statusWarning;
+  }
 }
 
 function getInitials(name: string) {
@@ -342,7 +354,7 @@ export default function MyRequestDetailScreen() {
                           <Text className="text-xs text-textMuted">{formatTime(resp.createdAt)}</Text>
                         </View>
                         <Text className="text-xs text-textMuted" numberOfLines={1}>
-                          {resp.message}
+                          {resp.comment}
                         </Text>
                       </View>
                     </Pressable>

--- a/app/(dashboard)/my-requests/index.tsx
+++ b/app/(dashboard)/my-requests/index.tsx
@@ -27,7 +27,7 @@ interface SpecialistProfile {
 
 interface ResponseItem {
   id: string;
-  message: string;
+  comment: string;
   specialist: { id: string; email: string; specialistProfile?: SpecialistProfile | null };
   createdAt: string;
 }
@@ -92,16 +92,25 @@ export default function MyRequestsScreen() {
     fetchRequests(true);
   }
 
+  const ACTIVE_STATUSES = ['OPEN', 'NEW', 'IN_PROGRESS', 'CLOSING_SOON'];
   const filtered = items.filter((r) =>
     tab === 'active'
-      ? r.status === 'OPEN'
-      : r.status !== 'OPEN',
+      ? ACTIVE_STATUSES.includes(r.status)
+      : !ACTIVE_STATUSES.includes(r.status),
   );
 
   function getStatusConfig(status: string) {
     switch (status) {
       case 'OPEN':
         return { label: 'Открыт', bg: Colors.statusBg.info, color: Colors.brandPrimary };
+      case 'NEW':
+        return { label: 'Новая', bg: Colors.statusBg.info, color: Colors.brandPrimary };
+      case 'IN_PROGRESS':
+        return { label: 'В работе', bg: Colors.statusBg.warning, color: Colors.statusWarning };
+      case 'CLOSING_SOON':
+        return { label: 'Скоро закроется', bg: Colors.statusBg.warning, color: Colors.statusWarning };
+      case 'CANCELLED':
+        return { label: 'Отменена', bg: Colors.statusBg.error, color: Colors.statusError };
       default:
         return { label: 'Закрыт', bg: Colors.statusBg.warning, color: Colors.textMuted };
     }

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -18,7 +18,6 @@ import { api, ApiError } from '../../../lib/api';
 import { Colors } from '../../../constants/Colors';
 import { Header } from '../../../components/Header';
 import { IfnsSearch } from '../../../components/IfnsSearch';
-import { Toggle } from '../../../components/ui/Toggle';
 import { useBreakpoints } from '../../../hooks/useBreakpoints';
 
 const MAX_FILES = 5;
@@ -71,7 +70,6 @@ export default function CreateRequestScreen() {
   const [city, setCity] = useState('');
   const [selectedIfns, setSelectedIfns] = useState<any>(null);
   const [budget, setBudget] = useState('');
-  const [publicVisible, setPublicVisible] = useState(false);
   const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
   const [fileError, setFileError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
@@ -210,7 +208,7 @@ export default function CreateRequestScreen() {
         title: title.trim(),
         description: description.trim(),
         city: effectiveCity,
-        isPublic: publicVisible,
+        isPublic: false,
       };
       if (selectedIfns) {
         body.ifnsId = selectedIfns.id;
@@ -396,16 +394,6 @@ export default function CreateRequestScreen() {
               </View>
               <Text className="text-xs text-textMuted">PDF, JPG, PNG до 10 МБ. Макс. {MAX_FILES} файлов.</Text>
               {fileError && <Text className="text-xs text-statusError">{fileError}</Text>}
-            </View>
-
-            {/* Public toggle */}
-            <View className="mb-4 py-1">
-              <Toggle
-                value={publicVisible}
-                onValueChange={setPublicVisible}
-                label="Показать неавторизованным"
-                sublabel="Заявку увидят без входа в аккаунт"
-              />
             </View>
 
             {/* Submit (inline, not sticky) */}

--- a/lib/adminEmails.ts
+++ b/lib/adminEmails.ts
@@ -1,7 +1,6 @@
 // Admin emails are loaded from EXPO_PUBLIC_ADMIN_EMAILS env var (comma-separated).
-// If the env var is not set (e.g. local dev without Doppler), falls back to dev email.
-// Never hardcode production emails here.
-const raw = process.env.EXPO_PUBLIC_ADMIN_EMAILS ?? 'admin@p2ptax.ru,dev@p2ptax.ru';
+// If the env var is not set, defaults to empty array (no admins).
+const raw = process.env.EXPO_PUBLIC_ADMIN_EMAILS ?? '';
 
 export const ADMIN_EMAILS: string[] = raw
   .split(',')

--- a/lib/hooks/useChat.ts
+++ b/lib/hooks/useChat.ts
@@ -2,7 +2,6 @@ import { useEffect, useState, useRef, useCallback } from 'react';
 import { api } from '../api';
 import {
   getSocket,
-  disconnectSocket,
   useSocket,
   type TypedSocket,
   type MessageReceivedEvent,
@@ -208,7 +207,6 @@ export function useChat({ threadId, userId, token }: UseChatOptions): UseChatRet
       socket.off('typing:start', onTyping);
       socket.off('typing', onTyping);
       if (typingTimer.current) clearTimeout(typingTimer.current);
-      disconnectSocket();
     };
   }, [token, threadId, userId]);
 


### PR DESCRIPTION
## Summary
- **#6**: Remove hardcoded admin emails from frontend bundle — env var only, empty array fallback
- **#7**: Active tab filter includes NEW, IN_PROGRESS, CLOSING_SOON (was OPEN only)
- **#8**: ResponseItem uses `comment` field matching API (was `message`)
- **#9**: useChat cleanup unsubscribes without destroying global socket
- **#10**: Remove non-functional isPublic toggle from new request form
- **#11**: Batch N+1 queries in syncJoinTables using createMany
- **#13**: Add missing status labels (NEW, IN_PROGRESS, CLOSING_SOON, CANCELLED) with Russian text and colors

Skipped #12 and #14 (specialist/[id].tsx being deleted by another agent).

## Test plan
- [ ] Verify admin check works only when EXPO_PUBLIC_ADMIN_EMAILS is set
- [ ] Verify active tab shows requests with NEW/IN_PROGRESS/CLOSING_SOON statuses
- [ ] Verify response comments render correctly on request detail page
- [ ] Verify chat socket persists across navigation
- [ ] Verify new request form has no isPublic toggle
- [ ] Verify specialist profile creation with fnsServices doesn't N+1

🤖 Generated with [Claude Code](https://claude.com/claude-code)