### PR TITLE
feat(admin): real dashboard data + close-all-requests endpoint

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Post,
   Patch,
   Delete,
   Param,
@@ -25,6 +26,20 @@ export class AdminController {
     return this.adminService.getStats();
   }
 
+  /** GET /admin/stats/weekly — last 7 days: signups, new requests, new responses */
+  @Get('stats/weekly')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getWeeklyStats() {
+    return this.adminService.getWeeklyStats();
+  }
+
+  /** GET /admin/activity — recent platform events (new users, specialists, requests) */
+  @Get('activity')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  getActivity(@Query('limit') limit?: string) {
+    return this.adminService.getActivity(limit ? parseInt(limit, 10) : 20);
+  }
+
   /** GET /admin/users — all users, optional ?role=CLIENT|SPECIALIST&page=1&limit=50 */
   @Get('users')
   @UseGuards(JwtAuthGuard, AdminGuard)
@@ -41,6 +56,13 @@ export class AdminController {
   @UseGuards(JwtAuthGuard, AdminGuard)
   blockUser(@Param('id') id: string, @Body() dto: BlockUserDto) {
     return this.adminService.blockUser(id, dto.isBlocked);
+  }
+
+  /** POST /admin/users/:id/close-all-requests — close every active request of a user */
+  @Post('users/:id/close-all-requests')
+  @UseGuards(JwtAuthGuard, AdminGuard)
+  closeAllUserRequests(@Param('id') id: string) {
+    return this.adminService.closeAllUserRequests(id);
   }
 
   /** GET /admin/specialists — all specialist profiles, optional ?page=1&limit=50 */

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -202,6 +202,228 @@ export class AdminService {
     return { items, total, page, pages: Math.ceil(total / take) };
   }
 
+  // ── Weekly stats (last 7 days) ─────────────────────────────────────────
+
+  async getWeeklyStats() {
+    // Build 7 day buckets ending today (inclusive), start-of-day in local time
+    const now = new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const from = new Date(startOfToday);
+    from.setDate(from.getDate() - 6); // 7 buckets: from..today
+
+    const [users, specialists, requests, responses] = await Promise.all([
+      this.prisma.user.findMany({
+        where: { createdAt: { gte: from } },
+        select: { createdAt: true, role: true },
+      }),
+      this.prisma.specialistProfile.findMany({
+        where: { createdAt: { gte: from } },
+        select: { createdAt: true },
+      }),
+      this.prisma.request.findMany({
+        where: { createdAt: { gte: from } },
+        select: { createdAt: true },
+      }),
+      // "responses" = threads opened (specialist responded to a request)
+      this.prisma.thread.findMany({
+        where: { createdAt: { gte: from } },
+        select: { createdAt: true },
+      }),
+    ]);
+
+    const dayKey = (d: Date) => {
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return `${y}-${m}-${day}`;
+    };
+
+    const buckets: Array<{
+      date: string;
+      signups: number;
+      newSpecialists: number;
+      newRequests: number;
+      newResponses: number;
+    }> = [];
+
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(from);
+      d.setDate(from.getDate() + i);
+      buckets.push({
+        date: dayKey(d),
+        signups: 0,
+        newSpecialists: 0,
+        newRequests: 0,
+        newResponses: 0,
+      });
+    }
+
+    const indexByDate = new Map(buckets.map((b, i) => [b.date, i]));
+
+    for (const u of users) {
+      const idx = indexByDate.get(dayKey(new Date(u.createdAt)));
+      if (idx !== undefined) buckets[idx].signups += 1;
+    }
+    for (const sp of specialists) {
+      const idx = indexByDate.get(dayKey(new Date(sp.createdAt)));
+      if (idx !== undefined) buckets[idx].newSpecialists += 1;
+    }
+    for (const r of requests) {
+      const idx = indexByDate.get(dayKey(new Date(r.createdAt)));
+      if (idx !== undefined) buckets[idx].newRequests += 1;
+    }
+    for (const t of responses) {
+      const idx = indexByDate.get(dayKey(new Date(t.createdAt)));
+      if (idx !== undefined) buckets[idx].newResponses += 1;
+    }
+
+    return buckets;
+  }
+
+  // ── Recent platform activity ───────────────────────────────────────────
+
+  async getActivity(limit = 20) {
+    const take = Math.min(Math.max(limit, 1), 100);
+    const since = new Date();
+    since.setHours(since.getHours() - 24 * 7); // look back up to 7 days
+
+    type Row = {
+      type: string;
+      actorName: string;
+      targetName: string;
+      action: string;
+      createdAt: Date;
+    };
+
+    const displayName = (u: {
+      firstName?: string | null;
+      lastName?: string | null;
+      username?: string | null;
+      email?: string | null;
+    } | null) => {
+      if (!u) return '—';
+      const full = `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim();
+      return full || u.username || u.email || '—';
+    };
+
+    const [newUsers, newSpecialists, newRequests, blockedUsers] = await Promise.all([
+      this.prisma.user.findMany({
+        where: { createdAt: { gte: since } },
+        orderBy: { createdAt: 'desc' },
+        take,
+        select: {
+          createdAt: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          username: true,
+          role: true,
+        },
+      }),
+      this.prisma.specialistProfile.findMany({
+        where: { createdAt: { gte: since } },
+        orderBy: { createdAt: 'desc' },
+        take,
+        select: {
+          createdAt: true,
+          nick: true,
+          displayName: true,
+          user: {
+            select: { email: true, firstName: true, lastName: true, username: true },
+          },
+        },
+      }),
+      this.prisma.request.findMany({
+        where: { createdAt: { gte: since } },
+        orderBy: { createdAt: 'desc' },
+        take,
+        select: {
+          createdAt: true,
+          title: true,
+          client: {
+            select: { email: true, firstName: true, lastName: true, username: true },
+          },
+        },
+      }),
+      this.prisma.user.findMany({
+        where: { isBlocked: true },
+        orderBy: { createdAt: 'desc' },
+        take,
+        select: {
+          createdAt: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          username: true,
+        },
+      }),
+    ]);
+
+    const rows: Row[] = [];
+
+    for (const u of newUsers) {
+      rows.push({
+        type: u.role === 'SPECIALIST' ? 'user.specialist_signup' : 'user.signup',
+        actorName: displayName(u),
+        targetName: '',
+        action: u.role === 'SPECIALIST' ? 'Регистрация специалиста' : 'Регистрация пользователя',
+        createdAt: u.createdAt,
+      });
+    }
+    for (const sp of newSpecialists) {
+      rows.push({
+        type: 'specialist.profile_created',
+        actorName: sp.displayName || sp.nick || displayName(sp.user),
+        targetName: '',
+        action: 'Новый профиль специалиста',
+        createdAt: sp.createdAt,
+      });
+    }
+    for (const r of newRequests) {
+      rows.push({
+        type: 'request.created',
+        actorName: displayName(r.client),
+        targetName: r.title,
+        action: 'Новая заявка',
+        createdAt: r.createdAt,
+      });
+    }
+    for (const u of blockedUsers) {
+      rows.push({
+        type: 'user.blocked',
+        actorName: 'Администратор',
+        targetName: displayName(u),
+        action: 'Пользователь заблокирован',
+        createdAt: u.createdAt,
+      });
+    }
+
+    rows.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return rows.slice(0, take);
+  }
+
+  // ── Close-all-requests (admin action on blocked/deleted user) ──────────
+
+  async closeAllUserRequests(id: string) {
+    const user = await this.prisma.user.findUnique({ where: { id }, select: { id: true } });
+    if (!user) {
+      throw new NotFoundException(`User ${id} not found`);
+    }
+
+    // Active states: anything not already CLOSED / CANCELLED. Works with current
+    // enum (NEW|OPEN|IN_PROGRESS|CLOSING_SOON|CLOSED|CANCELLED) and also if
+    // Task A later replaces open states with ACTIVE.
+    const result = await this.prisma.request.updateMany({
+      where: {
+        clientId: id,
+        status: { notIn: ['CLOSED', 'CANCELLED'] as any },
+      },
+      data: { status: 'CLOSED' as any },
+    });
+
+    return { closed: result.count };
+  }
+
   // ── Settings ──────────────────────────────────────────────────────────
 
   async getSettings(): Promise<Record<string, string>> {

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -29,24 +29,83 @@ function StatCard({ label, value, color, trend, icon }: { label: string; value: 
   );
 }
 
-function ChartPlaceholder({ title }: { title: string }) {
+interface WeeklyBucket {
+  date: string;
+  signups: number;
+  newSpecialists: number;
+  newRequests: number;
+  newResponses: number;
+}
+
+const DOW_RU = ['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб'];
+
+function WeeklyChart({ title, data }: { title: string; data: WeeklyBucket[] }) {
+  // Total activity per day (signups + requests + responses)
+  const totals = data.map((b) => b.signups + b.newRequests + b.newResponses);
+  const max = Math.max(1, ...totals);
+  const labels = data.map((b) => {
+    const d = new Date(b.date + 'T00:00:00');
+    return DOW_RU[d.getDay()];
+  });
+  const allZero = totals.every((t) => t === 0);
+
   return (
     <View style={s.chartCard}>
       <Text style={s.chartTitle}>{title}</Text>
-      <View style={s.chartArea}>
-        <View style={s.chartBars}>
-          {[40, 65, 45, 80, 55, 70, 90].map((h, i) => (
-            <View key={i} style={[s.chartBar, { height: h, backgroundColor: i === 6 ? Colors.brandPrimary : Colors.bgSecondary }]} />
-          ))}
+      {allZero ? (
+        <View style={{ paddingVertical: Spacing.xl, alignItems: 'center' }}>
+          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>
+            Нет активности за последние 7 дней
+          </Text>
         </View>
-        <View style={s.chartLabels}>
-          {['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'].map((d) => (
-            <Text key={d} style={s.chartLabel}>{d}</Text>
-          ))}
+      ) : (
+        <View style={s.chartArea}>
+          <View style={s.chartBars}>
+            {totals.map((t, i) => {
+              const h = Math.max(4, Math.round((t / max) * 100));
+              const isLast = i === totals.length - 1;
+              return (
+                <View
+                  key={i}
+                  style={[
+                    s.chartBar,
+                    { height: h, backgroundColor: isLast ? Colors.brandPrimary : Colors.bgSecondary },
+                  ]}
+                />
+              );
+            })}
+          </View>
+          <View style={s.chartLabels}>
+            {labels.map((d, i) => (
+              <Text key={i} style={s.chartLabel}>{d}</Text>
+            ))}
+          </View>
         </View>
-      </View>
+      )}
     </View>
   );
+}
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffSec = Math.max(0, Math.floor((now - then) / 1000));
+  if (diffSec < 60) return 'только что';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} мин назад`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour} ч назад`;
+  const diffDay = Math.floor(diffHour / 24);
+  return `${diffDay} дн назад`;
+}
+
+function activityIconFor(type: string): string {
+  if (type.startsWith('user.signup')) return 'user-plus';
+  if (type === 'user.specialist_signup' || type === 'specialist.profile_created') return 'briefcase';
+  if (type === 'request.created') return 'file-text';
+  if (type === 'user.blocked') return 'shield-off';
+  if (type === 'review.created') return 'star';
+  return 'activity';
 }
 
 // ---------------------------------------------------------------------------
@@ -60,19 +119,27 @@ interface AdminStats {
   [key: string]: unknown;
 }
 
+interface ActivityRow {
+  type: string;
+  actorName: string;
+  targetName: string;
+  action: string;
+  createdAt: string;
+}
+
 // ---------------------------------------------------------------------------
 // STATE: DEFAULT (populated with stats)
 // ---------------------------------------------------------------------------
 
-function DefaultDashboard({ st }: { st: AdminStats }) {
-  const activities = [
-    { icon: 'user-plus', action: 'Регистрация', detail: 'Новый пользователь', time: '5 мин назад' },
-    { icon: 'file-text', action: 'Заявка', detail: 'Новая заявка в системе', time: '12 мин назад' },
-    { icon: 'shield', action: 'Модерация', detail: 'Специалист ожидает проверки', time: '30 мин назад' },
-    { icon: 'star', action: 'Отзыв', detail: 'Новый отзыв', time: '1 час назад' },
-    { icon: 'alert-triangle', action: 'Жалоба', detail: 'Новая жалоба на специалиста', time: '2 часа назад' },
-  ];
-
+function DefaultDashboard({
+  st,
+  weekly,
+  activities,
+}: {
+  st: AdminStats;
+  weekly: WeeklyBucket[];
+  activities: ActivityRow[];
+}) {
   return (
     <ScrollView style={{ flex: 1 }} contentContainerStyle={s.container}>
       <View style={s.pageHeader}>
@@ -87,7 +154,7 @@ function DefaultDashboard({ st }: { st: AdminStats }) {
         <StatCard label="Открытые жалобы" value={st.openComplaints ?? '—'} color={Colors.statusWarning} icon="alert-triangle" />
       </View>
 
-      <ChartPlaceholder title="Активность за неделю" />
+      <WeeklyChart title="Активность за неделю" data={weekly} />
 
       <View style={s.recentSection}>
         <View style={s.sectionHeader}>
@@ -96,18 +163,33 @@ function DefaultDashboard({ st }: { st: AdminStats }) {
             <Text style={s.sectionBadgeText}>{activities.length}</Text>
           </View>
         </View>
-        {activities.map((item, i) => (
-          <View key={i} style={s.activityRow}>
-            <View style={s.activityIconWrap}>
-              <Feather name={item.icon as any} size={16} color={Colors.brandPrimary} />
-            </View>
-            <View style={s.activityContent}>
-              <Text style={s.activityAction}>{item.action}: <Text style={s.activityDetail}>{item.detail}</Text></Text>
-              <Text style={s.activityTime}>{item.time}</Text>
-            </View>
-            <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+        {activities.length === 0 ? (
+          <View style={{ paddingVertical: Spacing.xl, alignItems: 'center' }}>
+            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>
+              Пока нет активности
+            </Text>
           </View>
-        ))}
+        ) : (
+          activities.map((item, i) => {
+            const detailText = item.targetName
+              ? `${item.actorName} — ${item.targetName}`
+              : item.actorName;
+            return (
+              <View key={i} style={s.activityRow}>
+                <View style={s.activityIconWrap}>
+                  <Feather name={activityIconFor(item.type) as any} size={16} color={Colors.brandPrimary} />
+                </View>
+                <View style={s.activityContent}>
+                  <Text style={s.activityAction} numberOfLines={1}>
+                    {item.action}: <Text style={s.activityDetail}>{detailText}</Text>
+                  </Text>
+                  <Text style={s.activityTime}>{formatRelativeTime(item.createdAt)}</Text>
+                </View>
+                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+              </View>
+            );
+          })
+        )}
       </View>
     </ScrollView>
   );
@@ -115,18 +197,22 @@ function DefaultDashboard({ st }: { st: AdminStats }) {
 
 export default function AdminDashboardPage() {
   const [stats, setStats] = useState<AdminStats | null>(null);
+  const [weekly, setWeekly] = useState<WeeklyBucket[]>([]);
+  const [activities, setActivities] = useState<ActivityRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const load = () => {
     setLoading(true);
     setError(null);
-    admin.getStats()
-      .then((res) => {
-        setStats((res as any).data ?? res);
+    Promise.all([admin.getStats(), admin.getWeeklyStats(), admin.getActivity(20)])
+      .then(([statsRes, weeklyRes, activityRes]) => {
+        setStats(((statsRes as any).data ?? statsRes) as AdminStats);
+        setWeekly((((weeklyRes as any).data ?? weeklyRes) as WeeklyBucket[]) ?? []);
+        setActivities((((activityRes as any).data ?? activityRes) as ActivityRow[]) ?? []);
       })
       .catch((e) => {
-        setError(e.message ?? 'Ошибка загрузки');
+        setError(e?.message ?? 'Ошибка загрузки');
       })
       .finally(() => {
         setLoading(false);
@@ -155,7 +241,7 @@ export default function AdminDashboardPage() {
           </Pressable>
         </View>
       ) : (
-        <DefaultDashboard st={stats ?? {}} />
+        <DefaultDashboard st={stats ?? {}} weekly={weekly} activities={activities} />
       )}
     </View>
   );

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -295,12 +295,36 @@ export const admin = {
     return client.get('/admin/stats');
   },
 
+  getWeeklyStats() {
+    return client.get<Array<{
+      date: string;
+      signups: number;
+      newSpecialists: number;
+      newRequests: number;
+      newResponses: number;
+    }>>('/admin/stats/weekly');
+  },
+
+  getActivity(limit = 20) {
+    return client.get<Array<{
+      type: string;
+      actorName: string;
+      targetName: string;
+      action: string;
+      createdAt: string;
+    }>>('/admin/activity', { params: { limit } });
+  },
+
   getUsers(params?: { role?: string; page?: number; limit?: number }) {
     return client.get('/admin/users', { params });
   },
 
   blockUser(id: string, isBlocked: boolean) {
     return client.patch(`/admin/users/${id}`, { isBlocked });
+  },
+
+  closeAllUserRequests(id: string) {
+    return client.post<{ closed: number }>(`/admin/users/${id}/close-all-requests`);
   },
 
   getSpecialists(params?: { page?: number; limit?: number }) {


### PR DESCRIPTION
## Summary
- New backend endpoints: `GET /admin/stats/weekly`, `GET /admin/activity`, `POST /admin/users/:id/close-all-requests`
- Admin dashboard (`app/(admin)/index.tsx`) now pulls real activity rows and real weekly chart data (hardcoded arrays removed)
- Close-all-requests is defensive about RequestStatus enum (works both with current NEW/OPEN/IN_PROGRESS/CLOSING_SOON/CLOSED/CANCELLED and a future ACTIVE state)

## Notes
- No schema changes (Task A owns the enum migration)
- No audit log (schema has no AuditLog model — explicitly out of scope)
- Admin users list UI doesn't exist yet, so no close-all button wired into UI; endpoint is callable

## Test plan
- [ ] Login as admin → `/admin` shows real activity rows (not the old hardcoded Russian strings)
- [ ] Weekly chart reflects real data (or "Нет активности" empty state)
- [ ] `POST /admin/users/<test-user>/close-all-requests` returns `{closed: N}`; user's non-terminal requests become CLOSED