### PR TITLE
fix(tabs): wire dashboard/profile/settings to real API

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,8 +1,10 @@
-import React from "react";
-import { View, Text, ScrollView, Pressable } from "react-native";
+import React, { useEffect, useState } from "react";
+import { View, Text, ScrollView, Pressable, ActivityIndicator } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { router } from "expo-router";
 import { Colors } from "../../constants/Colors";
+import { useAuth } from "../../lib/auth/AuthContext";
+import { requests, threads } from "../../lib/api/endpoints";
 
 function getGreeting(): string {
   const h = new Date().getHours();
@@ -24,31 +26,59 @@ function StatCard({ icon, label, value, color }: { icon: string; label: string; 
   );
 }
 
-function RequestCard({ id, title, service, fns, city, date, messageCount, status, statusColor }: {
-  id?: string; title: string; service: string; fns: string; city: string; date: string;
-  messageCount: number; status: string; statusColor: string;
+function getStatusLabel(status: string): string {
+  const map: Record<string, string> = {
+    active: 'Новая',
+    in_progress: 'В работе',
+    closed: 'Закрыта',
+    cancelled: 'Отменена',
+  };
+  return map[status] ?? status;
+}
+
+function getStatusColor(status: string): string {
+  const map: Record<string, string> = {
+    active: Colors.brandPrimary,
+    in_progress: Colors.statusWarning,
+    closed: Colors.textMuted,
+    cancelled: Colors.statusError,
+  };
+  return map[status] ?? Colors.textMuted;
+}
+
+function RequestCard({ id, title, service, fns, city, date, messageCount, status }: {
+  id: string; title: string; service: string; fns?: string; city?: string; date: string;
+  messageCount: number; status: string;
 }) {
+  const statusColor = getStatusColor(status);
+  const statusLabel = getStatusLabel(status);
   return (
-    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4" onPress={() => id && router.push(`/(dashboard)/my-requests/${id}` as any)}>
+    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4" onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
       <View className="flex-row items-start justify-between gap-2">
         <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
         <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + "18" }}>
-          <Text className="text-xs font-semibold" style={{ color: statusColor }}>{status}</Text>
+          <Text className="text-xs font-semibold" style={{ color: statusColor }}>{statusLabel}</Text>
         </View>
       </View>
       <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
-        <View className="flex-row items-center gap-1">
-          <Feather name="briefcase" size={12} color={Colors.textMuted} />
-          <Text className="text-xs text-textMuted">{service}</Text>
-        </View>
-        <View className="flex-row items-center gap-1">
-          <Feather name="home" size={12} color={Colors.textMuted} />
-          <Text className="text-xs text-textMuted">{fns}</Text>
-        </View>
-        <View className="flex-row items-center gap-1">
-          <Feather name="map-pin" size={12} color={Colors.textMuted} />
-          <Text className="text-xs text-textMuted">{city}</Text>
-        </View>
+        {service ? (
+          <View className="flex-row items-center gap-1">
+            <Feather name="briefcase" size={12} color={Colors.textMuted} />
+            <Text className="text-xs text-textMuted">{service}</Text>
+          </View>
+        ) : null}
+        {fns ? (
+          <View className="flex-row items-center gap-1">
+            <Feather name="home" size={12} color={Colors.textMuted} />
+            <Text className="text-xs text-textMuted">{fns}</Text>
+          </View>
+        ) : null}
+        {city ? (
+          <View className="flex-row items-center gap-1">
+            <Feather name="map-pin" size={12} color={Colors.textMuted} />
+            <Text className="text-xs text-textMuted">{city}</Text>
+          </View>
+        ) : null}
       </View>
       <View className="flex-row items-center justify-between">
         <View className="flex-row items-center gap-1">
@@ -66,11 +96,33 @@ function RequestCard({ id, title, service, fns, city, date, messageCount, status
   );
 }
 
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((p) => p[0] ?? '')
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatThreadTime(isoString: string): string {
+  if (!isoString) return '';
+  const d = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffH = diffMs / 1000 / 3600;
+  if (diffH < 24) {
+    return d.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+  }
+  if (diffH < 48) return 'вчера';
+  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit' });
+}
+
 function MessagePreview({ id, initials, name, snippet, time, unread }: {
-  id?: string; initials: string; name: string; snippet: string; time: string; unread?: boolean;
+  id: string; initials: string; name: string; snippet: string; time: string; unread?: boolean;
 }) {
   return (
-    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3" onPress={() => id ? router.push(`/chat/${id}` as any) : router.push('/(tabs)/messages' as any)}>
+    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3" onPress={() => router.push(`/chat/${id}` as any)}>
       <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
         <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
       </View>
@@ -107,12 +159,68 @@ function QuickActions() {
   );
 }
 
+interface RequestItem {
+  id: string;
+  title: string;
+  serviceType?: string;
+  fnsName?: string;
+  city?: string;
+  createdAt: string;
+  status: string;
+  _count?: { threads?: number };
+}
+
+interface ThreadItem {
+  id: string;
+  specialist?: { firstName?: string; lastName?: string; nick?: string; [key: string]: unknown };
+  client?: { firstName?: string; lastName?: string; [key: string]: unknown };
+  lastMessage?: { content?: string; createdAt?: string };
+  unreadCount?: number;
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
 export default function DashboardScreen() {
+  const { user } = useAuth();
+
+  const [reqs, setReqs] = useState<RequestItem[]>([]);
+  const [reqsLoading, setReqsLoading] = useState(true);
+
+  const [msgs, setMsgs] = useState<ThreadItem[]>([]);
+  const [msgsLoading, setMsgsLoading] = useState(true);
+
+  useEffect(() => {
+    requests.getMyRequests({ limit: 3, status: 'active' })
+      .then((res: any) => {
+        const data = res.data;
+        setReqs(Array.isArray(data) ? data : (data.items ?? data.data ?? []));
+      })
+      .catch(() => setReqs([]))
+      .finally(() => setReqsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    threads.getThreads()
+      .then((res: any) => {
+        const data = res.data;
+        const list: ThreadItem[] = Array.isArray(data) ? data : (data.items ?? data.data ?? []);
+        setMsgs(list.slice(0, 3));
+      })
+      .catch(() => setMsgs([]))
+      .finally(() => setMsgsLoading(false));
+  }, []);
+
+  const firstName = user?.firstName ?? user?.email?.split('@')[0] ?? 'друг';
+
   return (
     <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <View className="flex-row items-start justify-between">
         <View className="flex-1">
-          <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, Елена!</Text>
+          <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, {firstName}!</Text>
           <Text className="text-sm text-textMuted">Ваши заявки и сообщения</Text>
         </View>
         <Pressable className="h-10 w-10 items-center justify-center rounded-full bg-bgSurface" onPress={() => router.push('/(tabs)/messages' as any)}>
@@ -120,32 +228,84 @@ export default function DashboardScreen() {
         </Pressable>
       </View>
 
-      <View className="flex-row gap-2">
-        <StatCard icon="file-text" label="Активные" value="3" color={Colors.brandPrimary} />
-        <StatCard icon="message-circle" label="Сообщения" value="5" color={Colors.statusSuccess} />
-        <StatCard icon="check-circle" label="Завершены" value="12" color={Colors.textMuted} />
-      </View>
-
       <QuickActions />
 
+      {/* Active requests */}
       <View className="gap-3">
         <View className="flex-row items-center justify-between">
           <Text className="text-base font-semibold text-textPrimary">Активные заявки</Text>
-          <Pressable onPress={() => router.push('/(tabs)/requests' as any)}><Text className="text-sm font-medium text-brandPrimary">Все заявки</Text></Pressable>
+          <Pressable onPress={() => router.push('/(tabs)/requests' as any)}>
+            <Text className="text-sm font-medium text-brandPrimary">Все заявки</Text>
+          </Pressable>
         </View>
-        <RequestCard title="Камеральная проверка декларации по НДС" service="Камеральная проверка" fns="ФНС №46 по г. Москве" city="Москва" date="08.04.2026" messageCount={2} status="Новая" statusColor={Colors.brandPrimary} />
-        <RequestCard title="Отдел оперативного контроля — требование" service="Отдел оперативного контроля" fns="ФНС №12 по г. Новосибирску" city="Новосибирск" date="07.04.2026" messageCount={4} status="В работе" statusColor={Colors.statusWarning} />
-        <RequestCard title="Выездная проверка ООО «Ромашка»" service="Выездная проверка" fns="ФНС №15 по г. Москве" city="Москва" date="05.04.2026" messageCount={0} status="Новая" statusColor={Colors.brandPrimary} />
+        {reqsLoading ? (
+          <ActivityIndicator color={Colors.brandPrimary} />
+        ) : reqs.length === 0 ? (
+          <View className="items-center gap-3 rounded-xl border border-borderLight bg-white p-6">
+            <Feather name="file-text" size={32} color={Colors.textMuted} />
+            <Text className="text-sm text-textMuted">Нет активных заявок</Text>
+            <Pressable
+              className="h-10 flex-row items-center gap-1.5 rounded-xl bg-brandPrimary px-4"
+              onPress={() => router.push('/(dashboard)/my-requests/new' as any)}
+            >
+              <Feather name="plus" size={16} color={Colors.white} />
+              <Text className="text-sm font-semibold text-white">Создать заявку</Text>
+            </Pressable>
+          </View>
+        ) : (
+          reqs.map((req) => (
+            <RequestCard
+              key={req.id}
+              id={req.id}
+              title={req.title}
+              service={req.serviceType ?? ''}
+              fns={req.fnsName}
+              city={req.city}
+              date={formatDate(req.createdAt)}
+              messageCount={req._count?.threads ?? 0}
+              status={req.status}
+            />
+          ))
+        )}
       </View>
 
+      {/* Recent messages */}
       <View className="gap-3">
         <View className="flex-row items-center justify-between">
           <Text className="text-base font-semibold text-textPrimary">Новые сообщения</Text>
-          <Pressable onPress={() => router.push('/(tabs)/messages' as any)}><Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text></Pressable>
+          <Pressable onPress={() => router.push('/(tabs)/messages' as any)}>
+            <Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text>
+          </Pressable>
         </View>
-        <MessagePreview initials="АП" name="Алексей Петров" snippet="Здравствуйте! Готов помочь с камеральной проверкой. Опыт 8 лет." time="14:32" unread />
-        <MessagePreview initials="ОС" name="Ольга Смирнова" snippet="Специализируюсь на сопровождении проверок. Помогу подготовиться." time="12:15" unread />
-        <MessagePreview initials="ИК" name="Игорь Козлов" snippet="Добрый день! По вашей заявке на оперативный контроль..." time="вчера" />
+        {msgsLoading ? (
+          <ActivityIndicator color={Colors.brandPrimary} />
+        ) : msgs.length === 0 ? (
+          <View className="items-center rounded-xl border border-borderLight bg-white p-6">
+            <Text className="text-sm text-textMuted">Нет сообщений</Text>
+          </View>
+        ) : (
+          msgs.map((thread) => {
+            const other = thread.specialist ?? thread.client;
+            const name = other
+              ? [other.firstName, other.lastName].filter(Boolean).join(' ') || other.nick || 'Специалист'
+              : 'Специалист';
+            const initials = getInitials(name);
+            const snippet = thread.lastMessage?.content ?? '';
+            const time = thread.lastMessage?.createdAt ? formatThreadTime(thread.lastMessage.createdAt) : '';
+            const unread = (thread.unreadCount ?? 0) > 0;
+            return (
+              <MessagePreview
+                key={thread.id}
+                id={thread.id}
+                initials={initials}
+                name={name}
+                snippet={snippet}
+                time={time}
+                unread={unread}
+              />
+            );
+          })
+        )}
       </View>
     </ScrollView>
   );

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,8 +1,11 @@
-import React, { useState } from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, Pressable, ActivityIndicator, Alert } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { useAuth } from '../../lib/auth/AuthContext';
+import { users, upload } from '../../lib/api/endpoints';
 
 function InfoRow({ label, value, icon }: { label: string; value: string; icon: string }) {
   return (
@@ -24,37 +27,163 @@ function StatBlock({ icon, value, label }: { icon: string; value: string; label:
   );
 }
 
-export default function ProfileScreen() {
-  const [editMode, setEditMode] = useState(false);
-  const [name, setName] = useState('Елена Васильева');
-  const [city, setCity] = useState('Москва');
-  const [savedName, setSavedName] = useState('Елена Васильева');
-  const [savedCity, setSavedCity] = useState('Москва');
+function getInitials(firstName?: string, lastName?: string): string {
+  const f = firstName?.[0] ?? '';
+  const l = lastName?.[0] ?? '';
+  return (f + l).toUpperCase() || '?';
+}
 
-  const handleSave = () => { setSavedName(name); setSavedCity(city); setEditMode(false); };
-  const handleCancel = () => { setName(savedName); setCity(savedCity); setEditMode(false); };
+function formatDate(iso?: string): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+export default function ProfileScreen() {
+  const { user, refreshUser } = useAuth();
+
+  // Profile data from API
+  const [profile, setProfile] = useState<{
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    city?: string;
+    avatarUrl?: string;
+    createdAt?: string;
+    stats?: { total?: number; active?: number; rating?: number };
+  }>({});
+  const [profileLoading, setProfileLoading] = useState(true);
+
+  const [editMode, setEditMode] = useState(false);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [city, setCity] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [avatarLoading, setAvatarLoading] = useState(false);
+
+  useEffect(() => {
+    users.getMe()
+      .then((res: any) => {
+        const d = res.data as any;
+        setProfile(d);
+        setFirstName(d.firstName ?? '');
+        setLastName(d.lastName ?? '');
+        setCity(d.city ?? d.profile?.city ?? '');
+      })
+      .catch(() => {
+        // Fallback to cached auth user
+        if (user) {
+          setFirstName(user.firstName ?? '');
+          setLastName(user.lastName ?? '');
+        }
+      })
+      .finally(() => setProfileLoading(false));
+  }, []);
+
+  const handleChangePicture = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Нет доступа', 'Разрешите доступ к галерее в настройках.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+    if (result.canceled || !result.assets?.[0]) return;
+    const asset = result.assets[0];
+    const formData = new FormData();
+    formData.append('file', {
+      uri: asset.uri,
+      type: asset.mimeType ?? 'image/jpeg',
+      name: asset.fileName ?? 'avatar.jpg',
+    } as any);
+    try {
+      setAvatarLoading(true);
+      const res = await upload.avatar(formData);
+      const avatarUrl = (res.data as any).avatarUrl;
+      setProfile((p) => ({ ...p, avatarUrl }));
+      await refreshUser();
+    } catch {
+      Alert.alert('Ошибка', 'Не удалось загрузить фото.');
+    } finally {
+      setAvatarLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      await users.updateMe({ firstName, lastName, city });
+      setProfile((p) => ({ ...p, firstName, lastName, city }));
+      await refreshUser();
+      setEditMode(false);
+    } catch {
+      Alert.alert('Ошибка', 'Не удалось сохранить изменения.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setFirstName(profile.firstName ?? '');
+    setLastName(profile.lastName ?? '');
+    setCity(profile.city ?? '');
+    setEditMode(false);
+  };
+
+  if (profileLoading) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <ActivityIndicator color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
+  const displayName = [profile.firstName, profile.lastName].filter(Boolean).join(' ') || user?.email?.split('@')[0] || 'Профиль';
+  const email = profile.email ?? user?.email ?? '—';
+  const initials = getInitials(profile.firstName, profile.lastName);
+  const stats = profile.stats as any;
 
   if (editMode) {
     return (
       <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
           <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-            <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>ЕВ</Text>
+            <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>{initials}</Text>
           </View>
-          <Pressable style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-            <Feather name="camera" size={14} color={Colors.brandPrimary} />
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>Изменить фото</Text>
+          <Pressable
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
+            onPress={handleChangePicture}
+            disabled={avatarLoading}
+          >
+            {avatarLoading ? (
+              <ActivityIndicator size="small" color={Colors.brandPrimary} />
+            ) : (
+              <>
+                <Feather name="camera" size={14} color={Colors.brandPrimary} />
+                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>Изменить фото</Text>
+              </>
+            )}
           </Pressable>
         </View>
         <View style={{ gap: Spacing.lg }}>
           <View style={{ gap: Spacing.xs }}>
             <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Имя</Text>
-            <TextInput value={name} onChangeText={setName} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
+            <TextInput value={firstName} onChangeText={setFirstName} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
+          </View>
+          <View style={{ gap: Spacing.xs }}>
+            <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Фамилия</Text>
+            <TextInput value={lastName} onChangeText={setLastName} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
           </View>
           <View style={{ gap: Spacing.xs }}>
             <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Email</Text>
-            <TextInput value="elena@mail.ru" editable={false} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, opacity: 0.5, outlineStyle: 'none' } as any} />
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}><Feather name="lock" size={12} color={Colors.textMuted} /><Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>Email нельзя изменить</Text></View>
+            <TextInput value={email} editable={false} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, opacity: 0.5, outlineStyle: 'none' } as any} />
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+              <Feather name="lock" size={12} color={Colors.textMuted} />
+              <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>Email нельзя изменить</Text>
+            </View>
           </View>
           <View style={{ gap: Spacing.xs }}>
             <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Город</Text>
@@ -62,8 +191,19 @@ export default function ProfileScreen() {
           </View>
         </View>
         <View style={{ gap: Spacing.sm }}>
-          <Pressable onPress={handleSave} style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}>
-            <Feather name="check" size={16} color={Colors.white} /><Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Сохранить</Text>
+          <Pressable
+            onPress={handleSave}
+            disabled={saving}
+            style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}
+          >
+            {saving ? (
+              <ActivityIndicator color={Colors.white} />
+            ) : (
+              <>
+                <Feather name="check" size={16} color={Colors.white} />
+                <Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Сохранить</Text>
+              </>
+            )}
           </Pressable>
           <Pressable onPress={handleCancel} style={{ height: 48, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
             <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>Отмена</Text>
@@ -77,26 +217,29 @@ export default function ProfileScreen() {
     <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
         <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>ЕВ</Text>
+          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>{initials}</Text>
         </View>
         <View>
-          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>{savedName}</Text>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}><Feather name="user" size={14} color={Colors.textMuted} /><Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>Клиент</Text></View>
+          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>{displayName}</Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}>
+            <Feather name="user" size={14} color={Colors.textMuted} />
+            <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>Клиент</Text>
+          </View>
         </View>
       </View>
       <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-        <StatBlock icon="file-text" value="5" label="Заявок" />
-        <StatBlock icon="check-circle" value="3" label="Завершено" />
-        <StatBlock icon="star" value="4.9" label="Рейтинг" />
+        <StatBlock icon="file-text" value={String(stats?.total ?? '—')} label="Заявок" />
+        <StatBlock icon="check-circle" value={String(stats?.closed ?? stats?.completed ?? '—')} label="Завершено" />
+        <StatBlock icon="star" value={stats?.rating != null ? String(stats.rating) : '—'} label="Рейтинг" />
       </View>
       <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.md, ...Shadows.sm }}>
-        <InfoRow label="Email" value="elena@mail.ru" icon="mail" />
-        <InfoRow label="Город" value={savedCity} icon="map-pin" />
-        <InfoRow label="Регистрация" value="15.02.2026" icon="calendar" />
-        <InfoRow label="Заявки" value="5 (3 активных)" icon="file-text" />
+        <InfoRow label="Email" value={email} icon="mail" />
+        <InfoRow label="Город" value={profile.city ?? '—'} icon="map-pin" />
+        <InfoRow label="Регистрация" value={formatDate((profile as any).createdAt)} icon="calendar" />
       </View>
       <Pressable onPress={() => setEditMode(true)} style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}>
-        <Feather name="edit-2" size={16} color={Colors.white} /><Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Редактировать</Text>
+        <Feather name="edit-2" size={16} color={Colors.white} />
+        <Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Редактировать</Text>
       </Pressable>
       <Pressable style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, backgroundColor: Colors.bgCard, padding: Spacing.lg, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border }} onPress={() => router.push('/(tabs)/settings' as any)}>
         <Feather name="settings" size={16} color={Colors.textMuted} />

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -27,7 +27,7 @@ function ToggleRow({ label, icon, enabled, onToggle }: { label: string; icon: st
 }
 
 export default function SettingsScreen() {
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
   const router = useRouter();
   const [emailNotif, setEmailNotif] = useState(true);
   const [pushNotif, setPushNotif] = useState(false);
@@ -57,16 +57,18 @@ export default function SettingsScreen() {
       <View style={{ gap: Spacing.sm }}>
         <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Аккаунт</Text>
         <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <SettingRow label="Email" value="elena@mail.ru" icon="mail" />
+          <SettingRow label="Email" value={user?.email ?? '—'} icon="mail" />
+          {/* TODO: Language screen not implemented yet */}
           <SettingRow label="Язык" value="Русский" icon="globe" />
+          {/* TODO: Theme screen not implemented yet */}
           <SettingRow label="Тема" value="Светлая" icon="sun" />
         </View>
       </View>
       <View style={{ gap: Spacing.sm }}>
         <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Информация</Text>
         <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <SettingRow label="Политика конфиденциальности" icon="shield" />
-          <SettingRow label="Условия использования" icon="file-text" />
+          <SettingRow label="Политика конфиденциальности" icon="shield" onPress={() => router.push('/terms' as any)} />
+          <SettingRow label="Условия использования" icon="file-text" onPress={() => router.push('/terms' as any)} />
           <SettingRow label="Версия" value="1.0.0" icon="info" />
         </View>
       </View>
@@ -79,8 +81,12 @@ export default function SettingsScreen() {
           <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.statusBg.error, gap: Spacing.md, ...Shadows.sm }}>
             <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, textAlign: 'center' }}>Вы уверены, что хотите выйти?</Text>
             <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-              <Pressable onPress={() => setShowLogout(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}><Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text></Pressable>
-              <Pressable onPress={handleLogout} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}><Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Выйти</Text></Pressable>
+              <Pressable onPress={() => setShowLogout(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
+                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text>
+              </Pressable>
+              <Pressable onPress={handleLogout} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}>
+                <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Выйти</Text>
+              </Pressable>
             </View>
           </View>
         )}
@@ -92,8 +98,12 @@ export default function SettingsScreen() {
           <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.statusBg.error, gap: Spacing.md, ...Shadows.sm }}>
             <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, textAlign: 'center' }}>Это действие необратимо. Все данные будут удалены.</Text>
             <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-              <Pressable onPress={() => setShowDelete(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}><Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text></Pressable>
-              <Pressable style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}><Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Удалить</Text></Pressable>
+              <Pressable onPress={() => setShowDelete(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
+                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text>
+              </Pressable>
+              <Pressable style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}>
+                <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Удалить</Text>
+              </Pressable>
             </View>
           </View>
         )}

