### PR TITLE
fix(create-request): wire submit + validation

### DIFF
--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -1,12 +1,24 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Pressable, ScrollView } from 'react-native';
+import { Alert, View, Text, TextInput, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { useRouter } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import { Colors } from '../../../constants/Colors';
 import { Toggle } from '../../../components/proto/Toggle';
-import { ifns } from '../../../lib/api/endpoints';
+import { ifns, requests } from '../../../lib/api/endpoints';
 
 // Fixed service list per product spec
 const SERVICES = ['Выездная проверка', 'Отдел оперативного контроля', 'Камеральная проверка', 'Не знаю'];
+
+interface CityItem {
+  id: string;
+  name: string;
+}
+
+interface IfnsItem {
+  id: string;
+  name: string;
+  cityId: string;
+}
 
 function FileItem({ name, size, onRemove }: { name: string; size: string; onRemove: () => void }) {
   return (
@@ -24,16 +36,22 @@ function FileItem({ name, size, onRemove }: { name: string; size: string; onRemo
 }
 
 function LocationServicePicker({
-  city, fns, service, onCityChange, onFnsChange, onServiceChange,
+  city, fns: selectedFns, service,
+  onCityChange, onFnsChange, onServiceChange,
   cities, fnsByCity,
 }: {
-  city: string; fns: string; service: string;
-  onCityChange: (v: string) => void; onFnsChange: (v: string) => void; onServiceChange: (v: string) => void;
-  cities: string[]; fnsByCity: Record<string, string[]>;
+  city: CityItem | null;
+  fns: IfnsItem | null;
+  service: string;
+  onCityChange: (v: CityItem) => void;
+  onFnsChange: (v: IfnsItem) => void;
+  onServiceChange: (v: string) => void;
+  cities: CityItem[];
+  fnsByCity: Record<string, IfnsItem[]>;
 }) {
   const [openLevel, setOpenLevel] = useState<'city' | 'fns' | 'service' | null>(null);
-  const fnsOptions = city ? (fnsByCity[city] || []) : [];
-  const summary = city ? [city, fns, service].filter(Boolean).join(' / ') : '';
+  const fnsOptions = city ? (fnsByCity[city.id] || []) : [];
+  const summary = city ? [city.name, selectedFns?.name, service].filter(Boolean).join(' / ') : '';
 
   return (
     <View className="gap-1">
@@ -51,24 +69,24 @@ function LocationServicePicker({
         <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
           <View className="flex-row border-b border-bgSecondary">
             <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => setOpenLevel('city')}>
-              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>{city || 'Город'}</Text>
+              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>{city?.name || 'Город'}</Text>
             </Pressable>
             <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => city && setOpenLevel('fns')} disabled={!city}>
-              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : fns ? 'text-textPrimary' : 'text-textMuted'}`}>{fns ? fns.replace(/^ФНС\s*/, '').substring(0, 20) : 'ФНС'}</Text>
+              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : selectedFns ? 'text-textPrimary' : 'text-textMuted'}`}>{selectedFns ? selectedFns.name.replace(/^ФНС\s*/, '').substring(0, 20) : 'ФНС'}</Text>
             </Pressable>
-            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => fns && setOpenLevel('service')} disabled={!fns}>
+            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => selectedFns && setOpenLevel('service')} disabled={!selectedFns}>
               <Text className={`text-xs font-semibold ${openLevel === 'service' ? 'text-brandPrimary' : service ? 'text-textPrimary' : 'text-textMuted'}`}>{service || 'Услуга'}</Text>
             </Pressable>
           </View>
           <View className="max-h-48">
             {openLevel === 'city' && cities.map((c) => (
-              <Pressable key={c} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onCityChange(c); onFnsChange(''); onServiceChange(''); setOpenLevel('fns'); }}>
-                <Text className={`text-base ${city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
+              <Pressable key={c.id} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onCityChange(c); onServiceChange(''); setOpenLevel('fns'); }}>
+                <Text className={`text-base ${city?.id === c.id ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c.name}</Text>
               </Pressable>
             ))}
             {openLevel === 'fns' && fnsOptions.map((f) => (
-              <Pressable key={f} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onFnsChange(f); setOpenLevel('service'); }}>
-                <Text className={`text-base ${fns === f ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f}</Text>
+              <Pressable key={f.id} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onFnsChange(f); setOpenLevel('service'); }}>
+                <Text className={`text-base ${selectedFns?.id === f.id ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f.name}</Text>
               </Pressable>
             ))}
             {openLevel === 'service' && SERVICES.map((s) => (
@@ -84,22 +102,31 @@ function LocationServicePicker({
 }
 
 export default function NewRequestScreen() {
+  const router = useRouter();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [city, setCity] = useState('');
-  const [fns, setFns] = useState('');
+  const [city, setCity] = useState<CityItem | null>(null);
+  const [selectedFns, setSelectedFns] = useState<IfnsItem | null>(null);
   const [service, setService] = useState('');
   const [publicVisible, setPublicVisible] = useState(false);
   const [files] = useState<{ name: string; size: string }[]>([]);
-  const [cities, setCities] = useState<string[]>([]);
-  const [fnsByCity, setFnsByCity] = useState<Record<string, string[]>>({});
+  const [cities, setCities] = useState<CityItem[]>([]);
+  const [fnsByCity, setFnsByCity] = useState<Record<string, IfnsItem[]>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  // Validation
+  const titleError = title.length > 0 && title.length < 5 ? 'Минимум 5 символов' : null;
+  const descError = description.length > 0 && description.length < 20 ? 'Минимум 20 символов' : null;
+  const isValid = title.length >= 5 && description.length >= 20 && !!service;
 
   // Load cities
   useEffect(() => {
     ifns.getCities()
       .then((res) => {
         const data = (res as any).data ?? res;
-        const list: string[] = Array.isArray(data) ? data.map((c: any) => c.name ?? c) : [];
+        const list: CityItem[] = Array.isArray(data)
+          ? data.map((c: any) => ({ id: c.id, name: c.name ?? c }))
+          : [];
         setCities(list);
       })
       .catch(() => {});
@@ -107,27 +134,97 @@ export default function NewRequestScreen() {
 
   // Load FNS when city changes
   useEffect(() => {
-    if (!city || fnsByCity[city]) return;
-    ifns.getIfns({ city })
+    if (!city || fnsByCity[city.id]) return;
+    ifns.getIfns({ city_id: city.id })
       .then((res) => {
         const data = (res as any).data ?? res;
-        const list: string[] = Array.isArray(data) ? data.map((f: any) => f.name ?? f) : [];
-        setFnsByCity((prev) => ({ ...prev, [city]: list }));
+        const list: IfnsItem[] = Array.isArray(data)
+          ? data.map((f: any) => ({ id: f.id, name: f.name ?? f, cityId: f.cityId ?? city.id }))
+          : [];
+        setFnsByCity((prev) => ({ ...prev, [city.id]: list }));
       })
       .catch(() => {});
   }, [city]);
 
+  const handleCityChange = (c: CityItem) => {
+    setCity(c);
+    setSelectedFns(null);
+    setService('');
+  };
+
+  const handleSubmit = async () => {
+    if (!isValid || submitting) return;
+
+    setSubmitting(true);
+    try {
+      const payload: Record<string, unknown> = {
+        title: title.trim(),
+        description: description.trim(),
+        city: city?.name ?? '',
+        serviceType: service,
+      };
+      if (selectedFns) {
+        payload.ifnsId = selectedFns.id;
+        payload.ifnsName = selectedFns.name;
+      }
+
+      const res = await requests.createRequest(payload);
+      const result = (res as any).data ?? res;
+      const id = result?.id;
+
+      if (id) {
+        router.replace(`/(dashboard)/my-requests/${id}` as any);
+      } else {
+        router.back();
+      }
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.message ??
+        err?.message ??
+        'Не удалось создать заявку. Попробуйте ещё раз.';
+      Alert.alert('Ошибка', Array.isArray(msg) ? msg.join('\n') : String(msg));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <Text className="text-xl font-bold text-textPrimary">Новая заявка</Text>
-      <LocationServicePicker city={city} fns={fns} service={service} onCityChange={setCity} onFnsChange={setFns} onServiceChange={setService} cities={cities} fnsByCity={fnsByCity} />
+      <LocationServicePicker
+        city={city}
+        fns={selectedFns}
+        service={service}
+        onCityChange={handleCityChange}
+        onFnsChange={setSelectedFns}
+        onServiceChange={setService}
+        cities={cities}
+        fnsByCity={fnsByCity}
+      />
       <View className="gap-1">
         <Text className="text-sm font-medium text-textSecondary">Заголовок</Text>
-        <TextInput value={title} onChangeText={setTitle} placeholder="Кратко опишите задачу" placeholderTextColor={Colors.textMuted} className="h-12 rounded-xl border border-borderLight bg-white px-4 text-base text-textPrimary" style={{ outlineStyle: 'none' } as any} />
+        <TextInput
+          value={title}
+          onChangeText={setTitle}
+          placeholder="Кратко опишите задачу"
+          placeholderTextColor={Colors.textMuted}
+          className={`h-12 rounded-xl border px-4 text-base text-textPrimary bg-white ${titleError ? 'border-red-400' : 'border-borderLight'}`}
+          style={{ outlineStyle: 'none' } as any}
+        />
+        {titleError && <Text className="text-xs text-red-500">{titleError}</Text>}
       </View>
       <View className="gap-1">
         <Text className="text-sm font-medium text-textSecondary">Описание</Text>
-        <TextInput value={description} onChangeText={setDescription} placeholder="Подробно опишите, что нужно сделать..." placeholderTextColor={Colors.textMuted} multiline className="min-h-[96px] rounded-xl border border-borderLight bg-white p-4 text-base text-textPrimary" style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any} />
+        <TextInput
+          value={description}
+          onChangeText={setDescription}
+          placeholder="Подробно опишите, что нужно сделать..."
+          placeholderTextColor={Colors.textMuted}
+          multiline
+          className={`min-h-[96px] rounded-xl border p-4 text-base text-textPrimary bg-white ${descError ? 'border-red-400' : 'border-borderLight'}`}
+          style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
+        />
+        {descError && <Text className="text-xs text-red-500">{descError}</Text>}
       </View>
       <View className="gap-2">
         <Text className="text-sm font-medium text-textSecondary">Файлы</Text>
@@ -136,14 +233,25 @@ export default function NewRequestScreen() {
           <Feather name="paperclip" size={16} color={Colors.brandPrimary} />
           <Text className="text-sm font-medium text-brandPrimary">Прикрепить файл</Text>
         </Pressable>
+        {/* TODO: wire file upload to api.upload when document upload endpoint is available */}
         <Text className="text-xs text-textMuted">PDF, JPG, PNG до 10 МБ. Макс. 5 файлов.</Text>
       </View>
       <View className="py-1">
         <Toggle value={publicVisible} onValueChange={setPublicVisible} label="Показать неавторизованным" sublabel="Заявку увидят без входа в аккаунт" />
       </View>
-      <Pressable className="mt-2 h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary">
-        <Feather name="send" size={16} color={Colors.white} />
-        <Text className="text-base font-semibold text-white">Отправить заявку</Text>
+      <Pressable
+        onPress={handleSubmit}
+        disabled={!isValid || submitting}
+        className={`mt-2 h-12 flex-row items-center justify-center gap-2 rounded-xl ${isValid && !submitting ? 'bg-brandPrimary' : 'bg-brandPrimary/50'}`}
+      >
+        {submitting ? (
+          <ActivityIndicator color={Colors.white} size="small" />
+        ) : (
+          <>
+            <Feather name="send" size={16} color={Colors.white} />
+            <Text className="text-base font-semibold text-white">Отправить заявку</Text>
+          </>
+        )}
       </Pressable>
     </ScrollView>
   );


### PR DESCRIPTION
Closes #1006

## Changes
- Wire `onPress` on submit button to `requests.createRequest` API call
- Validation: title >=5 chars, description >=20 chars, service required (shown inline)
- Loading state with `ActivityIndicator`, button disabled when invalid or submitting
- On success: `router.replace` to `/(dashboard)/my-requests/:id`
- Server errors displayed via `Alert` (handles array messages from class-validator)
- Remove mock files from `useState` — initial state is empty array
- Store full `CityItem`/`IfnsItem` objects (with `id`) to correctly pass `ifnsId` and `ifnsName` to API
- Fix IFNS fetch to use `city_id` param instead of `city` name
- File upload left as TODO comment (no document upload endpoint available yet)