### PR TITLE
feat(auth): role selection screen (#1016)

### DIFF
--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,15 +1,23 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, Pressable, TextInput } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Header } from '../../components/Header';
 import { auth } from '../../lib/api/endpoints';
 
 export default function AuthEmailScreen() {
   const router = useRouter();
+  const { role } = useLocalSearchParams<{ role?: string }>();
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  // If role is missing, redirect to role selection
+  useEffect(() => {
+    if (!role) {
+      router.replace('/(auth)/role');
+    }
+  }, [role]);
 
   const handleSubmit = async () => {
     if (!email || !email.includes('@')) {
@@ -20,7 +28,7 @@ export default function AuthEmailScreen() {
     setLoading(true);
     try {
       await auth.requestOtp(email.trim().toLowerCase());
-      router.push({ pathname: '/(auth)/otp', params: { email: email.trim().toLowerCase() } });
+      router.push({ pathname: '/(auth)/otp', params: { email: email.trim().toLowerCase(), role: role ?? 'CLIENT' } });
     } catch (err: any) {
       const msg = err?.response?.data?.message || err?.message || 'Не удалось отправить код. Попробуйте ещё раз.';
       setError(Array.isArray(msg) ? msg.join(', ') : msg);
@@ -38,7 +46,9 @@ export default function AuthEmailScreen() {
           <Feather name="shield" size={28} color="#0284C7" />
         </View>
         <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
-        <Text className="text-base text-textMuted">Найдите налогового специалиста</Text>
+        <Text className="text-base text-textMuted">
+          {role === 'SPECIALIST' ? 'Регистрация специалиста' : 'Найдите налогового специалиста'}
+        </Text>
       </View>
 
       <View className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6">

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -3,11 +3,11 @@ import { View, Text, Pressable, TextInput } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Header } from '../../components/Header';
-import { auth, users } from '../../lib/api/endpoints';
+import { auth } from '../../lib/api/endpoints';
 
 export default function OtpScreen() {
   const router = useRouter();
-  const { email } = useLocalSearchParams<{ email: string }>();
+  const { email, role } = useLocalSearchParams<{ email: string; role?: string }>();
   const [digits, setDigits] = useState<string[]>(['', '', '', '', '', '']);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -44,19 +44,20 @@ export default function OtpScreen() {
     setLoading(true);
     setError('');
     try {
-      await auth.verifyOtp(email, code);
-      // Check if user has a profile (firstName set means onboarding done)
-      try {
-        const meRes = await users.getMe();
-        const me = (meRes as any).data ?? meRes;
-        if (me?.firstName) {
-          router.replace('/(tabs)/dashboard');
-        } else {
-          router.replace('/(onboarding)/profile');
-        }
-      } catch {
-        // If getMe fails, go to onboarding to be safe
-        router.replace('/(onboarding)/profile');
+      // Pass role (lowercase) so backend assigns it on first registration
+      const normalizedRole = role ? role.toLowerCase() : 'client';
+      const res = await auth.verifyOtp(email, code, normalizedRole);
+      const data = (res as any).data ?? res;
+      const isNewUser: boolean = data?.isNewUser ?? false;
+      const userRole: string = data?.user?.role ?? role ?? 'CLIENT';
+
+      if (isNewUser) {
+        // New user: start onboarding
+        router.replace('/(onboarding)/username' as any);
+      } else if (userRole === 'SPECIALIST') {
+        router.replace('/(tabs)/specialist-dashboard' as any);
+      } else {
+        router.replace('/(tabs)/dashboard' as any);
       }
     } catch (err: any) {
       const msg = err?.response?.data?.message || err?.message || 'Неверный код. Попробуйте ещё раз.';

--- a/app/(auth)/role.tsx
+++ b/app/(auth)/role.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { Header } from '../../components/Header';
+import { Colors } from '../../constants/Colors';
+
+export default function RoleScreen() {
+  const router = useRouter();
+
+  function selectRole(role: 'CLIENT' | 'SPECIALIST') {
+    router.push({ pathname: '/(auth)/email', params: { role } });
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+      <Header variant="back" backTitle="Выбор роли" onBack={() => router.back()} />
+      <View className="flex-1 items-center justify-center bg-white px-4 py-8">
+        <View className="mb-8 items-center gap-2">
+          <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
+            <Feather name="shield" size={28} color={Colors.brandPrimary} />
+          </View>
+          <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
+          <Text className="text-base text-textMuted">Кто вы на платформе?</Text>
+        </View>
+
+        <View className="w-full max-w-md gap-4">
+          <Pressable
+            onPress={() => selectRole('CLIENT')}
+            className="rounded-2xl border-2 border-borderLight bg-white p-6 active:border-brandPrimary active:bg-bgSecondary"
+            style={{ borderColor: Colors.borderLight }}
+          >
+            <View className="mb-3 h-12 w-12 items-center justify-center rounded-xl bg-bgSecondary">
+              <Feather name="search" size={24} color={Colors.brandPrimary} />
+            </View>
+            <Text className="text-lg font-bold text-textPrimary">Я ищу специалиста</Text>
+            <Text className="mt-1 text-sm leading-5 text-textMuted">
+              Нужна помощь с налоговой проверкой или вопросом — найду специалиста по своей ФНС
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={() => selectRole('SPECIALIST')}
+            className="rounded-2xl border-2 border-borderLight bg-white p-6 active:border-brandPrimary active:bg-bgSecondary"
+            style={{ borderColor: Colors.borderLight }}
+          >
+            <View className="mb-3 h-12 w-12 items-center justify-center rounded-xl bg-bgSecondary">
+              <Feather name="briefcase" size={24} color={Colors.brandPrimary} />
+            </View>
+            <Text className="text-lg font-bold text-textPrimary">Я специалист по налогам</Text>
+            <Text className="mt-1 text-sm leading-5 text-textMuted">
+              Консультирую клиентов по вопросам налоговых проверок в конкретных ФНС
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -61,9 +61,9 @@ export default function OnboardingProfilePage() {
 
       await refreshUser();
 
-      // Navigate to dashboard based on role
+      // SPECIALIST continues to work-area (step 3/3), CLIENT is done (step 2/2)
       if (role === 'SPECIALIST') {
-        router.replace('/(tabs)/specialist-dashboard' as any);
+        router.push('/(onboarding)/work-area' as any);
       } else {
         router.replace('/(tabs)/dashboard' as any);
       }
@@ -81,9 +81,11 @@ export default function OnboardingProfilePage() {
       <View className="flex-1 bg-white px-4 py-6">
         {/* Progress */}
         <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
+          <View className="h-1 rounded-full bg-green-600" style={{ width: role === 'SPECIALIST' ? '66%' : '100%' }} />
         </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 3 из 3</Text>
+        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
+          {role === 'SPECIALIST' ? 'Шаг 2 из 3' : 'Шаг 2 из 2'}
+        </Text>
 
         <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>
         <Text className="mb-4 text-base text-textMuted">Эта информация поможет клиентам выбрать вас</Text>

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -58,12 +58,8 @@ export default function UsernameScreen() {
     setError('');
     try {
       await users.setUsername({ username: value });
-
-      if (role === 'SPECIALIST') {
-        router.push('/(onboarding)/work-area' as any);
-      } else {
-        router.replace('/(tabs)/dashboard' as any);
-      }
+      // Both roles go to profile next (CLIENT: step 2/2, SPECIALIST: step 2/3)
+      router.push('/(onboarding)/profile' as any);
     } catch (e: any) {
       const msg = e?.response?.data?.message || e?.message || 'Ошибка сохранения';
       setError(typeof msg === 'string' ? msg : 'Ошибка сохранения');
@@ -77,9 +73,11 @@ export default function UsernameScreen() {
       <Header variant="back" backTitle="Имя" onBack={() => router.back()} />
       <View className="flex-1 bg-white px-4 py-6">
         <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '33%' }} />
+          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: role === 'SPECIALIST' ? '33%' : '50%' }} />
         </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 1 из 3</Text>
+        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
+          {role === 'SPECIALIST' ? 'Шаг 1 из 3' : 'Шаг 1 из 2'}
+        </Text>
         <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
         <Text className="mb-4 text-base leading-6 text-textMuted">Это имя будет видно клиентам в вашем профиле</Text>
         <Text className="mb-1 text-sm font-medium text-textSecondary">Имя пользователя</Text>

--- a/app/(onboarding)/work-area.tsx
+++ b/app/(onboarding)/work-area.tsx
@@ -65,9 +65,9 @@ export default function WorkAreaScreenPage() {
       <Header variant="back" backTitle="Регион" onBack={() => router.back()} />
       <View className="flex-1 bg-white px-4 py-6">
         <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '66%' }} />
+          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '100%' }} />
         </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 2 из 3</Text>
+        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 3 из 3</Text>
         <Text className="text-xl font-bold text-textPrimary">Рабочая зона</Text>
         <Text className="mb-4 text-base text-textMuted">Выберите города, инспекции и услуги</Text>
         <View className="mb-2 h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -211,7 +211,7 @@ function HeroSection() {
               />
             </View>
 
-            <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" onPress={() => router.push('/(auth)/email' as any)}>
+            <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" onPress={() => router.push('/(auth)/role' as any)}>
               <Feather name="send" size={16} color={Colors.white} />
               <Text className="text-base font-semibold text-white">Отправить заявку</Text>
             </Pressable>
@@ -513,7 +513,7 @@ function BottomCTA() {
       <View className="mt-6 flex-row items-center gap-2">
         <Feather name="briefcase" size={14} color={Colors.textMuted} />
         <Text className="text-sm text-textMuted">Вы налоговый специалист?</Text>
-        <Pressable onPress={() => router.push('/(auth)/email' as any)}>
+        <Pressable onPress={() => router.push('/(auth)/role' as any)}>
           <Text className="text-sm font-medium text-brandPrimary">Присоединиться</Text>
         </Pressable>
       </View>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -46,7 +46,7 @@ function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void 
           </Pressable>
         ))}
         <View className="my-2 h-px bg-borderLight" />
-        <Pressable className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push('/(auth)/email' as any); }}>
+        <Pressable className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push('/(auth)/role' as any); }}>
           <Feather name="log-in" size={18} color={Colors.brandPrimary} />
           <Text className="text-base font-semibold text-brandPrimary">Войти</Text>
         </Pressable>
@@ -98,7 +98,7 @@ export function Header({
         >
           <LogoBlock />
           <View className="flex-row items-center gap-4">
-            <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4" onPress={() => router.push('/(auth)/email' as any)}>
+            <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4" onPress={() => router.push('/(auth)/role' as any)}>
               <Text className="text-sm font-semibold text-white">Войти</Text>
             </Pressable>
             <Pressable onPress={() => setBurgerOpen(!burgerOpen)}>

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -19,8 +19,8 @@ export const auth = {
     return client.post<{ message: string }>('/auth/request-otp', { email });
   },
 
-  async verifyOtp(email: string, code: string) {
-    const res = await client.post<AuthTokens>('/auth/verify-otp', { email, code });
+  async verifyOtp(email: string, code: string, role?: string) {
+    const res = await client.post<AuthTokens & { isNewUser: boolean; user: { userId: string; email: string; role: string; username: string | null } }>('/auth/verify-otp', { email, code, ...(role ? { role } : {}) });
     await setAccessToken(res.data.accessToken);
     await setRefreshToken(res.data.refreshToken);
     return res;


### PR DESCRIPTION
## Summary
- Add `/(auth)/role` screen with CLIENT / SPECIALIST card picker
- Wire role param through email → otp → verifyOtp API call
- otp.tsx uses `isNewUser` from API response to route new users to onboarding
- Onboarding progress bars now role-aware (CLIENT: 2 steps, SPECIALIST: 3 steps)
- username → profile → work-area (SPECIALIST) / dashboard (CLIENT)
- index.tsx + Header.tsx CTAs now point to `/role` instead of `/email`

Closes #1016