### PR TITLE
feat(header): universal header + fix dead buttons

### DIFF
--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -12,6 +12,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { Colors } from '../../../constants/Colors';
 import { requests } from '../../../lib/api/endpoints';
 import { useAuth } from '../../../lib/auth';
+import { Header } from '../../../components/Header';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -211,21 +212,27 @@ export default function RequestDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 items-center justify-center bg-white">
-        <ActivityIndicator color={Colors.brandPrimary} />
+      <View className="flex-1 bg-white">
+        <Header variant="back" onBack={() => router.back()} />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
       </View>
     );
   }
 
   if (error || !request) {
     return (
-      <View className="flex-1 items-center justify-center bg-white p-6">
-        <Text className="text-center text-base text-statusError">
-          {error ?? 'Заявка не найдена'}
-        </Text>
-        <Pressable onPress={fetchRequest} className="mt-4">
-          <Text className="text-sm text-brandPrimary">Повторить</Text>
-        </Pressable>
+      <View className="flex-1 bg-white">
+        <Header variant="back" onBack={() => router.back()} />
+        <View className="flex-1 items-center justify-center p-6">
+          <Text className="text-center text-base text-statusError">
+            {error ?? 'Заявка не найдена'}
+          </Text>
+          <Pressable onPress={fetchRequest} className="mt-4">
+            <Text className="text-sm text-brandPrimary">Повторить</Text>
+          </Pressable>
+        </View>
       </View>
     );
   }
@@ -238,7 +245,9 @@ export default function RequestDetailScreen() {
   const isClosed = status === 'CLOSED' || status === 'CANCELLED';
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <View className="flex-1 bg-white">
+    <Header variant="back" backTitle={request.title} onBack={() => router.back()} />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
       {/* Request card */}
       <View className="gap-4 rounded-xl border border-borderLight bg-white p-4">
         <View className="flex-row items-start justify-between gap-2">
@@ -342,5 +351,6 @@ export default function RequestDetailScreen() {
         </View>
       )}
     </ScrollView>
+    </View>
   );
 }

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -6,6 +6,7 @@ import * as DocumentPicker from 'expo-document-picker';
 import { Colors } from '../../../constants/Colors';
 import { Toggle } from '../../../components/proto/Toggle';
 import { ifns, requests, upload } from '../../../lib/api/endpoints';
+import { Header } from '../../../components/Header';
 
 // Fixed service list per product spec
 const SERVICES = ['Выездная проверка', 'Отдел оперативного контроля', 'Камеральная проверка', 'Не знаю'];
@@ -234,7 +235,9 @@ export default function NewRequestScreen() {
   };
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <View className="flex-1 bg-white">
+    <Header variant="back" backTitle="Новая заявка" onBack={() => router.back()} />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <Text className="text-xl font-bold text-textPrimary">Новая заявка</Text>
       <LocationServicePicker
         city={city}
@@ -303,5 +306,6 @@ export default function NewRequestScreen() {
         )}
       </Pressable>
     </ScrollView>
+    </View>
   );
 }

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -5,6 +5,7 @@ import { router } from "expo-router";
 import { Colors } from "../../constants/Colors";
 import { useAuth } from "../../lib/auth/AuthContext";
 import { requests, threads } from "../../lib/api/endpoints";
+import { Header } from "../../components/Header";
 
 function getGreeting(): string {
   const h = new Date().getHours();
@@ -170,10 +171,16 @@ interface RequestItem {
   _count?: { threads?: number };
 }
 
+interface ThreadParticipant {
+  firstName?: string;
+  lastName?: string;
+  nick?: string;
+}
+
 interface ThreadItem {
   id: string;
-  specialist?: { firstName?: string; lastName?: string; nick?: string; [key: string]: unknown };
-  client?: { firstName?: string; lastName?: string; [key: string]: unknown };
+  specialist?: ThreadParticipant;
+  client?: ThreadParticipant;
   lastMessage?: { content?: string; createdAt?: string };
   unreadCount?: number;
 }
@@ -217,7 +224,9 @@ export default function DashboardScreen() {
   const firstName = user?.firstName ?? user?.email?.split('@')[0] ?? 'друг';
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <View className="flex-1 bg-white">
+    <Header variant="auth" />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <View className="flex-row items-start justify-between">
         <View className="flex-1">
           <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, {firstName}!</Text>
@@ -308,5 +317,6 @@ export default function DashboardScreen() {
         )}
       </View>
     </ScrollView>
+    </View>
   );
 }

