### PR TITLE
feat: convert proto states to real app pages

### DIFF
--- a/app/(admin)/_layout.tsx
+++ b/app/(admin)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function AdminLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_ADMIN_STATS } from '../../constants/protoMockData';
+
+function StatCard({ label, value, color, trend, icon }: { label: string; value: string | number; color: string; trend?: string; icon: string }) {
+  return (
+    <View className="w-[48%] gap-1 rounded-xl border border-borderLight bg-white p-3 shadow-sm">
+      <View className="h-9 w-9 items-center justify-center rounded-full" style={{ backgroundColor: color + '15' }}>
+        <Feather name={icon as any} size={18} color={color} />
+      </View>
+      <Text className="text-sm text-textMuted">{label}</Text>
+      <Text className="text-[22px] font-bold" style={{ color }}>{value}</Text>
+      {trend && (
+        <View className="flex-row items-center gap-1">
+          <Feather name="trending-up" size={12} color={Colors.statusSuccess} />
+          <Text className="text-xs text-statusSuccess">{trend}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function ChartPlaceholder({ title }: { title: string }) {
+  return (
+    <View className="gap-3 rounded-xl border border-borderLight bg-white p-4 shadow-sm">
+      <Text className="text-base font-semibold text-textPrimary">{title}</Text>
+      <View className="gap-2">
+        <View className="h-[100px] flex-row items-end gap-2">
+          {[40, 65, 45, 80, 55, 70, 90].map((h, i) => (
+            <View key={i} className={`flex-1 rounded-sm ${i === 6 ? 'bg-brandPrimary' : 'bg-bgSecondary'}`} style={{ height: h }} />
+          ))}
+        </View>
+        <View className="flex-row gap-2">
+          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map((d) => (
+            <Text key={d} className="flex-1 text-center text-xs text-textMuted">{d}</Text>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const st = MOCK_ADMIN_STATS;
+
+  const activities = [
+    { icon: 'user-plus', action: 'Регистрация', detail: 'Новый пользователь: Сергей К.', time: '5 мин назад' },
+    { icon: 'file-text', action: 'Заявка', detail: 'Новая заявка: Декларация 3-НДФЛ', time: '12 мин назад' },
+    { icon: 'shield', action: 'Модерация', detail: 'Специалист ожидает проверки', time: '30 мин назад' },
+    { icon: 'star', action: 'Отзыв', detail: 'Новый отзыв от Елены В.', time: '1 час назад' },
+    { icon: 'alert-triangle', action: 'Жалоба', detail: 'Жалоба на специалиста Козлова Д.', time: '2 часа назад' },
+  ];
+
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="gap-1">
+        <Text className="text-xl font-bold text-textPrimary">Панель администратора</Text>
+        <Text className="text-sm text-textMuted">Обзор за сегодня</Text>
+      </View>
+
+      <View className="flex-row flex-wrap gap-2">
+        <StatCard label="Всего пользователей" value={st.totalUsers} color={Colors.textPrimary} trend="+23 сегодня" icon="users" />
+        <StatCard label="Специалистов" value={st.totalSpecialists} color={Colors.brandPrimary} icon="briefcase" />
+        <StatCard label="Всего заявок" value={st.totalRequests} color={Colors.textPrimary} trend="+15 сегодня" icon="file-text" />
+        <StatCard label="Активные заявки" value={st.activeRequests} color={Colors.statusSuccess} icon="check-circle" />
+        <StatCard label="На модерации" value={st.pendingModeration} color={Colors.statusWarning} icon="clock" />
+        <StatCard label="Средний рейтинг" value={st.avgRating} color={Colors.brandPrimary} icon="star" />
+      </View>
+
+      <View className="items-center gap-1 rounded-xl bg-textPrimary p-4 shadow-md">
+        <Feather name="dollar-sign" size={24} color="rgba(255,255,255,0.7)" />
+        <Text className="text-base text-white/70">Общий доход</Text>
+        <Text className="text-[28px] font-bold text-white">{st.revenue}</Text>
+        <View className="mt-1 flex-row items-center gap-1">
+          <Feather name="trending-up" size={14} color="rgba(255,255,255,0.8)" />
+          <Text className="text-xs text-white/60">+12% к прошлому месяцу</Text>
+        </View>
+      </View>
+
+      <ChartPlaceholder title="Регистрации за неделю" />
+      <ChartPlaceholder title="Заявки за неделю" />
+
+      <View className="gap-3">
+        <View className="flex-row items-center gap-2">
+          <Text className="text-lg font-semibold text-textPrimary">Последние действия</Text>
+          <View className="h-[22px] min-w-[22px] items-center justify-center rounded-full bg-brandPrimary px-1">
+            <Text className="text-xs font-bold text-white">{activities.length}</Text>
+          </View>
+        </View>
+        {activities.map((item, i) => (
+          <View key={i} className="flex-row items-center gap-3 border-b border-bgSecondary py-2">
+            <View className="h-8 w-8 items-center justify-center rounded-full" style={{ backgroundColor: Colors.brandPrimary + '15' }}>
+              <Feather name={item.icon as any} size={16} color={Colors.brandPrimary} />
+            </View>
+            <View className="flex-1 gap-0.5">
+              <Text className="text-base font-semibold text-textPrimary">
+                {item.action}: <Text className="font-normal text-textSecondary">{item.detail}</Text>
+              </Text>
+              <Text className="text-sm text-textMuted">{item.time}</Text>
+            </View>
+            <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function AuthLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}

--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export default function AuthEmailPage() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = () => {
+    if (!email || !email.includes('@')) {
+      setError('Введите корректный email адрес');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1500);
+  };
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white px-4 py-8">
+      {/* Logo */}
+      <View className="mb-8 items-center gap-2">
+        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+          <Feather name="shield" size={28} color="#0284C7" />
+        </View>
+        <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
+        <Text className="text-base text-textMuted">Найдите налогового специалиста</Text>
+      </View>
+
+      {/* Card */}
+      <View className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6">
+        <Text className="mb-1 text-center text-lg font-bold text-textPrimary">Войти или зарегистрироваться</Text>
+        <Text className="mb-4 text-center text-sm text-textMuted">Отправим код подтверждения на ваш email</Text>
+
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Email</Text>
+        <View className={`mb-2 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'} ${loading ? 'opacity-60' : ''}`}>
+          <Feather name="mail" size={18} color={error ? '#DC2626' : '#94A3B8'} />
+          <TextInput
+            value={email}
+            onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
+            placeholder="your@email.com"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' as any }}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            editable={!loading}
+          />
+          {email.length > 0 && !loading && (
+            <Pressable onPress={() => setEmail('')} hitSlop={8}>
+              <Feather name="x-circle" size={16} color="#94A3B8" />
+            </Pressable>
+          )}
+        </View>
+
+        {error ? (
+          <View className="mb-2 flex-row items-center gap-1">
+            <Feather name="alert-circle" size={14} color="#DC2626" />
+            <Text className="text-sm text-red-600">{error}</Text>
+          </View>
+        ) : null}
+
+        <Pressable
+          onPress={handleSubmit}
+          disabled={loading}
+          className={`mt-1 h-12 items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
+        >
+          <Text className="text-base font-semibold text-white">
+            {loading ? 'Отправка...' : 'Отправить код'}
+          </Text>
+        </Pressable>
+      </View>
+
+      <Text className="mt-6 text-center text-xs text-textMuted">
+        {'Нажимая кнопку, вы соглашаетесь с\nусловиями использования'}
+      </Text>
+    </View>
+  );
+}

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useRef } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export default function AuthOtpPage() {
+  const [digits, setDigits] = useState<string[]>(['', '', '', '', '', '']);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [resendTimer] = useState(57);
+  const inputRefs = useRef<(TextInput | null)[]>([]);
+
+  const handleDigitChange = (index: number, value: string) => {
+    if (value.length > 1) value = value.slice(-1);
+    if (value && !/^\d$/.test(value)) return;
+    const next = [...digits];
+    next[index] = value;
+    setDigits(next);
+    if (error) setError('');
+    if (value && index < 5) inputRefs.current[index + 1]?.focus();
+  };
+
+  const handleSubmit = () => {
+    if (digits.join('').length < 6) { setError('Введите все 6 цифр'); return; }
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1500);
+  };
+
+  return (
+    <View className="flex-1 items-center bg-white px-4 py-8">
+      {/* Back */}
+      <View className="w-full max-w-sm">
+        <Pressable className="flex-row items-center gap-1 py-1">
+          <Feather name="arrow-left" size={20} color="#475569" />
+          <Text className="text-sm text-textSecondary">Изменить email</Text>
+        </Pressable>
+      </View>
+
+      {/* Header */}
+      <View className="mt-6 items-center gap-2">
+        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+          <Feather name="mail" size={28} color="#0284C7" />
+        </View>
+        <Text className="text-xl font-bold text-textPrimary">Введите код</Text>
+        <View className="flex-row items-center">
+          <Text className="text-base text-textMuted">Код отправлен на </Text>
+          <Text className="text-base font-medium text-textPrimary">elena@mail.ru</Text>
+        </View>
+      </View>
+
+      {/* OTP inputs */}
+      <View className="mt-5 flex-row justify-center gap-2">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <View
+            key={i}
+            className={`h-14 w-12 items-center justify-center rounded-lg border-2 ${error ? 'border-red-500 bg-red-50' : digits[i] ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200 bg-white'}`}
+          >
+            <TextInput
+              ref={(ref) => { inputRefs.current[i] = ref; }}
+              value={digits[i]}
+              onChangeText={(v) => handleDigitChange(i, v)}
+              keyboardType="number-pad"
+              maxLength={1}
+              selectTextOnFocus
+              editable={!loading}
+              className="h-full w-full text-center text-2xl font-bold text-textPrimary"
+              style={{ outlineStyle: 'none' as any }}
+            />
+          </View>
+        ))}
+      </View>
+
+      {/* Error */}
+      {error ? (
+        <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm font-medium text-red-600">{error}</Text>
+        </View>
+      ) : null}
+
+      {/* Submit */}
+      <Pressable
+        onPress={handleSubmit}
+        disabled={loading}
+        className={`mt-4 h-12 w-full max-w-xs items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
+      >
+        <Text className="text-base font-semibold text-white">
+          {loading ? 'Проверка...' : 'Подтвердить'}
+        </Text>
+      </Pressable>
+
+      {/* Resend */}
+      <View className="mt-3 flex-row items-center gap-1">
+        {resendTimer > 0 ? (
+          <>
+            <Feather name="clock" size={14} color="#94A3B8" />
+            <Text className="text-sm text-textMuted">Отправить повторно через {resendTimer} сек</Text>
+          </>
+        ) : (
+          <>
+            <Feather name="refresh-cw" size={14} color="#0284C7" />
+            <Text className="text-sm font-medium text-brandPrimary">Отправить код повторно</Text>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function DashboardLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View, Text, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { BackHeader } from '../../../components/AppHeader';
+
+export default function RequestDetailPage() {
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Заявка" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-4 rounded-xl border border-borderLight bg-white p-4">
+          <View className="flex-row items-start justify-between gap-2">
+            <Text className="flex-1 text-lg font-bold text-textPrimary">Камеральная проверка декларации по НДС</Text>
+            <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: Colors.statusSuccess + '18' }}>
+              <Text className="text-xs font-semibold" style={{ color: Colors.statusSuccess }}>Активная</Text>
+            </View>
+          </View>
+          <Text className="text-base leading-6 text-textSecondary">Получили требование о предоставлении документов при камеральной проверке декларации по НДС. Нужна помощь.</Text>
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2"><Feather name="map-pin" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">Москва</Text></View>
+            <View className="flex-row items-center gap-2"><Feather name="home" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">ФНС №46 по г. Москве</Text></View>
+            <View className="flex-row items-center gap-2"><Feather name="briefcase" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">Камеральная проверка</Text></View>
+            <View className="flex-row items-center gap-2"><Feather name="calendar" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">08.04.2026</Text></View>
+          </View>
+          <View className="flex-row gap-2">
+            <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary">
+              <Feather name="edit-2" size={14} color={Colors.brandPrimary} />
+              <Text className="text-sm font-medium text-brandPrimary">Редактировать</Text>
+            </Pressable>
+            <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg border border-statusError">
+              <Feather name="x-circle" size={14} color={Colors.statusError} />
+              <Text className="text-sm font-medium text-statusError">Закрыть</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <View className="gap-3">
+          <Text className="text-base font-semibold text-textPrimary">Сообщения (2)</Text>
+          <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
+            <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+              <Text className="text-sm font-bold text-brandPrimary">АП</Text>
+            </View>
+            <View className="flex-1">
+              <View className="flex-row items-center justify-between">
+                <Text className="text-sm font-semibold text-textPrimary">Алексей Петров</Text>
+                <Text className="text-xs text-textMuted">14:32</Text>
+              </View>
+              <Text className="text-xs text-textMuted" numberOfLines={1}>Готов помочь с камеральной проверкой.</Text>
+            </View>
+            <View className="h-2.5 w-2.5 rounded-full bg-brandPrimary" />
+          </Pressable>
+          <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
+            <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+              <Text className="text-sm font-bold text-brandPrimary">ОС</Text>
+            </View>
+            <View className="flex-1">
+              <View className="flex-row items-center justify-between">
+                <Text className="text-sm font-medium text-textPrimary">Ольга Смирнова</Text>
+                <Text className="text-xs text-textMuted">вчера</Text>
+              </View>
+              <Text className="text-xs text-textMuted" numberOfLines={1}>Специализируюсь на сопровождении проверок.</Text>
+            </View>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { MOCK_CITIES, MOCK_SERVICES, MOCK_FNS } from '../../../constants/protoMockData';
+import { BackHeader } from '../../../components/AppHeader';
+
+function LocationServicePicker({ city, fns, service, onCityChange, onFnsChange, onServiceChange }: {
+  city: string; fns: string; service: string;
+  onCityChange: (v: string) => void; onFnsChange: (v: string) => void; onServiceChange: (v: string) => void;
+}) {
+  const [openLevel, setOpenLevel] = useState<'city' | 'fns' | 'service' | null>(null);
+  const fnsOptions = city ? (MOCK_FNS[city] || []) : [];
+  const summary = city ? [city, fns, service].filter(Boolean).join(' / ') : '';
+
+  return (
+    <View className="gap-1">
+      <Text className="text-sm font-medium text-textSecondary">Город, ФНС и услуга</Text>
+      <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
+        <View className={`min-h-[48px] flex-row items-center gap-2 rounded-xl border px-4 py-3 ${openLevel ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
+          <Feather name="map-pin" size={16} color={Colors.textMuted} />
+          <Text className={`flex-1 text-base ${summary ? 'text-textPrimary' : 'text-textMuted'}`} numberOfLines={2}>{summary || 'Выберите город, ФНС и услугу'}</Text>
+          <Feather name={openLevel ? 'chevron-up' : 'chevron-down'} size={16} color={Colors.textMuted} />
+        </View>
+      </Pressable>
+      {openLevel && (
+        <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
+          <View className="flex-row border-b border-bgSecondary">
+            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => setOpenLevel('city')}>
+              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>{city || 'Город'}</Text>
+            </Pressable>
+            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => city && setOpenLevel('fns')} disabled={!city}>
+              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : fns ? 'text-textPrimary' : 'text-textMuted'}`}>{fns ? fns.replace(/^ФНС\s*/, '').substring(0, 20) : 'ФНС'}</Text>
+            </Pressable>
+            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => fns && setOpenLevel('service')} disabled={!fns}>
+              <Text className={`text-xs font-semibold ${openLevel === 'service' ? 'text-brandPrimary' : service ? 'text-textPrimary' : 'text-textMuted'}`}>{service || 'Услуга'}</Text>
+            </Pressable>
+          </View>
+          <View className="max-h-48">
+            {openLevel === 'city' && MOCK_CITIES.map((c) => (
+              <Pressable key={c} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onCityChange(c); onFnsChange(''); onServiceChange(''); setOpenLevel('fns'); }}>
+                <Text className={`text-base ${city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
+              </Pressable>
+            ))}
+            {openLevel === 'fns' && fnsOptions.map((f) => (
+              <Pressable key={f} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onFnsChange(f); setOpenLevel('service'); }}>
+                <Text className={`text-base ${fns === f ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f}</Text>
+              </Pressable>
+            ))}
+            {openLevel === 'service' && MOCK_SERVICES.map((sv) => (
+              <Pressable key={sv} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onServiceChange(sv); setOpenLevel(null); }}>
+                <Text className={`text-base ${service === sv ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{sv}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+export default function NewRequestPage() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [city, setCity] = useState('');
+  const [fns, setFns] = useState('');
+  const [service, setService] = useState('');
+
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Новая заявка" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <LocationServicePicker city={city} fns={fns} service={service} onCityChange={setCity} onFnsChange={setFns} onServiceChange={setService} />
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Заголовок</Text>
+          <TextInput value={title} onChangeText={setTitle} placeholder="Кратко опишите задачу" placeholderTextColor={Colors.textMuted} className="h-12 rounded-xl border border-borderLight bg-white px-4 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Описание</Text>
+          <TextInput value={description} onChangeText={setDescription} placeholder="Подробно опишите..." placeholderTextColor={Colors.textMuted} multiline className="min-h-[96px] rounded-xl border border-borderLight bg-white p-4 text-base text-textPrimary" style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any} />
+        </View>
+        <Pressable className="h-10 flex-row items-center justify-center gap-2 rounded-lg border border-dashed border-borderLight bg-bgSurface">
+          <Feather name="paperclip" size={16} color={Colors.brandPrimary} />
+          <Text className="text-sm font-medium text-brandPrimary">Прикрепить файл</Text>
+        </Pressable>
+        <Pressable className="mt-2 h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary">
+          <Feather name="send" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Отправить заявку</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_RESPONSES } from '../../constants/protoMockData';
+import { BackHeader } from '../../components/AppHeader';
+
+function Stars({ rating, size = 14 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row gap-0.5">
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= Math.round(rating) ? Colors.statusWarning : Colors.border} />
+      ))}
+    </View>
+  );
+}
+
+function ResponseItem({ name, price, message, rating, reviews }: {
+  name: string; price: string; message: string; rating: number; reviews: number;
+}) {
+  const initials = name.split(' ').map(n => n[0]).join('');
+  return (
+    <View className="gap-2 rounded-xl border border-borderLight bg-white p-4 shadow-sm">
+      <View className="flex-row items-center gap-3">
+        <View className="h-11 w-11 items-center justify-center rounded-full border border-borderLight bg-bgSecondary">
+          <Text className="text-base font-bold text-brandPrimary">{initials}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-base font-semibold text-textPrimary">{name}</Text>
+          <View className="flex-row items-center gap-1">
+            <Stars rating={rating} />
+            <Text className="text-sm text-textMuted">{rating} ({reviews} отзывов)</Text>
+          </View>
+        </View>
+        <Text className="text-lg font-bold text-brandPrimary">{price}</Text>
+      </View>
+      <Text className="text-base leading-5 text-textSecondary" numberOfLines={2}>{message}</Text>
+      <View className="flex-row gap-2">
+        <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1 rounded-lg bg-brandPrimary shadow-sm">
+          <Feather name="check" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Принять</Text>
+        </Pressable>
+        <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1 rounded-lg border border-borderLight">
+          <Feather name="x" size={16} color={Colors.textMuted} />
+          <Text className="text-base text-textMuted">Отклонить</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export default function ResponsesPage() {
+  const sorted = [...MOCK_RESPONSES].sort((a, b) => {
+    const priceA = parseInt(a.price.replace(/\D/g, ''));
+    const priceB = parseInt(b.price.replace(/\D/g, ''));
+    return priceA - priceB;
+  });
+  const cheapest = sorted[0];
+
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Отклики" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 12 }}>
+        <View className="flex-row items-center gap-2">
+          <Text className="text-xl font-bold text-textPrimary">Отклики</Text>
+          <View className="h-6 min-w-[24px] items-center justify-center rounded-full bg-brandPrimary px-1.5">
+            <Text className="text-xs font-bold text-white">{MOCK_RESPONSES.length}</Text>
+          </View>
+        </View>
+
+        <View className="flex-row items-center gap-2 rounded-xl bg-green-50 p-3">
+          <Feather name="trending-down" size={14} color={Colors.statusSuccess} />
+          <Text className="text-sm text-textSecondary">
+            Лучшая цена: <Text className="font-bold text-statusSuccess">{cheapest.price}</Text> от {cheapest.specialistName}
+          </Text>
+        </View>
+
+        {MOCK_RESPONSES.map((r) => (
+          <ResponseItem
+            key={r.id}
+            name={r.specialistName}
+            price={r.price}
+            message={r.message}
+            rating={r.rating}
+            reviews={r.reviewCount}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function OnboardingLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export default function OnboardingProfilePage() {
+  const [description, setDescription] = useState('');
+  const [phone, setPhone] = useState('');
+  const [telegram, setTelegram] = useState('');
+  const [hasPhoto, setHasPhoto] = useState(false);
+  const maxChars = 1000;
+
+  return (
+    <View className="flex-1 bg-white px-4 py-6">
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary">
+        <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
+      </View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 3 из 3</Text>
+
+      <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>
+      <Text className="mb-4 text-base text-textMuted">Эта информация поможет клиентам выбрать вас</Text>
+
+      <View className="mb-4 flex-row items-center gap-4">
+        <View className={`h-16 w-16 items-center justify-center rounded-full ${hasPhoto ? 'bg-brandPrimary' : 'border-2 border-dashed border-gray-300 bg-bgSecondary'}`}>
+          <Feather name="user" size={28} color={hasPhoto ? '#fff' : '#0284C7'} />
+        </View>
+        <View>
+          <Pressable className="flex-row items-center gap-1" onPress={() => setHasPhoto(true)}>
+            <Feather name="camera" size={14} color="#0284C7" />
+            <Text className="text-base font-medium text-brandPrimary">{hasPhoto ? 'Изменить фото' : 'Загрузить фото'}</Text>
+          </Pressable>
+          <Text className="text-xs text-textMuted">JPG или PNG, до 5 МБ</Text>
+        </View>
+      </View>
+
+      <View className="mb-3">
+        <View className="mb-1 flex-row items-center justify-between">
+          <Text className="text-sm font-medium text-textSecondary">О себе</Text>
+          <Text className={`text-xs ${description.length > maxChars ? 'text-red-600' : 'text-textMuted'}`}>{description.length}/{maxChars}</Text>
+        </View>
+        <TextInput
+          value={description}
+          onChangeText={setDescription}
+          placeholder="Расскажите о вашем опыте..."
+          placeholderTextColor="#94A3B8"
+          multiline
+          className="rounded-lg border border-gray-200 p-3 text-base text-textPrimary"
+          style={{ minHeight: 80, textAlignVertical: 'top', outlineStyle: 'none' } as any}
+          maxLength={maxChars}
+        />
+      </View>
+
+      <View className="mb-3">
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Телефон</Text>
+        <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+          <Feather name="phone" size={16} color="#94A3B8" />
+          <TextInput
+            value={phone}
+            onChangeText={setPhone}
+            placeholder="+7XXXXXXXXXX"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' } as any}
+            keyboardType="phone-pad"
+          />
+        </View>
+      </View>
+
+      <View className="mb-4">
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Telegram</Text>
+        <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+          <Feather name="send" size={16} color="#94A3B8" />
+          <TextInput
+            value={telegram}
+            onChangeText={setTelegram}
+            placeholder="@username"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' } as any}
+          />
+        </View>
+      </View>
+
+      <View className="flex-row gap-3">
+        <Pressable className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4">
+          <Feather name="arrow-left" size={16} color="#475569" />
+          <Text className="text-base font-medium text-textSecondary">Назад</Text>
+        </Pressable>
+        <Pressable className="h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+          <Feather name="check" size={16} color="#fff" />
+          <Text className="text-base font-semibold text-white">Завершить</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+export default function OnboardingUsernamePage() {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+  const [available, setAvailable] = useState(false);
+  const [agreed, setAgreed] = useState(false);
+
+  const canContinue = available && agreed && value.length >= 2;
+
+  return (
+    <View className="flex-1 bg-white px-4 py-6">
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary">
+        <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '33%' }} />
+      </View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 1 из 3</Text>
+
+      <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
+      <Text className="mb-4 text-base leading-6 text-textMuted">Это имя будет видно клиентам в вашем профиле</Text>
+
+      <Text className="mb-1 text-sm font-medium text-textSecondary">Имя пользователя</Text>
+      <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : available ? 'border-green-600 bg-green-50' : 'border-gray-200 bg-white'}`}>
+        <Feather name="user" size={18} color={error ? '#DC2626' : available ? '#15803D' : '#94A3B8'} />
+        <TextInput
+          value={value}
+          onChangeText={(t) => { setValue(t); setError(''); setAvailable(t.length >= 2); }}
+          placeholder="Например: Елена Васильева"
+          placeholderTextColor="#94A3B8"
+          className="flex-1 text-base text-textPrimary"
+          style={{ outlineStyle: 'none' } as any}
+        />
+        {available && <Feather name="check-circle" size={18} color="#15803D" />}
+        {error ? <Feather name="x-circle" size={18} color="#DC2626" /> : null}
+      </View>
+
+      {error ? (
+        <View className="mb-2 flex-row items-center gap-1">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm text-red-600">{error}</Text>
+        </View>
+      ) : available ? (
+        <View className="mb-2 flex-row items-center gap-1">
+          <Feather name="check-circle" size={14} color="#15803D" />
+          <Text className="text-sm font-medium text-green-700">Имя свободно</Text>
+        </View>
+      ) : null}
+
+      <Pressable className="mt-3 flex-row items-start gap-2" onPress={() => setAgreed(!agreed)}>
+        <View className={`mt-0.5 h-5 w-5 items-center justify-center rounded border ${agreed ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300 bg-white'}`}>
+          {agreed && <Feather name="check" size={13} color="#fff" />}
+        </View>
+        <Text className="flex-1 text-sm text-textSecondary">
+          Принимаю <Text className="text-brandPrimary">условия использования</Text>
+        </Text>
+      </Pressable>
+
+      <Pressable
+        disabled={!canContinue}
+        className={`mt-6 h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${!canContinue ? 'opacity-40' : ''}`}
+      >
+        <Text className="text-base font-semibold text-white">Далее</Text>
+        <Feather name="arrow-right" size={16} color="#fff" />
+      </Pressable>
+    </View>
+  );
+}

--- a/app/(onboarding)/work-area.tsx
+++ b/app/(onboarding)/work-area.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+
+const SVCS = ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'];
+const CF: Record<string, string[]> = {
+  'Москва': ['ИФНС №5', 'ИФНС №12', 'ИФНС №46'],
+  'СПб': ['ИФНС №3', 'ИФНС №15', 'ИФНС №28'],
+  'Казань': ['ИФНС №1', 'ИФНС №6'],
+};
+type Bind = Record<string, string[]>;
+
+export default function OnboardingWorkAreaPage() {
+  const [search, setSearch] = useState('');
+  const [cities, setCities] = useState<string[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [bind, setBind] = useState<Bind>({});
+
+  const allCities = Object.keys(CF);
+  const filtered = search ? allCities.filter((c) => c.toLowerCase().includes(search.toLowerCase()) && !cities.includes(c)) : [];
+
+  const addCity = (c: string) => { setCities((p) => [...p, c]); setSearch(''); setExpanded(c); };
+  const removeCity = (c: string) => {
+    setCities((p) => p.filter((x) => x !== c));
+    setBind((p) => { const n = { ...p }; Object.keys(n).forEach((k) => { if (k.startsWith(c + ':')) delete n[k]; }); return n; });
+  };
+  const k = (c: string, f: string) => `${c}:${f}`;
+  const toggleFns = (c: string, f: string) => {
+    const key = k(c, f);
+    setBind((p) => { if (p[key]) { const n = { ...p }; delete n[key]; return n; } return { ...p, [key]: [] }; });
+  };
+  const toggleSvc = (key: string, s: string) => {
+    setBind((p) => { const cur = p[key] || []; return { ...p, [key]: cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s] }; });
+  };
+  const total = Object.keys(bind).length;
+
+  return (
+    <View className="flex-1 bg-white px-4 py-6">
+      <View className="mb-1 h-1 rounded-full bg-bgSecondary">
+        <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '66%' }} />
+      </View>
+      <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 2 из 3</Text>
+
+      <Text className="text-xl font-bold text-textPrimary">Рабочая зона</Text>
+      <Text className="mb-4 text-base text-textMuted">Выберите города, инспекции и услуги</Text>
+
+      <View className="mb-2 h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+        <Feather name="search" size={18} color="#94A3B8" />
+        <TextInput value={search} onChangeText={setSearch} placeholder="Найти город..." placeholderTextColor="#94A3B8" className="flex-1 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+        {search.length > 0 && <Pressable onPress={() => setSearch('')}><Feather name="x" size={16} color="#94A3B8" /></Pressable>}
+      </View>
+
+      {filtered.map((c) => (
+        <Pressable key={c} className="flex-row items-center gap-2 border-b border-gray-100 px-4 py-3" onPress={() => addCity(c)}>
+          <Feather name="map-pin" size={14} color="#94A3B8" />
+          <Text className="flex-1 text-base text-textPrimary">{c}</Text>
+          <Feather name="plus" size={14} color="#0284C7" />
+        </Pressable>
+      ))}
+
+      {cities.length === 0 && !search && (
+        <View className="items-center py-6 opacity-60">
+          <Feather name="map-pin" size={20} color="#94A3B8" />
+          <Text className="mt-1 text-base text-textMuted">Начните вводить название города</Text>
+        </View>
+      )}
+
+      {cities.map((city) => {
+        const exp = expanded === city;
+        const offices = CF[city] || [];
+        const cnt = Object.keys(bind).filter((x) => x.startsWith(city + ':')).length;
+        return (
+          <View key={city} className="mb-2 overflow-hidden rounded-lg border border-gray-200">
+            <Pressable className="flex-row items-center justify-between px-4 py-3" onPress={() => setExpanded(exp ? null : city)}>
+              <View className="flex-row items-center gap-2">
+                <Feather name="map-pin" size={14} color="#0284C7" />
+                <Text className="text-base font-semibold text-textPrimary">{city}</Text>
+                {cnt > 0 && <View className="h-5 w-5 items-center justify-center rounded-full bg-brandPrimary"><Text className="text-xs font-bold text-white">{cnt}</Text></View>}
+              </View>
+              <View className="flex-row items-center gap-3">
+                <Pressable onPress={() => removeCity(city)}><Feather name="trash-2" size={14} color="#94A3B8" /></Pressable>
+                <Feather name={exp ? 'chevron-up' : 'chevron-down'} size={16} color="#94A3B8" />
+              </View>
+            </Pressable>
+            {exp && offices.map((fns) => {
+              const key = k(city, fns);
+              const sel = key in bind;
+              const sv = bind[key] || [];
+              return (
+                <View key={fns} className="border-t border-gray-100">
+                  <Pressable className="flex-row items-center gap-3 px-4 py-3" onPress={() => toggleFns(city, fns)}>
+                    <View className={`h-5 w-5 items-center justify-center rounded border ${sel ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300'}`}>
+                      {sel && <Feather name="check" size={13} color="#fff" />}
+                    </View>
+                    <Text className={`text-sm ${sel ? 'font-medium text-brandPrimary' : 'text-textPrimary'}`}>{fns}</Text>
+                  </Pressable>
+                  {sel && (
+                    <View className="flex-row flex-wrap gap-2 px-4 pb-3 pl-12">
+                      {SVCS.map((svc) => {
+                        const on = sv.includes(svc);
+                        return (
+                          <Pressable key={svc} className={`flex-row items-center gap-1 rounded-full border px-3 py-1 ${on ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200'}`} onPress={() => toggleSvc(key, svc)}>
+                            {on && <Feather name="check" size={12} color="#0284C7" />}
+                            <Text className={`text-xs ${on ? 'font-medium text-brandPrimary' : 'text-textSecondary'}`}>{svc}</Text>
+                          </Pressable>
+                        );
+                      })}
+                    </View>
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        );
+      })}
+
+      <View className="mt-4 flex-row gap-3">
+        <Pressable className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4">
+          <Feather name="arrow-left" size={16} color="#475569" />
+          <Text className="text-base font-medium text-textSecondary">Назад</Text>
+        </Pressable>
+        <Pressable className={`h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${total === 0 ? 'opacity-40' : ''}`}>
+          <Text className="text-base font-semibold text-white">Далее</Text>
+          <Feather name="arrow-right" size={16} color="#fff" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router';
+import { Colors } from '../../constants/Colors';
+
+export default function TabsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: Colors.bgPrimary },
+      }}
+    />
+  );
+}

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { View, Text, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+function getGreeting(): string {
+  const h = new Date().getHours();
+  if (h < 6) return 'Доброй ночи';
+  if (h < 12) return 'Доброе утро';
+  if (h < 18) return 'Добрый день';
+  return 'Добрый вечер';
+}
+
+function StatCard({ icon, label, value, color }: { icon: string; label: string; value: string; color: string }) {
+  return (
+    <View className="flex-1 items-center gap-1 rounded-xl border border-borderLight bg-white p-3">
+      <View className="h-9 w-9 items-center justify-center rounded-full" style={{ backgroundColor: color + '15' }}>
+        <Feather name={icon as any} size={18} color={color} />
+      </View>
+      <Text className="text-lg font-bold" style={{ color }}>{value}</Text>
+      <Text className="text-xs text-textMuted">{label}</Text>
+    </View>
+  );
+}
+
+function RequestCard({ title, service, fns, city, date, messageCount, status, statusColor }: {
+  title: string; service: string; fns: string; city: string; date: string;
+  messageCount: number; status: string; statusColor: string;
+}) {
+  return (
+    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+      <View className="flex-row items-start justify-between gap-2">
+        <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
+        <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + '18' }}>
+          <Text className="text-xs font-semibold" style={{ color: statusColor }}>{status}</Text>
+        </View>
+      </View>
+      <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
+        <View className="flex-row items-center gap-1">
+          <Feather name="briefcase" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{service}</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <Feather name="home" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{fns}</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <Feather name="map-pin" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{city}</Text>
+        </View>
+      </View>
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center gap-1">
+          <Feather name="calendar" size={12} color={Colors.textMuted} />
+          <Text className="text-xs text-textMuted">{date}</Text>
+        </View>
+        {messageCount > 0 && (
+          <View className="flex-row items-center gap-1">
+            <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
+            <Text className="text-xs font-medium text-brandPrimary">{messageCount} сообщ.</Text>
+          </View>
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+function MessagePreview({ initials, name, snippet, time, unread }: {
+  initials: string; name: string; snippet: string; time: string; unread?: boolean;
+}) {
+  return (
+    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
+      <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+        <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
+      </View>
+      <View className="flex-1">
+        <View className="flex-row items-center justify-between">
+          <Text className={`text-sm ${unread ? 'font-bold text-textPrimary' : 'font-medium text-textPrimary'}`}>{name}</Text>
+          <Text className="text-xs text-textMuted">{time}</Text>
+        </View>
+        <Text className={`text-xs ${unread ? 'font-medium text-textSecondary' : 'text-textMuted'}`} numberOfLines={1}>{snippet}</Text>
+      </View>
+      {unread && <View className="h-2.5 w-2.5 rounded-full bg-brandPrimary" />}
+    </Pressable>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader hasNotif />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="flex-row items-start justify-between">
+          <View className="flex-1">
+            <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, Елена!</Text>
+            <Text className="text-sm text-textMuted">Ваши заявки и сообщения</Text>
+          </View>
+        </View>
+
+        <View className="flex-row gap-2">
+          <StatCard icon="file-text" label="Активные" value="3" color={Colors.brandPrimary} />
+          <StatCard icon="message-circle" label="Сообщения" value="5" color={Colors.statusSuccess} />
+          <StatCard icon="check-circle" label="Завершены" value="12" color={Colors.textMuted} />
+        </View>
+
+        <View className="flex-row gap-2">
+          <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl bg-brandPrimary">
+            <Feather name="plus" size={16} color={Colors.white} />
+            <Text className="text-sm font-semibold text-white">Новая заявка</Text>
+          </Pressable>
+          <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white">
+            <Feather name="list" size={16} color={Colors.brandPrimary} />
+            <Text className="text-sm font-medium text-brandPrimary">Мои заявки</Text>
+          </Pressable>
+        </View>
+
+        <View className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-base font-semibold text-textPrimary">Активные заявки</Text>
+            <Pressable><Text className="text-sm font-medium text-brandPrimary">Все заявки</Text></Pressable>
+          </View>
+          <RequestCard title="Камеральная проверка декларации по НДС" service="Камеральная проверка" fns="ФНС №46 по г. Москве" city="Москва" date="08.04.2026" messageCount={2} status="Новая" statusColor={Colors.brandPrimary} />
+          <RequestCard title="Отдел оперативного контроля — требование" service="Отдел оперативного контроля" fns="ФНС №12 по г. Новосибирску" city="Новосибирск" date="07.04.2026" messageCount={4} status="В работе" statusColor={Colors.statusWarning} />
+        </View>
+
+        <View className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-base font-semibold text-textPrimary">Новые сообщения</Text>
+            <Pressable><Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text></Pressable>
+          </View>
+          <MessagePreview initials="АП" name="Алексей Петров" snippet="Здравствуйте! Готов помочь с камеральной проверкой." time="14:32" unread />
+          <MessagePreview initials="ОС" name="Ольга Смирнова" snippet="Специализируюсь на сопровождении проверок." time="12:15" unread />
+          <MessagePreview initials="ИК" name="Игорь Козлов" snippet="Добрый день! По вашей заявке на оперативный контроль..." time="вчера" />
+        </View>
+      </ScrollView>
+      <BottomNav activeId="home" variant="client" />
+    </View>
+  );
+}

--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_CITIES, MOCK_FNS } from '../../constants/protoMockData';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+const MOCK_REQUESTS = [
+  { id: 1, title: 'Выездная проверка ООО «Ромашка»', description: 'Назначена выездная налоговая проверка.', city: 'Москва', fns: 'ФНС №15 по г. Москве', service: 'Выездная проверка', date: '12.04.2026', author: 'Елена В.', memberSince: 2024, messageCount: 3 },
+  { id: 2, title: 'Камеральная проверка декларации', description: 'Получил требование при камеральной проверке.', city: 'Москва', fns: 'ФНС №46 по г. Москве', service: 'Камеральная проверка', date: '11.04.2026', author: 'Дмитрий К.', memberSince: 2023, messageCount: 5 },
+  { id: 3, title: 'Оперативный контроль — помощь', description: 'Пришло уведомление от отдела оперативного контроля.', city: 'Санкт-Петербург', fns: 'ФНС №1 по г. Санкт-Петербургу', service: 'Отдел оперативного контроля', date: '10.04.2026', author: 'Татьяна Ф.', memberSince: 2022, messageCount: 1 },
+  { id: 4, title: 'Не знаю какая услуга — нужна помощь', description: 'Получил письмо от налоговой, не понимаю что делать.', city: 'Казань', fns: 'ФНС №3 по г. Казани', service: 'Не знаю', date: '09.04.2026', author: 'Иван М.', memberSince: 2025, messageCount: 0 },
+];
+
+export default function FeedPage() {
+  const [filterCity, setFilterCity] = useState('');
+  const [selectedFns, setSelectedFns] = useState<string[]>([]);
+
+  const requests = MOCK_REQUESTS.filter((r) => {
+    if (filterCity && r.city !== filterCity) return false;
+    if (selectedFns.length > 0 && !selectedFns.includes(r.fns)) return false;
+    return true;
+  });
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader hasNotif initials="АП" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View>
+          <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
+          <Text className="mt-0.5 text-sm text-textMuted">{requests.length} активных заявок</Text>
+        </View>
+
+        {requests.map((r) => (
+          <Pressable key={r.id} className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+            <View className="flex-row items-center justify-between">
+              <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={1}>{r.title}</Text>
+              <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+            </View>
+            <Text className="text-sm leading-5 text-textSecondary" numberOfLines={2}>{r.description}</Text>
+            <View className="flex-row flex-wrap gap-2">
+              <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-0.5">
+                <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
+                <Text className="text-xs font-medium text-brandPrimary">{r.city}</Text>
+              </View>
+              <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-0.5">
+                <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
+                <Text className="text-xs font-medium text-brandPrimary">{r.service}</Text>
+              </View>
+            </View>
+            <View className="mt-1 flex-row items-center justify-between border-t border-borderLight pt-2">
+              <View className="flex-row items-center gap-2">
+                <View className="h-7 w-7 items-center justify-center rounded-full bg-bgSecondary">
+                  <Feather name="user" size={14} color={Colors.textMuted} />
+                </View>
+                <Text className="text-sm font-medium text-textPrimary">{r.author}</Text>
+              </View>
+              <Text className="text-xs text-textMuted">{r.date}</Text>
+            </View>
+          </Pressable>
+        ))}
+      </ScrollView>
+      <BottomNav activeId="dashboard" variant="specialist" />
+    </View>
+  );
+}

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_THREADS } from '../../constants/protoMockData';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+export default function MessagesPage() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const filtered = search
+    ? MOCK_THREADS.filter(t => t.name.toLowerCase().includes(search.toLowerCase()) || t.lastMessage.toLowerCase().includes(search.toLowerCase()))
+    : MOCK_THREADS;
+  const totalUnread = MOCK_THREADS.reduce((sum, t) => sum + t.unread, 0);
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader hasNotif />
+      <View className="flex-1 p-4 gap-2">
+        <View className="flex-row items-center gap-2 mb-2">
+          <Text className="text-xl font-bold text-textPrimary">Сообщения</Text>
+          {totalUnread > 0 && (
+            <View className="min-w-[24px] h-6 items-center justify-center rounded-full bg-brandPrimary px-1.5">
+              <Text className="text-xs font-bold text-white">{totalUnread}</Text>
+            </View>
+          )}
+        </View>
+
+        <View className="flex-row items-center gap-2 h-10 rounded-xl border border-borderLight bg-white px-3 mb-1">
+          <Feather name="search" size={16} color={Colors.textMuted} />
+          <TextInput
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Поиск по сообщениям..."
+            placeholderTextColor={Colors.textMuted}
+            className="flex-1 text-sm text-textPrimary"
+            style={{ outlineStyle: 'none' } as any}
+          />
+          {search.length > 0 && (
+            <Pressable onPress={() => setSearch('')}>
+              <Feather name="x" size={16} color={Colors.textMuted} />
+            </Pressable>
+          )}
+        </View>
+
+        {filtered.map((t) => {
+          const initials = t.name.split(' ').map(n => n[0]).join('');
+          const selected = selectedId === t.id;
+          return (
+            <Pressable
+              key={t.id}
+              onPress={() => setSelectedId(selected ? null : t.id)}
+              className={`flex-row items-center gap-3 rounded-xl border p-3 ${selected ? 'border-brandPrimary bg-bgSecondary' : 'border-borderLight bg-white'}`}
+            >
+              <View className="h-11 w-11 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+                <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
+              </View>
+              <View className="flex-1 gap-0.5">
+                <View className="flex-row items-center justify-between">
+                  <Text className={`text-base ${t.unread > 0 ? 'font-bold' : 'font-medium'} text-textPrimary`}>{t.name}</Text>
+                  <Text className="text-xs text-textMuted">{t.time}</Text>
+                </View>
+                <View className="flex-row items-center gap-2">
+                  <Text className={`flex-1 text-sm ${t.unread > 0 ? 'font-medium text-textPrimary' : 'text-textMuted'}`} numberOfLines={1}>{t.lastMessage}</Text>
+                  {t.unread > 0 && (
+                    <View className="min-w-[20px] h-5 items-center justify-center rounded-full bg-brandPrimary px-1">
+                      <Text className="text-xs font-bold text-white">{t.unread}</Text>
+                    </View>
+                  )}
+                </View>
+              </View>
+              <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+            </Pressable>
+          );
+        })}
+      </View>
+      <BottomNav activeId="messages" variant="client" />
+    </View>
+  );
+}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+export default function ProfilePage() {
+  const [editMode, setEditMode] = useState(false);
+  const [name, setName] = useState('Елена Васильева');
+  const [city, setCity] = useState('Москва');
+
+  if (editMode) {
+    return (
+      <View className="flex-1 bg-white">
+        <AppHeader />
+        <View className="flex-1 p-4 gap-4">
+          <View className="flex-row items-center gap-4">
+            <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+              <Text className="text-xl font-bold text-brandPrimary">ЕВ</Text>
+            </View>
+            <Pressable className="flex-row items-center gap-1">
+              <Feather name="camera" size={14} color={Colors.brandPrimary} />
+              <Text className="text-sm font-medium text-brandPrimary">Изменить фото</Text>
+            </Pressable>
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Имя</Text>
+            <TextInput value={name} onChangeText={setName} className="h-12 rounded-xl border border-borderLight bg-white px-4 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Email</Text>
+            <TextInput value="elena@mail.ru" editable={false} className="h-12 rounded-xl border border-borderLight bg-bgSecondary px-4 text-base text-textPrimary opacity-50" style={{ outlineStyle: 'none' } as any} />
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Город</Text>
+            <TextInput value={city} onChangeText={setCity} className="h-12 rounded-xl border border-borderLight bg-white px-4 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+          </View>
+          <Pressable onPress={() => setEditMode(false)} className="h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+            <Feather name="check" size={16} color={Colors.white} />
+            <Text className="text-base font-semibold text-white">Сохранить</Text>
+          </Pressable>
+          <Pressable onPress={() => setEditMode(false)} className="h-12 items-center justify-center rounded-lg border border-borderLight">
+            <Text className="text-base text-textMuted">Отмена</Text>
+          </Pressable>
+        </View>
+        <BottomNav activeId="profile" variant="client" />
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader />
+      <View className="flex-1 p-4 gap-4">
+        <View className="flex-row items-center gap-4">
+          <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+            <Text className="text-xl font-bold text-brandPrimary">ЕВ</Text>
+          </View>
+          <View>
+            <Text className="text-xl font-bold text-textPrimary">{name}</Text>
+            <View className="flex-row items-center gap-1 mt-0.5">
+              <Feather name="user" size={14} color={Colors.textMuted} />
+              <Text className="text-base text-textMuted">Клиент</Text>
+            </View>
+          </View>
+        </View>
+
+        <View className="flex-row gap-2">
+          {[
+            { icon: 'file-text', value: '5', label: 'Заявок' },
+            { icon: 'check-circle', value: '3', label: 'Завершено' },
+            { icon: 'star', value: '4.9', label: 'Рейтинг' },
+          ].map((s) => (
+            <View key={s.label} className="flex-1 items-center gap-1 rounded-xl border border-borderLight bg-white p-3">
+              <Feather name={s.icon as any} size={18} color={Colors.brandPrimary} />
+              <Text className="text-lg font-bold text-textPrimary">{s.value}</Text>
+              <Text className="text-xs text-textMuted">{s.label}</Text>
+            </View>
+          ))}
+        </View>
+
+        <View className="rounded-xl border border-borderLight bg-white p-4 gap-3">
+          {[
+            { label: 'Email', value: 'elena@mail.ru', icon: 'mail' },
+            { label: 'Город', value: city, icon: 'map-pin' },
+            { label: 'Регистрация', value: '15.02.2026', icon: 'calendar' },
+            { label: 'Заявки', value: '5 (3 активных)', icon: 'file-text' },
+          ].map((row) => (
+            <View key={row.label} className="flex-row items-center gap-2">
+              <Feather name={row.icon as any} size={16} color={Colors.textMuted} />
+              <Text className="flex-1 text-sm text-textMuted">{row.label}</Text>
+              <Text className="text-sm font-medium text-textPrimary">{row.value}</Text>
+            </View>
+          ))}
+        </View>
+
+        <Pressable onPress={() => setEditMode(true)} className="h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+          <Feather name="edit-2" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Редактировать</Text>
+        </Pressable>
+
+        <Pressable className="flex-row items-center gap-2 rounded-xl border border-borderLight bg-white p-4">
+          <Feather name="settings" size={16} color={Colors.textMuted} />
+          <Text className="flex-1 text-base text-textPrimary">Настройки</Text>
+          <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+        </Pressable>
+      </View>
+      <BottomNav activeId="profile" variant="client" />
+    </View>
+  );
+}

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_REQUESTS } from '../../constants/protoMockData';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> = {
+  NEW: { label: 'Новая', color: Colors.brandPrimary, bg: Colors.statusBg.info },
+  ACTIVE: { label: 'Активная', color: Colors.statusSuccess, bg: Colors.statusBg.success },
+  IN_PROGRESS: { label: 'В работе', color: Colors.statusWarning, bg: Colors.statusBg.warning },
+  COMPLETED: { label: 'Завершена', color: Colors.textMuted, bg: Colors.statusBg.neutral },
+  CANCELLED: { label: 'Отменена', color: Colors.statusError, bg: Colors.statusBg.error },
+};
+
+export default function RequestsPage() {
+  const [tab, setTab] = useState<'active' | 'completed' | 'all'>('active');
+  const activeRequests = MOCK_REQUESTS.filter((r) => ['NEW', 'ACTIVE', 'IN_PROGRESS'].includes(r.status));
+  const completedRequests = MOCK_REQUESTS.filter((r) => ['COMPLETED', 'CANCELLED'].includes(r.status));
+  const allRequests = MOCK_REQUESTS;
+  const visibleRequests = tab === 'active' ? activeRequests : tab === 'completed' ? completedRequests : allRequests;
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader hasNotif />
+      <View className="flex-1 p-4 gap-3">
+        <View className="flex-row items-center justify-between">
+          <Text className="text-xl font-bold text-textPrimary">Мои заявки</Text>
+          <Pressable className="flex-row items-center gap-1 rounded-lg bg-brandPrimary px-3 py-2">
+            <Feather name="plus" size={16} color={Colors.white} />
+            <Text className="text-sm font-semibold text-white">Новая</Text>
+          </Pressable>
+        </View>
+        <View className="flex-row gap-1">
+          {([
+            { key: 'active' as const, label: `Активные (${activeRequests.length})` },
+            { key: 'completed' as const, label: `Завершённые (${completedRequests.length})` },
+            { key: 'all' as const, label: `Все (${allRequests.length})` },
+          ] as const).map((t) => (
+            <Pressable key={t.key} onPress={() => setTab(t.key)} className={`flex-1 h-10 items-center justify-center rounded-lg border ${tab === t.key ? 'border-brandPrimary bg-brandPrimary' : 'border-borderLight bg-white'}`}>
+              <Text className={`text-xs font-medium ${tab === t.key ? 'font-semibold text-white' : 'text-textMuted'}`}>{t.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+        {visibleRequests.map((r) => {
+          const st = STATUS_MAP[r.status] || STATUS_MAP.NEW;
+          return (
+            <Pressable key={r.id} className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+              <View className="flex-row items-start justify-between gap-2">
+                <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{r.title}</Text>
+                <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: st.bg }}>
+                  <Text className="text-xs font-semibold" style={{ color: st.color }}>{st.label}</Text>
+                </View>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <Feather name="briefcase" size={12} color={Colors.textMuted} />
+                <Text className="text-xs text-textMuted">{r.service}</Text>
+                <Feather name="map-pin" size={12} color={Colors.textMuted} />
+                <Text className="text-xs text-textMuted">{r.city}</Text>
+              </View>
+              <View className="flex-row items-center justify-between">
+                <View className="flex-row items-center gap-1">
+                  <Feather name="calendar" size={12} color={Colors.textMuted} />
+                  <Text className="text-xs text-textMuted">{r.createdAt}</Text>
+                </View>
+                {r.messageCount > 0 && (
+                  <View className="flex-row items-center gap-1">
+                    <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
+                    <Text className="text-xs font-medium text-brandPrimary">{r.messageCount} сообщ.</Text>
+                  </View>
+                )}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+      <BottomNav activeId="requests" variant="client" />
+    </View>
+  );
+}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, Switch } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+export default function SettingsPage() {
+  const [emailNotif, setEmailNotif] = useState(true);
+  const [pushNotif, setPushNotif] = useState(false);
+  const [responseNotif, setResponseNotif] = useState(true);
+  const [showLogout, setShowLogout] = useState(false);
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader />
+      <View className="flex-1 p-4 gap-4">
+        <Text className="text-xl font-bold text-textPrimary">Настройки</Text>
+
+        <View className="gap-2">
+          <Text className="text-xs font-semibold uppercase tracking-wider text-textMuted">Уведомления</Text>
+          <View className="rounded-xl border border-borderLight bg-white overflow-hidden">
+            {[
+              { label: 'Email-уведомления', icon: 'mail', value: emailNotif, toggle: () => setEmailNotif(!emailNotif) },
+              { label: 'Push-уведомления', icon: 'bell', value: pushNotif, toggle: () => setPushNotif(!pushNotif) },
+              { label: 'Новые отклики', icon: 'message-circle', value: responseNotif, toggle: () => setResponseNotif(!responseNotif) },
+            ].map((row) => (
+              <View key={row.label} className="flex-row items-center gap-3 border-b border-bgSecondary px-4 py-3">
+                <Feather name={row.icon as any} size={18} color={Colors.textMuted} />
+                <Text className="flex-1 text-sm text-textPrimary">{row.label}</Text>
+                <Switch value={row.value} onValueChange={row.toggle} trackColor={{ false: '#D1D5DB', true: '#0284C7' }} thumbColor="#fff" />
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View className="gap-2">
+          <Text className="text-xs font-semibold uppercase tracking-wider text-textMuted">Аккаунт</Text>
+          <View className="rounded-xl border border-borderLight bg-white overflow-hidden">
+            {[
+              { label: 'Email', value: 'elena@mail.ru', icon: 'mail' },
+              { label: 'Язык', value: 'Русский', icon: 'globe' },
+              { label: 'Тема', value: 'Светлая', icon: 'sun' },
+            ].map((row) => (
+              <Pressable key={row.label} className="flex-row items-center gap-3 border-b border-bgSecondary px-4 py-3">
+                <Feather name={row.icon as any} size={18} color={Colors.textMuted} />
+                <Text className="flex-1 text-sm text-textPrimary">{row.label}</Text>
+                <Text className="text-sm text-textMuted mr-2">{row.value}</Text>
+                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        <View className="gap-2">
+          <Pressable onPress={() => setShowLogout(!showLogout)} className="h-12 flex-row items-center justify-center gap-2 rounded-lg" style={{ backgroundColor: Colors.statusBg.error }}>
+            <Feather name="log-out" size={18} color={Colors.statusError} />
+            <Text className="text-sm font-semibold text-statusError">Выйти из аккаунта</Text>
+          </Pressable>
+          {showLogout && (
+            <View className="rounded-xl border p-4 gap-3" style={{ borderColor: Colors.statusBg.error }}>
+              <Text className="text-sm text-textSecondary text-center">Вы уверены, что хотите выйти?</Text>
+              <View className="flex-row gap-2">
+                <Pressable onPress={() => setShowLogout(false)} className="flex-1 h-10 items-center justify-center rounded-lg border border-borderLight">
+                  <Text className="text-sm text-textMuted">Отмена</Text>
+                </Pressable>
+                <Pressable className="flex-1 h-10 items-center justify-center rounded-lg bg-statusError">
+                  <Text className="text-sm font-semibold text-white">Выйти</Text>
+                </Pressable>
+              </View>
+            </View>
+          )}
+        </View>
+      </View>
+      <BottomNav activeId="profile" variant="client" />
+    </View>
+  );
+}

--- a/app/(tabs)/specialist-dashboard.tsx
+++ b/app/(tabs)/specialist-dashboard.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { AppHeader } from '../../components/AppHeader';
+import { BottomNav } from '../../components/BottomNav';
+
+const REQUESTS = [
+  { id: '1', title: 'Выездная проверка ООО «Ромашка»', description: 'Назначена выездная налоговая проверка за 2023–2025 годы.', city: 'Москва', fns: 'ФНС №46 по г. Москве', service: 'Выездная проверка', date: '12.04.2026', author: 'Елена В.' },
+  { id: '2', title: 'Отдел оперативного контроля — требование', description: 'Получили требование от отдела оперативного контроля.', city: 'Новосибирск', fns: 'ФНС №12 по г. Новосибирску', service: 'Отдел оперативного контроля', date: '11.04.2026', author: 'Дмитрий К.' },
+  { id: '3', title: 'Камеральная проверка декларации по НДС', description: 'Получили требование о предоставлении документов.', city: 'Москва', fns: 'ФНС №15 по г. Москве', service: 'Камеральная проверка', date: '10.04.2026', author: 'Татьяна Ф.' },
+];
+
+export default function SpecialistDashboardPage() {
+  const [search, setSearch] = useState('');
+  const filtered = search
+    ? REQUESTS.filter((r) => r.title.toLowerCase().includes(search.toLowerCase()) || r.service.toLowerCase().includes(search.toLowerCase()))
+    : REQUESTS;
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader hasNotif initials="АП" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View>
+          <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
+          <Text className="text-sm text-textMuted">{REQUESTS.length} заявок в вашем регионе</Text>
+        </View>
+
+        <View className="flex-row items-center gap-2 rounded-xl border border-borderLight bg-white px-3">
+          <Feather name="search" size={18} color={Colors.textMuted} />
+          <TextInput value={search} onChangeText={setSearch} placeholder="Поиск по заявкам..." placeholderTextColor={Colors.textMuted} className="h-11 flex-1 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+          {search ? <Pressable onPress={() => setSearch('')}><Feather name="x" size={18} color={Colors.textMuted} /></Pressable> : null}
+        </View>
+
+        {filtered.map((r) => (
+          <View key={r.id} className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+            <View className="flex-row items-start justify-between gap-2">
+              <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{r.title}</Text>
+              <Text className="text-xs text-textMuted">{r.date}</Text>
+            </View>
+            <Text className="text-sm leading-5 text-textSecondary" numberOfLines={2}>{r.description}</Text>
+            <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
+              <View className="flex-row items-center gap-1"><Feather name="map-pin" size={12} color={Colors.textMuted} /><Text className="text-xs text-textMuted">{r.city}</Text></View>
+              <View className="flex-row items-center gap-1"><Feather name="briefcase" size={12} color={Colors.textMuted} /><Text className="text-xs text-textMuted">{r.service}</Text></View>
+            </View>
+            <View className="mt-1 flex-row gap-2">
+              <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+                <Feather name="send" size={14} color={Colors.white} />
+                <Text className="text-sm font-semibold text-white">Написать по заявке</Text>
+              </Pressable>
+              <Pressable className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-borderLight px-4">
+                <Feather name="eye" size={14} color={Colors.textPrimary} />
+                <Text className="text-sm font-medium text-textPrimary">Подробнее</Text>
+              </Pressable>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+      <BottomNav activeId="dashboard" variant="specialist" />
+    </View>
+  );
+}

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_MESSAGES, MockMessage } from '../../constants/protoMockData';
+
+function ChatHeader({ name, online }: { name: string; online: boolean }) {
+  const initials = name.split(' ').map(n => n[0]).join('');
+  return (
+    <View className="flex-row items-center gap-3 border-b border-borderLight bg-white px-4 py-3 shadow-sm">
+      <Pressable className="h-9 w-9 items-center justify-center rounded-full">
+        <Feather name="arrow-left" size={20} color={Colors.brandPrimary} />
+      </Pressable>
+      <View className="relative h-9 w-9 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+        <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
+        {online && <View className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-white bg-statusSuccess" />}
+      </View>
+      <View className="flex-1">
+        <Text className="text-base font-semibold text-textPrimary">{name}</Text>
+        <Text className={`text-xs ${online ? 'text-statusSuccess' : 'text-textMuted'}`}>
+          {online ? 'Онлайн' : 'Был(а) 15 мин назад'}
+        </Text>
+      </View>
+      <Pressable className="h-9 w-9 items-center justify-center">
+        <Feather name="more-vertical" size={18} color={Colors.textMuted} />
+      </Pressable>
+    </View>
+  );
+}
+
+function FileAttachment({ name, size, type, fromMe }: { name: string; size: string; type: 'pdf' | 'image'; fromMe: boolean }) {
+  return (
+    <Pressable className={`mt-1 flex-row items-center gap-2 rounded-lg p-2 ${fromMe ? 'bg-white/10' : 'bg-bgSurface'}`}>
+      <View className={`h-9 w-9 items-center justify-center rounded-lg ${fromMe ? 'bg-white/15' : type === 'pdf' ? 'bg-red-50' : 'bg-bgSurface'}`}>
+        <Feather name={type === 'pdf' ? 'file-text' : 'image'} size={18} color={fromMe ? Colors.white : type === 'pdf' ? Colors.statusError : Colors.brandPrimary} />
+      </View>
+      <View className="flex-1">
+        <Text className={`text-xs font-medium ${fromMe ? 'text-white' : 'text-textPrimary'}`} numberOfLines={1}>{name}</Text>
+        <Text className={`text-[10px] ${fromMe ? 'text-white/60' : 'text-textMuted'}`}>{size}</Text>
+      </View>
+      <Feather name="download" size={14} color={fromMe ? 'rgba(255,255,255,0.6)' : Colors.textMuted} />
+    </Pressable>
+  );
+}
+
+function MessageBubble({ msg }: { msg: MockMessage }) {
+  const { text, fromMe, time, read, attachment } = msg;
+  return (
+    <View className={`flex-row ${fromMe ? 'justify-end' : 'justify-start'}`}>
+      <View className={`max-w-[78%] rounded-2xl p-3 ${fromMe ? 'rounded-br-sm bg-brandPrimary' : 'rounded-bl-sm border border-borderLight bg-white'}`}>
+        {text ? <Text className={`text-sm leading-5 ${fromMe ? 'text-white' : 'text-textPrimary'}`}>{text}</Text> : null}
+        {attachment && (
+          <FileAttachment name={attachment.name} size={attachment.size} type={attachment.type} fromMe={fromMe} />
+        )}
+        <View className="mt-1 flex-row items-center justify-end gap-1">
+          <Text className={`text-[10px] ${fromMe ? 'text-white/70' : 'text-textMuted'}`}>{time}</Text>
+          {fromMe && (
+            <View className="flex-row items-center">
+              <Feather name="check" size={10} color={read ? 'rgba(255,255,255,0.9)' : 'rgba(255,255,255,0.4)'} />
+              <Feather name="check" size={10} color={read ? 'rgba(255,255,255,0.9)' : 'rgba(255,255,255,0.4)'} style={{ marginLeft: -6 }} />
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function TypingIndicator() {
+  return (
+    <View className="flex-row justify-start">
+      <View className="rounded-2xl rounded-bl-sm border border-borderLight bg-white px-3 py-2">
+        <View className="flex-row items-center gap-1">
+          <View className="h-1.5 w-1.5 rounded-full bg-textMuted" />
+          <View className="h-1.5 w-1.5 rounded-full bg-textMuted opacity-60" />
+          <View className="h-1.5 w-1.5 rounded-full bg-textMuted opacity-30" />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function AttachmentPopup({ onClose }: { onClose: () => void }) {
+  const options = [
+    { icon: 'file-text' as const, label: 'Документ' },
+    { icon: 'image' as const, label: 'Фото' },
+    { icon: 'camera' as const, label: 'Камера' },
+  ];
+  return (
+    <View className="absolute bottom-0 left-0 right-0 z-10">
+      <Pressable className="absolute -top-[500px] bottom-0 left-0 right-0" onPress={onClose} />
+      <View className="mx-4 mb-2 rounded-xl border border-borderLight bg-white p-4 shadow-lg">
+        <Text className="mb-3 text-sm font-semibold text-textPrimary">Прикрепить файл</Text>
+        <View className="flex-row gap-6">
+          {options.map((opt) => (
+            <Pressable key={opt.label} className="items-center gap-1">
+              <View className="h-12 w-12 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+                <Feather name={opt.icon} size={20} color={Colors.brandPrimary} />
+              </View>
+              <Text className="text-xs text-textSecondary">{opt.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function ChatPage() {
+  const [messages] = useState<MockMessage[]>(MOCK_MESSAGES);
+  const [inputText, setInputText] = useState('');
+  const [showAttach, setShowAttach] = useState(false);
+
+  const handleSend = () => {
+    if (!inputText.trim()) return;
+    setInputText('');
+  };
+
+  return (
+    <View className="flex-1 bg-white">
+      <ChatHeader name="Алексей Петров" online={true} />
+      <View className="items-center py-2 px-4">
+        <Text className="rounded-full bg-bgSurface px-3 py-1 text-xs text-textMuted">
+          Заявка: Камеральная проверка декларации по НДС
+        </Text>
+      </View>
+      <ScrollView className="flex-1 px-4" contentContainerStyle={{ gap: 4, paddingVertical: 8 }}>
+        {messages.map((m) => (
+          <MessageBubble key={m.id} msg={m} />
+        ))}
+        <TypingIndicator />
+      </ScrollView>
+      <View className="relative">
+        {showAttach && <AttachmentPopup onClose={() => setShowAttach(false)} />}
+        <View className="border-t border-borderLight bg-white p-3">
+          <View className="flex-row items-center gap-2">
+            <Pressable className="h-9 w-9 items-center justify-center" onPress={() => setShowAttach(!showAttach)}>
+              <Feather name="paperclip" size={18} color={showAttach ? Colors.brandPrimary : Colors.textMuted} />
+            </Pressable>
+            <TextInput
+              value={inputText}
+              onChangeText={setInputText}
+              placeholder="Введите сообщение..."
+              placeholderTextColor={Colors.textMuted}
+              className="h-10 flex-1 rounded-full border border-borderLight bg-bgPrimary px-4 text-sm text-textPrimary"
+              style={{ outlineStyle: 'none' } as any}
+              onSubmitEditing={handleSend}
+              returnKeyType="send"
+            />
+            <Pressable onPress={handleSend} className={`h-10 w-10 items-center justify-center rounded-full bg-brandPrimary shadow-sm ${!inputText.trim() ? 'opacity-50' : ''}`}>
+              <Feather name="arrow-up" size={18} color={Colors.white} />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,181 @@
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView, useWindowDimensions } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, Shadows } from '../constants/Colors';
+import { MOCK_CITIES, MOCK_FNS, MOCK_SERVICES } from '../constants/protoMockData';
 
-export default function Index() {
+function useLayout() {
+  const { width } = useWindowDimensions();
+  return { isDesktop: width >= 768 };
+}
+
+function LandingLocationPicker({
+  city, fns, service, onCityChange, onFnsChange, onServiceChange,
+}: {
+  city: string; fns: string; service: string;
+  onCityChange: (v: string) => void; onFnsChange: (v: string) => void; onServiceChange: (v: string) => void;
+}) {
+  const [openLevel, setOpenLevel] = useState<'city' | 'fns' | 'service' | null>(null);
+  const fnsOptions = city ? (MOCK_FNS[city] || []) : [];
+  const summary = city ? [city, fns, service].filter(Boolean).join(' / ') : '';
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>P2PTax</Text>
+    <View className="gap-1">
+      <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
+        <View className={`min-h-[44px] flex-row items-center gap-2 rounded-xl border px-3 py-2.5 ${openLevel ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
+          <Feather name="map-pin" size={14} color={Colors.textMuted} />
+          <Text className={`flex-1 text-sm ${summary ? 'text-textPrimary' : 'text-textMuted'}`} numberOfLines={2}>
+            {summary || 'Город, ФНС и услуга'}
+          </Text>
+          <Feather name={openLevel ? 'chevron-up' : 'chevron-down'} size={14} color={Colors.textMuted} />
+        </View>
+      </Pressable>
+      {openLevel && (
+        <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
+          <View className="flex-row border-b border-bgSecondary">
+            <Pressable className={`flex-1 items-center py-2 ${openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => setOpenLevel('city')}>
+              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>{city || 'Город'}</Text>
+            </Pressable>
+            <Pressable className={`flex-1 items-center py-2 ${openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => city && setOpenLevel('fns')} disabled={!city}>
+              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : fns ? 'text-textPrimary' : 'text-textMuted'}`}>{fns ? fns.replace(/^ФНС\s*/, '').substring(0, 18) : 'ФНС'}</Text>
+            </Pressable>
+            <Pressable className={`flex-1 items-center py-2 ${openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => fns && setOpenLevel('service')} disabled={!fns}>
+              <Text className={`text-xs font-semibold ${openLevel === 'service' ? 'text-brandPrimary' : service ? 'text-textPrimary' : 'text-textMuted'}`}>{service || 'Услуга'}</Text>
+            </Pressable>
+          </View>
+          <ScrollView nestedScrollEnabled style={{ maxHeight: 160 }}>
+            {openLevel === 'city' && MOCK_CITIES.map((c) => (
+              <Pressable key={c} className="border-b border-bgSecondary px-3 py-2.5" onPress={() => { onCityChange(c); onFnsChange(''); onServiceChange(''); setOpenLevel('fns'); }}>
+                <Text className={`text-sm ${city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
+              </Pressable>
+            ))}
+            {openLevel === 'fns' && fnsOptions.map((f) => (
+              <Pressable key={f} className="border-b border-bgSecondary px-3 py-2.5" onPress={() => { onFnsChange(f); setOpenLevel('service'); }}>
+                <Text className={`text-sm ${fns === f ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f}</Text>
+              </Pressable>
+            ))}
+            {openLevel === 'service' && MOCK_SERVICES.map((sv) => (
+              <Pressable key={sv} className="border-b border-bgSecondary px-3 py-2.5" onPress={() => { onServiceChange(sv); setOpenLevel(null); }}>
+                <Text className={`text-sm ${service === sv ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{sv}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        </View>
+      )}
     </View>
+  );
+}
+
+const SPECIALISTS = [
+  { name: 'Алексей Петров', city: 'Москва', fns: 'ФНС №46', service: 'Выездная проверка', rating: 4.9, reviews: 34, since: 2020, initials: 'АП', color: '#0284C7' },
+  { name: 'Елена Морозова', city: 'Москва', fns: 'ФНС №15', service: 'Камеральная проверка', rating: 4.8, reviews: 28, since: 2021, initials: 'ЕМ', color: '#059669' },
+  { name: 'Дмитрий Волков', city: 'СПб', fns: 'ФНС №1', service: 'Отдел оперативного контроля', rating: 4.9, reviews: 41, since: 2019, initials: 'ДВ', color: '#7C3AED' },
+  { name: 'Ольга Смирнова', city: 'Новосибирск', fns: 'ФНС №12', service: 'Камеральная проверка', rating: 4.7, reviews: 19, since: 2022, initials: 'ОС', color: '#DC2626' },
+  { name: 'Игорь Козлов', city: 'Казань', fns: 'ФНС №3', service: 'Выездная проверка', rating: 4.8, reviews: 23, since: 2021, initials: 'ИК', color: '#D97706' },
+  { name: 'Анна Фёдорова', city: 'Екатеринбург', fns: 'ФНС №8', service: 'Камеральная проверка', rating: 4.6, reviews: 15, since: 2023, initials: 'АФ', color: '#0891B2' },
+];
+
+export default function LandingPage() {
+  const { isDesktop } = useLayout();
+  const [city, setCity] = useState('');
+  const [fns, setFns] = useState('');
+  const [service, setService] = useState('');
+  const [description, setDescription] = useState('');
+
+  return (
+    <ScrollView className="flex-1 bg-white">
+      {/* Hero */}
+      <View className="bg-white px-5" style={{ paddingTop: 40, paddingBottom: 40 }}>
+        <View className="w-full self-center" style={{ maxWidth: 800 }}>
+          <View className={isDesktop ? 'flex-row gap-10' : 'gap-8'}>
+            <View className="flex-1 justify-center">
+              <Text className="font-bold text-textPrimary" style={{ fontSize: isDesktop ? 36 : 28, lineHeight: isDesktop ? 44 : 36, marginBottom: 12 }}>
+                Специалисты, которые знают{'\n'}вашу ФНС изнутри
+              </Text>
+              <Text className="text-textSecondary" style={{ fontSize: 16, lineHeight: 24, marginBottom: 20, maxWidth: 400 }}>
+                Не общие юристы, а конкретные консультанты с опытом работы в конкретных налоговых инспекциях.
+              </Text>
+              <View className="flex-row flex-wrap gap-4">
+                {['Знают вашу инспекцию лично', 'Ответ в течение часа', 'Бесплатная первая консультация'].map((t) => (
+                  <View key={t} className="flex-row items-center gap-2">
+                    <Feather name="check-circle" size={16} color={Colors.statusSuccess} />
+                    <Text className="text-sm text-textSecondary">{t}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+            <View className="rounded-2xl border border-borderLight bg-bgSecondary p-5" style={{ width: isDesktop ? 340 : ('100%' as any), ...Shadows.md }}>
+              <Text className="mb-1 text-lg font-bold text-textPrimary">Разместить запрос</Text>
+              <Text className="mb-4 text-sm text-textSecondary">Опишите вашу ситуацию — специалисты свяжутся с вами</Text>
+              <View className="mb-3">
+                <LandingLocationPicker city={city} fns={fns} service={service} onCityChange={setCity} onFnsChange={setFns} onServiceChange={setService} />
+              </View>
+              <View className="mb-4 gap-1">
+                <TextInput value={description} onChangeText={setDescription} placeholder="Кратко опишите ситуацию..." placeholderTextColor={Colors.textMuted} multiline className="min-h-[72px] rounded-xl border border-borderLight bg-white p-3 text-sm text-textPrimary" style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any} />
+              </View>
+              <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary">
+                <Feather name="send" size={16} color={Colors.white} />
+                <Text className="text-base font-semibold text-white">Отправить заявку</Text>
+              </Pressable>
+              <Text className="mt-2 text-center text-xs text-textMuted">Бесплатно. Специалисты напишут вам сами.</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+
+      {/* Specialists Carousel */}
+      <View className="py-10" style={{ backgroundColor: Colors.bgSecondary }}>
+        <View className="mb-6 w-full self-center px-5" style={{ maxWidth: 800 }}>
+          <Text className="mb-1 text-xs font-bold uppercase" style={{ color: Colors.brandPrimary, letterSpacing: 1.2 }}>Наши специалисты</Text>
+          <Text className="text-2xl font-bold text-textPrimary">Работают на платформе</Text>
+        </View>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingHorizontal: 20, gap: 12 }}>
+          {SPECIALISTS.map((spec) => (
+            <View key={spec.name} className="gap-3 rounded-2xl bg-white p-4" style={{ width: 220, ...Shadows.sm }}>
+              <View className="flex-row items-center gap-3">
+                <View className="items-center justify-center rounded-full" style={{ width: 48, height: 48, backgroundColor: spec.color + '15' }}>
+                  <Text style={{ fontSize: 16, fontWeight: '700', color: spec.color }}>{spec.initials}</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-sm font-semibold text-textPrimary">{spec.name}</Text>
+                  <Text className="text-xs text-textMuted">{spec.city}</Text>
+                </View>
+              </View>
+              <View className="flex-row items-center gap-1.5">
+                <Feather name="home" size={12} color={Colors.brandPrimary} />
+                <Text className="text-xs font-medium text-brandPrimary">{spec.fns}</Text>
+              </View>
+              <View className="self-start rounded-full px-2.5 py-1" style={{ backgroundColor: Colors.brandPrimary + '12' }}>
+                <Text className="text-xs font-medium" style={{ color: Colors.brandPrimary }}>{spec.service}</Text>
+              </View>
+              <View className="flex-row items-center justify-between">
+                <View className="flex-row items-center gap-1">
+                  <Feather name="star" size={12} color="#D97706" />
+                  <Text className="text-xs font-semibold text-textPrimary">{spec.rating}</Text>
+                  <Text className="text-xs text-textMuted">({spec.reviews})</Text>
+                </View>
+                <Text className="text-xs text-textMuted">c {spec.since} г.</Text>
+              </View>
+              <Pressable className="h-9 flex-row items-center justify-center rounded-lg border border-brandPrimary">
+                <Text className="text-xs font-semibold text-brandPrimary">Подробнее</Text>
+              </Pressable>
+            </View>
+          ))}
+        </ScrollView>
+      </View>
+
+      {/* Footer */}
+      <View className="items-center border-t px-5 py-6" style={{ borderTopColor: Colors.borderLight, backgroundColor: '#FAFAFA' }}>
+        <View className="w-full flex-row items-center justify-between" style={{ maxWidth: 800 }}>
+          <View className="flex-row items-center gap-2">
+            <View className="h-6 w-6 items-center justify-center rounded-lg bg-brandPrimary">
+              <Feather name="shield" size={13} color={Colors.white} />
+            </View>
+            <Text className="text-sm font-bold text-textPrimary">P2PTax</Text>
+          </View>
+          <Text className="text-xs text-textMuted">2026. Все права защищены.</Text>
+        </View>
+      </View>
+    </ScrollView>
   );
 }

--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { BackHeader } from '../../components/AppHeader';
+
+const MOCK_REQUEST = {
+  title: 'Выездная проверка ООО «Ромашка»',
+  description:
+    'Назначена выездная налоговая проверка за 2022–2024 годы. Нужен специалист для сопровождения, подготовки документов и представления интересов.',
+  city: 'Москва',
+  fns: 'ФНС №15 по г. Москве',
+  service: 'Выездная проверка',
+  date: '10.03.2024',
+  author: 'Мария К.',
+  responseCount: 3,
+};
+
+const SERVICES = ['Выездная проверка', 'Отдел оперативного контроля', 'Камеральная проверка'];
+
+export default function PublicRequestDetailPage() {
+  const [message, setMessage] = useState('');
+
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Заявка" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-3 rounded-xl border border-borderLight bg-white p-5">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-row items-center gap-1.5 rounded-full bg-[#DCFCE7] px-2 py-0.5">
+              <View className="h-1.5 w-1.5 rounded-full bg-[#15803D]" />
+              <Text className="text-xs font-semibold text-[#15803D]">Активна</Text>
+            </View>
+            <Text className="text-xs text-textMuted">{MOCK_REQUEST.date}</Text>
+          </View>
+
+          <Text className="text-xl font-bold leading-7 text-textPrimary">{MOCK_REQUEST.title}</Text>
+          <Text className="text-base leading-6 text-textSecondary">{MOCK_REQUEST.description}</Text>
+
+          <View className="flex-row flex-wrap gap-2">
+            <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
+              <Feather name="map-pin" size={12} color={Colors.brandPrimary} />
+              <Text className="text-xs font-medium text-brandPrimary">{MOCK_REQUEST.city}</Text>
+            </View>
+            <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
+              <Feather name="briefcase" size={12} color={Colors.brandPrimary} />
+              <Text className="text-xs font-medium text-brandPrimary">{MOCK_REQUEST.service}</Text>
+            </View>
+          </View>
+
+          <View className="h-px bg-borderLight" />
+
+          <View className="flex-row flex-wrap gap-5">
+            <View className="gap-0.5">
+              <Text className="text-xs uppercase tracking-wide text-textMuted">ФНС</Text>
+              <Text className="text-base font-semibold text-textPrimary">{MOCK_REQUEST.fns}</Text>
+            </View>
+            <View className="gap-0.5">
+              <Text className="text-xs uppercase tracking-wide text-textMuted">Клиент</Text>
+              <Text className="text-base font-semibold text-textPrimary">{MOCK_REQUEST.author}</Text>
+            </View>
+          </View>
+
+          <View className="gap-1.5">
+            <Text className="text-xs uppercase tracking-wide text-textMuted">Услуги</Text>
+            <View className="flex-row flex-wrap gap-1.5">
+              {SERVICES.map((s) => (
+                <View key={s} className="rounded-full bg-bgSecondary px-2.5 py-1">
+                  <Text className="text-xs font-medium text-brandPrimary">{s}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        <View className="flex-row items-center gap-2 rounded-lg bg-bgSecondary px-3 py-2">
+          <Feather name="users" size={14} color={Colors.brandPrimary} />
+          <Text className="text-sm text-textSecondary">
+            <Text className="font-semibold text-brandPrimary">{MOCK_REQUEST.responseCount} специалистов</Text> уже написали
+          </Text>
+        </View>
+
+        <View className="gap-2">
+          <Text className="text-sm font-medium text-textSecondary">Написать клиенту</Text>
+          <TextInput
+            value={message}
+            onChangeText={setMessage}
+            multiline
+            placeholder="Напишите первое сообщение клиенту..."
+            placeholderTextColor={Colors.textMuted}
+            className="min-h-[100px] rounded-lg border border-borderLight bg-white p-3 text-base text-textPrimary"
+            style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
+          />
+        </View>
+
+        <View className="flex-row items-center gap-3">
+          <Pressable className="h-12 w-12 items-center justify-center rounded-lg border border-borderLight bg-white">
+            <Feather name="paperclip" size={20} color={Colors.textMuted} />
+          </Pressable>
+          <Pressable className="h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+            <Feather name="send" size={16} color={Colors.white} />
+            <Text className="text-base font-semibold text-white">Отправить</Text>
+          </Pressable>
+        </View>
+
+        <View className="flex-row items-center justify-center gap-1.5">
+          <Feather name="info" size={14} color={Colors.textMuted} />
+          <Text className="text-center text-sm text-textMuted">
+            После отправки вы будете перенаправлены в чат
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialist/respond/[requestId].tsx
+++ b/app/specialist/respond/[requestId].tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { BackHeader } from '../../../components/AppHeader';
+
+export default function SpecialistRespondPage() {
+  const [message, setMessage] = useState('Здравствуйте! Готов помочь с декларацией. Опыт — 8 лет, 200+ успешных деклараций.');
+
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Написать по заявке" />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+          <View className="self-start rounded-full bg-bgSecondary px-2 py-0.5">
+            <Text className="text-xs font-medium text-textMuted">Заявка #1</Text>
+          </View>
+          <Text className="text-lg font-semibold text-textPrimary">Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+          <Text className="text-sm text-textSecondary" numberOfLines={2}>
+            Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры.
+          </Text>
+          <View className="flex-row flex-wrap gap-2">
+            <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
+              <Feather name="map-pin" size={12} color={Colors.textMuted} />
+              <Text className="text-xs text-textMuted">Москва &middot; ИФНС №46</Text>
+            </View>
+            <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
+              <Feather name="dollar-sign" size={12} color={Colors.textMuted} />
+              <Text className="text-xs text-textMuted">3 000 — 5 000 ₽</Text>
+            </View>
+          </View>
+        </View>
+
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Сообщение клиенту</Text>
+          <TextInput
+            value={message}
+            onChangeText={setMessage}
+            multiline
+            placeholder="Напишите первое сообщение клиенту..."
+            placeholderTextColor={Colors.textMuted}
+            className="min-h-[100px] rounded-lg border border-borderLight bg-white p-3 text-base text-textPrimary"
+            style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
+          />
+          <Text className="self-end text-xs text-textMuted">{message.length}/500</Text>
+        </View>
+
+        <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary">
+          <Feather name="send" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Написать по заявке</Text>
+        </Pressable>
+        <Pressable className="items-center py-2">
+          <Text className="text-sm text-textMuted">Отмена</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView, Modal } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { BackHeader } from '../../components/AppHeader';
+
+const MOCK_SPECIALIST = {
+  name: 'Алексей Петров',
+  city: 'Москва',
+  memberSince: 2022,
+  avatar: null,
+  rating: 4.8,
+  reviewCount: 12,
+  about: `Специализируюсь на сопровождении налоговых проверок для юридических лиц и индивидуальных предпринимателей. Более 10 лет опыта работы в сфере налогового консультирования.
+
+Основные направления работы:
+— Подготовка к выездным налоговым проверкам: анализ рисков, систематизация документации, разработка стратегии защиты интересов налогоплательщика.
+— Сопровождение камеральных проверок: подготовка пояснений, ответы на требования ФНС, представление интересов в налоговых органах.
+— Работа с отделом оперативного контроля: консультирование по вопросам оперативных мероприятий, подготовка ответов на запросы.
+
+Имею успешный опыт работы со сложными случаями: крупные доначисления, встречные проверки, проверки по цепочкам контрагентов.
+
+Работаю в нескольких ФНС города Москвы. Консультирую как лично, так и дистанционно.
+
+Гарантирую конфиденциальность и индивидуальный подход к каждому клиенту. Первая консультация — бесплатно.`,
+  fnsServices: [
+    { fns: 'ФНС №15 по г. Москве', services: ['Выездная проверка', 'Камеральная проверка'] },
+    { fns: 'ФНС №46 по г. Москве', services: ['Камеральная проверка', 'Отдел оперативного контроля'] },
+    { fns: 'ФНС №7 по г. Москве', services: ['Выездная проверка'] },
+    { fns: 'ФНС №1 по г. Москве', services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'] },
+    { fns: 'ФНС №33 по г. Москве', services: ['Камеральная проверка'] },
+  ],
+  reviews: [
+    { author: 'Мария К.', date: '15.03.2024', rating: 5, text: 'Отличный специалист, помог с камеральной проверкой' },
+    { author: 'Иван С.', date: '20.02.2024', rating: 4, text: 'Быстро и профессионально сопроводил выездную проверку' },
+  ],
+};
+
+function Stars({ rating, size = 14 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row gap-0.5">
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= rating ? '#F59E0B' : '#E2E8F0'} />
+      ))}
+    </View>
+  );
+}
+
+function FnsModal({ visible, onClose }: { visible: boolean; onClose: () => void }) {
+  const spec = MOCK_SPECIALIST;
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View className="flex-1 items-center justify-center bg-black/50 px-4">
+        <View className="w-full max-w-lg rounded-2xl bg-white">
+          <View className="flex-row items-center justify-between border-b border-gray-200 px-5 py-4">
+            <View className="flex-row items-center gap-2">
+              <Feather name="briefcase" size={18} color="#0284C7" />
+              <Text className="text-lg font-bold text-textPrimary">ФНС и услуги</Text>
+            </View>
+            <Pressable onPress={onClose} className="rounded-full p-1">
+              <Feather name="x" size={22} color="#64748B" />
+            </Pressable>
+          </View>
+          <ScrollView className="max-h-96 px-5 py-3">
+            {spec.fnsServices.map((group, idx) => (
+              <View key={group.fns} className={`gap-2 py-3 ${idx < spec.fnsServices.length - 1 ? 'border-b border-gray-100' : ''}`}>
+                <View className="flex-row items-center gap-2">
+                  <Feather name="home" size={14} color="#64748B" />
+                  <Text className="text-base font-semibold text-textPrimary">{group.fns}</Text>
+                </View>
+                <View className="flex-row flex-wrap gap-2 pl-6">
+                  {group.services.map((svc) => (
+                    <View key={svc} className="flex-row items-center gap-1 rounded-full bg-sky-50 px-3 py-1.5">
+                      <Feather name="check" size={12} color="#0284C7" />
+                      <Text className="text-sm text-brandPrimary">{svc}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+export default function SpecialistProfilePage() {
+  const [message, setMessage] = useState('');
+  const [fnsModalVisible, setFnsModalVisible] = useState(false);
+  const spec = MOCK_SPECIALIST;
+
+  return (
+    <View className="flex-1 bg-white">
+      <BackHeader title="Профиль специалиста" />
+      <ScrollView className="flex-1">
+        <View className="gap-4 p-4">
+          <View className="gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+            <View className="flex-row gap-4">
+              <View className="h-20 w-20 items-center justify-center rounded-full bg-bgSecondary">
+                <Feather name="user" size={32} color="#94A3B8" />
+              </View>
+              <View className="flex-1 gap-1">
+                <Text className="text-xl font-bold text-textPrimary">{spec.name}</Text>
+                <View className="flex-row items-center gap-1">
+                  <Feather name="map-pin" size={14} color="#94A3B8" />
+                  <Text className="text-base text-textMuted">{spec.city}</Text>
+                </View>
+                <View className="flex-row items-center gap-1">
+                  <Stars rating={Math.round(spec.rating)} size={16} />
+                  <Text className="text-sm text-textMuted">{spec.rating} ({spec.reviewCount} отзывов)</Text>
+                </View>
+                <View className="mt-1 flex-row items-center gap-1">
+                  <Feather name="clock" size={13} color="#94A3B8" />
+                  <Text className="text-sm text-textMuted">На сайте с {spec.memberSince} г.</Text>
+                </View>
+              </View>
+            </View>
+            <Text className="text-base leading-6 text-textSecondary">{spec.about}</Text>
+          </View>
+
+          <View className="gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+            <View className="flex-row items-center gap-2">
+              <Feather name="briefcase" size={16} color="#0284C7" />
+              <Text className="text-lg font-semibold text-textPrimary">ФНС и услуги</Text>
+            </View>
+            {spec.fnsServices.slice(0, 2).map((group, idx) => (
+              <View key={group.fns} className={`gap-2 ${idx > 0 ? 'border-t border-gray-100 pt-3' : ''}`}>
+                <View className="flex-row items-center gap-2">
+                  <Feather name="home" size={14} color="#64748B" />
+                  <Text className="text-base font-medium text-textPrimary">{group.fns}</Text>
+                </View>
+                <View className="flex-row flex-wrap gap-2 pl-6">
+                  {group.services.map((svc) => (
+                    <View key={svc} className="flex-row items-center gap-1 rounded-full bg-sky-50 px-3 py-1.5">
+                      <Feather name="check" size={12} color="#0284C7" />
+                      <Text className="text-sm text-brandPrimary">{svc}</Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ))}
+            {spec.fnsServices.length > 2 && (
+              <Pressable onPress={() => setFnsModalVisible(true)} className="mt-1 flex-row items-center justify-center gap-2 rounded-lg border border-brandPrimary py-2.5">
+                <Text className="text-sm font-semibold text-brandPrimary">Все ФНС и услуги ({spec.fnsServices.length})</Text>
+                <Feather name="chevron-right" size={16} color="#0284C7" />
+              </Pressable>
+            )}
+          </View>
+
+          <FnsModal visible={fnsModalVisible} onClose={() => setFnsModalVisible(false)} />
+
+          <View className="gap-3">
+            <View className="flex-row items-center gap-2">
+              <Feather name="message-square" size={16} color="#0284C7" />
+              <Text className="text-lg font-semibold text-textPrimary">Отзывы</Text>
+              <Pressable className="ml-auto flex-row items-center">
+                <Text className="text-base font-medium text-brandPrimary">Все {spec.reviewCount}</Text>
+                <Feather name="chevron-right" size={16} color="#0284C7" />
+              </Pressable>
+            </View>
+            {spec.reviews.map((r) => (
+              <View key={r.date} className="gap-1 border-b border-bgSecondary py-3">
+                <View className="flex-row justify-between">
+                  <View className="flex-row items-center gap-1">
+                    <Feather name="user" size={14} color="#94A3B8" />
+                    <Text className="text-base font-semibold text-textPrimary">{r.author}</Text>
+                  </View>
+                  <View className="flex-row items-center gap-1">
+                    <Feather name="calendar" size={12} color="#94A3B8" />
+                    <Text className="text-sm text-textMuted">{r.date}</Text>
+                  </View>
+                </View>
+                <Stars rating={r.rating} />
+                <Text className="text-base leading-6 text-textSecondary">{r.text}</Text>
+              </View>
+            ))}
+          </View>
+
+          <View className="gap-2">
+            <View className="flex-row items-center gap-2">
+              <Feather name="edit-3" size={16} color="#0284C7" />
+              <Text className="text-lg font-semibold text-textPrimary">Написать специалисту</Text>
+            </View>
+            <TextInput
+              className="min-h-[100px] rounded-lg bg-white p-3 text-base text-textPrimary"
+              style={{ borderWidth: 1, borderColor: '#E5E7EB', outlineStyle: 'none' } as any}
+              placeholder="Опишите вашу задачу или задайте вопрос..."
+              placeholderTextColor="#94A3B8"
+              multiline
+              textAlignVertical="top"
+              value={message}
+              onChangeText={setMessage}
+            />
+            <Pressable className={`mt-1 h-12 flex-row items-center justify-center gap-2 rounded-lg shadow-sm ${message.trim() ? 'bg-brandPrimary' : 'bg-gray-300'}`} disabled={!message.trim()}>
+              <Feather name="send" size={18} color="#FFFFFF" />
+              <Text className="text-base font-semibold text-white">Отправить</Text>
+            </Pressable>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,0 +1,228 @@
+import React, { useState, useMemo } from 'react';
+import { View, Text, Pressable, ScrollView, useWindowDimensions } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { AppHeader } from '../../components/AppHeader';
+
+const MOCK_SPECIALISTS = [
+  { id: '1', name: 'Алексей Петров', city: 'Москва', rating: 4.8, reviewCount: 12, memberSince: 2022,
+    fnsServices: [
+      { fns: 'ФНС №15 по г. Москве', services: ['Выездная проверка', 'Камеральная проверка'] },
+      { fns: 'ФНС №46 по г. Москве', services: ['Камеральная проверка', 'Отдел оперативного контроля'] },
+    ]},
+  { id: '2', name: 'Ольга Смирнова', city: 'Москва', rating: 4.5, reviewCount: 8, memberSince: 2023,
+    fnsServices: [
+      { fns: 'ФНС №15 по г. Москве', services: ['Выездная проверка'] },
+    ]},
+  { id: '3', name: 'Игорь Козлов', city: 'Санкт-Петербург', rating: 4.9, reviewCount: 25, memberSince: 2021,
+    fnsServices: [
+      { fns: 'ФНС №1 по г. Санкт-Петербургу', services: ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'] },
+    ]},
+  { id: '4', name: 'Анна Морозова', city: 'Казань', rating: 4.7, reviewCount: 15, memberSince: 2023,
+    fnsServices: [
+      { fns: 'ФНС №3 по г. Казани', services: ['Камеральная проверка'] },
+      { fns: 'ФНС №14 по г. Казани', services: ['Выездная проверка', 'Отдел оперативного контроля'] },
+    ]},
+];
+
+function getInitials(name: string): string {
+  return name.split(' ').map(w => w[0]).join('').slice(0, 2);
+}
+
+function pluralize(n: number): string {
+  if (n === 1) return 'специалист';
+  if (n >= 2 && n <= 4) return 'специалиста';
+  return 'специалистов';
+}
+
+function Stars({ rating }: { rating: number }) {
+  return (
+    <View className="flex-row gap-0.5">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Feather key={i} name="star" size={13} color={i <= Math.round(rating) ? '#D97706' : '#BAE6FD'} />
+      ))}
+    </View>
+  );
+}
+
+function DropdownSelect({ label, icon, value, options, onSelect, placeholder, disabled }: {
+  label: string;
+  icon: React.ComponentProps<typeof Feather>['name'];
+  value: string;
+  options: string[];
+  onSelect: (v: string) => void;
+  placeholder: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View className="flex-1 gap-1" style={{ zIndex: 10 }}>
+      <Text className="text-xs font-semibold uppercase text-slate-500">{label}</Text>
+      <Pressable
+        className={`h-11 flex-row items-center gap-2 rounded-lg border bg-white px-3 ${open ? 'border-sky-600' : 'border-sky-200'} ${disabled ? 'opacity-50' : ''}`}
+        onPress={() => !disabled && setOpen(!open)}
+      >
+        <Feather name={icon} size={14} color={value ? '#0284C7' : '#94A3B8'} />
+        <Text className={`flex-1 text-sm ${value ? 'text-slate-900' : 'text-slate-400'}`} numberOfLines={1}>
+          {value || placeholder}
+        </Text>
+        <Feather name={open ? 'chevron-up' : 'chevron-down'} size={14} color="#94A3B8" />
+      </Pressable>
+      {open && (
+        <View className="mt-1 max-h-48 rounded-xl border border-sky-200 bg-white shadow-sm">
+          <Pressable className="px-3 py-2" onPress={() => { onSelect(''); setOpen(false); }}>
+            <Text className={`text-sm ${!value ? 'font-semibold text-sky-600' : 'text-slate-900'}`}>Все</Text>
+          </Pressable>
+          {options.map((opt) => (
+            <Pressable key={opt} className="px-3 py-2" onPress={() => { onSelect(opt); setOpen(false); }}>
+              <Text className={`text-sm ${value === opt ? 'font-semibold text-sky-600' : 'text-slate-900'}`}>{opt}</Text>
+            </Pressable>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function SpecialistCard({ specialist, matchedFns }: {
+  specialist: typeof MOCK_SPECIALISTS[0];
+  matchedFns?: string;
+}) {
+  const fnsToShow = matchedFns
+    ? specialist.fnsServices.filter(f => f.fns === matchedFns)
+    : specialist.fnsServices;
+
+  return (
+    <View className="flex-1 gap-3 rounded-xl border border-sky-100 bg-white p-4" style={{ minWidth: 280, shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}>
+      <View className="flex-row gap-3">
+        <View className="h-12 w-12 items-center justify-center rounded-full bg-sky-50">
+          <Text className="text-base font-bold text-sky-600">{getInitials(specialist.name)}</Text>
+        </View>
+        <View className="flex-1 gap-0.5">
+          <Text className="text-base font-semibold text-slate-900">{specialist.name}</Text>
+          <View className="flex-row items-center gap-1">
+            <Feather name="map-pin" size={12} color="#94A3B8" />
+            <Text className="text-sm text-slate-400">{specialist.city}</Text>
+          </View>
+          <View className="mt-0.5 flex-row items-center gap-1">
+            <Stars rating={specialist.rating} />
+            <Text className="text-sm font-bold text-slate-900">{specialist.rating}</Text>
+            <Text className="text-xs text-slate-400">({specialist.reviewCount})</Text>
+          </View>
+        </View>
+      </View>
+
+      <View className="flex-row items-center gap-1">
+        <Feather name="calendar" size={12} color="#94A3B8" />
+        <Text className="text-xs text-slate-400">На сайте с {specialist.memberSince} г.</Text>
+      </View>
+
+      {fnsToShow.map((entry) => (
+        <View key={entry.fns} className="gap-2">
+          <View className="flex-row items-center gap-1.5 rounded-lg bg-sky-50 px-2.5 py-1.5">
+            <Feather name="home" size={13} color="#0284C7" />
+            <Text className="flex-1 text-xs font-semibold text-sky-600" numberOfLines={1}>{entry.fns}</Text>
+          </View>
+          <View className="flex-row flex-wrap gap-1.5">
+            {entry.services.map((svc) => (
+              <View key={svc} className="rounded-full bg-sky-50 px-2 py-1">
+                <Text className="text-xs font-medium text-sky-600">{svc}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      ))}
+
+      <Pressable className="h-10 flex-row items-center justify-center gap-1 rounded-xl border border-sky-600">
+        <Text className="text-sm font-medium text-sky-600">Подробнее</Text>
+        <Feather name="chevron-right" size={16} color="#0284C7" />
+      </Pressable>
+    </View>
+  );
+}
+
+export default function SpecialistsCatalogPage() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
+  const [selectedCity, setSelectedCity] = useState('');
+  const [selectedFns, setSelectedFns] = useState('');
+
+  const cities = useMemo(() => [...new Set(MOCK_SPECIALISTS.map(s => s.city))], []);
+  const fnsOptions = useMemo(() => {
+    if (!selectedCity) return [];
+    const allFns = MOCK_SPECIALISTS
+      .filter(s => s.city === selectedCity)
+      .flatMap(s => s.fnsServices.map(f => f.fns));
+    return [...new Set(allFns)];
+  }, [selectedCity]);
+
+  const handleCityChange = (city: string) => {
+    setSelectedCity(city);
+    setSelectedFns('');
+  };
+
+  const filtered = useMemo(() => {
+    return MOCK_SPECIALISTS.filter((sp) => {
+      if (selectedCity && sp.city !== selectedCity) return false;
+      if (selectedFns && !sp.fnsServices.some(f => f.fns === selectedFns)) return false;
+      return true;
+    });
+  }, [selectedCity, selectedFns]);
+
+  return (
+    <View className="flex-1 bg-white">
+      <AppHeader />
+      <ScrollView className="flex-1" contentContainerStyle={{ padding: 20, gap: 12 }}>
+        <View className="gap-0.5">
+          <Text className="text-xl font-bold text-slate-900">Каталог специалистов</Text>
+          <Text className="text-sm text-slate-400">
+            {filtered.length} {pluralize(filtered.length)} найдено
+          </Text>
+        </View>
+
+        <View className={`gap-3 ${isDesktop ? 'flex-row' : ''}`}>
+          <DropdownSelect label="Город" icon="map-pin" value={selectedCity} options={cities} onSelect={handleCityChange} placeholder="Выберите город" />
+          <DropdownSelect label="ФНС" icon="home" value={selectedFns} options={fnsOptions} onSelect={setSelectedFns} placeholder={selectedCity ? 'Выберите ФНС' : 'Сначала выберите город'} disabled={!selectedCity} />
+        </View>
+
+        {(selectedCity || selectedFns) && (
+          <View className="flex-row flex-wrap items-center gap-2">
+            {selectedCity !== '' && (
+              <Pressable className="flex-row items-center gap-1 rounded-full border border-sky-600 bg-sky-50 px-2 py-1" onPress={() => handleCityChange('')}>
+                <Text className="text-xs font-medium text-sky-600">{selectedCity}</Text>
+                <Feather name="x" size={12} color="#0284C7" />
+              </Pressable>
+            )}
+            {selectedFns !== '' && (
+              <Pressable className="flex-row items-center gap-1 rounded-full border border-sky-600 bg-sky-50 px-2 py-1" onPress={() => setSelectedFns('')}>
+                <Text className="text-xs font-medium text-sky-600">{selectedFns}</Text>
+                <Feather name="x" size={12} color="#0284C7" />
+              </Pressable>
+            )}
+            <Pressable onPress={() => { setSelectedCity(''); setSelectedFns(''); }}>
+              <Text className="text-xs font-medium text-red-600">Сбросить</Text>
+            </Pressable>
+          </View>
+        )}
+
+        {filtered.length === 0 ? (
+          <View className="items-center gap-3 py-10">
+            <View className="h-16 w-16 items-center justify-center rounded-full bg-sky-50">
+              <Feather name="search" size={32} color="#94A3B8" />
+            </View>
+            <Text className="text-lg font-semibold text-slate-900">Специалисты не найдены</Text>
+            <Text className="max-w-xs text-center text-sm text-slate-400">Попробуйте изменить параметры фильтрации</Text>
+          </View>
+        ) : (
+          <View className={`gap-3 ${isDesktop ? 'flex-row flex-wrap' : ''}`}>
+            {filtered.map((sp) => (
+              <SpecialistCard key={sp.id} specialist={sp} matchedFns={selectedFns || undefined} />
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../constants/Colors';
+
+function LogoBlock() {
+  return (
+    <View className="flex-row items-center gap-2">
+      <View className="h-7 w-7 items-center justify-center rounded-md bg-brandPrimary">
+        <Feather name="shield" size={16} color={Colors.white} />
+      </View>
+      <Text className="text-lg font-bold text-textPrimary">Nalogovik</Text>
+    </View>
+  );
+}
+
+function NotifBell({ hasNotif = false }: { hasNotif?: boolean }) {
+  return (
+    <Pressable onPress={() => {}}>
+      <Feather name="bell" size={20} color={Colors.textSecondary} />
+      {hasNotif && (
+        <View className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-statusError" />
+      )}
+    </Pressable>
+  );
+}
+
+function AvatarCircle({ initials }: { initials: string }) {
+  return (
+    <View
+      className="h-8 w-8 items-center justify-center rounded-full border bg-bgSecondary"
+      style={{ borderColor: Colors.border }}
+    >
+      <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
+    </View>
+  );
+}
+
+// Variant: back navigation header for detail/inner pages
+export function BackHeader({ title, onBack }: { title: string; onBack?: () => void }) {
+  return (
+    <View
+      className="h-14 flex-row items-center justify-between border-b bg-bgCard px-4"
+      style={{ borderBottomColor: Colors.borderLight }}
+    >
+      <Pressable className="flex-row items-center gap-2" onPress={onBack}>
+        <Feather name="arrow-left" size={20} color={Colors.brandPrimary} />
+        <Text className="text-base font-semibold text-textPrimary">{title}</Text>
+      </Pressable>
+      <Pressable>
+        <Feather name="more-vertical" size={20} color={Colors.textMuted} />
+      </Pressable>
+    </View>
+  );
+}
+
+// Main authenticated header with logo, bell, avatar
+export function AppHeader({
+  initials = 'EV',
+  hasNotif = false,
+}: {
+  initials?: string;
+  hasNotif?: boolean;
+}) {
+  return (
+    <View
+      className="h-14 flex-row items-center justify-between border-b bg-bgCard px-4"
+      style={{ borderBottomColor: Colors.borderLight }}
+    >
+      <LogoBlock />
+      <View className="flex-row items-center gap-3">
+        <NotifBell hasNotif={hasNotif} />
+        <AvatarCircle initials={initials} />
+      </View>
+    </View>
+  );
+}

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View, Text, Pressable, useWindowDimensions } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../constants/Colors';
+
+type TabDef = {
+  id: string;
+  icon: React.ComponentProps<typeof Feather>['name'];
+  label: string;
+  badge?: boolean;
+};
+
+const CLIENT_TABS: TabDef[] = [
+  { id: 'home', icon: 'home', label: 'Glavnaya' },
+  { id: 'requests', icon: 'file-text', label: 'Zayavki' },
+  { id: 'messages', icon: 'message-circle', label: 'Soobscheniya', badge: true },
+  { id: 'profile', icon: 'user', label: 'Profil' },
+];
+
+const SPECIALIST_TABS: TabDef[] = [
+  { id: 'dashboard', icon: 'briefcase', label: 'Kabinet' },
+  { id: 'responses', icon: 'send', label: 'Otkliki' },
+  { id: 'messages', icon: 'message-circle', label: 'Soobscheniya', badge: true },
+  { id: 'profile', icon: 'user', label: 'Profil' },
+];
+
+export function BottomNav({
+  activeId,
+  variant = 'client',
+  onTabPress,
+}: {
+  activeId: string;
+  variant?: 'client' | 'specialist';
+  onTabPress?: (id: string) => void;
+}) {
+  const { width } = useWindowDimensions();
+  // Hide bottom nav on desktop — desktop uses top nav links
+  if (width >= 640) return null;
+
+  const tabs = variant === 'specialist' ? SPECIALIST_TABS : CLIENT_TABS;
+
+  return (
+    <View
+      className="h-[60px] flex-row items-center border-t bg-bgCard"
+      style={{ borderTopColor: Colors.borderLight }}
+    >
+      {tabs.map((tab) => {
+        const active = tab.id === activeId;
+        return (
+          <Pressable
+            key={tab.id}
+            className="flex-1 items-center justify-center gap-[2px]"
+            onPress={() => onTabPress?.(tab.id)}
+          >
+            <View>
+              <Feather
+                name={tab.icon}
+                size={20}
+                color={active ? Colors.brandPrimary : Colors.textMuted}
+              />
+              {tab.badge && (
+                <View className="absolute -right-1.5 -top-[3px] h-2 w-2 rounded-full bg-statusError" />
+              )}
+            </View>
+            <Text
+              className={`font-medium ${active ? 'font-bold text-brandPrimary' : 'text-textMuted'}`}
+              style={{ fontSize: 10 }}
+            >
+              {tab.label}
+            </Text>
+            {active && (
+              <View className="absolute bottom-0 h-0.5 w-5 rounded-sm bg-brandPrimary" />
+            )}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract DEFAULT state from 22+ proto state files into standalone Expo Router pages
- Create shared AppHeader (logo+bell+avatar, BackHeader) and BottomNav (client/specialist tab variants) components
- Add 5 route group layouts: (auth), (tabs), (dashboard), (onboarding), (admin)
- All pages use NativeWind className, Feather icons, Pressable — no StyleSheet.create
- Mock data preserved from proto for future API replacement

## Pages created
**Auth:** email, otp
**Tabs (client):** dashboard, requests, messages, profile, settings
**Tabs (specialist):** specialist-dashboard, feed
**Dashboard:** my-requests/new, my-requests/[id], responses
**Onboarding:** username, work-area, profile
**Public:** landing (index), specialists catalog, specialist profile, public request detail, chat thread, specialist respond
**Admin:** admin dashboard

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally, no new errors)
- [ ] Each page renders without crash on web
- [ ] Navigation between pages works via Expo Router
- [ ] BottomNav shows correct variant (client vs specialist)

Generated with [Claude Code](https://claude.com/claude-code)