### PR TITLE
fix: align nav, OTP, settings with proto states

### DIFF
--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { View, Text, Pressable, TextInput, SafeAreaView, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, Pressable, TextInput, SafeAreaView, ScrollView, KeyboardAvoidingView, Platform, ActivityIndicator } from 'react-native';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import { api, ApiError, setRefreshToken } from '../../lib/api';
 import { useAuth } from '../../stores/authStore';
 import { secureStorage } from '../../stores/storage';
+import { Colors } from '../../constants/Colors';
 
 const CODE_LENGTH = 6;
 const RESEND_SECONDS = 60;
@@ -201,44 +202,40 @@ export default function OtpScreen() {
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps="handled"
         >
-          <View className="flex-1 items-center px-4 py-8">
+          <View className="flex-1 items-center px-6 py-6" style={{ gap: 24 }}>
             {/* Back */}
-            <View className="w-full max-w-sm">
+            <View className="w-full" style={{ maxWidth: 300 }}>
               <Pressable
                 onPress={() => router.back()}
                 className="flex-row items-center gap-1 py-1"
                 accessibilityRole="button"
                 accessibilityLabel="Изменить email"
               >
-                <Feather name="arrow-left" size={20} color="#475569" />
-                <Text className="text-sm text-textSecondary">Изменить email</Text>
+                <Feather name="arrow-left" size={20} color={Colors.brandPrimary} />
+                <Text className="text-sm" style={{ color: Colors.brandPrimary }}>Изменить email</Text>
               </Pressable>
             </View>
 
-            {/* Header */}
-            <View className="mt-6 items-center gap-2">
-              <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
-                <Feather name="mail" size={28} color="#0284C7" />
-              </View>
-              <Text className="text-xl font-bold text-textPrimary">Введите код</Text>
-              <View className="flex-row flex-wrap justify-center items-center">
-                <Text className="text-base text-textMuted">Код отправлен на </Text>
-                <Text className="text-base font-medium text-textPrimary">{email}</Text>
-              </View>
+            {/* Header — matching proto: title + subtitle with email */}
+            <View className="items-center" style={{ gap: 4, marginTop: 24 }}>
+              <Text className="text-xl font-bold" style={{ color: Colors.textPrimary }}>Введите код</Text>
+              <Text className="text-sm" style={{ color: Colors.textMuted }}>Код отправлен на {email}</Text>
             </View>
 
-            {/* OTP inputs */}
-            <View className="mt-5 flex-row justify-center gap-2">
+            {/* OTP inputs — proto: 44x52, border 1.5, borderRadius 6 */}
+            <View className="flex-row justify-center" style={{ gap: 8 }}>
               {[0, 1, 2, 3, 4, 5].map((i) => (
                 <View
                   key={i}
-                  className={`h-14 w-12 items-center justify-center rounded-lg border-2 ${
-                    error
-                      ? 'border-red-500 bg-red-50'
-                      : digits[i]
-                        ? 'border-brandPrimary bg-bgSecondary'
-                        : 'border-gray-200 bg-white'
-                  }`}
+                  className="items-center justify-center"
+                  style={{
+                    width: 44,
+                    height: 52,
+                    borderWidth: 1.5,
+                    borderColor: error ? Colors.statusError : digits[i] ? Colors.brandPrimary : Colors.border,
+                    borderRadius: 6,
+                    backgroundColor: Colors.bgCard,
+                  }}
                 >
                   <TextInput
                     ref={(ref) => { inputRefs.current[i] = ref; }}
@@ -249,77 +246,72 @@ export default function OtpScreen() {
                     maxLength={CODE_LENGTH}
                     selectTextOnFocus
                     editable={!loading}
-                    className="h-full w-full text-center text-2xl font-bold text-textPrimary"
-                    style={{ outlineStyle: 'none' as any }}
+                    className="h-full w-full text-center font-bold"
+                    style={{
+                      fontSize: 22,
+                      color: error ? Colors.statusError : Colors.textPrimary,
+                      outlineStyle: 'none' as any,
+                    }}
                   />
                 </View>
               ))}
             </View>
 
-            {/* Error */}
+            {/* Error — proto: simple text, xs size */}
             {error ? (
-              <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-                <Feather name="alert-circle" size={14} color="#DC2626" />
-                <Text className="text-sm font-medium text-red-600">{error}</Text>
-              </View>
+              <Text className="text-center" style={{ fontSize: 11, color: Colors.statusError }}>{error}</Text>
             ) : null}
 
             {/* Attempt counter */}
             {attemptsUsed > 0 && attemptsUsed < MAX_ATTEMPTS && (
-              <Text className="mt-2 text-sm text-textMuted">
+              <Text className="text-sm" style={{ color: Colors.textMuted }}>
                 Попытка {attemptsUsed} из {MAX_ATTEMPTS}
               </Text>
             )}
 
             {/* Max attempts reached */}
             {attemptsUsed >= MAX_ATTEMPTS && (
-              <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-                <Feather name="alert-circle" size={14} color="#DC2626" />
-                <Text className="text-sm font-medium text-red-600">
-                  Превышено количество попыток. Запросите новый код.
-                </Text>
-              </View>
+              <Text className="text-center" style={{ fontSize: 11, color: Colors.statusError }}>
+                Превышено количество попыток. Запросите новый код.
+              </Text>
             )}
 
-            {/* Submit */}
+            {/* Submit — proto: h48, maxWidth 300, borderRadius 6 */}
             <Pressable
               onPress={handleVerify}
               disabled={loading || !isComplete || attemptsUsed >= MAX_ATTEMPTS}
-              className={`mt-4 h-12 w-full max-w-xs items-center justify-center rounded-lg bg-brandPrimary ${
-                loading || !isComplete || attemptsUsed >= MAX_ATTEMPTS ? 'opacity-60' : ''
-              }`}
+              className="items-center justify-center w-full"
+              style={{
+                height: 48,
+                backgroundColor: Colors.brandPrimary,
+                borderRadius: 6,
+                maxWidth: 300,
+                opacity: loading || !isComplete || attemptsUsed >= MAX_ATTEMPTS ? 0.7 : 1,
+              }}
             >
-              <Text className="text-base font-semibold text-white">
-                {loading ? 'Проверка...' : 'Подтвердить'}
-              </Text>
+              {loading ? (
+                <ActivityIndicator size="small" color={Colors.white} />
+              ) : (
+                <Text className="font-semibold" style={{ fontSize: 15, color: Colors.white }}>Подтвердить</Text>
+              )}
             </Pressable>
 
-            {/* Resend */}
-            <View className="mt-3 flex-row items-center gap-1">
-              {timer > 0 ? (
-                <>
-                  <Feather name="clock" size={14} color="#94A3B8" />
-                  <Text className="text-sm text-textMuted">
-                    Отправить повторно через {timer} сек
-                  </Text>
-                </>
-              ) : (
-                <Pressable
-                  onPress={handleResend}
-                  disabled={resending}
-                  className="flex-row items-center gap-1"
-                >
-                  <Feather name="refresh-cw" size={14} color="#0284C7" />
-                  <Text className="text-sm font-medium text-brandPrimary">
-                    {resending ? 'Отправляем...' : 'Отправить код повторно'}
-                  </Text>
-                </Pressable>
-              )}
-            </View>
+            {/* Resend — proto: plain text, no icons */}
+            {timer > 0 ? (
+              <Text className="text-sm" style={{ color: Colors.textMuted }}>
+                Отправить код повторно через {timer} сек
+              </Text>
+            ) : (
+              <Pressable onPress={handleResend} disabled={resending}>
+                <Text className="text-sm font-medium" style={{ color: Colors.brandPrimary }}>
+                  {resending ? 'Отправляем...' : 'Отправить код повторно'}
+                </Text>
+              </Pressable>
+            )}
 
             {/* Dev mode hint */}
             {isDev && (
-              <View className="mt-6 rounded-lg bg-yellow-50 border border-yellow-200 px-4 py-3">
+              <View className="rounded-lg bg-yellow-50 border border-yellow-200 px-4 py-3">
                 <Text className="text-xs text-yellow-700">
                   В режиме разработки код: 000000
                 </Text>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -49,6 +49,7 @@ function buildClientSidebarNav(unreadNotifs: number): NavGroup[] {
         { label: 'Сообщения', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
         { label: 'Уведомления', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
         { label: 'Профиль', icon: 'user', route: '/(tabs)/profile', segment: 'profile' },
+        { label: 'Настройки', icon: 'settings', route: '/(tabs)/settings', segment: 'settings' },
       ],
     },
   ];
@@ -68,6 +69,7 @@ function buildSpecialistSidebarNav(unreadNotifs: number): NavGroup[] {
         { label: 'Сообщения', icon: 'message-circle', route: '/(tabs)/messages', segment: 'messages' },
         { label: 'Уведомления', icon: 'bell', route: '/notifications', segment: 'notifications', badgeCount: unreadNotifs },
         { label: 'Профиль', icon: 'user', route: '/(tabs)/dashboard', segment: 'dashboard' },
+        { label: 'Настройки', icon: 'settings', route: '/(tabs)/settings', segment: 'settings' },
       ],
     },
   ];
@@ -102,14 +104,17 @@ export default function TabsLayout() {
         tabBarStyle: isMobile
           ? {
               backgroundColor: Colors.bgCard,
-              borderTopColor: Colors.borderLight,
+              borderTopColor: Colors.border,
               borderTopWidth: 1,
-              height: 60,
+              height: 56,
             }
           : { display: 'none' },
         tabBarLabelStyle: {
           fontSize: 10,
-          fontWeight: '600',
+          fontWeight: '500',
+        },
+        tabBarItemStyle: {
+          gap: 2,
         },
       }}
     >

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -9,7 +9,6 @@ import {
   Alert,
   Platform,
 } from 'react-native';
-import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useAuth } from '../../stores/authStore';
 import { api } from '../../lib/api';
