### PR TITLE
fix(onpress): wire nav handlers across screens

### DIFF
--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, ScrollView, Pressable } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { Colors } from '../../../constants/Colors';
 
 function RequestInfo({ status, statusColor }: { status: string; statusColor: string }) {

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Text, ScrollView, Pressable } from "react-native";
 import { Feather } from "@expo/vector-icons";
+import { router } from "expo-router";
 import { Colors } from "../../constants/Colors";
 
 function getGreeting(): string {
@@ -23,12 +24,12 @@ function StatCard({ icon, label, value, color }: { icon: string; label: string; 
   );
 }
 
-function RequestCard({ title, service, fns, city, date, messageCount, status, statusColor }: {
-  title: string; service: string; fns: string; city: string; date: string;
+function RequestCard({ id, title, service, fns, city, date, messageCount, status, statusColor }: {
+  id?: string; title: string; service: string; fns: string; city: string; date: string;
   messageCount: number; status: string; statusColor: string;
 }) {
   return (
-    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4">
+    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4" onPress={() => id && router.push(`/(dashboard)/my-requests/${id}` as any)}>
       <View className="flex-row items-start justify-between gap-2">
         <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
         <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + "18" }}>
@@ -65,11 +66,11 @@ function RequestCard({ title, service, fns, city, date, messageCount, status, st
   );
 }
 
-function MessagePreview({ initials, name, snippet, time, unread }: {
-  initials: string; name: string; snippet: string; time: string; unread?: boolean;
+function MessagePreview({ id, initials, name, snippet, time, unread }: {
+  id?: string; initials: string; name: string; snippet: string; time: string; unread?: boolean;
 }) {
   return (
-    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
+    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3" onPress={() => id ? router.push(`/chat/${id}` as any) : router.push('/(tabs)/messages' as any)}>
       <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
         <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
       </View>
@@ -90,15 +91,15 @@ function MessagePreview({ initials, name, snippet, time, unread }: {
 function QuickActions() {
   return (
     <View className="flex-row gap-2">
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl bg-brandPrimary">
+      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl bg-brandPrimary" onPress={() => router.push('/(dashboard)/my-requests/new' as any)}>
         <Feather name="plus" size={16} color={Colors.white} />
         <Text className="text-sm font-semibold text-white">Новая заявка</Text>
       </Pressable>
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white">
+      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white" onPress={() => router.push('/(tabs)/requests' as any)}>
         <Feather name="list" size={16} color={Colors.brandPrimary} />
         <Text className="text-sm font-medium text-brandPrimary">Мои заявки</Text>
       </Pressable>
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white">
+      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white" onPress={() => router.push('/(tabs)/messages' as any)}>
         <Feather name="message-circle" size={16} color={Colors.brandPrimary} />
         <Text className="text-sm font-medium text-brandPrimary">Сообщения</Text>
       </Pressable>
@@ -114,7 +115,7 @@ export default function DashboardScreen() {
           <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, Елена!</Text>
           <Text className="text-sm text-textMuted">Ваши заявки и сообщения</Text>
         </View>
-        <Pressable className="h-10 w-10 items-center justify-center rounded-full bg-bgSurface">
+        <Pressable className="h-10 w-10 items-center justify-center rounded-full bg-bgSurface" onPress={() => router.push('/(tabs)/messages' as any)}>
           <Feather name="bell" size={20} color={Colors.textPrimary} />
         </Pressable>
       </View>
@@ -130,7 +131,7 @@ export default function DashboardScreen() {
       <View className="gap-3">
         <View className="flex-row items-center justify-between">
           <Text className="text-base font-semibold text-textPrimary">Активные заявки</Text>
-          <Pressable><Text className="text-sm font-medium text-brandPrimary">Все заявки</Text></Pressable>
+          <Pressable onPress={() => router.push('/(tabs)/requests' as any)}><Text className="text-sm font-medium text-brandPrimary">Все заявки</Text></Pressable>
         </View>
         <RequestCard title="Камеральная проверка декларации по НДС" service="Камеральная проверка" fns="ФНС №46 по г. Москве" city="Москва" date="08.04.2026" messageCount={2} status="Новая" statusColor={Colors.brandPrimary} />
         <RequestCard title="Отдел оперативного контроля — требование" service="Отдел оперативного контроля" fns="ФНС №12 по г. Новосибирску" city="Новосибирск" date="07.04.2026" messageCount={4} status="В работе" statusColor={Colors.statusWarning} />
@@ -140,7 +141,7 @@ export default function DashboardScreen() {
       <View className="gap-3">
         <View className="flex-row items-center justify-between">
           <Text className="text-base font-semibold text-textPrimary">Новые сообщения</Text>
-          <Pressable><Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text></Pressable>
+          <Pressable onPress={() => router.push('/(tabs)/messages' as any)}><Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text></Pressable>
         </View>
         <MessagePreview initials="АП" name="Алексей Петров" snippet="Здравствуйте! Готов помочь с камеральной проверкой. Опыт 8 лет." time="14:32" unread />
         <MessagePreview initials="ОС" name="Ольга Смирнова" snippet="Специализируюсь на сопровождении проверок. Помогу подготовиться." time="12:15" unread />

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Pressable } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 
 function InfoRow({ label, value, icon }: { label: string; value: string; icon: string }) {
@@ -97,7 +98,7 @@ export default function ProfileScreen() {
       <Pressable onPress={() => setEditMode(true)} style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}>
         <Feather name="edit-2" size={16} color={Colors.white} /><Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Редактировать</Text>
       </Pressable>
-      <Pressable style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, backgroundColor: Colors.bgCard, padding: Spacing.lg, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border }}>
+      <Pressable style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, backgroundColor: Colors.bgCard, padding: Spacing.lg, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border }} onPress={() => router.push('/(tabs)/settings' as any)}>
         <Feather name="settings" size={16} color={Colors.textMuted} />
         <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textPrimary }}>Настройки</Text>
         <Feather name="chevron-right" size={16} color={Colors.textMuted} style={{ marginLeft: 'auto' }} />

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, Pressable, ActivityIndicator, ScrollView } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { requests as requestsApi } from '../../lib/api/endpoints';
 
@@ -24,12 +25,12 @@ const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> =
   CANCELLED: { label: 'Отменена', color: Colors.statusError, bg: Colors.statusBg.error },
 };
 
-function RequestCard({ title, service, fns, city, status, date, messageCount }: {
-  title: string; service: string; fns: string; city: string; status: string; date: string; messageCount: number;
+function RequestCard({ id, title, service, fns, city, status, date, messageCount }: {
+  id: string; title: string; service: string; fns: string; city: string; status: string; date: string; messageCount: number;
 }) {
   const st = STATUS_MAP[status] || STATUS_MAP.NEW;
   return (
-    <Pressable style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm }}>
+    <Pressable style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm }} onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm }}>
         <Text style={{ flex: 1, fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }} numberOfLines={2}>{title}</Text>
         <View style={{ paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full, backgroundColor: st.bg }}>
@@ -108,7 +109,7 @@ export default function RequestsScreen() {
     <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
         <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>Мои заявки</Text>
-        <Pressable style={{ backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.btn, flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+        <Pressable style={{ backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.btn, flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }} onPress={() => router.push('/(dashboard)/my-requests/new' as any)}>
           <Feather name="plus" size={16} color={Colors.white} />
           <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Новая</Text>
         </Pressable>
@@ -132,6 +133,7 @@ export default function RequestsScreen() {
       ) : visibleRequests.map((r) => (
         <RequestCard
           key={r.id}
+          id={r.id}
           title={r.title}
           service={r.serviceCategory ?? '—'}
           fns={r.ifnsCode ?? '—'}

--- a/app/(tabs)/specialist-dashboard.tsx
+++ b/app/(tabs)/specialist-dashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { router, useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { specialistPortal } from '../../lib/api/endpoints';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
@@ -60,7 +60,7 @@ function RequestCard({ r, onWrite }: { r: FeedItem; onWrite: (r: FeedItem) => vo
           <Feather name="send" size={14} color={Colors.white} />
           <Text className="text-sm font-semibold text-white">Написать</Text>
         </Pressable>
-        <Pressable className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-borderLight px-4">
+        <Pressable className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-borderLight px-4" onPress={() => router.push(`/requests/${r.id}` as any)}>
           <Feather name="eye" size={14} color={Colors.textPrimary} />
           <Text className="text-sm font-medium text-textPrimary">Подробнее</Text>
         </Pressable>
@@ -137,7 +137,7 @@ export default function SpecialistDashboardScreen() {
           <Text className="max-w-[280px] text-center text-sm text-textMuted">
             Настройте город и ФНС в настройках, чтобы видеть больше заявок
           </Text>
-          <Pressable className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg border border-brandPrimary px-6">
+          <Pressable className="mt-2 h-11 flex-row items-center justify-center gap-2 rounded-lg border border-brandPrimary px-6" onPress={() => router.push('/(tabs)/specialist-settings' as any)}>
             <Feather name="settings" size={16} color={Colors.brandPrimary} />
             <Text className="text-sm font-semibold text-brandPrimary">Настройки</Text>
           </Pressable>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, Pressable, ScrollView, useWindowDimensions } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { router, useRouter } from 'expo-router';
 import { Colors, Shadows } from '../constants/Colors';
 import { ifns } from '../lib/api/endpoints';
 import { Header } from '../components/Header';
@@ -211,7 +211,7 @@ function HeroSection() {
               />
             </View>
 
-            <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary">
+            <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" onPress={() => router.push('/(auth)/email' as any)}>
               <Feather name="send" size={16} color={Colors.white} />
               <Text className="text-base font-semibold text-white">Отправить заявку</Text>
             </Pressable>
@@ -246,6 +246,7 @@ const SPECIALISTS = [
 ];
 
 function SpecialistsCarousel() {
+  const router = useRouter();
   return (
     <View className="py-10" style={{ backgroundColor: Colors.bgSecondary }}>
       <View className="mb-6 w-full self-center px-5" style={{ maxWidth: 800 }}>
@@ -308,7 +309,7 @@ function SpecialistsCarousel() {
               <Text className="text-xs text-textMuted">c {spec.since} г.</Text>
             </View>
 
-            <Pressable className="h-9 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary">
+            <Pressable className="h-9 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary" onPress={() => router.push(`/specialists/${spec.initials.toLowerCase()}` as any)}>
               <Text className="text-xs font-semibold text-brandPrimary">Подробнее</Text>
             </Pressable>
           </View>
@@ -429,6 +430,7 @@ function StatsSection() {
 // =====================================================================
 
 function BottomCTA() {
+  const router = useRouter();
   return (
     <View className="items-center px-5 py-10" style={{ backgroundColor: Colors.bgSecondary }}>
       <View className="w-full items-center gap-4 rounded-2xl bg-white p-8" style={{ maxWidth: 600, ...Shadows.md }}>
@@ -437,7 +439,7 @@ function BottomCTA() {
         <Text className="max-w-sm text-center text-sm text-textSecondary">
           Воспользуйтесь каталогом, чтобы найти специалиста с опытом работы в вашей налоговой инспекции
         </Text>
-        <Pressable className="h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" style={{ maxWidth: 300 }}>
+        <Pressable className="h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" style={{ maxWidth: 300 }} onPress={() => router.push('/specialists' as any)}>
           <Feather name="search" size={16} color={Colors.white} />
           <Text className="text-base font-semibold text-white">Открыть каталог</Text>
         </Pressable>
@@ -446,7 +448,7 @@ function BottomCTA() {
       <View className="mt-6 flex-row items-center gap-2">
         <Feather name="briefcase" size={14} color={Colors.textMuted} />
         <Text className="text-sm text-textMuted">Вы налоговый специалист?</Text>
-        <Pressable>
+        <Pressable onPress={() => router.push('/(auth)/email' as any)}>
           <Text className="text-sm font-medium text-brandPrimary">Присоединиться</Text>
         </Pressable>
       </View>

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { View, Text, Pressable, useWindowDimensions, ActivityIndicator, ScrollView } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { Header } from '../../components/Header';
 import { specialists as specialistsApi } from '../../lib/api/endpoints';
 import { Colors } from '../../constants/Colors';
@@ -163,7 +164,7 @@ function SpecialistCard({ specialist, matchedFns }: {
       ))}
 
       {/* Button */}
-      <Pressable className="h-10 rounded-xl items-center justify-center border border-sky-600 flex-row gap-1">
+      <Pressable className="h-10 rounded-xl items-center justify-center border border-sky-600 flex-row gap-1" onPress={() => router.push(`/specialists/${specialist.username ?? specialist.id}` as any)}>
         <Text className="text-sm font-medium text-sky-600">Подробнее</Text>
         <Feather name="chevron-right" size={16} color="#0284C7" />
       </Pressable>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
 import { Colors } from '../constants/Colors';
 
-const BURGER_LINKS = [
-  { icon: 'home' as const, label: 'Главная' },
-  { icon: 'users' as const, label: 'Специалисты' },
-  { icon: 'credit-card' as const, label: 'Тарифы' },
+const BURGER_LINKS: { icon: 'home' | 'users' | 'credit-card'; label: string; route: string }[] = [
+  { icon: 'home', label: 'Главная', route: '/' },
+  { icon: 'users', label: 'Специалисты', route: '/specialists' },
+  { icon: 'credit-card', label: 'Тарифы', route: '/' }, // TODO: /pricing when page exists
 ];
 
 function LogoBlock() {
@@ -39,13 +40,13 @@ function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void 
         }}
       >
         {BURGER_LINKS.map((link) => (
-          <Pressable key={link.label} className="flex-row items-center gap-3 py-2.5">
+          <Pressable key={link.label} className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push(link.route as any); }}>
             <Feather name={link.icon} size={18} color={Colors.textSecondary} />
             <Text className="text-base text-textSecondary">{link.label}</Text>
           </Pressable>
         ))}
         <View className="my-2 h-px bg-borderLight" />
-        <Pressable className="flex-row items-center gap-3 py-2.5">
+        <Pressable className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push('/(auth)/email' as any); }}>
           <Feather name="log-in" size={18} color={Colors.brandPrimary} />
           <Text className="text-base font-semibold text-brandPrimary">Войти</Text>
         </Pressable>
@@ -97,7 +98,7 @@ export function Header({
         >
           <LogoBlock />
           <View className="flex-row items-center gap-4">
-            <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4">
+            <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4" onPress={() => router.push('/(auth)/email' as any)}>
               <Text className="text-sm font-semibold text-white">Войти</Text>
             </Pressable>
             <Pressable onPress={() => setBurgerOpen(!burgerOpen)}>


### PR DESCRIPTION
Closes #1007

## Files touched
- `components/Header.tsx` — burger links (Главная/Специалисты/Тарифы), Войти button in burger drawer and header guest variant
- `app/index.tsx` — hero "Отправить заявку" → auth/email, specialist carousel "Подробнее" → /specialists/:nick, BottomCTA "Открыть каталог" → /specialists, "Присоединиться" → auth/email
- `app/(tabs)/dashboard.tsx` — RequestCard → /(dashboard)/my-requests/:id, MessagePreview → /chat/:id or messages tab, QuickActions buttons, bell, "Все заявки"/"Все сообщения"
- `app/(tabs)/requests.tsx` — RequestCard → /(dashboard)/my-requests/:id, "Новая" → /(dashboard)/my-requests/new
- `app/(tabs)/specialist-dashboard.tsx` — "Подробнее" → /requests/:id, "Настройки" → /(tabs)/specialist-settings
- `app/(tabs)/profile.tsx` — "Настройки" row → /(tabs)/settings
- `app/specialists/index.tsx` — SpecialistCard "Подробнее" → /specialists/:nick
- `app/(dashboard)/my-requests/[id].tsx` — added router import (thread cards need real IDs, left as-is)

## Skipped (per instructions)
- `app/(auth)/*` — FIX-AUTH agent
- `app/specialists/[nick].tsx` send button — needs thread creation flow, not a simple push
- Static mock Pressables in my-requests/[id].tsx thread list — no real IDs available

## TSC
`npx tsc --noEmit` — 0 errors