### PR TITLE
feat(close-request): close button + review CTA

### DIFF
--- a/api/src/requests/requests.controller.ts
+++ b/api/src/requests/requests.controller.ts
@@ -161,6 +161,14 @@ export class RequestsController {
     return this.requestsService.createReviewForRequest(req.user.id, id, body);
   }
 
+  // PATCH /requests/:id/close — client closes own request (NEW/OPEN/IN_PROGRESS/CLOSING_SOON)
+  @Patch(':id/close')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.CLIENT)
+  close(@Request() req: any, @Param('id') id: string) {
+    return this.requestsService.closeRequest(req.user.id, id);
+  }
+
   // DELETE /requests/:id — client deletes own request (only OPEN status)
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -389,6 +389,51 @@ export class RequestsService {
   }
 
   /**
+   * Close a request manually. Owner only. Allowed from NEW/OPEN/IN_PROGRESS/CLOSING_SOON.
+   * Returns the updated request with threads so frontend can show review CTAs.
+   */
+  async closeRequest(clientId: string, requestId: string) {
+    const request = await this.prisma.request.findUnique({ where: { id: requestId } });
+    if (!request) throw new NotFoundException('Request not found');
+    if (request.clientId !== clientId) throw new ForbiddenException('Not your request');
+
+    const closeable = new Set<RequestStatus>([
+      RequestStatus.NEW,
+      RequestStatus.OPEN,
+      RequestStatus.IN_PROGRESS,
+      RequestStatus.CLOSING_SOON,
+    ]);
+    if (!closeable.has(request.status)) {
+      throw new BadRequestException(`Cannot close a request with status ${request.status}`);
+    }
+
+    return this.prisma.request.update({
+      where: { id: requestId },
+      data: { status: RequestStatus.CLOSED },
+      include: {
+        _count: { select: { threads: true } },
+        threads: {
+          include: {
+            participant1: {
+              select: {
+                id: true, email: true,
+                specialistProfile: { select: { nick: true, displayName: true, avatarUrl: true } },
+              },
+            },
+            participant2: {
+              select: {
+                id: true, email: true,
+                specialistProfile: { select: { nick: true, displayName: true, avatarUrl: true } },
+              },
+            },
+          },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+  }
+
+  /**
    * Delete a request and all related responses/reviews.
    * Only the owner can delete, and only OPEN requests.
    */

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -1,61 +1,346 @@
-import React from 'react';
-import { View, Text, ScrollView, Pressable } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { Colors } from '../../../constants/Colors';
+import { requests } from '../../../lib/api/endpoints';
+import { useAuth } from '../../../stores/authStore';
 
-function RequestInfo({ status, statusColor }: { status: string; statusColor: string }) {
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type RequestStatus =
+  | 'NEW'
+  | 'OPEN'
+  | 'IN_PROGRESS'
+  | 'CLOSING_SOON'
+  | 'CLOSED'
+  | 'CANCELLED';
+
+interface SpecialistProfile {
+  nick: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface ThreadUser {
+  id: string;
+  email: string;
+  specialistProfile: SpecialistProfile | null;
+}
+
+interface Thread {
+  id: string;
+  participant1Id: string;
+  participant1: ThreadUser;
+  participant2Id: string;
+  participant2: ThreadUser;
+  createdAt: string;
+}
+
+interface RequestDetail {
+  id: string;
+  clientId: string;
+  title: string;
+  description: string;
+  city: string;
+  ifnsName: string | null;
+  serviceType: string | null;
+  budget: number | null;
+  category: string | null;
+  status: RequestStatus;
+  createdAt: string;
+  threads: Thread[];
+  _count: { threads: number };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const CLOSEABLE_STATUSES: RequestStatus[] = ['NEW', 'OPEN', 'IN_PROGRESS', 'CLOSING_SOON'];
+
+const STATUS_LABELS: Record<RequestStatus, string> = {
+  NEW: 'Новая',
+  OPEN: 'Активная',
+  IN_PROGRESS: 'В работе',
+  CLOSING_SOON: 'Скоро закроется',
+  CLOSED: 'Закрыта',
+  CANCELLED: 'Отменена',
+};
+
+const STATUS_COLORS: Record<RequestStatus, string> = {
+  NEW: Colors.brandPrimary,
+  OPEN: Colors.statusSuccess,
+  IN_PROGRESS: '#F59E0B',
+  CLOSING_SOON: '#F97316',
+  CLOSED: Colors.textMuted,
+  CANCELLED: Colors.statusError,
+};
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+function getSpecialist(thread: Thread, clientId: string): ThreadUser {
+  return thread.participant1Id === clientId ? thread.participant2 : thread.participant1;
+}
+
+function getInitials(name: string | null | undefined, email: string) {
+  if (name) {
+    const parts = name.trim().split(' ');
+    return parts.length >= 2
+      ? (parts[0][0] + parts[1][0]).toUpperCase()
+      : name.slice(0, 2).toUpperCase();
+  }
+  return email.slice(0, 2).toUpperCase();
+}
+
+// ─── Review CTA list ─────────────────────────────────────────────────────────
+
+function ReviewCTAList({
+  requestId,
+  threads,
+  clientId,
+}: {
+  requestId: string;
+  threads: Thread[];
+  clientId: string;
+}) {
+  if (threads.length === 0) return null;
+
   return (
-    <View className="gap-4 rounded-xl border border-borderLight bg-white p-4">
-      <View className="flex-row items-start justify-between gap-2">
-        <Text className="flex-1 text-lg font-bold text-textPrimary">Камеральная проверка декларации по НДС</Text>
-        <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + '18' }}>
-          <Text className="text-xs font-semibold" style={{ color: statusColor }}>{status}</Text>
-        </View>
-      </View>
-      <Text className="text-base leading-6 text-textSecondary">Получили требование о предоставлении документов при камеральной проверке декларации по НДС. Нужна помощь.</Text>
-      <View className="gap-2">
-        <View className="flex-row items-center gap-2"><Feather name="map-pin" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">Москва</Text></View>
-        <View className="flex-row items-center gap-2"><Feather name="home" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">ФНС №46 по г. Москве</Text></View>
-        <View className="flex-row items-center gap-2"><Feather name="briefcase" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">Камеральная проверка</Text></View>
-        <View className="flex-row items-center gap-2"><Feather name="calendar" size={14} color={Colors.textMuted} /><Text className="text-sm text-textMuted">08.04.2026</Text></View>
-      </View>
-      <View className="flex-row gap-2">
-        <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary">
-          <Feather name="edit-2" size={14} color={Colors.brandPrimary} />
-          <Text className="text-sm font-medium text-brandPrimary">Редактировать</Text>
-        </Pressable>
-        <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-lg border border-statusError bg-statusError/10">
-          <Feather name="x-circle" size={14} color={Colors.statusError} />
-          <Text className="text-sm font-medium text-statusError">Закрыть</Text>
-        </Pressable>
-      </View>
+    <View className="gap-3 rounded-xl border border-brandPrimary/30 bg-brandPrimary/5 p-4">
+      <Text className="text-sm font-semibold text-brandPrimary">
+        Заявка закрыта. Оставьте отзыв специалисту:
+      </Text>
+      {threads.map((thread) => {
+        const specialist = getSpecialist(thread, clientId);
+        const nick = specialist.specialistProfile?.nick;
+        const displayName = specialist.specialistProfile?.displayName ?? specialist.email;
+        const initials = getInitials(specialist.specialistProfile?.displayName, specialist.email);
+
+        return (
+          <Pressable
+            key={thread.id}
+            onPress={() =>
+              router.push(
+                `/leave-review?requestId=${requestId}&specialistId=${specialist.id}${nick ? `&specialistNick=${nick}` : ''}` as any,
+              )
+            }
+            className="flex-row items-center gap-3 rounded-lg border border-borderLight bg-white p-3"
+          >
+            <View className="h-9 w-9 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+              <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
+            </View>
+            <View className="flex-1">
+              <Text className="text-sm font-semibold text-textPrimary">{displayName}</Text>
+              {nick && <Text className="text-xs text-textMuted">@{nick}</Text>}
+            </View>
+            <Feather name="star" size={16} color={Colors.brandPrimary} />
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
 
+// ─── Main Screen ──────────────────────────────────────────────────────────────
+
 export default function RequestDetailScreen() {
-  return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      <RequestInfo status="Активная" statusColor={Colors.statusSuccess} />
-      <View className="gap-3">
-        <Text className="text-base font-semibold text-textPrimary">Сообщения (2)</Text>
-        <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
-          <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface"><Text className="text-sm font-bold text-brandPrimary">АП</Text></View>
-          <View className="flex-1">
-            <View className="flex-row items-center justify-between"><Text className="text-sm font-semibold text-textPrimary">Алексей Петров</Text><Text className="text-xs text-textMuted">14:32</Text></View>
-            <Text className="text-xs text-textMuted" numberOfLines={1}>Готов помочь с камеральной проверкой. Опыт работы 8 лет.</Text>
-          </View>
-          <View className="h-2.5 w-2.5 rounded-full bg-brandPrimary" />
-        </Pressable>
-        <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3">
-          <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface"><Text className="text-sm font-bold text-brandPrimary">ОС</Text></View>
-          <View className="flex-1">
-            <View className="flex-row items-center justify-between"><Text className="text-sm font-medium text-textPrimary">Ольга Смирнова</Text><Text className="text-xs text-textMuted">вчера</Text></View>
-            <Text className="text-xs text-textMuted" numberOfLines={1}>Специализируюсь на сопровождении проверок. Помогу подготовиться.</Text>
-          </View>
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { user } = useAuth();
+
+  const [request, setRequest] = useState<RequestDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [closing, setClosing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRequest = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await requests.getRequest(id);
+      setRequest(res.data as RequestDetail);
+    } catch {
+      setError('Не удалось загрузить заявку');
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchRequest();
+  }, [fetchRequest]);
+
+  const handleClose = useCallback(() => {
+    if (!request) return;
+    Alert.alert(
+      'Закрыть заявку',
+      'После закрытия заявка перейдёт в статус "Закрыта" и вы сможете оставить отзыв специалистам.',
+      [
+        { text: 'Отмена', style: 'cancel' },
+        {
+          text: 'Закрыть',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              setClosing(true);
+              const res = await requests.closeRequest(request.id);
+              setRequest(res.data as RequestDetail);
+            } catch (e: any) {
+              const msg = e?.response?.data?.message ?? 'Не удалось закрыть заявку';
+              Alert.alert('Ошибка', msg);
+            } finally {
+              setClosing(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [request]);
+
+  if (loading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white">
+        <ActivityIndicator color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  if (error || !request) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white p-6">
+        <Text className="text-center text-base text-statusError">
+          {error ?? 'Заявка не найдена'}
+        </Text>
+        <Pressable onPress={fetchRequest} className="mt-4">
+          <Text className="text-sm text-brandPrimary">Повторить</Text>
         </Pressable>
       </View>
+    );
+  }
+
+  const status = request.status as RequestStatus;
+  const statusLabel = STATUS_LABELS[status] ?? status;
+  const statusColor = STATUS_COLORS[status] ?? Colors.textMuted;
+  const isOwner = user?.userId === request.clientId;
+  const canClose = isOwner && CLOSEABLE_STATUSES.includes(status);
+  const isClosed = status === 'CLOSED' || status === 'CANCELLED';
+
+  return (
+    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      {/* Request card */}
+      <View className="gap-4 rounded-xl border border-borderLight bg-white p-4">
+        <View className="flex-row items-start justify-between gap-2">
+          <Text className="flex-1 text-lg font-bold text-textPrimary">{request.title}</Text>
+          <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + '18' }}>
+            <Text className="text-xs font-semibold" style={{ color: statusColor }}>
+              {statusLabel}
+            </Text>
+          </View>
+        </View>
+
+        <Text className="text-base leading-6 text-textSecondary">{request.description}</Text>
+
+        <View className="gap-2">
+          <View className="flex-row items-center gap-2">
+            <Feather name="map-pin" size={14} color={Colors.textMuted} />
+            <Text className="text-sm text-textMuted">{request.city}</Text>
+          </View>
+          {request.ifnsName && (
+            <View className="flex-row items-center gap-2">
+              <Feather name="home" size={14} color={Colors.textMuted} />
+              <Text className="text-sm text-textMuted">{request.ifnsName}</Text>
+            </View>
+          )}
+          {request.serviceType && (
+            <View className="flex-row items-center gap-2">
+              <Feather name="briefcase" size={14} color={Colors.textMuted} />
+              <Text className="text-sm text-textMuted">{request.serviceType}</Text>
+            </View>
+          )}
+          <View className="flex-row items-center gap-2">
+            <Feather name="calendar" size={14} color={Colors.textMuted} />
+            <Text className="text-sm text-textMuted">{formatDate(request.createdAt)}</Text>
+          </View>
+        </View>
+
+        {/* Close button — owner only, closeable statuses */}
+        {canClose && (
+          <Pressable
+            onPress={handleClose}
+            disabled={closing}
+            className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-statusError bg-statusError/10"
+          >
+            {closing ? (
+              <ActivityIndicator size="small" color={Colors.statusError} />
+            ) : (
+              <>
+                <Feather name="x-circle" size={14} color={Colors.statusError} />
+                <Text className="text-sm font-medium text-statusError">Закрыть заявку</Text>
+              </>
+            )}
+          </Pressable>
+        )}
+      </View>
+
+      {/* Review CTAs — shown immediately after closing if threads exist */}
+      {isClosed && isOwner && request.threads.length > 0 && (
+        <ReviewCTAList
+          requestId={request.id}
+          threads={request.threads}
+          clientId={request.clientId}
+        />
+      )}
+
+      {/* Threads list */}
+      {request.threads.length > 0 && (
+        <View className="gap-3">
+          <Text className="text-base font-semibold text-textPrimary">
+            Сообщения ({request._count.threads})
+          </Text>
+          {request.threads.map((thread) => {
+            const specialist = getSpecialist(thread, request.clientId);
+            const displayName =
+              specialist.specialistProfile?.displayName ?? specialist.email;
+            const initials = getInitials(
+              specialist.specialistProfile?.displayName,
+              specialist.email,
+            );
+
+            return (
+              <Pressable
+                key={thread.id}
+                onPress={() => router.push(`/chat/${thread.id}` as any)}
+                className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3"
+              >
+                <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+                  <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-sm font-semibold text-textPrimary">{displayName}</Text>
+                  {specialist.specialistProfile?.nick && (
+                    <Text className="text-xs text-textMuted">
+                      @{specialist.specialistProfile.nick}
+                    </Text>
+                  )}
+                </View>
+                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
     </ScrollView>
   );
 }

--- a/app/leave-review.tsx
+++ b/app/leave-review.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  Alert,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { Colors } from '../constants/Colors';
+import { reviews } from '../lib/api/endpoints';
+
+export default function LeaveReviewScreen() {
+  const { requestId, specialistNick } = useLocalSearchParams<{
+    requestId: string;
+    specialistNick?: string;
+  }>();
+
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!specialistNick) {
+      Alert.alert('Ошибка', 'Не удалось определить специалиста');
+      return;
+    }
+    if (rating === 0) {
+      Alert.alert('Оценка', 'Пожалуйста, выберите оценку');
+      return;
+    }
+    if (!requestId) {
+      Alert.alert('Ошибка', 'Не удалось определить заявку');
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await reviews.create({
+        specialistNick,
+        requestId,
+        rating,
+        comment: comment.trim() || undefined,
+      });
+      setSubmitted(true);
+    } catch (e: any) {
+      const msg = e?.response?.data?.message ?? 'Не удалось отправить отзыв';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <View className="flex-1 items-center justify-center bg-white p-8 gap-6">
+        <View className="h-16 w-16 items-center justify-center rounded-full bg-statusSuccess/10">
+          <Feather name="check-circle" size={32} color={Colors.statusSuccess} />
+        </View>
+        <Text className="text-center text-xl font-bold text-textPrimary">Отзыв отправлен</Text>
+        <Text className="text-center text-base text-textSecondary">
+          Спасибо за вашу оценку. Это помогает другим клиентам выбрать специалиста.
+        </Text>
+        <Pressable
+          onPress={() => router.replace('/(dashboard)/my-requests' as any)}
+          className="h-12 w-full items-center justify-center rounded-xl bg-brandPrimary"
+        >
+          <Text className="text-base font-semibold text-white">Вернуться к заявкам</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 20 }}>
+        <Text className="text-xl font-bold text-textPrimary">Оставить отзыв</Text>
+        {specialistNick && (
+          <Text className="text-sm text-textMuted">Специалист: @{specialistNick}</Text>
+        )}
+
+        {/* Star rating */}
+        <View className="gap-2">
+          <Text className="text-sm font-semibold text-textPrimary">Оценка *</Text>
+          <View className="flex-row gap-3">
+            {[1, 2, 3, 4, 5].map((star) => (
+              <Pressable key={star} onPress={() => setRating(star)}>
+                <Feather
+                  name="star"
+                  size={36}
+                  color={star <= rating ? '#F59E0B' : Colors.borderLight ?? '#E5E7EB'}
+                />
+              </Pressable>
+            ))}
+          </View>
+          {rating > 0 && (
+            <Text className="text-xs text-textMuted">
+              {['', 'Плохо', 'Ниже среднего', 'Нормально', 'Хорошо', 'Отлично'][rating]}
+            </Text>
+          )}
+        </View>
+
+        {/* Comment */}
+        <View className="gap-2">
+          <Text className="text-sm font-semibold text-textPrimary">Комментарий</Text>
+          <TextInput
+            className="min-h-[120px] rounded-xl border border-borderLight bg-bgSurface p-3 text-base text-textPrimary"
+            placeholder="Опишите ваш опыт работы со специалистом..."
+            placeholderTextColor={Colors.textMuted}
+            value={comment}
+            onChangeText={setComment}
+            multiline
+            textAlignVertical="top"
+            maxLength={1000}
+          />
+          <Text className="text-right text-xs text-textMuted">{comment.length}/1000</Text>
+        </View>
+
+        <Pressable
+          onPress={handleSubmit}
+          disabled={submitting || rating === 0}
+          className="h-12 items-center justify-center rounded-xl bg-brandPrimary disabled:opacity-50"
+        >
+          {submitting ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text className="text-base font-semibold text-white">Отправить отзыв</Text>
+          )}
+        </Pressable>
+
+        <Pressable onPress={() => router.back()} className="items-center py-2">
+          <Text className="text-sm text-textMuted">Отмена</Text>
+        </Pressable>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -129,6 +129,10 @@ export const requests = {
   extendRequest(id: string) {
     return client.post(`/requests/${id}/extend`);
   },
+
+  closeRequest(id: string) {
+    return client.patch(`/requests/${id}/close`);
+  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1008

## Changes
- Backend: `PATCH /api/requests/:id/close` — owner-only, validates status (NEW/OPEN/IN_PROGRESS/CLOSING_SOON), sets CLOSED, returns updated request with threads
- Frontend `[id].tsx`: replaced stub with real API wiring, close button (owner only, closeable statuses), review CTA block shown immediately after closing
- `app/leave-review.tsx`: new screen with star rating 1-5 + comment textarea → `POST /reviews` via existing endpoint
- `lib/api/endpoints.ts`: added `requests.closeRequest(id)`