@@ -35,9 +34,11 @@ interface SpecialistProfile {
 const APP_VERSION = '1.0.0';
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// Sub-components — matching proto SettingsStates
 // ---------------------------------------------------------------------------
-function Toggle({
+
+/** Proto-matching toggle: 44x24 track, 20x20 dot */
+function ToggleRow({
   label,
   value,
   onValueChange,
@@ -48,31 +49,113 @@ function Toggle({
   onValueChange: (v: boolean) => void;
   disabled?: boolean;
 }) {
-  const trackColor = value ? Colors.brandPrimary : '#D1D5DB';
   return (
     <Pressable
       className="flex-row items-center justify-between"
+      style={{
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: Colors.bgSecondary,
+        opacity: disabled ? 0.5 : 1,
+      }}
       onPress={() => !disabled && onValueChange(!value)}
-      style={{ opacity: disabled ? 0.5 : 1 }}
     >
-      <Text className="mr-3 flex-1 text-sm text-textSecondary">{label}</Text>
+      <Text className="flex-1 text-sm" style={{ color: Colors.textPrimary }}>{label}</Text>
       <View
-        className="h-7 w-12 justify-center rounded-full px-0.5"
-        style={{ backgroundColor: trackColor }}
+        className="justify-center"
+        style={{
+          width: 44,
+          height: 24,
+          borderRadius: 12,
+          backgroundColor: value ? Colors.brandPrimary : Colors.border,
+          paddingHorizontal: 2,
+        }}
       >
         <View
-          className="h-[22px] w-[22px] rounded-full bg-white"
+          className="rounded-full bg-white"
           style={{
+            width: 20,
+            height: 20,
+            borderRadius: 10,
             alignSelf: value ? 'flex-end' : 'flex-start',
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: 1 },
-            shadowOpacity: 0.2,
-            shadowRadius: 2,
-            elevation: 2,
           }}
         />
       </View>
     </Pressable>
+  );
+}
+
+/** Proto-matching setting row with label, optional value, and ">" arrow */
+function SettingRow({
+  label,
+  value,
+  danger,
+  onPress,
+}: {
+  label: string;
+  value?: string;
+  danger?: boolean;
+  onPress?: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center justify-between"
+      style={{
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: Colors.bgSecondary,
+      }}
+    >
+      <Text
+        className="flex-1 text-sm"
+        style={{ color: danger ? Colors.statusError : Colors.textPrimary }}
+      >
+        {label}
+      </Text>
+      {value ? (
+        <Text className="text-sm" style={{ color: Colors.textMuted, marginRight: 8 }}>
+          {value}
+        </Text>
+      ) : null}
+      <Text className="text-sm" style={{ color: Colors.textMuted }}>{'>'}</Text>
+    </Pressable>
+  );
+}
+
+/** Proto-matching section title: uppercase, letterSpacing */
+function SectionTitle({ text }: { text: string }) {
+  return (
+    <Text
+      className="font-semibold"
+      style={{
+        fontSize: 13,
+        color: Colors.textMuted,
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+      }}
+    >
+      {text}
+    </Text>
+  );
+}
+
+/** Proto-matching card wrapper */
+function Card({ children, danger }: { children: React.ReactNode; danger?: boolean }) {
+  return (
+    <View
+      style={{
+        backgroundColor: Colors.bgCard,
+        borderRadius: 6,
+        borderWidth: 1,
+        borderColor: danger ? Colors.statusBg.error : Colors.border,
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </View>
   );
 }
 
@@ -256,12 +339,11 @@ export default function SettingsTab() {
   }, [logout, router]);
 
   const displayEmail = user?.email || '';
-  const displayPhone = profile?.phone || null;
 
   return (
     <ScrollView
       className="flex-1 bg-white"
-      contentContainerStyle={{ padding: 16, gap: 20 }}
+      contentContainerStyle={{ padding: 16, gap: 16 }}
       keyboardShouldPersistTaps="handled"
       refreshControl={
         <RefreshControl
@@ -271,90 +353,91 @@ export default function SettingsTab() {
         />
       }
     >
-      {/* Page title */}
-      <Text className="text-xl font-bold text-textPrimary">Настройки</Text>
+      {/* Page title — proto: lg/bold */}
+      <Text
+        className="font-bold"
+        style={{ fontSize: 18, color: Colors.textPrimary }}
+      >
+        Настройки
+      </Text>
 
-      {/* ============ Account card ============ */}
-      <View className="gap-3 rounded-xl border border-borderLight p-4">
-        <Text className="text-base font-semibold text-textPrimary">Аккаунт</Text>
-
-        {/* Email — read-only */}
-        <View className="gap-1">
-          <Text className="text-sm font-medium text-textMuted">Email</Text>
-          <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
-            <Feather name="mail" size={16} color={Colors.textMuted} />
-            <Text className="ml-2 flex-1 text-base text-textSecondary" numberOfLines={1}>
-              {displayEmail || '\u2014'}
-            </Text>
-          </View>
-        </View>
-
-        {/* Phone — with edit icon (matching proto) */}
-        <View className="gap-1">
-          <Text className="text-sm font-medium text-textMuted">Телефон</Text>
-          <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
-            <Feather name="phone" size={16} color={Colors.textMuted} />
-            <Text className="ml-2 flex-1 text-base text-textSecondary">
-              {displayPhone || '\u2014'}
-            </Text>
-          </View>
-        </View>
-      </View>
-
-      {/* ============ Notifications (2 toggles matching proto) ============ */}
-      <View className="gap-3 rounded-xl border border-borderLight p-4">
-        <Text className="text-base font-semibold text-textPrimary">Уведомления</Text>
-        <Toggle
-          label="Email-уведомления"
-          value={notifSettings.new_responses}
-          onValueChange={(v) => handleNotifToggle('new_responses', v)}
-        />
-        <Toggle
-          label="Push-уведомления"
-          value={notifSettings.new_messages}
-          onValueChange={(v) => handleNotifToggle('new_messages', v)}
-        />
-      </View>
-
-      {/* ============ Public profile toggle (matching proto) ============ */}
-      {isSpecialist && (
-        <View className="gap-3 rounded-xl border border-borderLight p-4">
-          <Text className="text-base font-semibold text-textPrimary">Публичный профиль</Text>
-          <Toggle
-            label="Профиль виден всем"
-            value={publicProfile}
-            onValueChange={handleTogglePublicProfile}
-            disabled={savingPublicProfile}
+      {/* ============ Notifications — proto order: first section ============ */}
+      <View style={{ gap: 8 }}>
+        <SectionTitle text="Уведомления" />
+        <Card>
+          <ToggleRow
+            label="Email-уведомления"
+            value={notifSettings.new_responses}
+            onValueChange={(v) => handleNotifToggle('new_responses', v)}
           />
+          <ToggleRow
+            label="Push-уведомления"
+            value={notifSettings.new_messages}
+            onValueChange={(v) => handleNotifToggle('new_messages', v)}
+          />
+        </Card>
+      </View>
+
+      {/* ============ Account — proto: rows with value + arrow ============ */}
+      <View style={{ gap: 8 }}>
+        <SectionTitle text="Аккаунт" />
+        <Card>
+          <SettingRow label="Email" value={displayEmail || '\u2014'} />
+          <SettingRow label="Язык" value="Русский" />
+        </Card>
+      </View>
+
+      {/* ============ Public profile toggle (specialist only) ============ */}
+      {isSpecialist && (
+        <View style={{ gap: 8 }}>
+          <SectionTitle text="Публичный профиль" />
+          <Card>
+            <ToggleRow
+              label="Профиль виден всем"
+              value={publicProfile}
+              onValueChange={handleTogglePublicProfile}
+              disabled={savingPublicProfile}
+            />
+          </Card>
         </View>
       )}
+
+      {/* ============ Other — proto: privacy, terms, version ============ */}
+      <View style={{ gap: 8 }}>
+        <SectionTitle text="Прочее" />
+        <Card>
+          <SettingRow label="Политика конфиденциальности" />
+          <SettingRow label="Условия использования" />
+          <SettingRow label="Версия" value={APP_VERSION} />
+        </Card>
+      </View>
 
       {/* ============ Admin ============ */}
       {isAdmin(user?.email) && (
-        <View className="gap-3 rounded-xl border border-borderLight p-4">
-          <Text className="text-base font-semibold text-textPrimary">Администрирование</Text>
-          <Pressable
-            className="h-10 flex-row items-center justify-center gap-2 rounded-lg border border-borderLight"
-            onPress={() => router.push('/(admin)')}
-          >
-            <Feather name="shield" size={16} color={Colors.textMuted} />
-            <Text className="text-sm font-medium text-textPrimary">Панель администратора</Text>
-            <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-          </Pressable>
+        <View style={{ gap: 8 }}>
+          <SectionTitle text="Администрирование" />
+          <Card>
+            <SettingRow
+              label="Панель администратора"
+              onPress={() => router.push('/(admin)')}
+            />
+          </Card>
         </View>
       )}
 
-      {/* ============ Logout ============ */}
-      <Pressable
-        className="h-12 flex-row items-center justify-center gap-2 rounded-xl"
-        style={{ backgroundColor: Colors.statusBg.error }}
-        onPress={() => setShowLogoutConfirm(true)}
-      >
-        <Feather name="log-out" size={18} color={Colors.statusError} />
-        <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
-          Выйти из аккаунта
-        </Text>
-      </Pressable>
+      {/* ============ Danger zone — proto: error border card ============ */}
+      <Card danger>
+        <SettingRow
+          label="Выйти из аккаунта"
+          danger
+          onPress={() => setShowLogoutConfirm(true)}
+        />
+        <SettingRow
+          label="Удалить аккаунт"
+          danger
+          onPress={() => setShowDeleteConfirm(true)}
+        />
+      </Card>
 
       {showLogoutConfirm && (
         <ConfirmCard
@@ -366,18 +449,6 @@ export default function SettingsTab() {
         />
       )}
 
-      {/* ============ Delete account ============ */}
-      <Pressable
-        className="h-12 flex-row items-center justify-center gap-2 rounded-xl border"
-        style={{ borderColor: Colors.statusBg.error }}
-        onPress={() => setShowDeleteConfirm(true)}
-      >
-        <Feather name="trash-2" size={18} color={Colors.statusError} />
-        <Text className="text-base font-semibold" style={{ color: Colors.statusError }}>
-          Удалить аккаунт
-        </Text>
-      </Pressable>
-
       {showDeleteConfirm && (
         <ConfirmCard
           message="Это действие необратимо. Все ваши данные будут удалены."
@@ -387,11 +458,6 @@ export default function SettingsTab() {
           loading={deleteLoading}
         />
       )}
-
-      {/* Version */}
-      <Text className="text-xs text-center text-textMuted">
-        Версия {APP_VERSION}
-      </Text>
     </ScrollView>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -55,9 +55,9 @@ export function Sidebar({ items, userEmail, onLogout, width }: SidebarProps) {
           paddingHorizontal: Spacing.md,
           borderRadius: BorderRadius.md,
           ...(active ? {
-            backgroundColor: Colors.brandPrimary + '22',
-            borderWidth: 1,
-            borderColor: Colors.brandPrimary + '44',
+            backgroundColor: Colors.brandPrimary + '10',
+            borderLeftWidth: 3,
+            borderLeftColor: Colors.brandPrimary,
           } : {}),
         }}
         onPress={() => router.push(item.route as any)}


### PR DESCRIPTION
## Summary
- Tab bar: height 56px, border color, gap matching proto NavComponents
- Sidebar: active state with blue left border, added Settings nav link
- OTP page: box sizes 44x52, border 1.5, simplified error/resend text, ActivityIndicator on loading
- Settings: restructured to proto layout (Notifications > Account > Other > Danger zone), proto-matching toggle 44x24, setting rows with arrow, uppercase section titles

## Test plan
- [ ] Verify mobile bottom tab bar matches proto tab bar styling
- [ ] Verify sidebar active state shows blue left border on desktop
- [ ] Verify OTP page code boxes match proto dimensions and styling
- [ ] Verify Settings page sections match proto order and card structure
- [ ] Verify toggle dimensions match proto (44x24 track, 20x20 dot)