--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { requests as requestsApi, ifns } from '../../lib/api/endpoints';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
+import { Header } from '../../components/Header';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -283,8 +284,10 @@ function FeedState() {
   const hasFilters = !!(filterCity || selectedFns.length > 0);
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      {/* Header */}
+    <View className="flex-1 bg-white">
+    <Header variant="auth" />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      {/* Page title */}
       <View>
         <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
         {!loading && <Text className="mt-0.5 text-sm text-textMuted">{feedData.length} активных заявок</Text>}
@@ -375,6 +378,7 @@ function FeedState() {
         }}
       />
     </ScrollView>
+    </View>
   );
 }
 

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { threads as threadsApi } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
+import { Header } from '../../components/Header';
 
 // ---------------------------------------------------------------------------
 // Types — shape from GET /threads?grouped_by=request
@@ -362,10 +363,12 @@ export default function MessagesScreen() {
     return sum;
   }, [groups, user?.id]);
 
-  if (loading) return <LoadingState />;
-  if (error) return <ErrorState onRetry={load} />;
+  if (loading) return <View style={{ flex: 1 }}><Header variant="auth" /><LoadingState /></View>;
+  if (error) return <View style={{ flex: 1 }}><Header variant="auth" /><ErrorState onRetry={load} /></View>;
 
   return (
+    <View style={{ flex: 1 }}>
+    <Header variant="auth" />
     <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
         <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
@@ -435,5 +438,6 @@ export default function MessagesScreen() {
         ))
       )}
     </ScrollView>
+    </View>
   );
 }

--- a/app/(tabs)/my-responses.tsx
+++ b/app/(tabs)/my-responses.tsx
@@ -4,6 +4,7 @@ import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { specialistPortal } from '../../lib/api/endpoints';
+import { Header } from '../../components/Header';
 
 // ---------------------------------------------------------------------------
 // Types — response shape from GET /specialist/responses (post-W-1)
@@ -147,13 +148,15 @@ export default function SpecialistMyDialogsScreen() {
 
   useEffect(() => { load(); }, [load]);
 
-  if (loading) return <LoadingState />;
-  if (error) return <ErrorState onRetry={load} />;
+  if (loading) return <View className="flex-1"><Header variant="auth" /><LoadingState /></View>;
+  if (error) return <View className="flex-1"><Header variant="auth" /><ErrorState onRetry={load} /></View>;
 
   const list = threads ?? [];
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <View className="flex-1 bg-white">
+    <Header variant="auth" />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <View className="flex-row items-center gap-2">
         <Feather name="mail" size={20} color={Colors.brandPrimary} />
         <Text className="text-xl font-bold text-textPrimary">Мои диалоги</Text>
@@ -166,5 +169,6 @@ export default function SpecialistMyDialogsScreen() {
         ))
       )}
     </ScrollView>
+    </View>
   );
 }

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -4,6 +4,7 @@ import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { requests as requestsApi } from '../../lib/api/endpoints';
+import { Header } from '../../components/Header';
 
 interface ApiRequest {
   id: string;
@@ -90,22 +91,30 @@ export default function RequestsScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <ActivityIndicator color={Colors.brandPrimary} />
+      <View style={{ flex: 1 }}>
+        <Header variant="auth" />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
       </View>
     );
   }
 
   if (error) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.xl, gap: Spacing.md }}>
