### PR TITLE
feat(chat+requests): multi-file attach (3) + Продлить on CLOSING_SOON

### DIFF
--- a/api/src/chat/chat.controller.ts
+++ b/api/src/chat/chat.controller.ts
@@ -11,12 +11,13 @@ import {
   UseGuards,
   UseInterceptors,
   UploadedFile,
+  UploadedFiles,
   Request,
   ForbiddenException,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
+import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import { randomUUID } from 'crypto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { StorageService } from '../storage/storage.service';
@@ -28,17 +29,18 @@ import { SendMessageDto } from './dto/send-message.dto';
 import { CreateThreadDto } from './dto/create-thread.dto';
 import { Role } from '@prisma/client';
 
+// SA biz-files: chat attachments restricted to PDF + JPG + PNG only.
 const ALLOWED_MIME_TYPES = new Set([
   'image/jpeg',
   'image/png',
-  'image/gif',
-  'image/webp',
   'application/pdf',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 ]);
 
-const IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+const IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png']);
+
+// SA screen-chat: up to 3 attachments per attach action.
+const MAX_CHAT_ATTACHMENTS = 3;
+const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024; // 10 MB per file
 
 @Controller('threads')
 @UseGuards(JwtAuthGuard)
@@ -121,11 +123,11 @@ export class ChatController {
     return this.chatService.getMessages(req.user.id, threadId, parseInt(page ?? '1', 10) || 1);
   }
 
-  // POST /threads/:id/upload — upload a file attachment for a thread message
+  // POST /threads/:id/upload — upload a single file attachment (legacy, kept for backward compat)
   @Post(':id/upload')
   @UseInterceptors(
     FileInterceptor('file', {
-      limits: { fileSize: 20 * 1024 * 1024 }, // 20 MB max
+      limits: { fileSize: MAX_ATTACHMENT_SIZE },
       fileFilter: (_req, file, cb) => {
         if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
           cb(null, true);
@@ -144,9 +146,39 @@ export class ChatController {
       throw new BadRequestException('No file uploaded');
     }
 
-    // Image limit: 10 MB
-    if (IMAGE_MIME_TYPES.has(file.mimetype) && file.size > 10 * 1024 * 1024) {
-      throw new BadRequestException('Image files must be under 10 MB');
+    // Verify caller is a thread participant
+    const thread = await this.chatService.verifyParticipant(req.user.id, threadId);
+    if (!thread) {
+      throw new NotFoundException('Thread not found or access denied');
+    }
+
+    return this.persistAttachment(threadId, file);
+  }
+
+  // POST /threads/:id/uploads — upload up to 3 file attachments at once (SA biz-files / screen-chat)
+  @Post(':id/uploads')
+  @UseInterceptors(
+    FilesInterceptor('files', MAX_CHAT_ATTACHMENTS, {
+      limits: { fileSize: MAX_ATTACHMENT_SIZE, files: MAX_CHAT_ATTACHMENTS },
+      fileFilter: (_req, file, cb) => {
+        if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new BadRequestException(`File type not allowed: ${file.mimetype}`), false);
+        }
+      },
+    }),
+  )
+  async uploadChatFiles(
+    @Request() req: { user: { id: string } },
+    @Param('id') threadId: string,
+    @UploadedFiles() files: Express.Multer.File[] | undefined,
+  ): Promise<Array<{ url: string; signedUrl: string; type: string; name: string }>> {
+    if (!files || files.length === 0) {
+      throw new BadRequestException('No files uploaded');
+    }
+    if (files.length > MAX_CHAT_ATTACHMENTS) {
+      throw new BadRequestException(`Maximum ${MAX_CHAT_ATTACHMENTS} files per message`);
     }
 
     // Verify caller is a thread participant
@@ -155,6 +187,18 @@ export class ChatController {
       throw new NotFoundException('Thread not found or access denied');
     }
 
+    const results: Array<{ url: string; signedUrl: string; type: string; name: string }> = [];
+    for (const file of files) {
+      results.push(await this.persistAttachment(threadId, file));
+    }
+    return results;
+  }
+
+  /** Store a single uploaded chat file in S3 and return attachment metadata. */
+  private async persistAttachment(
+    threadId: string,
+    file: Express.Multer.File,
+  ): Promise<{ url: string; signedUrl: string; type: string; name: string }> {
     const ext = file.originalname.split('.').pop()?.toLowerCase() || 'bin';
     const fileId = randomUUID();
     const key = `chat/${threadId}/${fileId}.${ext}`;

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -57,9 +57,13 @@ interface RequestDetail {
   category: string | null;
   status: RequestStatus;
   createdAt: string;
+  lastActivityAt?: string;
+  extensionsCount?: number;
   threads: Thread[];
   _count: { threads: number };
 }
+
+const MAX_EXTENSIONS = 3;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -163,6 +167,7 @@ export default function RequestDetailScreen() {
   const [request, setRequest] = useState<RequestDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [closing, setClosing] = useState(false);
+  const [extending, setExtending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchRequest = useCallback(async () => {
@@ -182,6 +187,20 @@ export default function RequestDetailScreen() {
   useEffect(() => {
     fetchRequest();
   }, [fetchRequest]);
+
+  const handleExtend = useCallback(async () => {
+    if (!request || extending) return;
+    try {
+      setExtending(true);
+      const res = await requests.extendRequest(request.id);
+      setRequest(res.data as RequestDetail);
+    } catch (e: any) {
+      const msg = e?.response?.data?.message ?? 'Не удалось продлить заявку';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setExtending(false);
+    }
+  }, [request, extending]);
 
   const handleClose = useCallback(() => {
     if (!request) return;
@@ -243,6 +262,9 @@ export default function RequestDetailScreen() {
   const isOwner = user?.id === request.clientId;
   const canClose = isOwner && CLOSEABLE_STATUSES.includes(status);
   const isClosed = status === 'CLOSED' || status === 'CANCELLED';
+  const extensionsCount = request.extensionsCount ?? 0;
+  const canExtend =
+    isOwner && status === 'CLOSING_SOON' && extensionsCount < MAX_EXTENSIONS;
 
   return (
     <View className="flex-1 bg-white">
@@ -283,6 +305,26 @@ export default function RequestDetailScreen() {
             <Text className="text-sm text-textMuted">{formatDate(request.createdAt)}</Text>
           </View>
         </View>
+
+        {/* Extend button — owner, CLOSING_SOON, extensionsCount < 3 */}
+        {canExtend && (
+          <Pressable
+            onPress={handleExtend}
+            disabled={extending}
+            className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary bg-brandPrimary/10"
+          >
+            {extending ? (
+              <ActivityIndicator size="small" color={Colors.brandPrimary} />
+            ) : (
+              <>
+                <Feather name="refresh-cw" size={14} color={Colors.brandPrimary} />
+                <Text className="text-sm font-medium text-brandPrimary">
+                  Продлить (осталось {MAX_EXTENSIONS - extensionsCount})
+                </Text>
+              </>
+            )}
+          </Pressable>
+        )}
 
         {/* Close button — owner only, closeable statuses */}
         {canClose && (

--- a/app/chat/[id].tsx
+++ b/app/chat/[id].tsx
@@ -215,30 +215,45 @@ export default function ChatScreen() {
   const handleAttach = useCallback(async () => {
     if (!threadId || uploadingAttachment) return;
     try {
+      // SA biz-files: PDF + JPG + PNG only. SA screen-chat: up to 3 files per send.
       const result = await DocumentPicker.getDocumentAsync({
-        type: ['application/pdf', 'image/jpeg', 'image/png', 'image/gif', 'image/webp',
-               'application/msword',
-               'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+        type: ['application/pdf', 'image/jpeg', 'image/png'],
         copyToCacheDirectory: true,
+        multiple: true,
       });
 
       if (result.canceled || !result.assets || result.assets.length === 0) return;
 
-      const asset = result.assets[0];
+      if (result.assets.length > 3) {
+        Alert.alert('Слишком много файлов', 'Можно прикрепить до 3 файлов за раз.');
+        return;
+      }
+
+      const assets = result.assets.slice(0, 3);
       setUploadingAttachment(true);
 
       const formData = new FormData();
-      formData.append('file', {
-        uri: asset.uri,
-        name: asset.name,
-        type: asset.mimeType ?? 'application/octet-stream',
-      } as any);
+      for (const asset of assets) {
+        formData.append('files', {
+          uri: asset.uri,
+          name: asset.name,
+          type: asset.mimeType ?? 'application/octet-stream',
+        } as any);
+      }
 
-      const uploadRes = await upload.chatAttachment(threadId, formData);
-      const { url, signedUrl, type, name } = (uploadRes as any).data ?? uploadRes;
+      const uploadRes = await upload.chatAttachments(threadId, formData);
+      const uploaded = ((uploadRes as any).data ?? uploadRes) as Array<{
+        url: string;
+        signedUrl: string;
+        type: string;
+        name: string;
+      }>;
 
-      const attachmentType = type === 'IMAGE' ? 'image' : 'pdf';
-      await sendMessage('', { url, type: attachmentType, name });
+      // No schema change for Message model: send one message per attachment.
+      for (const file of uploaded) {
+        const attachmentType = file.type === 'IMAGE' ? 'image' : 'pdf';
+        await sendMessage('', { url: file.url, type: attachmentType, name: file.name });
+      }
     } catch (err: any) {
       Alert.alert('Ошибка', err?.response?.data?.message ?? 'Не удалось загрузить файл');
     } finally {

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -430,10 +430,23 @@ export const upload = {
     });
   },
 
-  /** Upload file attachment in a chat thread. Returns { url, signedUrl, type, name }. */
+  /** Upload single file attachment in a chat thread (legacy). Returns { url, signedUrl, type, name }. */
   chatAttachment(threadId: string, formData: FormData) {
     return client.post<{ url: string; signedUrl: string; type: string; name: string }>(
       `/threads/${threadId}/upload`,
+      formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
+    );
+  },
+
+  /**
+   * Upload up to 3 file attachments in a single chat thread request.
+   * FormData must include field name 'files' per file.
+   * Returns array of { url, signedUrl, type, name } (one per uploaded file).
+   */
+  chatAttachments(threadId: string, formData: FormData) {
+    return client.post<Array<{ url: string; signedUrl: string; type: string; name: string }>>(
+      `/threads/${threadId}/uploads`,
       formData,
       { headers: { 'Content-Type': 'multipart/form-data' } },
     );


### PR DESCRIPTION
## Summary
- Chat attach supports up to 3 files per action (SA biz-files + screen-chat).
  - New `POST /threads/:id/uploads` accepts up to 3 files via `FilesInterceptor('files', 3)`.
  - Allowed MIME tightened to PDF + JPG + PNG only (dropped DOC/DOCX/GIF/WEBP).
  - Per-file limit: 10 MB.
  - Frontend `DocumentPicker` now uses `multiple: true`; uploads all 3 in one request and sends one chat message per file (no `Message` schema change → full backward compat with legacy single-attachment messages).
- `Продлить` button on `my-requests/[id]` (client-owned, status `CLOSING_SOON`, `extensionsCount < 3`).
  - Calls existing `POST /requests/:id/extend` through `requests.extendRequest`.
  - On success: refreshes the request (status flips back to `OPEN`, counter bumps).

Coordinated with Task A — no prisma schema / migration changes in this PR.

## Test plan
- [ ] Open a chat thread, tap paperclip, pick 3 files (1 PDF + 2 PNG) → 3 bubbles appear, each downloadable.
- [ ] Try to pick 4+ files → client alert, nothing uploaded.
- [ ] Try to upload a DOC → server rejects with 400.
- [ ] Create a request, seed `lastActivityAt` to 28 days ago so cron marks it `CLOSING_SOON`. Open detail → `Продлить` visible.
- [ ] Tap Продлить → status reverts to `OPEN`, `extensionsCount` +1, counter in button updates.
- [ ] After 3 extensions, button disappears.