### PR TITLE
feat: rewrite all 22 pages to exact proto DEFAULT copies with NativeWind

### DIFF
--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { View, Text, Image, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_ADMIN_STATS } from '../../constants/protoMockData';
+
+function StatCard({ label, value, color, trend }: { label: string; value: string | number; color: string; trend?: string }) {
+  return (
+    <View
+      className="rounded-lg border border-border bg-bgCard p-3"
+      style={{ width: '48%', gap: 2, shadowColor: '#000', shadowOpacity: 0.05, shadowRadius: 2, elevation: 1 }}
+    >
+      <Text className="text-xs text-textMuted">{label}</Text>
+      <Text className="font-bold" style={{ fontSize: 22, color }}>{value}</Text>
+      {trend && <Text className="text-xs text-statusSuccess">{trend}</Text>}
+    </View>
+  );
+}
+
+function ChartPlaceholder({ title }: { title: string }) {
+  return (
+    <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+      <Text className="text-sm font-semibold text-textPrimary">{title}</Text>
+      <View className="gap-2">
+        <View className="flex-row items-end gap-2" style={{ height: 100 }}>
+          {[40, 65, 45, 80, 55, 70, 90].map((h, i) => (
+            <View
+              key={i}
+              className="flex-1 rounded"
+              style={{ height: h, backgroundColor: i === 6 ? Colors.brandPrimary : Colors.bgSecondary }}
+            />
+          ))}
+        </View>
+        <View className="flex-row gap-2">
+          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map((d) => (
+            <Text key={d} className="flex-1 text-center text-xs text-textMuted">{d}</Text>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function AdminDashboardPage() {
+  const st = MOCK_ADMIN_STATS;
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <Text className="text-xl font-bold text-textPrimary">Панель администратора</Text>
+
+        <View className="flex-row flex-wrap gap-2">
+          <StatCard label="Всего пользователей" value={st.totalUsers} color={Colors.textPrimary} trend="+23 сегодня" />
+          <StatCard label="Специалистов" value={st.totalSpecialists} color={Colors.brandPrimary} />
+          <StatCard label="Всего заявок" value={st.totalRequests} color={Colors.textPrimary} trend="+15 сегодня" />
+          <StatCard label="Активные заявки" value={st.activeRequests} color={Colors.statusSuccess} />
+          <StatCard label="На модерации" value={st.pendingModeration} color={Colors.statusWarning} />
+          <StatCard label="Средний рейтинг" value={st.avgRating} color={Colors.brandPrimary} />
+        </View>
+
+        <View className="items-center gap-1 rounded-lg bg-textPrimary p-4">
+          <Text style={{ fontSize: 14, color: 'rgba(255,255,255,0.7)' }}>Общий доход</Text>
+          <Text className="font-bold text-white" style={{ fontSize: 28 }}>{st.revenue}</Text>
+        </View>
+
+        <Image source={{ uri: 'https://picsum.photos/seed/admin-promo/600/80' }} style={{ width: '100%', height: 80, borderRadius: 10 }} resizeMode="cover" />
+
+        <ChartPlaceholder title="Регистрации за неделю" />
+        <ChartPlaceholder title="Заявки за неделю" />
+
+        <View className="gap-3">
+          <Text className="text-base font-semibold text-textPrimary">Последние действия</Text>
+          {[
+            { action: 'Регистрация', detail: 'Новый пользователь: Сергей К.', time: '5 мин назад' },
+            { action: 'Заявка', detail: 'Новая заявка: Декларация 3-НДФЛ', time: '12 мин назад' },
+            { action: 'Модерация', detail: 'Специалист ожидает проверки', time: '30 мин назад' },
+            { action: 'Отзыв', detail: 'Новый отзыв от Елены В.', time: '1 час назад' },
+          ].map((item, i) => (
+            <View key={i} className="flex-row gap-3" style={{ alignItems: 'flex-start' }}>
+              <View className="mt-1.5 h-2 w-2 rounded-full bg-brandPrimary" />
+              <View className="flex-1" style={{ gap: 1 }}>
+                <Text className="text-sm text-textPrimary">
+                  <Text className="font-semibold">{item.action}: </Text>
+                  <Text className="text-textSecondary">{item.detail}</Text>
+                </Text>
+                <Text className="text-xs text-textMuted">{item.time}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, ActivityIndicator, Pressable } from 'react-native';
+import { Colors } from '../../constants/Colors';
+
+export default function AuthEmailPage() {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = () => {
+    if (!email || !email.includes('@')) {
+      setError('Введите корректный email адрес');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    setTimeout(() => setLoading(false), 1500);
+  };
+
+  return (
+    <View className="items-center gap-6 p-6">
+      <View className="mt-8 items-center gap-1">
+        <Text className="text-textPrimary" style={{ fontSize: 28, fontWeight: '700' }}>Налоговик</Text>
+        <Text className="text-base text-textMuted">Найдите налогового специалиста</Text>
+      </View>
+      <View className="w-full gap-3" style={{ maxWidth: 360 }}>
+        <Text className="text-sm font-medium text-textSecondary">Email</Text>
+        <TextInput
+          value={email}
+          onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
+          placeholder="your@email.com"
+          placeholderTextColor={Colors.textMuted}
+          className={`h-12 rounded-lg border bg-bgCard px-4 text-base text-textPrimary ${error ? 'border-statusError' : 'border-border'}`}
+          keyboardType="email-address"
+          autoCapitalize="none"
+        />
+        {error ? <Text className="text-xs text-statusError">{error}</Text> : null}
+        <Pressable
+          onPress={handleSubmit}
+          disabled={loading}
+          className={`mt-2 h-12 items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-70' : ''}`}
+        >
+          {loading ? (
+            <ActivityIndicator size="small" color={Colors.white} />
+          ) : (
+            <Text className="text-base font-semibold text-white">Получить код</Text>
+          )}
+        </Pressable>
+      </View>
+      <Text className="mt-4 text-center text-xs text-textMuted">Нажимая кнопку, вы соглашаетесь с условиями использования</Text>
+    </View>
+  );
+}

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useRef } from 'react';
+import { View, Text, TextInput, ActivityIndicator, Pressable } from 'react-native';
+import { Colors } from '../../constants/Colors';
+
+export default function AuthOtpPage() {
+  const [digits, setDigits] = useState<string[]>(['', '', '', '', '', '']);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [resendTimer, setResendTimer] = useState(0);
+  const inputRefs = useRef<(TextInput | null)[]>([]);
+
+  const handleDigitChange = (index: number, value: string) => {
+    if (value.length > 1) value = value.slice(-1);
+    if (value && !/^\d$/.test(value)) return;
+    const newDigits = [...digits];
+    newDigits[index] = value;
+    setDigits(newDigits);
+    if (error) setError('');
+    if (value && index < 5) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyPress = (index: number, key: string) => {
+    if (key === 'Backspace' && !digits[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handleSubmit = () => {
+    const code = digits.join('');
+    if (code.length < 6) {
+      setError('Введите все 6 цифр');
+      return;
+    }
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+      if (code !== '000000') {
+        setError('Неверный код. Попробуйте ещё раз.');
+      }
+    }, 1500);
+  };
+
+  const handleResend = () => {
+    if (resendTimer > 0) return;
+    setResendTimer(60);
+    setDigits(['', '', '', '', '', '']);
+    setError('');
+    const interval = setInterval(() => {
+      setResendTimer((prev) => {
+        if (prev <= 1) { clearInterval(interval); return 0; }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  return (
+    <View className="items-center gap-6 p-6">
+      <View className="mt-6 items-center gap-1">
+        <Text className="text-xl font-bold text-textPrimary">Введите код</Text>
+        <Text className="text-sm text-textMuted">Код отправлен на elena@mail.ru</Text>
+      </View>
+      <View className="flex-row justify-center gap-2">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <View
+            key={i}
+            className={`items-center justify-center rounded-lg bg-bgCard ${error ? 'border-statusError' : digits[i] ? 'border-brandPrimary' : 'border-border'}`}
+            style={{ width: 44, height: 52, borderWidth: 1.5 }}
+          >
+            <TextInput
+              ref={(ref) => { inputRefs.current[i] = ref; }}
+              value={digits[i]}
+              onChangeText={(v) => handleDigitChange(i, v)}
+              onKeyPress={(e) => handleKeyPress(i, e.nativeEvent.key)}
+              keyboardType="number-pad"
+              maxLength={1}
+              selectTextOnFocus
+              className="h-full w-full text-center text-textPrimary"
+              style={{ fontSize: 22, fontWeight: '700', color: error ? Colors.statusError : Colors.textPrimary }}
+            />
+          </View>
+        ))}
+      </View>
+      {error ? <Text className="text-center text-xs text-statusError">{error}</Text> : null}
+      <Pressable
+        onPress={handleSubmit}
+        disabled={loading}
+        className={`h-12 w-full items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-70' : ''}`}
+        style={{ maxWidth: 300 }}
+      >
+        {loading ? (
+          <ActivityIndicator size="small" color={Colors.white} />
+        ) : (
+          <Text className="text-base font-semibold text-white">Подтвердить</Text>
+        )}
+      </Pressable>
+      <Pressable onPress={handleResend}>
+        {resendTimer > 0 ? (
+          <Text className="text-sm text-textMuted">Отправить код повторно через {resendTimer} сек</Text>
+        ) : (
+          <Text className="text-sm font-medium text-brandPrimary">Отправить код повторно</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { View, Text, Image, ScrollView, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+import { MOCK_RESPONSES } from '../../../constants/protoMockData';
+
+function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row" style={{ gap: 1 }}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= rating ? Colors.statusWarning : Colors.border} />
+      ))}
+    </View>
+  );
+}
+
+function ResponseCard({ name, city, rating, reviews, price, message }: {
+  name: string; city: string; rating: number; reviews: number; price: string; message: string;
+}) {
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <View className="flex-row items-center gap-3">
+        <Image source={{ uri: `https://picsum.photos/seed/${name.replace(/\s/g, '')}/40/40` }} style={{ width: 40, height: 40, borderRadius: 20 }} />
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-textPrimary">{name}</Text>
+          <Text className="text-xs text-textMuted">{city}</Text>
+        </View>
+        <Text className="text-base font-bold text-brandPrimary">{price}</Text>
+      </View>
+      <View className="flex-row items-center gap-1">
+        <Stars rating={Math.round(rating)} size={14} />
+        <Text className="text-xs text-textMuted">{rating} ({reviews})</Text>
+      </View>
+      <Text className="text-sm text-textSecondary" numberOfLines={2} style={{ lineHeight: 20 }}>{message}</Text>
+      <View className="mt-1 flex-row gap-2">
+        <Pressable className="h-10 flex-1 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-sm font-semibold text-white">Принять</Text>
+        </Pressable>
+        <Pressable className="h-10 flex-1 items-center justify-center rounded-lg border border-border bg-transparent">
+          <Text className="text-sm font-medium text-textPrimary">Написать</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+export default function MyRequestDetailPage() {
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Заявка" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+          <View className="flex-row items-start justify-between gap-2">
+            <Text className="flex-1 text-base font-bold text-textPrimary">Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+            <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: Colors.brandPrimary + '20' }}>
+              <Text className="text-xs font-semibold text-brandPrimary">Активная</Text>
+            </View>
+          </View>
+          <Text className="text-sm text-textSecondary" style={{ lineHeight: 20 }}>
+            Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры.
+          </Text>
+          <View className="gap-2">
+            <View className="flex-row justify-between">
+              <Text className="text-xs text-textMuted">Город</Text>
+              <Text className="text-xs font-medium text-textPrimary">Москва</Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-xs text-textMuted">Услуга</Text>
+              <Text className="text-xs font-medium text-textPrimary">Декларация 3-НДФЛ</Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-xs text-textMuted">Бюджет</Text>
+              <Text className="text-xs font-medium text-textPrimary">3 000 — 5 000 ₽</Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-xs text-textMuted">Дата</Text>
+              <Text className="text-xs font-medium text-textPrimary">08.04.2026</Text>
+            </View>
+          </View>
+          <Text className="text-xs font-semibold text-textPrimary">Прикрепленные документы</Text>
+          <View className="flex-row gap-2">
+            <Image source={{ uri: 'https://picsum.photos/seed/doc-spravka/80/64' }} style={{ width: 80, height: 64, borderRadius: 6 }} />
+            <Image source={{ uri: 'https://picsum.photos/seed/photo-attach/80/64' }} style={{ width: 80, height: 64, borderRadius: 6 }} />
+          </View>
+        </View>
+
+        <Text className="text-base font-semibold text-textPrimary">
+          Отклики ({MOCK_RESPONSES.length})
+        </Text>
+
+        {MOCK_RESPONSES.map((r) => (
+          <ResponseCard
+            key={r.id} name={r.specialistName} city={r.specialistCity}
+            rating={r.rating} reviews={r.reviewCount} price={r.price} message={r.message}
+          />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -1,0 +1,151 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, ActivityIndicator, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+import { MOCK_CITIES, MOCK_SERVICES } from '../../../constants/protoMockData';
+
+export default function NewRequestPage() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [city, setCity] = useState('');
+  const [service, setService] = useState('');
+  const [budget, setBudget] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [showCityPicker, setShowCityPicker] = useState(false);
+  const [showServicePicker, setShowServicePicker] = useState(false);
+
+  const validate = () => {
+    const errs: Record<string, string> = {};
+    if (title.length < 5) errs.title = 'Заголовок должен содержать минимум 5 символов';
+    if (!description) errs.description = 'Обязательное поле';
+    if (!city) errs.city = 'Выберите город';
+    return errs;
+  };
+
+  const handleSubmit = () => {
+    const errs = validate();
+    if (Object.keys(errs).length > 0) { setErrors(errs); return; }
+    setErrors({});
+    setLoading(true);
+    setTimeout(() => { setLoading(false); setSuccess(true); }, 1500);
+  };
+
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Новая заявка" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        {success && (
+          <View className="absolute bottom-0 left-0 right-0 top-0 z-10 items-center justify-center p-4" style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <View className="w-full items-center gap-3 rounded-xl bg-bgCard p-6" style={{ maxWidth: 340 }}>
+              <Feather name="check-circle" size={48} color={Colors.statusSuccess} />
+              <Text className="text-lg font-bold text-textPrimary">Заявка создана!</Text>
+              <Text className="text-center text-sm text-textMuted">Специалисты получат уведомление и смогут откликнуться</Text>
+              <Pressable
+                onPress={() => { setSuccess(false); setTitle(''); setDescription(''); setCity(''); setService(''); setBudget(''); }}
+                className="mt-2 h-11 items-center justify-center rounded-lg bg-brandPrimary px-6"
+              >
+                <Text className="text-sm font-semibold text-white">К моим заявкам</Text>
+              </Pressable>
+            </View>
+          </View>
+        )}
+        <Text className="text-lg font-bold text-textPrimary">Новая заявка</Text>
+        <View className="gap-4">
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Заголовок *</Text>
+            <TextInput
+              value={title}
+              onChangeText={(t) => { setTitle(t); if (errors.title) { const e = { ...errors }; delete e.title; setErrors(e); } }}
+              placeholder="Кратко опишите задачу"
+              placeholderTextColor={Colors.textMuted}
+              className={`h-12 rounded-lg border bg-bgCard px-4 text-base text-textPrimary ${errors.title ? 'border-statusError' : 'border-border'}`}
+            />
+            {errors.title && <Text className="text-xs text-statusError">{errors.title}</Text>}
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Описание *</Text>
+            <TextInput
+              value={description}
+              onChangeText={(t) => { setDescription(t); if (errors.description) { const e = { ...errors }; delete e.description; setErrors(e); } }}
+              placeholder="Подробно опишите, что нужно сделать..."
+              placeholderTextColor={Colors.textMuted}
+              multiline
+              className={`rounded-lg border bg-bgCard p-4 text-base text-textPrimary ${errors.description ? 'border-statusError' : 'border-border'}`}
+              style={{ minHeight: 96, textAlignVertical: 'top' }}
+            />
+            {errors.description && <Text className="text-xs text-statusError">{errors.description}</Text>}
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Город *</Text>
+            <Pressable onPress={() => { setShowCityPicker(!showCityPicker); setShowServicePicker(false); }}>
+              <View className={`h-12 flex-row items-center justify-between rounded-lg border bg-bgCard px-4 ${errors.city ? 'border-statusError' : 'border-border'}`}>
+                <Text className={city ? 'text-base text-textPrimary' : 'text-base text-textMuted'}>{city || 'Выберите город'}</Text>
+                <Text className="text-sm text-textMuted">{'>'}</Text>
+              </View>
+            </Pressable>
+            {showCityPicker && (
+              <View className="overflow-hidden rounded-lg border border-border bg-bgCard" style={{ maxHeight: 200 }}>
+                {MOCK_CITIES.map((c) => (
+                  <Pressable
+                    key={c}
+                    onPress={() => { setCity(c); setShowCityPicker(false); if (errors.city) { const e = { ...errors }; delete e.city; setErrors(e); } }}
+                    className="border-b border-bgSecondary px-4 py-2"
+                  >
+                    <Text className={`text-sm ${city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            )}
+            {errors.city && <Text className="text-xs text-statusError">{errors.city}</Text>}
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Услуга *</Text>
+            <Pressable onPress={() => { setShowServicePicker(!showServicePicker); setShowCityPicker(false); }}>
+              <View className="h-12 flex-row items-center justify-between rounded-lg border border-border bg-bgCard px-4">
+                <Text className={service ? 'text-base text-textPrimary' : 'text-base text-textMuted'}>{service || 'Выберите услугу'}</Text>
+                <Text className="text-sm text-textMuted">{'>'}</Text>
+              </View>
+            </Pressable>
+            {showServicePicker && (
+              <View className="overflow-hidden rounded-lg border border-border bg-bgCard" style={{ maxHeight: 200 }}>
+                {MOCK_SERVICES.map((svc) => (
+                  <Pressable
+                    key={svc}
+                    onPress={() => { setService(svc); setShowServicePicker(false); }}
+                    className="border-b border-bgSecondary px-4 py-2"
+                  >
+                    <Text className={`text-sm ${service === svc ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{svc}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            )}
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Бюджет</Text>
+            <TextInput
+              value={budget}
+              onChangeText={setBudget}
+              placeholder="Например: 5 000 — 10 000 ₽"
+              placeholderTextColor={Colors.textMuted}
+              className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary"
+            />
+          </View>
+        </View>
+        <Pressable
+          onPress={handleSubmit}
+          disabled={loading}
+          className={`h-12 items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-70' : ''}`}
+        >
+          {loading ? (
+            <ActivityIndicator size="small" color={Colors.white} />
+          ) : (
+            <Text className="text-base font-semibold text-white">Создать заявку</Text>
+          )}
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_RESPONSES } from '../../constants/protoMockData';
+
+function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row" style={{ gap: 1 }}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= Math.round(rating) ? Colors.statusWarning : Colors.border} />
+      ))}
+    </View>
+  );
+}
+
+function ResponseItem({ name, price, message, rating, reviews, onAccept, onDecline }: {
+  name: string; price: string; message: string; rating: number; reviews: number;
+  onAccept: () => void; onDecline: () => void;
+}) {
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <View className="flex-row items-center gap-3">
+        <View className="h-10 w-10 items-center justify-center rounded-full bg-bgSecondary">
+          <Text className="text-base font-bold text-brandPrimary">{name[0]}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-textPrimary">{name}</Text>
+          <View className="flex-row items-center gap-1">
+            <Stars rating={rating} />
+            <Text className="text-xs text-textMuted">{rating} ({reviews})</Text>
+          </View>
+        </View>
+        <Text className="text-base font-bold text-brandPrimary">{price}</Text>
+      </View>
+      <Text className="text-sm text-textSecondary" numberOfLines={2}>{message}</Text>
+      <View className="mt-1 flex-row gap-2">
+        <Pressable onPress={onAccept} className="h-9 flex-1 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-sm font-semibold text-white">Принять</Text>
+        </Pressable>
+        <Pressable onPress={onDecline} className="h-9 flex-1 items-center justify-center rounded-lg border border-border">
+          <Text className="text-sm text-textMuted">Отклонить</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+function Popup({ type, name, onConfirm, onCancel }: { type: 'accept' | 'decline'; name: string; onConfirm: () => void; onCancel: () => void }) {
+  const isAccept = type === 'accept';
+  return (
+    <View className="absolute bottom-0 left-0 right-0 top-0 z-10 items-center justify-center p-4" style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
+      <View className="w-full items-center gap-3 rounded-xl bg-bgCard p-6" style={{ maxWidth: 340 }}>
+        <Feather name={isAccept ? 'check' : 'x'} size={40} color={isAccept ? Colors.brandPrimary : Colors.statusError} />
+        <Text className="text-lg font-bold text-textPrimary">{isAccept ? 'Принять отклик?' : 'Отклонить отклик?'}</Text>
+        <Text className="text-center text-sm text-textMuted">
+          {isAccept
+            ? `Специалист ${name} будет назначен исполнителем вашей заявки`
+            : `Отклик от ${name} будет отклонён`}
+        </Text>
+        <View className="w-full gap-2">
+          <Pressable
+            onPress={onConfirm}
+            className="h-11 items-center justify-center rounded-lg"
+            style={{ backgroundColor: isAccept ? Colors.brandPrimary : Colors.statusError }}
+          >
+            <Text className="text-sm font-semibold text-white">{isAccept ? 'Подтвердить' : 'Отклонить'}</Text>
+          </Pressable>
+          <Pressable onPress={onCancel} className="h-11 items-center justify-center rounded-lg border border-border">
+            <Text className="text-sm text-textMuted">Отмена</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function ResponsesPage() {
+  const [popupState, setPopupState] = useState<{ type: 'accept' | 'decline'; name: string } | null>(null);
+
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Отклики" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12, position: 'relative' }}>
+        <Text className="text-lg font-bold text-textPrimary">Отклики ({MOCK_RESPONSES.length})</Text>
+        {MOCK_RESPONSES.map((r) => (
+          <ResponseItem
+            key={r.id}
+            name={r.specialistName}
+            price={r.price}
+            message={r.message}
+            rating={r.rating}
+            reviews={r.reviewCount}
+            onAccept={() => setPopupState({ type: 'accept', name: r.specialistName })}
+            onDecline={() => setPopupState({ type: 'decline', name: r.specialistName })}
+          />
+        ))}
+        {popupState && (
+          <Popup
+            type={popupState.type}
+            name={popupState.name}
+            onConfirm={() => setPopupState(null)}
+            onCancel={() => setPopupState(null)}
+          />
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+export default function OnboardingProfilePage() {
+  const [about, setAbout] = useState('');
+  const [price, setPrice] = useState('');
+
+  return (
+    <View className="gap-4 p-6">
+      <View className="h-1 rounded-sm bg-bgSecondary">
+        <View className="h-1 rounded-sm bg-statusSuccess" style={{ width: '100%' }} />
+      </View>
+      <Text className="text-xs uppercase tracking-wide text-textMuted">Шаг 3 из 3</Text>
+      <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>
+      <Text className="text-sm text-textMuted">Информация поможет клиентам выбрать вас</Text>
+      <View className="gap-4">
+        <View className="flex-row items-center gap-3">
+          <View className="h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+            <Feather name="user" size={28} color={Colors.brandPrimary} />
+          </View>
+          <Pressable><Text className="text-sm font-medium text-brandPrimary">Загрузить фото</Text></Pressable>
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">О себе</Text>
+          <TextInput
+            value={about}
+            onChangeText={setAbout}
+            placeholder="Расскажите о вашем опыте и специализации..."
+            placeholderTextColor={Colors.textMuted}
+            multiline
+            className="rounded-lg border border-border bg-bgCard p-4 text-base text-textPrimary"
+            style={{ minHeight: 96, textAlignVertical: 'top' }}
+          />
+        </View>
+        <View className="gap-1">
+          <Text className="text-sm font-medium text-textSecondary">Стоимость консультации</Text>
+          <TextInput
+            value={price}
+            onChangeText={setPrice}
+            placeholder="Например: 2 000"
+            placeholderTextColor={Colors.textMuted}
+            className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary"
+          />
+        </View>
+      </View>
+      <Pressable className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+        <Text className="text-base font-semibold text-white">Завершить регистрацию</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable } from 'react-native';
+import { Colors } from '../../constants/Colors';
+
+export default function OnboardingUsernamePage() {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  const handleContinue = () => {
+    if (value.length < 3) {
+      setError('Имя должно содержать минимум 3 символа');
+    } else {
+      setError('');
+    }
+  };
+
+  return (
+    <View className="gap-4 p-6">
+      <View className="h-1 rounded-sm bg-bgSecondary">
+        <View className="h-1 rounded-sm bg-brandPrimary" style={{ width: '33%' }} />
+      </View>
+      <Text className="text-xs uppercase tracking-wide text-textMuted">Шаг 1 из 3</Text>
+      <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
+      <Text className="text-sm text-textMuted">Это имя будет отображаться в вашем профиле</Text>
+      <View className="gap-1">
+        <Text className="text-sm font-medium text-textSecondary">Имя пользователя</Text>
+        <TextInput
+          value={value}
+          onChangeText={(t) => { setValue(t); if (error) setError(''); }}
+          placeholder="Например: Елена Васильева"
+          placeholderTextColor={Colors.textMuted}
+          className={`h-12 rounded-lg border bg-bgCard px-4 text-base text-textPrimary ${error ? 'border-statusError' : 'border-border'}`}
+        />
+        {error ? <Text className="text-xs text-statusError">{error}</Text> : null}
+      </View>
+      <Pressable onPress={handleContinue} className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+        <Text className="text-base font-semibold text-white">Продолжить</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/app/(onboarding)/work-area.tsx
+++ b/app/(onboarding)/work-area.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+
+const SERVICES = [
+  'Выездная проверка',
+  'Отдел оперативного контроля',
+  'Камеральная проверка',
+];
+
+const CITIES_FNS: Record<string, string[]> = {
+  'Москва': ['ИФНС №5 по г. Москве', 'ИФНС №12 по г. Москве', 'ИФНС №46 по г. Москве'],
+  'Санкт-Петербург': ['ИФНС №3 по СПб', 'ИФНС №15 по СПб', 'ИФНС №28 по СПб'],
+  'Казань': ['ИФНС №1 по Казани', 'ИФНС №6 по Казани'],
+  'Новосибирск': ['ИФНС №2 по Новосибирску', 'ИФНС №13 по Новосибирску'],
+};
+
+const ALL_CITIES = Object.keys(CITIES_FNS);
+
+type FnsBindings = Record<string, string[]>;
+
+export default function OnboardingWorkAreaPage() {
+  const [search, setSearch] = useState('');
+  const [selectedCities, setSelectedCities] = useState<string[]>([]);
+  const [expandedCity, setExpandedCity] = useState<string | null>(null);
+  const [bindings, setBindings] = useState<FnsBindings>({});
+
+  const filteredCities = search.length > 0
+    ? ALL_CITIES.filter((c) => c.toLowerCase().includes(search.toLowerCase()) && !selectedCities.includes(c))
+    : [];
+
+  const addCity = (city: string) => {
+    setSelectedCities((prev) => [...prev, city]);
+    setSearch('');
+    setExpandedCity(city);
+  };
+
+  const removeCity = (city: string) => {
+    setSelectedCities((prev) => prev.filter((c) => c !== city));
+    setExpandedCity((prev) => prev === city ? null : prev);
+    setBindings((prev) => {
+      const next = { ...prev };
+      Object.keys(next).forEach((k) => { if (k.startsWith(city + ':')) delete next[k]; });
+      return next;
+    });
+  };
+
+  const fnsKey = (city: string, fns: string) => `${city}:${fns}`;
+
+  const toggleFns = (city: string, fns: string) => {
+    const key = fnsKey(city, fns);
+    setBindings((prev) => {
+      if (prev[key]) {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      }
+      return { ...prev, [key]: [] };
+    });
+  };
+
+  const toggleService = (key: string, service: string) => {
+    setBindings((prev) => {
+      const current = prev[key] || [];
+      const updated = current.includes(service)
+        ? current.filter((s) => s !== service)
+        : [...current, service];
+      return { ...prev, [key]: updated };
+    });
+  };
+
+  const totalBindings = Object.keys(bindings).length;
+
+  return (
+    <ScrollView contentContainerStyle={{ padding: 24, gap: 16 }}>
+      <View className="h-1 rounded-sm bg-bgSecondary">
+        <View className="h-1 rounded-sm bg-brandPrimary" style={{ width: '66%' }} />
+      </View>
+      <Text className="text-xs uppercase tracking-wide text-textMuted">Шаг 2 из 3</Text>
+      <Text className="text-xl font-bold text-textPrimary">Где и что вы делаете?</Text>
+      <Text className="text-sm text-textMuted">Выберите города, инспекции и услуги которые оказываете</Text>
+
+      <TextInput
+        value={search}
+        onChangeText={setSearch}
+        placeholder="Найти город..."
+        placeholderTextColor={Colors.textMuted}
+        className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary"
+      />
+
+      {filteredCities.length > 0 && (
+        <View className="overflow-hidden rounded-lg border border-border bg-bgCard">
+          {filteredCities.map((city) => (
+            <Pressable key={city} className="flex-row items-center gap-2 border-b border-bgSecondary px-4 py-3" onPress={() => addCity(city)}>
+              <Feather name="map-pin" size={14} color={Colors.textMuted} />
+              <Text className="flex-1 text-base text-textPrimary">{city}</Text>
+              <Feather name="plus" size={16} color={Colors.brandPrimary} />
+            </Pressable>
+          ))}
+        </View>
+      )}
+
+      {selectedCities.map((city) => {
+        const isExpanded = expandedCity === city;
+        const fnsOffices = CITIES_FNS[city] || [];
+        const cityBindingCount = Object.keys(bindings).filter((k) => k.startsWith(city + ':')).length;
+
+        return (
+          <View key={city} className="overflow-hidden rounded-xl border border-border bg-bgCard">
+            <Pressable className="flex-row items-center gap-2 px-4 py-3" onPress={() => setExpandedCity(isExpanded ? null : city)}>
+              <Feather name="map-pin" size={16} color={Colors.brandPrimary} />
+              <Text className="text-base font-semibold text-textPrimary">{city}</Text>
+              {cityBindingCount > 0 && (
+                <View className="h-5 w-5 items-center justify-center rounded-full bg-brandPrimary">
+                  <Text className="font-bold text-white" style={{ fontSize: 10 }}>{cityBindingCount}</Text>
+                </View>
+              )}
+              <View className="flex-1" />
+              <Pressable onPress={() => removeCity(city)} hitSlop={8}>
+                <Feather name="x" size={16} color={Colors.textMuted} />
+              </Pressable>
+              <Feather name={isExpanded ? 'chevron-up' : 'chevron-down'} size={16} color={Colors.textMuted} />
+            </Pressable>
+
+            {isExpanded && (
+              <View className="border-t border-border">
+                {fnsOffices.map((fns) => {
+                  const key = fnsKey(city, fns);
+                  const isSelected = key in bindings;
+                  const services = bindings[key] || [];
+
+                  return (
+                    <View key={fns}>
+                      <Pressable onPress={() => toggleFns(city, fns)} className="flex-row items-center gap-3 border-b border-bgSecondary px-4 py-3">
+                        <View
+                          className={`h-5.5 w-5.5 items-center justify-center rounded ${isSelected ? 'bg-brandPrimary' : 'border-border'}`}
+                          style={{ width: 22, height: 22, borderWidth: isSelected ? 0 : 1.5, borderColor: isSelected ? Colors.brandPrimary : Colors.border, borderRadius: 4, backgroundColor: isSelected ? Colors.brandPrimary : 'transparent' }}
+                        >
+                          {isSelected && <Feather name="check" size={13} color={Colors.white} />}
+                        </View>
+                        <Text className={`text-sm ${isSelected ? 'font-medium text-brandPrimary' : 'text-textPrimary'}`}>{fns}</Text>
+                      </Pressable>
+
+                      {isSelected && (
+                        <View style={{ paddingLeft: 56, paddingRight: 16, paddingBottom: 12, gap: 4 }}>
+                          {SERVICES.map((svc) => {
+                            const active = services.includes(svc);
+                            return (
+                              <Pressable key={svc} onPress={() => toggleService(key, svc)} className="flex-row items-center gap-2">
+                                <View
+                                  style={{ width: 18, height: 18, borderWidth: active ? 0 : 1.5, borderColor: active ? Colors.brandPrimary : Colors.border, borderRadius: 4, backgroundColor: active ? Colors.brandPrimary : 'transparent', alignItems: 'center', justifyContent: 'center' }}
+                                >
+                                  {active && <Feather name="check" size={11} color={Colors.white} />}
+                                </View>
+                                <Text className={`text-sm ${active ? 'font-medium text-textPrimary' : 'text-textSecondary'}`}>{svc}</Text>
+                              </Pressable>
+                            );
+                          })}
+                        </View>
+                      )}
+                    </View>
+                  );
+                })}
+              </View>
+            )}
+          </View>
+        );
+      })}
+
+      <Pressable className={`h-12 items-center justify-center rounded-lg bg-brandPrimary ${totalBindings === 0 ? 'opacity-45' : ''}`}>
+        <Text className="text-base font-semibold text-white">Продолжить{totalBindings > 0 ? ` (${totalBindings})` : ''}</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { View, Text, Image, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+function StatCard({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <View className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3" style={{ shadowColor: '#000', shadowOpacity: 0.05, shadowRadius: 2, shadowOffset: { width: 0, height: 1 }, elevation: 1 }}>
+      <Text className="font-bold" style={{ fontSize: 24, color }}>{value}</Text>
+      <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>{label}</Text>
+    </View>
+  );
+}
+
+function RequestRow({ title, status, date, statusColor }: { title: string; status: string; date: string; statusColor: string }) {
+  return (
+    <Pressable className="flex-row items-center justify-between rounded-lg border border-border bg-bgCard p-3">
+      <View className="mr-2 flex-1">
+        <Text className="text-sm font-medium text-textPrimary" numberOfLines={1}>{title}</Text>
+        <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>{date}</Text>
+      </View>
+      <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + '20' }}>
+        <Text className="text-xs font-semibold" style={{ color: statusColor }}>{status}</Text>
+      </View>
+    </Pressable>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-1 pt-2">
+          <Text className="text-xl font-bold text-textPrimary">Добрый день, Елена!</Text>
+          <Text className="text-sm text-textMuted">Добро пожаловать в Налоговик</Text>
+        </View>
+        <View className="items-center gap-3 p-8">
+          <Feather name="file-text" size={48} color={Colors.textMuted} />
+          <Text className="text-lg font-semibold text-textPrimary">Пока нет заявок</Text>
+          <Text className="text-center text-sm text-textMuted">Создайте первую заявку, чтобы найти налогового специалиста</Text>
+          <Pressable className="mt-2 h-11 items-center justify-center rounded-lg bg-brandPrimary px-6">
+            <Text className="text-sm font-semibold text-white">Создать заявку</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_REQUESTS, MOCK_CITIES, MOCK_SERVICES } from '../../constants/protoMockData';
+
+function RequestFeedCard({ title, description, city, service, date }: {
+  title: string; description: string; city: string; service: string; date: string;
+}) {
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <Text className="text-base font-semibold text-textPrimary">{title}</Text>
+      <Text className="text-sm text-textSecondary" numberOfLines={2} style={{ lineHeight: 20 }}>{description}</Text>
+      <View className="flex-row gap-2">
+        <View className="rounded-full bg-bgSecondary px-2 py-0.5">
+          <Text className="text-xs text-brandPrimary">{city}</Text>
+        </View>
+        <View className="rounded-full bg-bgSecondary px-2 py-0.5">
+          <Text className="text-xs text-brandPrimary">{service}</Text>
+        </View>
+      </View>
+      <View className="mt-1 flex-row items-center justify-between">
+        <Text className="text-xs text-textMuted">{date}</Text>
+      </View>
+    </View>
+  );
+}
+
+export default function PublicRequestsPage() {
+  const [showFilters, setShowFilters] = useState(false);
+  const [filterCity, setFilterCity] = useState('');
+  const [filterService, setFilterService] = useState('');
+  const [filterBudget, setFilterBudget] = useState('');
+  const [showCityPicker, setShowCityPicker] = useState(false);
+  const [showServicePicker, setShowServicePicker] = useState(false);
+
+  const requests = MOCK_REQUESTS.filter((r) => {
+    if (r.status === 'CANCELLED') return false;
+    if (filterCity && r.city !== filterCity) return false;
+    if (filterService && r.service !== filterService) return false;
+    return true;
+  });
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12 }}>
+        <View className="flex-row items-center justify-between">
+          <Text className="text-lg font-bold text-textPrimary">Заявки</Text>
+          <Pressable onPress={() => setShowFilters(!showFilters)} className="rounded-lg border border-border px-3 py-2">
+            <Text className="text-sm text-brandPrimary">{showFilters ? 'Скрыть' : 'Фильтры'}</Text>
+          </Pressable>
+        </View>
+        {showFilters && (
+          <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+            <Text className="text-base font-semibold text-textPrimary">Фильтры</Text>
+            <View className="gap-1">
+              <Text className="text-xs font-medium text-textMuted">Город</Text>
+              <Pressable onPress={() => { setShowCityPicker(!showCityPicker); setShowServicePicker(false); }}>
+                <View className="h-10 justify-center rounded-lg bg-bgPrimary px-3">
+                  <Text className="text-sm text-textSecondary">{filterCity || 'Все города'}</Text>
+                </View>
+              </Pressable>
+              {showCityPicker && (
+                <View className="overflow-hidden rounded-lg border border-border bg-bgCard" style={{ maxHeight: 200 }}>
+                  <Pressable onPress={() => { setFilterCity(''); setShowCityPicker(false); }} className="border-b border-bgSecondary px-3 py-2">
+                    <Text className="text-sm text-textPrimary">Все города</Text>
+                  </Pressable>
+                  {MOCK_CITIES.map((c) => (
+                    <Pressable key={c} onPress={() => { setFilterCity(c); setShowCityPicker(false); }} className="border-b border-bgSecondary px-3 py-2">
+                      <Text className={`text-sm ${filterCity === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </View>
+            <View className="gap-1">
+              <Text className="text-xs font-medium text-textMuted">Услуга</Text>
+              <Pressable onPress={() => { setShowServicePicker(!showServicePicker); setShowCityPicker(false); }}>
+                <View className="h-10 justify-center rounded-lg bg-bgPrimary px-3">
+                  <Text className="text-sm text-textSecondary">{filterService || 'Все услуги'}</Text>
+                </View>
+              </Pressable>
+              {showServicePicker && (
+                <View className="overflow-hidden rounded-lg border border-border bg-bgCard" style={{ maxHeight: 200 }}>
+                  <Pressable onPress={() => { setFilterService(''); setShowServicePicker(false); }} className="border-b border-bgSecondary px-3 py-2">
+                    <Text className="text-sm text-textPrimary">Все услуги</Text>
+                  </Pressable>
+                  {MOCK_SERVICES.map((svc) => (
+                    <Pressable key={svc} onPress={() => { setFilterService(svc); setShowServicePicker(false); }} className="border-b border-bgSecondary px-3 py-2">
+                      <Text className={`text-sm ${filterService === svc ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{svc}</Text>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </View>
+            <View className="gap-1">
+              <Text className="text-xs font-medium text-textMuted">Бюджет до</Text>
+              <TextInput
+                value={filterBudget}
+                onChangeText={setFilterBudget}
+                placeholder="Макс. сумма"
+                placeholderTextColor={Colors.textMuted}
+                keyboardType="number-pad"
+                className="h-10 rounded-lg bg-bgPrimary px-3 text-sm text-textPrimary"
+              />
+            </View>
+            <Pressable onPress={() => { setFilterCity(''); setFilterService(''); setFilterBudget(''); }} className="h-10 items-center justify-center rounded-lg border border-border">
+              <Text className="text-sm text-textMuted">Сбросить фильтры</Text>
+            </Pressable>
+          </View>
+        )}
+        {requests.length === 0 ? (
+          <View className="items-center gap-2 p-8">
+            <Text className="text-base font-semibold text-textPrimary">Нет заявок по вашим фильтрам</Text>
+            <Text className="text-center text-sm text-textMuted">Попробуйте изменить параметры поиска</Text>
+          </View>
+        ) : (
+          requests.map((r) => (
+            <RequestFeedCard key={r.id} title={r.title} description={r.description} city={r.city} service={r.service} date={r.createdAt} />
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { View, Text, Image, Pressable, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_THREADS } from '../../constants/protoMockData';
+
+function ThreadItem({ name, lastMessage, time, unread, selected, onPress }: {
+  name: string; lastMessage: string; time: string; unread: number; selected: boolean; onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`flex-row items-center gap-3 border-b border-bgSecondary py-3 ${selected ? 'rounded-lg bg-bgSecondary' : ''}`}
+      style={selected ? { marginHorizontal: -16, paddingHorizontal: 16 } : undefined}
+    >
+      <Image source={{ uri: `https://picsum.photos/seed/${name.replace(/\s/g, '')}/44/44` }} style={{ width: 44, height: 44, borderRadius: 22 }} />
+      <View className="flex-1" style={{ gap: 2 }}>
+        <View className="flex-row items-center justify-between">
+          <Text className={`text-sm ${unread > 0 ? 'font-bold' : 'font-medium'} text-textPrimary`}>{name}</Text>
+          <Text className="text-xs text-textMuted">{time}</Text>
+        </View>
+        <View className="flex-row items-center gap-2">
+          <Text className={`flex-1 text-xs ${unread > 0 ? 'font-medium text-textPrimary' : 'text-textMuted'}`} numberOfLines={1}>{lastMessage}</Text>
+          {unread > 0 && (
+            <View className="items-center justify-center rounded-full bg-brandPrimary" style={{ minWidth: 20, height: 20, paddingHorizontal: 5 }}>
+              <Text className="font-bold text-white" style={{ fontSize: 11 }}>{unread}</Text>
+            </View>
+          )}
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+export default function MessagesPage() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 8 }}>
+        <Text className="mb-2 text-lg font-bold text-textPrimary">Сообщения</Text>
+        {MOCK_THREADS.map((t) => (
+          <ThreadItem
+            key={t.id}
+            name={t.name}
+            lastMessage={t.lastMessage}
+            time={t.time}
+            unread={t.unread}
+            selected={selectedId === t.id}
+            onPress={() => setSelectedId(selectedId === t.id ? null : t.id)}
+          />
+        ))}
+        {selectedId && (
+          <View className="mt-2 rounded-lg bg-bgSecondary p-3">
+            <Text className="text-sm font-medium text-brandPrimary">
+              Открыт чат с: {MOCK_THREADS.find((t) => t.id === selectedId)?.name}
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, Image, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View className="flex-row justify-between">
+      <Text className="text-sm text-textMuted">{label}</Text>
+      <Text className="text-sm font-medium text-textPrimary">{value}</Text>
+    </View>
+  );
+}
+
+export default function ProfilePage() {
+  const [editMode, setEditMode] = useState(false);
+  const [name, setName] = useState('Елена Васильева');
+  const [city, setCity] = useState('Москва');
+  const [savedName, setSavedName] = useState('Елена Васильева');
+  const [savedCity, setSavedCity] = useState('Москва');
+
+  const handleSave = () => {
+    setSavedName(name);
+    setSavedCity(city);
+    setEditMode(false);
+  };
+
+  const handleCancel = () => {
+    setName(savedName);
+    setCity(savedCity);
+    setEditMode(false);
+  };
+
+  if (editMode) {
+    return (
+      <View className="flex-1">
+        <Header variant="auth" />
+        <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+          <View className="flex-row items-center gap-4">
+            <Image source={{ uri: 'https://picsum.photos/seed/ElenaV/64/64' }} style={{ width: 64, height: 64, borderRadius: 32 }} />
+            <Pressable><Text className="text-sm font-medium text-brandPrimary">Изменить фото</Text></Pressable>
+          </View>
+          <View className="gap-4">
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-textSecondary">Имя</Text>
+              <TextInput value={name} onChangeText={setName} className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary" />
+            </View>
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-textSecondary">Email</Text>
+              <TextInput value="elena@mail.ru" editable={false} className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary opacity-50" />
+              <Text className="text-xs text-textMuted">Email нельзя изменить</Text>
+            </View>
+            <View className="gap-1">
+              <Text className="text-sm font-medium text-textSecondary">Город</Text>
+              <TextInput value={city} onChangeText={setCity} className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary" />
+            </View>
+          </View>
+          <View className="gap-2">
+            <Pressable onPress={handleSave} className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+              <Text className="text-base font-semibold text-white">Сохранить</Text>
+            </Pressable>
+            <Pressable onPress={handleCancel} className="h-12 items-center justify-center rounded-lg border border-border">
+              <Text className="text-base text-textMuted">Отмена</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="flex-row items-center gap-4">
+          <Image source={{ uri: 'https://picsum.photos/seed/ElenaV/64/64' }} style={{ width: 64, height: 64, borderRadius: 32 }} />
+          <View>
+            <Text className="text-lg font-bold text-textPrimary">{savedName}</Text>
+            <Text className="text-sm text-textMuted">Клиент</Text>
+          </View>
+        </View>
+        <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+          <InfoRow label="Email" value="elena@mail.ru" />
+          <InfoRow label="Город" value={savedCity} />
+          <InfoRow label="Дата регистрации" value="15.02.2026" />
+          <InfoRow label="Заявки" value="5 (3 активных)" />
+        </View>
+        <Pressable onPress={() => setEditMode(true)} className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-base font-semibold text-white">Редактировать</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_REQUESTS } from '../../constants/protoMockData';
+
+const STATUS_MAP: Record<string, { label: string; color: string }> = {
+  NEW: { label: 'Новая', color: Colors.brandPrimary },
+  ACTIVE: { label: 'Активная', color: Colors.statusSuccess },
+  IN_PROGRESS: { label: 'В работе', color: Colors.statusWarning },
+  COMPLETED: { label: 'Завершена', color: Colors.textMuted },
+  CANCELLED: { label: 'Отменена', color: Colors.statusError },
+};
+
+function RequestCard({ title, service, city, status, date, responses }: {
+  title: string; service: string; city: string; status: string; date: string; responses: number;
+}) {
+  const st = STATUS_MAP[status] || STATUS_MAP.NEW;
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <View className="flex-row items-start justify-between gap-2">
+        <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
+        <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: st.color + '20' }}>
+          <Text className="text-xs font-semibold" style={{ color: st.color }}>{st.label}</Text>
+        </View>
+      </View>
+      <View className="flex-row items-center gap-1">
+        <Text className="text-xs text-textMuted">{service}</Text>
+        <Text className="text-xs text-border">{'·'}</Text>
+        <Text className="text-xs text-textMuted">{city}</Text>
+      </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-xs text-textMuted">{date}</Text>
+        {responses > 0 && <Text className="text-xs font-medium text-statusSuccess">{responses} откликов</Text>}
+      </View>
+    </View>
+  );
+}
+
+export default function MyRequestsPage() {
+  const [tab, setTab] = useState<'active' | 'completed'>('active');
+  const activeRequests = MOCK_REQUESTS.filter((r) => ['NEW', 'ACTIVE', 'IN_PROGRESS'].includes(r.status));
+  const completedRequests = MOCK_REQUESTS.filter((r) => ['COMPLETED', 'CANCELLED'].includes(r.status));
+  const visibleRequests = tab === 'active' ? activeRequests : completedRequests;
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12 }}>
+        <View className="flex-row items-center justify-between">
+          <Text className="text-lg font-bold text-textPrimary">Мои заявки</Text>
+          <Pressable className="rounded-lg bg-brandPrimary px-3 py-2">
+            <Text className="text-sm font-semibold text-white">+ Новая</Text>
+          </Pressable>
+        </View>
+        <View className="flex-row gap-2">
+          <Pressable
+            onPress={() => setTab('active')}
+            className={`h-10 flex-1 items-center justify-center rounded-lg border ${tab === 'active' ? 'border-brandPrimary bg-brandPrimary' : 'border-border bg-bgCard'}`}
+          >
+            <Text className={`text-sm font-medium ${tab === 'active' ? 'font-semibold text-white' : 'text-textMuted'}`}>
+              Активные ({activeRequests.length})
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setTab('completed')}
+            className={`h-10 flex-1 items-center justify-center rounded-lg border ${tab === 'completed' ? 'border-brandPrimary bg-brandPrimary' : 'border-border bg-bgCard'}`}
+          >
+            <Text className={`text-sm font-medium ${tab === 'completed' ? 'font-semibold text-white' : 'text-textMuted'}`}>
+              Завершённые ({completedRequests.length})
+            </Text>
+          </Pressable>
+        </View>
+        {visibleRequests.length === 0 ? (
+          <View className="items-center gap-2 p-8">
+            <Text className="text-lg font-semibold text-textPrimary">Нет заявок</Text>
+            <Text className="text-center text-sm text-textMuted">В этой категории пока нет заявок</Text>
+          </View>
+        ) : (
+          visibleRequests.map((r) => (
+            <RequestCard
+              key={r.id} title={r.title} service={r.service}
+              city={r.city} status={r.status} date={r.createdAt} responses={r.responseCount}
+            />
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+function SettingRow({ label, value, danger, onPress }: { label: string; value?: string; danger?: boolean; onPress?: () => void }) {
+  return (
+    <Pressable onPress={onPress} className="flex-row items-center justify-between border-b border-bgSecondary px-4 py-3">
+      <Text className={`flex-1 text-sm ${danger ? 'text-statusError' : 'text-textPrimary'}`}>{label}</Text>
+      {value && <Text className="mr-2 text-sm text-textMuted">{value}</Text>}
+      <Text className="text-sm text-textMuted">{'>'}</Text>
+    </Pressable>
+  );
+}
+
+function ToggleRow({ label, enabled, onToggle }: { label: string; enabled: boolean; onToggle: () => void }) {
+  return (
+    <Pressable onPress={onToggle} className="flex-row items-center justify-between border-b border-bgSecondary px-4 py-3">
+      <Text className="flex-1 text-sm text-textPrimary">{label}</Text>
+      <View
+        className={`justify-center rounded-full ${enabled ? 'bg-brandPrimary' : 'bg-border'}`}
+        style={{ width: 44, height: 24, paddingHorizontal: 2 }}
+      >
+        <View
+          className="rounded-full bg-white"
+          style={{ width: 20, height: 20, alignSelf: enabled ? 'flex-end' : 'flex-start' }}
+        />
+      </View>
+    </Pressable>
+  );
+}
+
+export default function SettingsPage() {
+  const [emailNotif, setEmailNotif] = useState(true);
+  const [pushNotif, setPushNotif] = useState(false);
+  const [responseNotif, setResponseNotif] = useState(true);
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <Text className="text-lg font-bold text-textPrimary">Настройки</Text>
+
+        <View className="gap-2">
+          <Text className="text-sm font-semibold uppercase tracking-wide text-textMuted">Уведомления</Text>
+          <View className="overflow-hidden rounded-lg border border-border bg-bgCard">
+            <ToggleRow label="Email-уведомления" enabled={emailNotif} onToggle={() => setEmailNotif(!emailNotif)} />
+            <ToggleRow label="Push-уведомления" enabled={pushNotif} onToggle={() => setPushNotif(!pushNotif)} />
+            <ToggleRow label="Уведомления о новых откликах" enabled={responseNotif} onToggle={() => setResponseNotif(!responseNotif)} />
+          </View>
+        </View>
+
+        <View className="gap-2">
+          <Text className="text-sm font-semibold uppercase tracking-wide text-textMuted">Аккаунт</Text>
+          <View className="overflow-hidden rounded-lg border border-border bg-bgCard">
+            <SettingRow label="Email" value="elena@mail.ru" />
+            <SettingRow label="Язык" value="Русский" />
+            <SettingRow label="Тема" value="Светлая" />
+          </View>
+        </View>
+
+        <View className="gap-2">
+          <Text className="text-sm font-semibold uppercase tracking-wide text-textMuted">Прочее</Text>
+          <View className="overflow-hidden rounded-lg border border-border bg-bgCard">
+            <SettingRow label="Политика конфиденциальности" />
+            <SettingRow label="Условия использования" />
+            <SettingRow label="Версия" value="1.0.0" />
+          </View>
+        </View>
+
+        <View className="overflow-hidden rounded-lg border border-statusBgError bg-bgCard">
+          <SettingRow label="Выйти из аккаунта" danger />
+          <SettingRow label="Удалить аккаунт" danger />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/(tabs)/specialist-dashboard.tsx
+++ b/app/(tabs)/specialist-dashboard.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { View, Text, Image, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_REQUESTS } from '../../constants/protoMockData';
+
+function RequestCard({ title, city, service, date }: {
+  title: string; city: string; service: string; date: string;
+}) {
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <Text className="text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
+      <View className="flex-row items-center gap-1">
+        <Text className="text-xs text-textMuted">{city}</Text>
+        <Text className="text-xs text-border">{'·'}</Text>
+        <Text className="text-xs text-textMuted">{service}</Text>
+      </View>
+      <View className="flex-row items-center justify-between">
+        <Text className="text-xs text-textMuted">{date}</Text>
+      </View>
+      <Pressable className="mt-1 h-10 items-center justify-center rounded-lg bg-brandPrimary">
+        <Text className="text-sm font-semibold text-white">Откликнуться</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default function SpecialistDashboardPage() {
+  const [tab, setTab] = useState<'new' | 'inProgress' | 'completed'>('new');
+
+  const newRequests = MOCK_REQUESTS.filter(r => r.status === 'NEW' || r.status === 'ACTIVE');
+  const inProgressRequests = MOCK_REQUESTS.filter(r => r.status === 'IN_PROGRESS');
+  const completedRequests = MOCK_REQUESTS.filter(r => r.status === 'COMPLETED' || r.status === 'CANCELLED');
+  const visibleRequests = tab === 'new' ? newRequests : tab === 'inProgress' ? inProgressRequests : completedRequests;
+
+  return (
+    <View className="flex-1">
+      <Header variant="auth" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <Text className="text-xl font-bold text-textPrimary">Добрый день, Алексей!</Text>
+        <Image source={{ uri: 'https://picsum.photos/seed/spec-promo/800/176' }} style={{ width: '100%', height: 88, borderRadius: 10 }} resizeMode="cover" />
+        <View className="flex-row gap-2">
+          <Pressable onPress={() => setTab('new')} className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3" style={{ shadowColor: '#000', shadowOpacity: 0.05, shadowRadius: 2, elevation: 1 }}>
+            <Text className="font-bold text-brandPrimary" style={{ fontSize: 22 }}>{newRequests.length}</Text>
+            <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>Новые</Text>
+          </Pressable>
+          <Pressable onPress={() => setTab('inProgress')} className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3" style={{ shadowColor: '#000', shadowOpacity: 0.05, shadowRadius: 2, elevation: 1 }}>
+            <Text className="font-bold text-statusWarning" style={{ fontSize: 22 }}>{inProgressRequests.length}</Text>
+            <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>В работе</Text>
+          </Pressable>
+          <Pressable onPress={() => setTab('completed')} className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3" style={{ shadowColor: '#000', shadowOpacity: 0.05, shadowRadius: 2, elevation: 1 }}>
+            <Text className="font-bold text-statusSuccess" style={{ fontSize: 22 }}>{completedRequests.length}</Text>
+            <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>Завершены</Text>
+          </Pressable>
+        </View>
+        <View className="flex-row gap-2">
+          {(['new', 'inProgress', 'completed'] as const).map((t) => (
+            <Pressable
+              key={t}
+              onPress={() => setTab(t)}
+              className={`h-9 flex-1 items-center justify-center rounded-lg border ${tab === t ? 'border-brandPrimary bg-brandPrimary' : 'border-border bg-bgCard'}`}
+            >
+              <Text className={`text-xs font-medium ${tab === t ? 'font-semibold text-white' : 'text-textMuted'}`}>
+                {t === 'new' ? 'Новые' : t === 'inProgress' ? 'В работе' : 'Завершены'}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+        {visibleRequests.length === 0 ? (
+          <View className="items-center gap-2 p-6">
+            <Text className="text-base font-semibold text-textPrimary">Нет заявок в этой категории</Text>
+          </View>
+        ) : (
+          visibleRequests.map((r) => (
+            <RequestCard key={r.id} title={r.title} city={r.city} service={r.service} date={r.createdAt} />
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { View, Text, Image, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { MOCK_MESSAGES, MockMessage } from '../../constants/protoMockData';
+
+function ChatHeader() {
+  return (
+    <View className="flex-row items-center gap-3 border-b border-border bg-bgCard px-4 py-3">
+      <Text className="text-lg font-bold text-brandPrimary">{'<'}</Text>
+      <Image source={{ uri: 'https://picsum.photos/seed/AlekseyPetrov/36/36' }} style={{ width: 36, height: 36, borderRadius: 18 }} />
+      <View>
+        <Text className="text-sm font-semibold text-textPrimary">Алексей Петров</Text>
+        <Text className="text-xs text-statusSuccess">Онлайн</Text>
+      </View>
+    </View>
+  );
+}
+
+function MessageBubble({ text, fromMe, time }: { text: string; fromMe: boolean; time: string }) {
+  return (
+    <View className={`flex-row ${fromMe ? 'justify-end' : 'justify-start'}`}>
+      <View
+        className={`rounded-xl p-3 ${fromMe ? 'bg-brandPrimary' : 'border border-border bg-bgCard'}`}
+        style={{ maxWidth: '80%', borderBottomRightRadius: fromMe ? 4 : 12, borderBottomLeftRadius: fromMe ? 12 : 4 }}
+      >
+        <Text className={`text-sm ${fromMe ? 'text-white' : 'text-textPrimary'}`} style={{ lineHeight: 20 }}>{text}</Text>
+        <Text
+          className="self-end"
+          style={{ fontSize: 10, marginTop: 4, color: fromMe ? 'rgba(255,255,255,0.7)' : Colors.textMuted }}
+        >
+          {time}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+export default function MessageThreadPage() {
+  const [messages, setMessages] = useState<MockMessage[]>(MOCK_MESSAGES);
+  const [inputText, setInputText] = useState('');
+
+  const handleSend = () => {
+    if (!inputText.trim()) return;
+    const now = new Date();
+    const time = `${now.getHours()}:${String(now.getMinutes()).padStart(2, '0')}`;
+    setMessages((prev) => [
+      ...prev,
+      { id: String(prev.length + 1), text: inputText.trim(), fromMe: true, time },
+    ]);
+    setInputText('');
+  };
+
+  return (
+    <View className="flex-1">
+      <ChatHeader />
+      <ScrollView contentContainerStyle={{ padding: 12, gap: 8 }}>
+        {messages.map((m, i) => (
+          <View key={m.id}>
+            <MessageBubble text={m.text} fromMe={m.fromMe} time={m.time} />
+            {i === 1 && (
+              <View className="px-3" style={{ marginTop: 4, marginBottom: 4 }}>
+                <Image source={{ uri: 'https://picsum.photos/seed/chat-photo/160/100' }} style={{ width: 160, height: 100, borderRadius: 10 }} />
+              </View>
+            )}
+            {i === 2 && (
+              <View className="items-end px-3" style={{ marginTop: 4, marginBottom: 4 }}>
+                <Image source={{ uri: 'https://picsum.photos/seed/doc-pdf/140/60' }} style={{ width: 140, height: 60, borderRadius: 8 }} />
+              </View>
+            )}
+          </View>
+        ))}
+      </ScrollView>
+      <View className="border-t border-border bg-bgCard p-3">
+        <View className="flex-row items-center gap-2">
+          <Pressable className="h-9 w-9 items-center justify-center">
+            <Feather name="paperclip" size={18} color={Colors.textMuted} />
+          </Pressable>
+          <TextInput
+            value={inputText}
+            onChangeText={setInputText}
+            placeholder="Введите сообщение..."
+            placeholderTextColor={Colors.textMuted}
+            className="h-10 flex-1 rounded-full bg-bgPrimary px-4 text-sm text-textPrimary"
+            onSubmitEditing={handleSend}
+            returnKeyType="send"
+          />
+          <Pressable onPress={handleSend} className="h-10 w-10 items-center justify-center rounded-full bg-brandPrimary">
+            <Text className="text-base font-bold text-white">{'>'}</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,299 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, TextInput, Pressable, Image } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../constants/Colors';
+import { Header } from '../components/Header';
+
+const CITIES = [
+  'Москва', 'Санкт-Петербург', 'Екатеринбург', 'Казань', 'Новосибирск',
+  'Краснодар', 'Нижний Новгород', 'Самара', 'Ростов-на-Дону', 'Уфа',
+  'Челябинск', 'Воронеж', 'Пермь', 'Волгоград', 'Красноярск', 'Омск',
+];
+
+const FNS_MAP: Record<string, string[]> = {
+  'Москва': ['ФНС №1', 'ФНС №5', 'ФНС №12', 'ФНС №18', 'ФНС №24'],
+  'Санкт-Петербург': ['ФНС №2', 'ФНС №7', 'ФНС №15'],
+  'Екатеринбург': ['ФНС №3', 'ФНС №9', 'ФНС №11'],
+  'Казань': ['ФНС №4', 'ФНС №6'],
+  'Новосибирск': ['ФНС №1', 'ФНС №8', 'ФНС №14'],
+  'Краснодар': ['ФНС №2', 'ФНС №10'],
+  'Нижний Новгород': ['ФНС №1', 'ФНС №5', 'ФНС №13'],
+  'Самара': ['ФНС №3', 'ФНС №7'],
+  'Ростов-на-Дону': ['ФНС №2', 'ФНС №6', 'ФНС №11'],
+  'Уфа': ['ФНС №1', 'ФНС №4'],
+  'Челябинск': ['ФНС №3', 'ФНС №8'],
+  'Воронеж': ['ФНС №2', 'ФНС №5'],
+  'Пермь': ['ФНС №1', 'ФНС №6'],
+  'Волгоград': ['ФНС №3', 'ФНС №7'],
+  'Красноярск': ['ФНС №2', 'ФНС №9'],
+  'Омск': ['ФНС №1', 'ФНС №4'],
+};
+
+const SPECIALISTS = [
+  { name: 'Алексей Петров', spec: 'Камеральные проверки', rating: 4.9, city: 'Москва', seed: 'alexei' },
+  { name: 'Мария Иванова', spec: 'Налоговый аудит', rating: 4.8, city: 'Санкт-Петербург', seed: 'maria' },
+  { name: 'Дмитрий Козлов', spec: 'ФНС споры', rating: 4.7, city: 'Екатеринбург', seed: 'dmitry' },
+  { name: 'Елена Соколова', spec: 'Оптимизация налогов', rating: 4.9, city: 'Казань', seed: 'elena' },
+  { name: 'Артём Волков', spec: 'Бухгалтерский учёт', rating: 4.6, city: 'Новосибирск', seed: 'artem' },
+];
+
+function Hero() {
+  return (
+    <View className="bg-textPrimary">
+      <View className="gap-4 p-6 pb-10 pt-8">
+        <View className="mb-3">
+          <Image
+            source={{ uri: 'https://picsum.photos/seed/taxlaw/600/140' }}
+            style={{ width: '100%', height: 140, borderRadius: 12 }}
+            resizeMode="cover"
+          />
+        </View>
+        <Text className="text-2xl font-bold text-white" style={{ lineHeight: 36 }}>
+          {'Найдите налогового\nспециалиста'}
+        </Text>
+        <Text className="text-base" style={{ lineHeight: 24, color: 'rgba(255,255,255,0.8)' }}>
+          Квалифицированные налоговые консультанты, бухгалтеры и юристы в вашем городе
+        </Text>
+        <View className="mt-2 flex-row gap-3">
+          <Pressable className="h-12 flex-row items-center gap-2 rounded-xl bg-brandPrimary px-5">
+            <Feather name="search" size={16} color={Colors.white} />
+            <Text className="text-base font-semibold text-white">Найти специалиста</Text>
+          </Pressable>
+          <Pressable
+            className="h-12 flex-row items-center gap-2 rounded-xl border px-5"
+            style={{ borderColor: 'rgba(255,255,255,0.35)' }}
+          >
+            <Feather name="user-check" size={16} color={Colors.white} />
+            <Text className="text-base font-medium text-white">Я специалист</Text>
+          </Pressable>
+        </View>
+        <View
+          className="mt-5 flex-row items-center rounded-xl p-4"
+          style={{ backgroundColor: 'rgba(255,255,255,0.08)' }}
+        >
+          <View className="flex-1 items-center">
+            <Text className="text-xl font-bold text-white">189</Text>
+            <Text style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', marginTop: 2 }}>Специалистов</Text>
+          </View>
+          <View style={{ width: 1, height: 32, backgroundColor: 'rgba(255,255,255,0.15)' }} />
+          <View className="flex-1 items-center">
+            <Text className="text-xl font-bold text-white">3 400+</Text>
+            <Text style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', marginTop: 2 }}>Заявок</Text>
+          </View>
+          <View style={{ width: 1, height: 32, backgroundColor: 'rgba(255,255,255,0.15)' }} />
+          <View className="flex-1 items-center">
+            <Text className="text-xl font-bold text-white">4.7</Text>
+            <Text style={{ fontSize: 12, color: 'rgba(255,255,255,0.6)', marginTop: 2 }}>Средняя оценка</Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function Features() {
+  const items: { icon: 'search' | 'shield' | 'message-circle' | 'star'; title: string; desc: string }[] = [
+    { icon: 'search', title: 'Умный поиск', desc: 'Найдите специалиста по городу, услуге и бюджету за минуты' },
+    { icon: 'shield', title: 'Верификация', desc: 'Все специалисты проверены через базы ФНС и реестры' },
+    { icon: 'message-circle', title: 'Прямая связь', desc: 'Безопасный чат со специалистом прямо на платформе' },
+    { icon: 'star', title: 'Честные отзывы', desc: 'Реальные оценки и отзывы от проверенных клиентов' },
+  ];
+  return (
+    <View className="gap-4 bg-bgCard p-6">
+      <Text className="text-center text-lg font-bold text-textPrimary">Почему Налоговик?</Text>
+      <View className="flex-row flex-wrap justify-center gap-3">
+        {items.map((item) => (
+          <View
+            key={item.title}
+            className="gap-2 rounded-xl border border-border bg-bgCard p-4"
+            style={{ width: '48%', minWidth: 220 }}
+          >
+            <View className="h-11 w-11 items-center justify-center rounded-xl bg-bgSecondary">
+              <Feather name={item.icon} size={22} color={Colors.brandPrimary} />
+            </View>
+            <Text className="text-base font-semibold text-textPrimary">{item.title}</Text>
+            <Text className="text-sm text-textSecondary" style={{ lineHeight: 20 }}>{item.desc}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function HowItWorks() {
+  const steps = [
+    { num: '1', title: 'Создайте заявку', desc: 'Опишите задачу, укажите город и отделение ФНС' },
+    { num: '2', title: 'Получите отклики', desc: 'Проверенные специалисты предложат свои условия' },
+    { num: '3', title: 'Выберите лучшего', desc: 'Сравните рейтинг, цены и опыт' },
+  ];
+  return (
+    <View className="gap-4 bg-bgPrimary p-6">
+      <Text className="text-center text-lg font-bold text-textPrimary">Как это работает</Text>
+      <View className="px-3">
+        {steps.map((step, i) => (
+          <View key={step.num} className="relative flex-row gap-4 pb-6" style={{ alignItems: 'flex-start' }}>
+            <View className="z-10 h-10 w-10 items-center justify-center rounded-full bg-brandPrimary">
+              <Text className="text-base font-bold text-white">{step.num}</Text>
+            </View>
+            <View className="flex-1 gap-1" style={{ paddingTop: 4 }}>
+              <Text className="text-base font-semibold text-textPrimary">{step.title}</Text>
+              <Text className="text-sm text-textSecondary" style={{ lineHeight: 20 }}>{step.desc}</Text>
+            </View>
+            {i < steps.length - 1 && (
+              <View className="absolute bg-border" style={{ left: 19, top: 44, bottom: 0, width: 2 }} />
+            )}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+function SpecialistsCarousel() {
+  return (
+    <View className="gap-4 bg-bgCard p-6">
+      <Text className="text-center text-lg font-bold text-textPrimary">Лучшие специалисты</Text>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ paddingHorizontal: 8, gap: 12 }}>
+        {SPECIALISTS.map((sp) => (
+          <View key={sp.name} className="items-center rounded-xl border border-border bg-bgCard p-4" style={{ width: 160, gap: 6 }}>
+            <Image source={{ uri: `https://picsum.photos/seed/${sp.seed}/56/56` }} style={{ width: 56, height: 56, borderRadius: 28 }} />
+            <Text className="text-center text-sm font-semibold text-textPrimary">{sp.name}</Text>
+            <Text className="text-center text-xs text-textSecondary">{sp.spec}</Text>
+            <View className="flex-row items-center gap-1">
+              <Feather name="star" size={13} color="#D4A843" />
+              <Text className="text-sm font-semibold text-textPrimary">{sp.rating}</Text>
+            </View>
+            <View className="flex-row items-center gap-1">
+              <Feather name="map-pin" size={12} color={Colors.textMuted} />
+              <Text className="text-xs text-textMuted">{sp.city}</Text>
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}
+
+function RequestForm() {
+  const [city, setCity] = useState('');
+  const [fns, setFns] = useState('');
+  const [description, setDescription] = useState('');
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+
+  const fnsOptions = city ? (FNS_MAP[city] || []) : [];
+
+  return (
+    <View className="gap-4 bg-bgPrimary p-6">
+      <Text className="text-center text-lg font-bold text-textPrimary">Оставить заявку</Text>
+      <View className="w-full gap-3 self-center rounded-xl border border-border bg-bgCard p-5" style={{ maxWidth: 640 }}>
+        <Text className="text-sm font-semibold text-textPrimary">Город</Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8, paddingVertical: 4 }}>
+          {CITIES.map((c) => (
+            <Pressable
+              key={c}
+              className={`rounded-full border px-3 py-2 ${city === c ? 'border-brandPrimary bg-brandPrimary' : 'border-border bg-bgCard'}`}
+              onPress={() => { setCity(c); setFns(''); }}
+            >
+              <Text className={`text-sm ${city === c ? 'font-medium text-white' : 'text-textPrimary'}`}>{c}</Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+
+        {fnsOptions.length > 0 && (
+          <View className="gap-2">
+            <Text className="text-sm font-semibold text-textPrimary">Отделение ФНС</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8, paddingVertical: 4 }}>
+              {fnsOptions.map((f) => (
+                <Pressable
+                  key={f}
+                  className={`rounded-full border px-3 py-2 ${fns === f ? 'border-brandPrimary bg-brandPrimary' : 'border-border bg-bgCard'}`}
+                  onPress={() => setFns(f)}
+                >
+                  <Text className={`text-sm ${fns === f ? 'font-medium text-white' : 'text-textPrimary'}`}>{f}</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </View>
+        )}
+
+        <Text className="text-sm font-semibold text-textPrimary">Опишите вашу задачу</Text>
+        <TextInput
+          className="rounded-lg border border-border bg-bgPrimary px-3 pt-3 text-base text-textPrimary"
+          style={{ minHeight: 88, textAlignVertical: 'top' }}
+          multiline
+          numberOfLines={4}
+          placeholder="Например: нужна помощь с камеральной проверкой за 2025 год..."
+          placeholderTextColor={Colors.textMuted}
+          value={description}
+          onChangeText={setDescription}
+        />
+
+        <Text className="text-sm font-semibold text-textPrimary">Ваше имя</Text>
+        <TextInput
+          className="h-11 rounded-lg border border-border bg-bgPrimary px-3 text-base text-textPrimary"
+          placeholder="Иван Иванов"
+          placeholderTextColor={Colors.textMuted}
+          value={name}
+          onChangeText={setName}
+        />
+
+        <Text className="text-sm font-semibold text-textPrimary">Email</Text>
+        <TextInput
+          className="h-11 rounded-lg border border-border bg-bgPrimary px-3 text-base text-textPrimary"
+          placeholder="your@email.com"
+          placeholderTextColor={Colors.textMuted}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          value={email}
+          onChangeText={setEmail}
+        />
+
+        <Pressable className="mt-2 h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary">
+          <Feather name="send" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Отправить заявку</Text>
+        </Pressable>
+
+        <View className="flex-row items-center gap-2">
+          <Feather name="info" size={13} color={Colors.textMuted} />
+          <Text className="flex-1 text-xs text-textMuted">После отправки вам придёт код подтверждения на email</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function FooterSection() {
+  return (
+    <View className="gap-4 bg-textPrimary p-6">
+      <View className="flex-row items-start justify-between">
+        <View className="flex-row items-center gap-2">
+          <Feather name="briefcase" size={18} color="#D4A843" />
+          <Text className="text-base font-bold text-white">Налоговик</Text>
+        </View>
+        <View className="items-end gap-2">
+          <Text style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>О сервисе</Text>
+          <Text style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>Специалисты</Text>
+          <Text style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>Тарифы</Text>
+          <Text style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)' }}>Контакты</Text>
+        </View>
+      </View>
+      <View style={{ height: 1, backgroundColor: 'rgba(255,255,255,0.1)' }} />
+      <Text style={{ fontSize: 12, color: 'rgba(255,255,255,0.4)', textAlign: 'center' }}>2026 Налоговик. Все права защищены.</Text>
+    </View>
+  );
+}
+
+export default function LandingPage() {
+  return (
+    <ScrollView className="bg-bgCard">
+      <Header variant="guest" />
+      <Hero />
+      <Features />
+      <HowItWorks />
+      <SpecialistsCarousel />
+      <RequestForm />
+      <FooterSection />
+    </ScrollView>
+  );
+}

--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { View, Text, Pressable, ScrollView } from 'react-native';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+
+export default function PublicRequestDetailPage() {
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Заявка" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+          <Text className="text-lg font-bold text-textPrimary">Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+          <Text className="text-sm text-textSecondary" style={{ lineHeight: 22 }}>
+            Нужно заполнить и подать декларацию 3-НДФЛ для получения налогового вычета за покупку квартиры. Документы готовы.
+          </Text>
+          <View className="flex-row gap-2">
+            <View className="rounded-full bg-bgSecondary px-2 py-1">
+              <Text className="text-xs text-brandPrimary">Москва</Text>
+            </View>
+            <View className="rounded-full bg-bgSecondary px-2 py-1">
+              <Text className="text-xs text-brandPrimary">Декларация 3-НДФЛ</Text>
+            </View>
+          </View>
+          <View className="gap-2 border-t border-bgSecondary pt-2">
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-textMuted">Бюджет</Text>
+              <Text className="text-sm font-medium text-textPrimary">3 000 — 5 000 ₽</Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-textMuted">Дата</Text>
+              <Text className="text-sm font-medium text-textPrimary">08.04.2026</Text>
+            </View>
+            <View className="flex-row justify-between">
+              <Text className="text-sm text-textMuted">Клиент</Text>
+              <Text className="text-sm font-medium text-textPrimary">Елена В.</Text>
+            </View>
+          </View>
+        </View>
+        <Pressable className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-base font-semibold text-white">Откликнуться</Text>
+        </Pressable>
+        <Text className="text-center text-xs text-textMuted">Для отклика необходимо войти как специалист</Text>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialist/respond/[requestId].tsx
+++ b/app/specialist/respond/[requestId].tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../../constants/Colors';
+import { Header } from '../../../components/Header';
+
+export default function SpecialistRespondPage() {
+  const [price, setPrice] = useState('4 500');
+  const [message, setMessage] = useState('Здравствуйте! Готов помочь с декларацией. Опыт — 8 лет, 200+ успешных деклараций.');
+  const [deadline, setDeadline] = useState('2 рабочих дня');
+  const [popup, setPopup] = useState<'success' | 'error' | null>(null);
+
+  const handleSubmit = () => {
+    setPopup(Math.random() > 0.3 ? 'success' : 'error');
+  };
+
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Откликнуться" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16, position: 'relative' }}>
+        {popup && (
+          <View className="absolute bottom-0 left-0 right-0 top-0 z-10 items-center justify-center p-4" style={{ backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <View className="w-full items-center gap-3 rounded-xl bg-bgCard p-6" style={{ maxWidth: 340 }}>
+              <Feather
+                name={popup === 'success' ? 'check' : 'x'}
+                size={44}
+                color={popup === 'success' ? Colors.statusSuccess : Colors.statusError}
+              />
+              <Text className="text-lg font-bold text-textPrimary">
+                {popup === 'success' ? 'Отклик отправлен!' : 'Ошибка отправки'}
+              </Text>
+              <Text className="text-center text-sm text-textMuted">
+                {popup === 'success'
+                  ? 'Клиент получит уведомление о вашем отклике и сможет связаться с вами'
+                  : 'Не удалось отправить отклик. Попробуйте ещё раз.'}
+              </Text>
+              <Pressable
+                onPress={() => setPopup(null)}
+                className="h-11 w-full items-center justify-center rounded-lg"
+                style={{ backgroundColor: popup === 'success' ? Colors.brandPrimary : Colors.statusError }}
+              >
+                <Text className="text-sm font-semibold text-white">
+                  {popup === 'success' ? 'К моим откликам' : 'Попробовать снова'}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        )}
+        <View className="gap-2 rounded-lg bg-bgSecondary p-4">
+          <Text className="text-base font-semibold text-textPrimary">Заполнить декларацию 3-НДФЛ за 2025 год</Text>
+          <View className="flex-row items-center gap-1">
+            <Text className="text-xs text-textMuted">Москва</Text>
+            <Text className="text-xs text-border">{'·'}</Text>
+            <Text className="text-xs text-textMuted">3 000 — 5 000 ₽</Text>
+          </View>
+        </View>
+        <View className="gap-4">
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Ваша цена *</Text>
+            <TextInput
+              value={price}
+              onChangeText={setPrice}
+              placeholder="Укажите стоимость в рублях"
+              placeholderTextColor={Colors.textMuted}
+              keyboardType="number-pad"
+              className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary"
+            />
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Сообщение клиенту *</Text>
+            <TextInput
+              value={message}
+              onChangeText={setMessage}
+              multiline
+              className="rounded-lg border border-border bg-bgCard p-4 text-base text-textPrimary"
+              style={{ minHeight: 80, textAlignVertical: 'top' }}
+            />
+          </View>
+          <View className="gap-1">
+            <Text className="text-sm font-medium text-textSecondary">Срок выполнения</Text>
+            <TextInput
+              value={deadline}
+              onChangeText={setDeadline}
+              className="h-12 rounded-lg border border-border bg-bgCard px-4 text-base text-textPrimary"
+            />
+          </View>
+        </View>
+        <Pressable onPress={handleSubmit} className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-base font-semibold text-white">Отправить отклик</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { View, Text, Image, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_REVIEWS } from '../../constants/protoMockData';
+
+function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row" style={{ gap: 1 }}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= rating ? Colors.statusWarning : Colors.border} />
+      ))}
+    </View>
+  );
+}
+
+function ReviewItem({ author, rating, text, date }: { author: string; rating: number; text: string; date: string }) {
+  return (
+    <View className="gap-1 border-b border-bgSecondary py-2">
+      <View className="flex-row justify-between">
+        <Text className="text-sm font-semibold text-textPrimary">{author}</Text>
+        <Text className="text-xs text-textMuted">{date}</Text>
+      </View>
+      <Stars rating={rating} />
+      <Text className="text-sm text-textSecondary" style={{ lineHeight: 20 }}>{text}</Text>
+    </View>
+  );
+}
+
+export default function SpecialistProfilePublicPage() {
+  return (
+    <View className="flex-1">
+      <Header variant="back" backTitle="Специалист" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+        <View className="gap-3 rounded-lg border border-border bg-bgCard p-4">
+          <View className="flex-row gap-4">
+            <Image source={{ uri: 'https://picsum.photos/seed/aleksei-petrov/80/80' }} style={{ width: 80, height: 80, borderRadius: 40 }} />
+            <View className="flex-1" style={{ gap: 2 }}>
+              <Text className="text-lg font-bold text-textPrimary">Алексей Петров</Text>
+              <Text className="text-sm text-textMuted">Санкт-Петербург</Text>
+              <View className="mt-0.5 flex-row items-center gap-1">
+                <Stars rating={5} size={14} />
+                <Text className="text-xs text-textMuted">4.8 (42 отзыва)</Text>
+              </View>
+            </View>
+          </View>
+          <View className="flex-row items-center gap-2 rounded bg-statusBgSuccess p-2">
+            <Feather name="check" size={16} color={Colors.statusSuccess} />
+            <Text className="text-xs font-medium text-statusSuccess">Верифицирован через ФНС</Text>
+          </View>
+          <Text className="text-sm text-textSecondary" style={{ lineHeight: 20 }}>
+            Налоговый консультант с опытом работы в ФНС. Специализация — НДФЛ и имущественные вычеты.
+            Более 200 успешно поданных деклараций.
+          </Text>
+        </View>
+
+        <View className="gap-3">
+          <Text className="text-base font-semibold text-textPrimary">Услуги</Text>
+          <View className="flex-row flex-wrap gap-2">
+            {['Декларация 3-НДФЛ', 'Налоговый вычет', 'Консультация по налогам'].map((svc) => (
+              <View key={svc} className="rounded-full bg-bgSecondary px-3 py-1">
+                <Text className="text-sm text-brandPrimary">{svc}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View className="gap-3">
+          <View className="flex-row gap-2">
+            <View className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3">
+              <Text className="text-lg font-bold text-textPrimary">8 лет</Text>
+              <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>Опыт</Text>
+            </View>
+            <View className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3">
+              <Text className="text-lg font-bold text-textPrimary">215</Text>
+              <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>Заказов</Text>
+            </View>
+            <View className="flex-1 items-center rounded-lg border border-border bg-bgCard p-3">
+              <Text className="text-lg font-bold text-textPrimary">98%</Text>
+              <Text className="text-xs text-textMuted" style={{ marginTop: 2 }}>Успешных</Text>
+            </View>
+          </View>
+        </View>
+
+        <View className="gap-3">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-base font-semibold text-textPrimary">Отзывы</Text>
+            <Text className="text-sm font-medium text-brandPrimary">Все 42 {'>'}</Text>
+          </View>
+          {MOCK_REVIEWS.slice(0, 2).map((r) => (
+            <ReviewItem key={r.id} author={r.author} rating={r.rating} text={r.text} date={r.date} />
+          ))}
+        </View>
+
+        <View className="gap-3">
+          <Text className="text-base font-semibold text-textPrimary">Документы и сертификаты</Text>
+          <View className="flex-row gap-2">
+            <Image source={{ uri: 'https://picsum.photos/seed/diploma/100/80' }} style={{ width: 100, height: 80, borderRadius: 6 }} />
+            <Image source={{ uri: 'https://picsum.photos/seed/certificate/100/80' }} style={{ width: 100, height: 80, borderRadius: 6 }} />
+            <Image source={{ uri: 'https://picsum.photos/seed/license/100/80' }} style={{ width: 100, height: 80, borderRadius: 6 }} />
+          </View>
+        </View>
+
+        <Pressable className="h-12 items-center justify-center rounded-lg bg-brandPrimary">
+          <Text className="text-base font-semibold text-white">Связаться</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { View, Text, Image, TextInput, Pressable, ScrollView } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors } from '../../constants/Colors';
+import { Header } from '../../components/Header';
+import { MOCK_SPECIALISTS } from '../../constants/protoMockData';
+
+function Stars({ rating, size = 12 }: { rating: number; size?: number }) {
+  return (
+    <View className="flex-row" style={{ gap: 1 }}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Feather key={i} name="star" size={size} color={i <= Math.round(rating) ? Colors.statusWarning : Colors.border} />
+      ))}
+    </View>
+  );
+}
+
+function SpecialistCard({ name, city, services, rating, reviews, experience, completedOrders }: {
+  name: string; city: string; services: string[]; rating: number; reviews: number; experience: string; completedOrders: number;
+}) {
+  const seed = name.replace(/\s/g, '-').toLowerCase();
+  return (
+    <View className="gap-2 rounded-lg border border-border bg-bgCard p-4">
+      <View className="flex-row gap-3">
+        <Image source={{ uri: `https://picsum.photos/seed/${seed}/48/48` }} style={{ width: 48, height: 48, borderRadius: 24 }} />
+        <View className="flex-1" style={{ gap: 1 }}>
+          <Text className="text-base font-semibold text-textPrimary">{name}</Text>
+          <Text className="text-xs text-textMuted">{city}</Text>
+          <View className="mt-0.5 flex-row items-center gap-1">
+            <Stars rating={rating} />
+            <Text className="text-xs text-textMuted">{rating} ({reviews})</Text>
+          </View>
+        </View>
+      </View>
+      <View className="flex-row flex-wrap gap-1">
+        {services.slice(0, 2).map((svc) => (
+          <View key={svc} className="rounded-full bg-bgSecondary px-2 py-0.5">
+            <Text className="text-xs text-brandPrimary">{svc}</Text>
+          </View>
+        ))}
+        {services.length > 2 && (
+          <View className="rounded-full bg-bgSecondary px-2 py-0.5">
+            <Text className="text-xs text-brandPrimary">+{services.length - 2}</Text>
+          </View>
+        )}
+      </View>
+      <View className="flex-row items-center gap-1">
+        <Text className="text-xs text-textMuted">Опыт: {experience}</Text>
+        <Text className="text-xs text-border">{'·'}</Text>
+        <Text className="text-xs text-textMuted">{completedOrders} заказов</Text>
+      </View>
+      <Pressable className="h-10 items-center justify-center rounded-lg border border-brandPrimary">
+        <Text className="text-sm font-medium text-brandPrimary">Подробнее</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default function SpecialistsCatalogPage() {
+  const [search, setSearch] = useState('');
+
+  const filtered = MOCK_SPECIALISTS.filter((sp) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      sp.name.toLowerCase().includes(q) ||
+      sp.city.toLowerCase().includes(q) ||
+      sp.services.some((svc) => svc.toLowerCase().includes(q))
+    );
+  });
+
+  return (
+    <View className="flex-1">
+      <Header variant="guest" />
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 12 }}>
+        <Text className="text-lg font-bold text-textPrimary">Специалисты</Text>
+        <TextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Поиск по имени, городу, услуге..."
+          placeholderTextColor={Colors.textMuted}
+          className="h-11 rounded-lg border border-border bg-bgCard px-4 text-sm text-textPrimary"
+        />
+        {search && (
+          <Text className="text-sm text-textMuted">Найдено: {filtered.length} {filtered.length === 1 ? 'специалист' : 'специалистов'}</Text>
+        )}
+        {filtered.length === 0 ? (
+          <View className="items-center gap-2 p-8">
+            <Text className="text-base font-semibold text-textPrimary">Специалисты не найдены</Text>
+            <Text className="text-center text-sm text-textMuted">Попробуйте изменить параметры поиска</Text>
+          </View>
+        ) : (
+          filtered.map((sp) => (
+            <SpecialistCard
+              key={sp.id} name={sp.name} city={sp.city} services={sp.services}
+              rating={sp.rating} reviews={sp.reviewCount} experience={sp.experience} completedOrders={sp.completedOrders}
+            />
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Rewrote all 22 app pages as exact copies of their proto state DEFAULT screens
- Converted StyleSheet.create to NativeWind className props throughout
- Replaced ProtoHeader/ProtoBurger with `<Header variant="..." />` component
- Removed StateSection wrappers, made all pages default exports
- Fixed mock data type mismatches (MOCK_SERVICES is string[], MockRequest has no budget field)

## Files changed (22)
All pages under `app/`: index, (auth)/email, (auth)/otp, (tabs)/dashboard, (tabs)/requests, (tabs)/messages, (tabs)/feed, (tabs)/profile, (tabs)/settings, (tabs)/specialist-dashboard, (dashboard)/my-requests/new, (dashboard)/my-requests/[id], (dashboard)/responses, (onboarding)/username, (onboarding)/work-area, (onboarding)/profile, (admin)/index, chat/[id], specialists/index, specialists/[nick], requests/[id], specialist/respond/[requestId]

## Test plan
- [x] `npx tsc --noEmit` passes (only pre-existing errors in e2e/lib files remain)
- [ ] Visual check of each page in browser

Generated with [Claude Code](https://claude.com/claude-code)