-        <Feather name="alert-circle" size={28} color={Colors.statusError} />
-        <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+      <View style={{ flex: 1 }}>
+        <Header variant="auth" />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.xl, gap: Spacing.md }}>
+          <Feather name="alert-circle" size={28} color={Colors.statusError} />
+          <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+        </View>
       </View>
     );
   }
 
   return (
+    <View style={{ flex: 1 }}>
+    <Header variant="auth" />
     <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}>
       <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
         <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>Мои заявки</Text>
@@ -144,5 +153,6 @@ export default function RequestsScreen() {
         />
       ))}
     </ScrollView>
+    </View>
   );
 }

--- a/app/(tabs)/specialist-dashboard.tsx
+++ b/app/(tabs)/specialist-dashboard.tsx
@@ -5,6 +5,7 @@ import { router, useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { specialistPortal } from '../../lib/api/endpoints';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
+import { Header } from '../../components/Header';
 
 interface FeedItem {
   id: string;
@@ -110,24 +111,32 @@ export default function SpecialistDashboardScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <ActivityIndicator color={Colors.brandPrimary} />
+      <View style={{ flex: 1 }}>
+        <Header variant="auth" />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
       </View>
     );
   }
 
   if (error) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 }}>
-        <Feather name="alert-circle" size={28} color={Colors.statusError} />
-        <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+      <View style={{ flex: 1 }}>
+        <Header variant="auth" />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 }}>
+          <Feather name="alert-circle" size={28} color={Colors.statusError} />
+          <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+        </View>
       </View>
     );
   }
 
   if (feedData.length === 0) {
     return (
-      <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <View className="flex-1 bg-white">
+        <Header variant="auth" />
+        <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
         <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
         <View className="items-center gap-3 py-10">
           <View className="h-16 w-16 items-center justify-center rounded-full border border-borderLight bg-bgSecondary">
@@ -142,12 +151,15 @@ export default function SpecialistDashboardScreen() {
             <Text className="text-sm font-semibold text-brandPrimary">Настройки</Text>
           </Pressable>
         </View>
-      </ScrollView>
+        </ScrollView>
+      </View>
     );
   }
 
   return (
-    <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
+    <View className="flex-1 bg-white">
+    <Header variant="auth" />
+    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
       <View>
         <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
         <Text className="text-sm text-textMuted">{feedData.length} заявок в вашем регионе</Text>
@@ -193,5 +205,6 @@ export default function SpecialistDashboardScreen() {
         }}
       />
     </ScrollView>
+    </View>
   );
 }

--- a/app/leave-review.tsx
+++ b/app/leave-review.tsx
@@ -14,6 +14,7 @@ import { Feather } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Colors } from '../constants/Colors';
 import { reviews } from '../lib/api/endpoints';