--- a/app/(tabs)/specialist-settings.tsx
+++ b/app/(tabs)/specialist-settings.tsx
@@ -1,17 +1,39 @@
-import React, { useState } from 'react';
-import { View, Text, ScrollView, Pressable } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { Toggle } from '../../components/proto/Toggle';
 import { useAuth } from '../../lib/auth/AuthContext';
+import { users, specialistPortal } from '../../lib/api/endpoints';
 
 function IdleState() {
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
   const router = useRouter();
   const [emailNotif, setEmailNotif] = useState(true);
   const [pushNotif, setPushNotif] = useState(false);
   const [publicProfile, setPublicProfile] = useState(true);
+
+  const [email, setEmail] = useState(user?.email ?? '');
+  const [phone, setPhone] = useState('');
+  const [profileLoading, setProfileLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      users.getMe().catch(() => null),
+      specialistPortal.getProfile().catch(() => null),
+    ]).then(([meRes, spRes]) => {
+      if (meRes?.data) {
+        const me = meRes.data as any;
+        setEmail(me.email ?? user?.email ?? '');
+        setPhone(me.phone ?? '');
+      }
+      if (spRes?.data) {
+        const sp = spRes.data as any;
+        if (!phone && sp.phone) setPhone(sp.phone);
+      }
+    }).finally(() => setProfileLoading(false));
+  }, []);
 
   const handleLogout = async () => {
     try {
@@ -33,7 +55,11 @@ function IdleState() {
           <Text className="text-sm font-medium text-textMuted">Email</Text>
           <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
             <Feather name="mail" size={16} color={Colors.textMuted} />
-            <Text className="ml-2 flex-1 text-base text-textSecondary">alex@mail.ru</Text>
+            {profileLoading ? (
+              <ActivityIndicator size="small" color={Colors.textMuted} style={{ marginLeft: 8 }} />
+            ) : (
+              <Text className="ml-2 flex-1 text-base text-textSecondary">{email || '—'}</Text>
+            )}
           </View>
         </View>
 
@@ -41,8 +67,13 @@ function IdleState() {
           <Text className="text-sm font-medium text-textMuted">Телефон</Text>
           <View className="h-11 flex-row items-center rounded-lg border border-borderLight bg-bgSecondary px-3">
             <Feather name="phone" size={16} color={Colors.textMuted} />
-            <Text className="ml-2 flex-1 text-base text-textSecondary">+7 (916) 123-45-67</Text>
-            <Pressable hitSlop={8}>
+            {profileLoading ? (
+              <ActivityIndicator size="small" color={Colors.textMuted} style={{ marginLeft: 8 }} />
+            ) : (
+              <Text className="ml-2 flex-1 text-base text-textSecondary">{phone || '—'}</Text>
+            )}
+            {/* TODO: phone edit screen not implemented */}
+            <Pressable hitSlop={8} onPress={() => router.push('/(tabs)/profile' as any)}>
               <Feather name="edit-2" size={16} color={Colors.brandPrimary} />
             </Pressable>
           </View>


### PR DESCRIPTION
Closes #1015

## Changes

- **dashboard.tsx**: greeting uses `useAuth().user.firstName`; active requests fetched via `requests.getMyRequests({limit:3,status:'active'})`; message threads fetched via `threads.getThreads()`; click on request card navigates to `/(dashboard)/my-requests/:id`; click on message navigates to `/chat/:id`; loading spinner + empty state with CTA
- **profile.tsx**: loads profile from `users.getMe()`; avatar change via `ImagePicker` → `upload.avatar(FormData)` → `users.updateMe`; save calls `users.updateMe` + `refreshUser()`; all mocks removed
- **settings.tsx**: email from `useAuth().user.email`; Policy/Terms rows have `onPress → router.push('/terms')`; Language/Theme commented with TODO; logout already wired correctly
- **specialist-settings.tsx**: loads email/phone from `users.getMe()` + `specialistPortal.getProfile()`; pencil icon has `onPress`; all hardcoded mocks removed