### PR TITLE
fix: repair broken navigation routes and Russian labels

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -33,7 +33,7 @@ function AuthHeader() {
           fontSize: Typography.fontSize.lg,
           fontWeight: Typography.fontWeight.bold,
           color: Colors.textPrimary,
-        }}>Nalogovik</Text>
+        }}>Налоговик</Text>
       </View>
     </View>
   );

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -160,7 +160,7 @@ export default function ProfileScreen() {
               <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
             </View>
             <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
-              Шаг 3 из 3
+              Шаг 5 из 5
             </Text>
 
             {/* Header */}

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -151,7 +151,7 @@ export default function UsernameScreen() {
             <View className="mb-1 h-1 rounded-full bg-bgSecondary">
               <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '33%' }} />
             </View>
-            <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 1 из 3</Text>
+            <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 1 из 5</Text>
 
             {/* Header */}
             <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -18,18 +18,18 @@ interface TabConfig {
 
 // Prototype: Client tabs — home, file-text, message-circle, user
 const CLIENT_TABS: TabConfig[] = [
-  { name: 'dashboard', title: 'Glavnaya', icon: 'home' },
-  { name: 'requests', title: 'Zayavki', icon: 'file-text' },
-  { name: 'messages', title: 'Soobscheniya', icon: 'message-circle' },
-  { name: 'profile', title: 'Profil', icon: 'user' },
+  { name: 'dashboard', title: 'Главная', icon: 'home' },
+  { name: 'requests', title: 'Заявки', icon: 'file-text' },
+  { name: 'messages', title: 'Сообщения', icon: 'message-circle' },
+  { name: 'profile', title: 'Профиль', icon: 'user' },
 ];
 
 // Prototype: Specialist tabs — briefcase, send, message-circle, user
 const SPECIALIST_TABS: TabConfig[] = [
-  { name: 'feed', title: 'Kabinet', icon: 'briefcase' },
-  { name: 'my-responses', title: 'Otkliki', icon: 'send' },
-  { name: 'messages', title: 'Soobscheniya', icon: 'message-circle' },
-  { name: 'dashboard', title: 'Profil', icon: 'user' },
+  { name: 'feed', title: 'Кабинет', icon: 'briefcase' },
+  { name: 'my-responses', title: 'Отклики', icon: 'send' },
+  { name: 'messages', title: 'Сообщения', icon: 'message-circle' },
+  { name: 'dashboard', title: 'Профиль', icon: 'user' },
 ];
 
 const ALL_TAB_NAMES = ['dashboard', 'requests', 'messages', 'settings', 'feed', 'my-responses', 'profile'];
@@ -39,16 +39,16 @@ function buildClientSidebarNav(unreadNotifs: number): NavGroup[] {
   return [
     {
       items: [
-        { label: 'Glavnaya', icon: 'home', route: '/(tabs)/dashboard', segment: 'dashboard' },
-        { label: 'Zayavki', icon: 'file-text', route: '/(tabs)/requests', segment: 'requests' },
+        { label: 'Главная', icon: 'home', route: '/(tabs)/dashboard', segment: 'dashboard' },
+        { label: 'Заявки', icon: 'file-text', route: '/(tabs)/requests', segment: 'requests' },
       ],
     },
     {
-      label: 'Lichnoe',
+      label: 'Личное',
       items: [
-        { label: 'Soobscheniya', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
-        { label: 'Uvedomleniya', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
-        { label: 'Profil', icon: 'user', route: '/(tabs)/profile', segment: 'profile' },
+        { label: 'Сообщения', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
+        { label: 'Уведомления', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
+        { label: 'Профиль', icon: 'user', route: '/(tabs)/profile', segment: 'profile' },
       ],
     },
   ];
@@ -58,16 +58,16 @@ function buildSpecialistSidebarNav(unreadNotifs: number): NavGroup[] {
   return [
     {
       items: [
-        { label: 'Kabinet', icon: 'briefcase', route: '/(tabs)/feed', segment: 'feed' },
-        { label: 'Otkliki', icon: 'send', route: '/(tabs)/my-responses', segment: 'my-responses' },
+        { label: 'Кабинет', icon: 'briefcase', route: '/(tabs)/feed', segment: 'feed' },
+        { label: 'Отклики', icon: 'send', route: '/(tabs)/my-responses', segment: 'my-responses' },
       ],
     },
     {
-      label: 'Lichnoe',
+      label: 'Личное',
       items: [
-        { label: 'Soobscheniya', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
-        { label: 'Uvedomleniya', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
-        { label: 'Profil', icon: 'user', route: '/(tabs)/dashboard', segment: 'dashboard' },
+        { label: 'Сообщения', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
+        { label: 'Уведомления', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
+        { label: 'Профиль', icon: 'user', route: '/(tabs)/dashboard', segment: 'dashboard' },
       ],
     },
   ];

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -139,7 +139,7 @@ function QuickActions() {
     <View className="flex-row gap-2">
       <Pressable
         className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl bg-brandPrimary"
-        onPress={() => router.push('/create-request')}
+        onPress={() => router.push('/(dashboard)/my-requests/new')}
       >
         <Feather name="plus" size={16} color={Colors.white} />
         <Text className="text-sm font-semibold text-white">Новая заявка</Text>
@@ -332,7 +332,7 @@ function EmptyDashboard({ userName }: { userName: string }) {
         </Text>
         <Pressable
           className="mt-2 h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary"
-          onPress={() => router.push('/create-request')}
+          onPress={() => router.push('/(dashboard)/my-requests/new')}
         >
           <Feather name="plus" size={18} color={Colors.white} />
           <Text className="text-base font-semibold text-white">Создать первую заявку</Text>
@@ -525,7 +525,7 @@ export default function DashboardTab() {
           {sc.newStatus === 'COMPLETED' && (
             <Pressable
               className="h-9 flex-row items-center justify-center gap-1.5 rounded-lg border border-borderLight bg-white"
-              onPress={() => router.push(`/request/${sc.requestId}`)}
+              onPress={() => router.push(`/(dashboard)/my-requests/${sc.requestId}`)}
             >
               <Feather name="star" size={14} color={Colors.statusWarning} />
               <Text className="text-sm font-medium text-textPrimary">Оставить отзыв</Text>
@@ -595,7 +595,7 @@ export default function DashboardTab() {
             <RequestCard
               key={req.id}
               item={req}
-              onPress={() => router.push(`/request/${req.id}`)}
+              onPress={() => router.push(`/(dashboard)/my-requests/${req.id}`)}
             />
           ))
         ) : (

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -272,11 +272,11 @@ export default function RequestsTab() {
     tab === 'active' ? activeRequests : tab === 'completed' ? completedRequests : allRequests;
 
   const goToCreate = () => {
-    router.push('/request/new' as never);
+    router.push('/(dashboard)/my-requests/new' as never);
   };
 
   const goToDetail = (id: string) => {
-    router.push(`/request/${id}` as never);
+    router.push(`/(dashboard)/my-requests/${id}` as never);
   };
 
   const tabs: { key: TabKey; label: string; count: number }[] = [

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -297,9 +297,6 @@ export default function SettingsTab() {
             <Text className="ml-2 flex-1 text-base text-textSecondary">
               {displayPhone || '\u2014'}
             </Text>
-            <Pressable hitSlop={8} onPress={() => router.push('/profile/edit')}>
-              <Feather name="edit-2" size={16} color={Colors.brandPrimary} />
-            </Pressable>
           </View>
         </View>
       </View>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -186,7 +186,7 @@ export default function NotificationsScreen() {
         (item.type === 'NEW_RESPONSE' || item.type === 'REQUEST_UPDATE') &&
         data.requestId
       ) {
-        router.push(`/request/${data.requestId}`);
+        router.push(`/(dashboard)/my-requests/${data.requestId}`);
       } else if (item.type === 'REVIEW') {
         router.push('/(tabs)/dashboard');
       }

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -156,7 +156,7 @@ export default function SearchScreen() {
     if (item._type === 'request') {
       return (
         <Pressable
-          onPress={() => router.push(`/request/${item.id}` as any)}
+          onPress={() => router.push(`/(dashboard)/my-requests/${item.id}` as any)}
           className="bg-bgCard border border-border rounded-lg p-3 mb-2 shadow-sm"
         >
           <View className="flex-row items-center gap-1 mb-2">

--- a/components/LandingHeader.tsx
+++ b/components/LandingHeader.tsx
@@ -20,10 +20,10 @@ interface NavLinkConfig {
 }
 
 const NAV_LINKS: NavLinkConfig[] = [
-  { label: 'Glavnaya', route: '/', segment: '(index)' },
-  { label: 'Specialisty', route: '/specialists', segment: 'specialists' },
-  { label: 'Zayavki', route: '/requests', segment: 'requests' },
-  { label: 'Tarify', route: '/pricing', segment: 'pricing' },
+  { label: 'Главная', route: '/', segment: '(index)' },
+  { label: 'Специалисты', route: '/specialists', segment: 'specialists' },
+  { label: 'Заявки', route: '/requests', segment: 'requests' },
+  { label: 'Тарифы', route: '/pricing', segment: 'pricing' },
 ];
 
 function LogoBlock({ onPress }: { onPress?: () => void }) {
@@ -43,7 +43,7 @@ function LogoBlock({ onPress }: { onPress?: () => void }) {
         fontSize: Typography.fontSize.lg,
         fontWeight: Typography.fontWeight.bold,
         color: Colors.textPrimary,
-      }}>Nalogovik</Text>
+      }}>Налоговик</Text>
     </Pressable>
   );
 }
@@ -158,7 +158,7 @@ export function LandingHeader() {
                 color: Colors.white,
                 fontSize: Typography.fontSize.sm,
                 fontWeight: Typography.fontWeight.semibold,
-              }}>Kabinet</Text>
+              }}>Кабинет</Text>
             </Pressable>
           </View>
         ) : (
@@ -177,7 +177,7 @@ export function LandingHeader() {
                 color: Colors.brandPrimary,
                 fontSize: Typography.fontSize.sm,
                 fontWeight: Typography.fontWeight.semibold,
-              }}>Voyti</Text>
+              }}>Войти</Text>
             </Pressable>
             <Pressable
               onPress={() => router.push('/(auth)/email?role=SPECIALIST')}
@@ -192,7 +192,7 @@ export function LandingHeader() {
                 color: Colors.white,
                 fontSize: Typography.fontSize.sm,
                 fontWeight: Typography.fontWeight.semibold,
-              }}>Razmestit zayavku</Text>
+              }}>Разместить заявку</Text>
             </Pressable>
           </View>
         )}
@@ -301,7 +301,7 @@ export function LandingHeader() {
                 color: Colors.white,
                 fontSize: Typography.fontSize.sm,
                 fontWeight: Typography.fontWeight.semibold,
-              }}>Kabinet</Text>
+              }}>Кабинет</Text>
             </Pressable>
           ) : (
             <View style={{ gap: Spacing.sm }}>
@@ -319,7 +319,7 @@ export function LandingHeader() {
                   color: Colors.brandPrimary,
                   fontSize: Typography.fontSize.sm,
                   fontWeight: Typography.fontWeight.semibold,
-                }}>Voyti</Text>
+                }}>Войти</Text>
               </Pressable>
               <Pressable
                 onPress={() => { setMenuOpen(false); router.push('/(auth)/email?role=SPECIALIST'); }}