+import { Header } from '../components/Header';
 
 export default function LeaveReviewScreen() {
   const { requestId, specialistNick } = useLocalSearchParams<{
@@ -59,7 +60,9 @@ export default function LeaveReviewScreen() {
 
   if (submitted) {
     return (
-      <View className="flex-1 items-center justify-center bg-white p-8 gap-6">
+      <View className="flex-1 bg-white">
+      <Header variant="back" onBack={() => router.back()} />
+      <View className="flex-1 items-center justify-center p-8 gap-6">
         <View className="h-16 w-16 items-center justify-center rounded-full bg-statusSuccess/10">
           <Feather name="check-circle" size={32} color={Colors.statusSuccess} />
         </View>
@@ -74,6 +77,7 @@ export default function LeaveReviewScreen() {
           <Text className="text-base font-semibold text-white">Вернуться к заявкам</Text>
         </Pressable>
       </View>
+      </View>
     );
   }
 
@@ -82,6 +86,7 @@ export default function LeaveReviewScreen() {
       className="flex-1"
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
+      <Header variant="back" onBack={() => router.back()} />
       <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 20 }}>
         <Text className="text-xl font-bold text-textPrimary">Оставить отзыв</Text>
         {specialistNick && (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,21 +3,21 @@ import { View, Text, Pressable } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { Colors } from '../constants/Colors';
+import { useAuth } from '../lib/auth';
 
-const BURGER_LINKS: { icon: 'home' | 'users' | 'credit-card'; label: string; route: string }[] = [
+const BURGER_LINKS: { icon: 'home' | 'users'; label: string; route: string }[] = [
   { icon: 'home', label: 'Главная', route: '/' },
   { icon: 'users', label: 'Специалисты', route: '/specialists' },
-  { icon: 'credit-card', label: 'Тарифы', route: '/' }, // TODO: /pricing when page exists
 ];
 
 function LogoBlock() {
   return (
-    <View className="flex-row items-center gap-2">
+    <Pressable className="flex-row items-center gap-2" onPress={() => router.push('/')}>
       <View className="h-7 w-7 items-center justify-center rounded-md bg-brandPrimary">
         <Feather name="shield" size={16} color={Colors.white} />
       </View>
       <Text className="text-lg font-bold text-textPrimary">Налоговик</Text>
-    </View>
+    </Pressable>
   );
 }
 
@@ -58,32 +58,28 @@ function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void 
 export function Header({
   variant,
   backTitle,
-  initials = 'EV',
   hasNotif = false,
   onBack,
 }: {
   variant: 'guest' | 'auth' | 'back';
   backTitle?: string;
-  initials?: string;
   hasNotif?: boolean;
   onBack?: () => void;
 }) {
   const [burgerOpen, setBurgerOpen] = useState(false);
+  const { user } = useAuth();
 
   if (variant === 'back') {
     return (
       <View
-        className="h-14 flex-row items-center justify-between border-b bg-bgCard px-4"
+        className="h-14 flex-row items-center border-b bg-bgCard px-4"
         style={{ borderBottomColor: Colors.borderLight }}
       >
-        <Pressable className="flex-row items-center gap-2" onPress={onBack}>
+        <Pressable className="flex-row items-center gap-2" onPress={onBack ?? (() => router.back())}>
           <Feather name="arrow-left" size={20} color={Colors.brandPrimary} />
           <Text className="text-base font-semibold text-textPrimary">
             {backTitle ?? 'Назад'}
           </Text>
-        </Pressable>
-        <Pressable>
-          <Feather name="more-vertical" size={20} color={Colors.textMuted} />
         </Pressable>
       </View>
     );
@@ -116,6 +112,10 @@ export function Header({
   }
 
   // variant === 'auth'
+  const initials = user
+    ? ((user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '')).toUpperCase() || 'U'
+    : 'U';
+
   return (
     <View
       className="h-14 flex-row items-center justify-between border-b bg-bgCard px-4"
@@ -123,7 +123,7 @@ export function Header({
     >
       <LogoBlock />
       <View className="flex-row items-center gap-3">
-        <Pressable>
+        <Pressable onPress={() => router.push('/(tabs)/messages' as any)}>
           <Feather name="bell" size={20} color={Colors.textSecondary} />
           {hasNotif && (
             <View className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-statusError" />


### PR DESCRIPTION
Closes #1017

## Changes

**Header.tsx fixes:**
- Removed "Тарифы" burger item (no page exists)
- LogoBlock → Pressable, navigates to /
- Bell button (auth variant) → navigates to /(tabs)/messages
- Three-dot button (back variant) → removed
- Initials: read from useAuth user.firstName/lastName, fallback 'U'

**Added Header to 9 screens:**
- `(tabs)/dashboard.tsx` — variant="auth"
- `(tabs)/requests.tsx` — variant="auth"
- `(tabs)/messages.tsx` — variant="auth"
- `(tabs)/feed.tsx` — variant="auth"
- `(tabs)/my-responses.tsx` — variant="auth"
- `(tabs)/specialist-dashboard.tsx` — variant="auth"
- `(dashboard)/my-requests/new.tsx` — variant="back"
- `(dashboard)/my-requests/[id].tsx` — variant="back"
- `app/leave-review.tsx` — variant="back"

**Did not touch:** profile, settings, specialist-settings, (auth)/*, (onboarding)/*, chat/*, index.tsx, (admin)/*

`npx tsc --noEmit` — clean.