### PR TITLE
fix: remove useAuth from pages — pages crash

### DIFF
--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -4,7 +4,6 @@ import { Feather } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { MOCK_ADMIN_STATS } from '../../constants/protoMockData';
 import { Header } from '../../components/Header';
-import { useAuth } from '../../lib/auth/AuthContext';
 
 function SkeletonBlock({ width, height, radius }: { width: string | number; height: number; radius?: number }) {
   return (
@@ -119,11 +118,9 @@ function DefaultDashboard() {
 }
 
 export default function AdminDashboardPage() {
-  const { user } = useAuth();
-  const initials = user?.email?.slice(0, 2).toUpperCase() ?? 'EV';
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <Header variant="auth" initials={initials} />
+      <Header variant="auth" />
       <DefaultDashboard />
     </View>
   );

--- a/app/(dashboard)/responses.tsx
+++ b/app/(dashboard)/responses.tsx
@@ -4,7 +4,6 @@ import { Feather } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { MOCK_RESPONSES } from '../../constants/protoMockData';
 import { Header } from '../../components/Header';
-import { useAuth } from '../../lib/auth/AuthContext';
 
 function Stars({ rating, size = 14 }: { rating: number; size?: number }) {
   return (
@@ -101,11 +100,9 @@ function DefaultResponses() {
 }
 
 export default function ResponsesScreen() {
-  const { user } = useAuth();
-  const initials = user?.email?.slice(0, 2).toUpperCase() ?? 'EV';
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <Header variant="auth" initials={initials} />
+      <Header variant="auth" />
       <DefaultResponses />
     </View>
   );

--- a/app/pricing.tsx
+++ b/app/pricing.tsx
@@ -4,7 +4,6 @@ import { Feather } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../constants/Colors';
 import { MOCK_PRICING_PLANS } from '../constants/protoMockData';
 import { Header } from '../components/Header';
-import { useAuth } from '../lib/auth/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -160,12 +159,9 @@ function DefaultState() {
 }
 
 export default function PricingPage() {
-  const { isAuthenticated, user } = useAuth();
-  const variant = isAuthenticated ? 'auth' : 'guest';
-  const initials = user?.email?.slice(0, 2).toUpperCase() ?? 'EV';
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <Header variant={variant} initials={initials} />
+      <Header variant="guest" />
       <DefaultState />
     </View>
   );

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from 'react';
 import { View, Text, Pressable, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Header } from '../../components/Header';
-import { useAuth } from '../../lib/auth/AuthContext';
 
 // ---------------------------------------------------------------------------
 // Mock data
@@ -273,12 +272,9 @@ function CatalogState() {
 }
 
 export default function SpecialistsCatalogPage() {
-  const { isAuthenticated, user } = useAuth();
-  const variant = isAuthenticated ? 'auth' : 'guest';
-  const initials = user?.email?.slice(0, 2).toUpperCase() ?? 'EV';
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <Header variant={variant} initials={initials} />
+      <Header variant="guest" />
       <CatalogState />
     </View>
   );

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -3,7 +3,6 @@ import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
 import { Header } from '../components/Header';
-import { useAuth } from '../lib/auth/AuthContext';
 
 // ---------------------------------------------------------------------------
 // LOADED state — terms content rendered
@@ -77,12 +76,9 @@ function LoadedState() {
 }
 
 export default function TermsPage() {
-  const { isAuthenticated, user } = useAuth();
-  const variant = isAuthenticated ? 'auth' : 'guest';
-  const initials = user?.email?.slice(0, 2).toUpperCase() ?? 'EV';
   return (
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
-      <Header variant={variant} initials={initials} />
+      <Header variant="guest" />
       <LoadedState />
     </View>
   );


### PR DESCRIPTION
Pages using useAuth crash because AuthProvider not wired up in deployed code. Hotfix hardcodes Header variant.