@@ -334,7 +334,7 @@ export function LandingHeader() {
                   color: Colors.white,
                   fontSize: Typography.fontSize.sm,
                   fontWeight: Typography.fontWeight.semibold,
-                }}>Razmestit zayavku</Text>
+                }}>Разместить заявку</Text>
               </Pressable>
             </View>
           )}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -140,7 +140,7 @@ export function Sidebar({ items, userEmail, onLogout, width }: SidebarProps) {
           fontSize: Typography.fontSize.lg,
           fontWeight: Typography.fontWeight.bold,
           color: Colors.textPrimary,
-        }}>Nalogovik</Text>
+        }}>Налоговик</Text>
       </Pressable>
 
       {/* Nav groups */}
@@ -199,7 +199,7 @@ export function Sidebar({ items, userEmail, onLogout, width }: SidebarProps) {
               fontSize: Typography.fontSize.sm,
               color: Colors.statusError,
               fontWeight: Typography.fontWeight.medium,
-            }}>Vyiti</Text>
+            }}>Выйти</Text>
           </Pressable>
         ) : null}
       </View>


### PR DESCRIPTION
## Summary
- Fix all broken `/create-request`, `/request/:id`, `/request/new` routes to use `/(dashboard)/my-requests/...` across dashboard, requests, notifications, and search pages
- Remove dead `/profile/edit` link from settings phone edit button
- Replace all transliterated labels (Glavnaya, Zayavki, Voyti, etc.) with proper Russian across tabs, sidebar, and landing header
- Fix onboarding step counters (1/3 -> 1/5, 3/3 -> 5/5)

## Test plan
- [ ] Verify dashboard "new request" button navigates correctly
- [ ] Verify request cards navigate to detail page
- [ ] Verify notification tap navigates to correct request
- [ ] Verify all UI labels display in Russian
- [ ] Verify onboarding shows correct step numbers

Generated with Claude Code