### PR TITLE
feat(landing): inline quick request + wire specialist write button

### DIFF
--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -200,8 +200,9 @@ export class SpecialistsService {
     const activity = await this.computeActivity(profile.userId);
     const fnsGroupedByCity = this.groupFnsByCity(profile.specialistFns, profile.specialistServices);
 
-    // Strip internal IDs from public profile response; structured contact fields are public
-    const { id: _id, userId: _userId, specialistFns: _sf, specialistServices: _ss, ...publicProfile } = profile;
+    // Strip internal profile id; expose userId so clients can open a direct chat thread.
+    // userId is non-sensitive (already broadcast in chat presence events).
+    const { id: _id, specialistFns: _sf, specialistServices: _ss, ...publicProfile } = profile;
     return {
       ...publicProfile,
       activity,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Pressable, ScrollView, useWindowDimensions } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, TextInput, Pressable, ScrollView, Modal, ActivityIndicator, useWindowDimensions } from 'react-native';
+import axios from 'axios';
 import { Feather } from '@expo/vector-icons';
-import { router, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { Colors, Shadows } from '../constants/Colors';
-import { ifns, specialists, stats } from '../lib/api/endpoints';
+import { auth, ifns, requests as requestsApi, specialists, stats } from '../lib/api/endpoints';
 import { Header } from '../components/Header';
+import { useAuth } from '../lib/auth/AuthContext';
 
 // Fixed service list per product spec
 const SERVICES = ['Выездная проверка', 'Отдел оперативного контроля', 'Камеральная проверка', 'Не знаю'];
@@ -118,10 +120,14 @@ function LandingLocationPicker({
 }
 
 // =====================================================================
-// HERO — USP headline + inline request form
+// HERO — USP headline + inline request form with inline OTP flow
 // =====================================================================
 
+type HeroStep = 'idle' | 'email' | 'otp' | 'done';
+
 function HeroSection() {
+  const router = useRouter();
+  const { isAuthenticated, login: authLogin } = useAuth();
   const { isDesktop } = useLayout();
   const [city, setCity] = useState('');
   const [fns, setFns] = useState('');
@@ -129,6 +135,14 @@ function HeroSection() {
   const [description, setDescription] = useState('');
   const [cities, setCities] = useState<string[]>([]);
   const [fnsByCity, setFnsByCity] = useState<Record<string, string[]>>({});
+
+  // Inline multi-step state
+  const [step, setStep] = useState<HeroStep>('idle');
+  const [email, setEmail] = useState('');
+  const [otpDigits, setOtpDigits] = useState<string[]>(['', '', '', '', '', '']);
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const otpInputRefs = useRef<(TextInput | null)[]>([]);
 
   useEffect(() => {
     ifns.getCities()
@@ -149,6 +163,335 @@ function HeroSection() {
       })
       .catch(() => {});
   }, [city]);
+
+  // --- validation ---
+  const trimmedDescription = description.trim();
+  const descriptionValid = trimmedDescription.length >= 10;
+  const serviceTypeValue = service || 'Не знаю';
+  const canContinue = descriptionValid && !submitting;
+
+  const extractErrorMessage = (err: unknown, fallback: string): string => {
+    if (axios.isAxiosError(err)) {
+      const raw = (err.response?.data as any)?.message;
+      if (Array.isArray(raw)) return raw.join(', ');
+      if (typeof raw === 'string' && raw) return raw;
+    }
+    return fallback;
+  };
+
+  const submitQuickRequest = async () => {
+    const payload: { description: string; serviceType: string; city?: string; ifnsName?: string } = {
+      description: trimmedDescription.slice(0, 500),
+      serviceType: serviceTypeValue.slice(0, 100),
+    };
+    if (city) payload.city = city.slice(0, 100);
+    if (fns) payload.ifnsName = fns.slice(0, 200);
+    await requestsApi.createQuick(payload);
+  };
+
+  const handleMainPress = async () => {
+    if (!descriptionValid) {
+      setErrorText('Опишите вашу ситуацию (минимум 10 символов)');
+      return;
+    }
+    setErrorText(null);
+    // Already logged in — submit directly and show thank-you
+    if (isAuthenticated) {
+      setSubmitting(true);
+      try {
+        await submitQuickRequest();
+        setStep('done');
+      } catch (err) {
+        setErrorText(extractErrorMessage(err, 'Не удалось отправить заявку. Попробуйте ещё раз.'));
+      } finally {
+        setSubmitting(false);
+      }
+      return;
+    }
+    // Otherwise open inline email step
+    setStep('email');
+  };
+
+  const handleEmailContinue = async () => {
+    const clean = email.trim().toLowerCase();
+    if (!clean || !clean.includes('@') || clean.length < 5) {
+      setErrorText('Введите корректный email адрес');
+      return;
+    }
+    setSubmitting(true);
+    setErrorText(null);
+    try {
+      await auth.requestOtp(clean);
+      setEmail(clean);
+      setOtpDigits(['', '', '', '', '', '']);
+      setStep('otp');
+      setTimeout(() => otpInputRefs.current[0]?.focus(), 50);
+    } catch (err) {
+      setErrorText(extractErrorMessage(err, 'Не удалось отправить код. Попробуйте ещё раз.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOtpDigitChange = (index: number, value: string) => {
+    let v = value;
+    if (v.length > 1) v = v.slice(-1);
+    if (v && !/^\d$/.test(v)) return;
+    const next = [...otpDigits];
+    next[index] = v;
+    setOtpDigits(next);
+    if (errorText) setErrorText(null);
+    if (v && index < 5) otpInputRefs.current[index + 1]?.focus();
+  };
+
+  const handleOtpSubmit = async () => {
+    const code = otpDigits.join('');
+    if (code.length < 6) {
+      setErrorText('Введите все 6 цифр');
+      return;
+    }
+    setSubmitting(true);
+    setErrorText(null);
+    try {
+      // 1. Verify OTP → tokens stored by endpoints.auth.verifyOtp
+      const verifyRes = await auth.verifyOtp(email, code, 'client');
+      const verifyData = (verifyRes as any).data ?? verifyRes;
+      // 2. Sync AuthContext in-memory state so Header / guards update without reload
+      try {
+        const u = verifyData?.user ?? {};
+        await authLogin(
+          verifyData.accessToken,
+          verifyData.refreshToken,
+          {
+            id: u.userId ?? u.id ?? '',
+            email: u.email ?? email,
+            role: (u.role ?? 'CLIENT') as 'CLIENT' | 'SPECIALIST' | 'ADMIN',
+            username: u.username ?? undefined,
+            isNewUser: verifyData.isNewUser,
+          },
+        );
+      } catch {
+        // Non-critical — tokens already persisted by verifyOtp
+      }
+      // 3. Post quick request with the fresh JWT attached by axios interceptor
+      await submitQuickRequest();
+      setStep('done');
+    } catch (err) {
+      setErrorText(extractErrorMessage(err, 'Неверный код. Попробуйте ещё раз.'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleBackToIdle = () => {
+    setStep('idle');
+    setErrorText(null);
+    setEmail('');
+    setOtpDigits(['', '', '', '', '', '']);
+  };
+
+  const goToDashboard = () => {
+    // Reload to pick up the freshly stored auth tokens in AuthContext.
+    router.replace('/(tabs)/dashboard' as any);
+  };
+
+  // --- render card content based on step ---
+  const renderIdleStep = () => (
+    <>
+      <Text className="mb-1 text-lg font-bold text-textPrimary">Разместить запрос</Text>
+      <Text className="mb-4 text-sm text-textSecondary">
+        Опишите вашу ситуацию — специалисты по вашей ФНС свяжутся с вами в чате
+      </Text>
+
+      <View className="mb-3">
+        <LandingLocationPicker
+          city={city} fns={fns} service={service}
+          onCityChange={setCity} onFnsChange={setFns} onServiceChange={setService}
+          cities={cities} fnsByCity={fnsByCity}
+        />
+      </View>
+
+      <View className="mb-4 gap-1">
+        <TextInput
+          value={description}
+          onChangeText={(t) => { setDescription(t); if (errorText) setErrorText(null); }}
+          placeholder="Кратко опишите вашу ситуацию..."
+          placeholderTextColor={Colors.textMuted}
+          multiline
+          className="min-h-[72px] rounded-xl border border-borderLight bg-white p-3 text-sm text-textPrimary"
+          style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
+        />
+      </View>
+
+      {errorText ? (
+        <View className="mb-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm text-red-600">{errorText}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        className={`h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary ${canContinue ? '' : 'opacity-60'}`}
+        onPress={handleMainPress}
+        disabled={!canContinue}
+        accessibilityLabel="Отправить заявку"
+      >
+        {submitting ? (
+          <ActivityIndicator size="small" color={Colors.white} />
+        ) : (
+          <Feather name="send" size={16} color={Colors.white} />
+        )}
+        <Text className="text-base font-semibold text-white">
+          {isAuthenticated ? 'Отправить заявку' : 'Продолжить'}
+        </Text>
+      </Pressable>
+
+      <Text className="mt-2 text-center text-xs text-textMuted">
+        Бесплатно. Специалисты напишут вам сами.
+      </Text>
+    </>
+  );
+
+  const renderEmailStep = () => (
+    <>
+      <View className="mb-3 flex-row items-center gap-2">
+        <Pressable onPress={handleBackToIdle} hitSlop={8}>
+          <Feather name="arrow-left" size={18} color={Colors.textMuted} />
+        </Pressable>
+        <Text className="text-lg font-bold text-textPrimary">Ваш email</Text>
+      </View>
+      <Text className="mb-4 text-sm text-textSecondary">
+        Отправим код для подтверждения. Никаких паролей.
+      </Text>
+
+      <View className={`mb-3 h-12 flex-row items-center gap-2 rounded-xl border px-3 ${errorText ? 'border-red-500 bg-red-50' : 'border-borderLight bg-white'}`}>
+        <Feather name="mail" size={16} color={errorText ? '#DC2626' : Colors.textMuted} />
+        <TextInput
+          value={email}
+          onChangeText={(t) => { setEmail(t); if (errorText) setErrorText(null); }}
+          placeholder="your@email.com"
+          placeholderTextColor={Colors.textMuted}
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoComplete="email"
+          className="flex-1 text-base text-textPrimary"
+          style={{ outlineStyle: 'none' } as any}
+          editable={!submitting}
+        />
+      </View>
+
+      {errorText ? (
+        <View className="mb-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm text-red-600">{errorText}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        className={`h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary ${submitting ? 'opacity-60' : ''}`}
+        onPress={handleEmailContinue}
+        disabled={submitting}
+      >
+        {submitting ? (
+          <ActivityIndicator size="small" color={Colors.white} />
+        ) : (
+          <Feather name="arrow-right" size={16} color={Colors.white} />
+        )}
+        <Text className="text-base font-semibold text-white">Получить код</Text>
+      </Pressable>
+    </>
+  );
+
+  const renderOtpStep = () => (
+    <>
+      <View className="mb-3 flex-row items-center gap-2">
+        <Pressable onPress={() => { setStep('email'); setErrorText(null); }} hitSlop={8}>
+          <Feather name="arrow-left" size={18} color={Colors.textMuted} />
+        </Pressable>
+        <Text className="text-lg font-bold text-textPrimary">Введите код</Text>
+      </View>
+      <Text className="mb-4 text-sm text-textSecondary">
+        Код отправлен на <Text className="font-medium text-textPrimary">{email}</Text>
+      </Text>
+
+      <View className="mb-3 flex-row justify-between">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <View
+            key={i}
+            className={`h-12 w-[14%] items-center justify-center rounded-lg border-2 ${errorText ? 'border-red-500 bg-red-50' : otpDigits[i] ? 'border-brandPrimary bg-bgSecondary' : 'border-borderLight bg-white'}`}
+          >
+            <TextInput
+              ref={(ref) => { otpInputRefs.current[i] = ref; }}
+              value={otpDigits[i]}
+              onChangeText={(v) => handleOtpDigitChange(i, v)}
+              keyboardType="number-pad"
+              maxLength={1}
+              selectTextOnFocus
+              editable={!submitting}
+              className="h-full w-full text-center text-xl font-bold text-textPrimary"
+              style={{ outlineStyle: 'none' } as any}
+            />
+          </View>
+        ))}
+      </View>
+
+      {errorText ? (
+        <View className="mb-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+          <Feather name="alert-circle" size={14} color="#DC2626" />
+          <Text className="text-sm text-red-600">{errorText}</Text>
+        </View>
+      ) : null}
+
+      <Pressable
+        className={`h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary ${submitting ? 'opacity-60' : ''}`}
+        onPress={handleOtpSubmit}
+        disabled={submitting}
+      >
+        {submitting ? (
+          <ActivityIndicator size="small" color={Colors.white} />
+        ) : (
+          <Feather name="check" size={16} color={Colors.white} />
+        )}
+        <Text className="text-base font-semibold text-white">Подтвердить и отправить</Text>
+      </Pressable>
+    </>
+  );
+
+  const renderDoneStep = () => (
+    <View className="items-center gap-3 py-2">
+      <View className="h-14 w-14 items-center justify-center rounded-full" style={{ backgroundColor: Colors.statusSuccess + '1A' }}>
+        <Feather name="check-circle" size={28} color={Colors.statusSuccess} />
+      </View>
+      <Text className="text-lg font-bold text-textPrimary">Заявка отправлена</Text>
+      <Text className="text-center text-sm text-textSecondary">
+        Специалисты по вашей ФНС получат уведомление и напишут вам в чате.
+      </Text>
+      {isAuthenticated ? (
+        <Pressable
+          className="mt-2 h-12 w-full flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary"
+          onPress={goToDashboard}
+        >
+          <Feather name="arrow-right" size={16} color={Colors.white} />
+          <Text className="text-base font-semibold text-white">Перейти в личный кабинет</Text>
+        </Pressable>
+      ) : (
+        <Pressable
+          className="mt-2 h-12 w-full flex-row items-center justify-center gap-2 rounded-xl border border-brandPrimary"
+          onPress={() => {
+            setDescription('');
+            setCity('');
+            setFns('');
+            setService('');
+            setEmail('');
+            setOtpDigits(['', '', '', '', '', '']);
+            setStep('idle');
+          }}
+        >
+          <Text className="text-base font-semibold text-brandPrimary">Отправить ещё одну</Text>
+        </Pressable>
+      )}
+    </View>
+  );
 
   return (
     <View className="bg-white px-5" style={{ paddingTop: 40, paddingBottom: 40 }}>
@@ -184,41 +527,10 @@ function HeroSection() {
 
           {/* Right: inline request form */}
           <View className="rounded-2xl border border-borderLight bg-bgSecondary p-5" style={{ width: isDesktop ? 340 : '100%', ...Shadows.md }}>
-            <Text className="mb-1 text-lg font-bold text-textPrimary">Разместить запрос</Text>
-            <Text className="mb-4 text-sm text-textSecondary">
-              Опишите вашу ситуацию — специалисты по вашей ФНС свяжутся с вами в чате
-            </Text>
-
-            {/* Unified City / FNS / Service */}
-            <View className="mb-3">
-              <LandingLocationPicker
-                city={city} fns={fns} service={service}
-                onCityChange={setCity} onFnsChange={setFns} onServiceChange={setService}
-                cities={cities} fnsByCity={fnsByCity}
-              />
-            </View>
-
-            {/* Description */}
-            <View className="mb-4 gap-1">
-              <TextInput
-                value={description}
-                onChangeText={setDescription}
-                placeholder="Кратко опишите вашу ситуацию..."
-                placeholderTextColor={Colors.textMuted}
-                multiline
-                className="min-h-[72px] rounded-xl border border-borderLight bg-white p-3 text-sm text-textPrimary"
-                style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
-              />
-            </View>
-
-            <Pressable className="h-12 flex-row items-center justify-center gap-2 rounded-xl bg-brandPrimary" onPress={() => router.push('/(auth)/role' as any)}>
-              <Feather name="send" size={16} color={Colors.white} />
-              <Text className="text-base font-semibold text-white">Отправить заявку</Text>
-            </Pressable>
-
-            <Text className="mt-2 text-center text-xs text-textMuted">
-              Бесплатно. Специалисты напишут вам сами.
-            </Text>
+            {step === 'idle' && renderIdleStep()}
+            {step === 'email' && renderEmailStep()}
+            {step === 'otp' && renderOtpStep()}
+            {step === 'done' && renderDoneStep()}
           </View>
         </View>
       </View>

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, Pressable, ScrollView, Modal, ActivityIndicator } from 'react-native';
+import axios from 'axios';
 import { Feather } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Header } from '../../components/Header';
-import { specialists as specialistsApi } from '../../lib/api/endpoints';
+import { specialists as specialistsApi, threads as threadsApi } from '../../lib/api/endpoints';
 import { Colors } from '../../constants/Colors';
+import { useAuth } from '../../lib/auth/AuthContext';
 
 interface FnsService {
   fns: string;
@@ -13,6 +15,7 @@ interface FnsService {
 
 interface SpecialistData {
   id: string;
+  userId?: string | null;
   username?: string | null;
   name?: string | null;
   user?: { firstName?: string | null; lastName?: string | null } | null;
@@ -94,14 +97,138 @@ function FnsModal({ visible, onClose, fnsServices }: { visible: boolean; onClose
   );
 }
 
+function WriteSpecialistConfirm({
+  visible,
+  displayName,
+  onClose,
+  onConfirm,
+  submitting,
+  errorText,
+}: {
+  visible: boolean;
+  displayName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  submitting: boolean;
+  errorText: string | null;
+}) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={{ flex: 1, backgroundColor: 'rgba(12,26,46,0.5)', justifyContent: 'center', alignItems: 'center', padding: 16 }}>
+        <View style={{ width: '100%', maxWidth: 420, backgroundColor: Colors.white, borderRadius: 16, padding: 20, gap: 14 }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <View style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="send" size={16} color={Colors.brandPrimary} />
+            </View>
+            <Text style={{ flex: 1, fontSize: 18, fontWeight: '700', color: Colors.textPrimary }}>Написать специалисту</Text>
+            <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }} accessibilityLabel="Закрыть">
+              <Feather name="x" size={20} color={Colors.textMuted} />
+            </Pressable>
+          </View>
+          <Text style={{ fontSize: 15, color: Colors.textSecondary, lineHeight: 21 }}>
+            Открыть чат с <Text style={{ fontWeight: '600', color: Colors.textPrimary }}>{displayName}</Text>?
+            Ваше первое сообщение будет отправлено, и специалист получит уведомление.
+          </Text>
+          {errorText ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, padding: 10, borderRadius: 8, backgroundColor: Colors.statusBg?.error ?? '#FEE2E2' }}>
+              <Feather name="alert-circle" size={14} color={Colors.statusError} />
+              <Text style={{ flex: 1, fontSize: 13, color: Colors.statusError }}>{errorText}</Text>
+            </View>
+          ) : null}
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <Pressable
+              onPress={onClose}
+              disabled={submitting}
+              style={{ flex: 1, height: 44, borderRadius: 10, borderWidth: 1, borderColor: Colors.borderLight, alignItems: 'center', justifyContent: 'center', opacity: submitting ? 0.5 : 1 }}
+            >
+              <Text style={{ fontSize: 15, fontWeight: '500', color: Colors.textSecondary }}>Отмена</Text>
+            </Pressable>
+            <Pressable
+              onPress={onConfirm}
+              disabled={submitting}
+              style={{ flex: 1, height: 44, borderRadius: 10, backgroundColor: Colors.brandPrimary, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, opacity: submitting ? 0.7 : 1 }}
+            >
+              {submitting ? (
+                <ActivityIndicator size="small" color={Colors.white} />
+              ) : (
+                <Feather name="send" size={15} color={Colors.white} />
+              )}
+              <Text style={{ fontSize: 15, fontWeight: '600', color: Colors.white }}>Написать</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
 function ProfileScreen({ spec }: { spec: SpecialistData }) {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
   const [message, setMessage] = useState('');
   const [fnsModalVisible, setFnsModalVisible] = useState(false);
+  const [confirmVisible, setConfirmVisible] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [errorText, setErrorText] = useState<string | null>(null);
   const fnsServices: FnsService[] = spec.fnsServices ?? [];
   const displayName = spec.name
     ?? ([spec.user?.firstName, spec.user?.lastName].filter(Boolean).join(' ') || '—');
   const memberYear = spec.memberSince
     ?? (spec.createdAt ? new Date(spec.createdAt).getFullYear() : null);
+
+  const canSend = !!message.trim();
+
+  const handleSendPress = () => {
+    if (!canSend) return;
+    if (!isAuthenticated) {
+      router.push({ pathname: '/(auth)/email', params: { role: 'CLIENT' } } as any);
+      return;
+    }
+    setErrorText(null);
+    setConfirmVisible(true);
+  };
+
+  const handleConfirm = async () => {
+    if (!spec.userId) {
+      setErrorText('Не удалось определить специалиста. Попробуйте позже.');
+      return;
+    }
+    setSubmitting(true);
+    setErrorText(null);
+    try {
+      const res = await threadsApi.startDirect({ otherUserId: spec.userId });
+      const data = (res as any).data ?? res;
+      const threadId: string | undefined = data?.threadId ?? data?.thread_id;
+      if (!threadId) throw new Error('Сервер не вернул идентификатор чата');
+      const firstMessage = message.trim();
+      if (firstMessage) {
+        try {
+          await threadsApi.sendMessage(threadId, { content: firstMessage });
+        } catch {
+          // fall through — navigate anyway, user can retry sending in chat
+        }
+      }
+      setConfirmVisible(false);
+      setMessage('');
+      router.push(`/chat/${threadId}` as any);
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err)) {
+        const status = err.response?.status;
+        if (status === 429) {
+          setErrorText('Лимит обращений в день исчерпан, попробуйте завтра');
+        } else if (status === 409) {
+          setErrorText('Нельзя открыть чат с этим пользователем');
+        } else {
+          const raw = (err.response?.data as any)?.message;
+          setErrorText(Array.isArray(raw) ? raw.join(', ') : (raw || 'Не удалось открыть чат'));
+        }
+      } else {
+        setErrorText('Не удалось открыть чат');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <ScrollView className="flex-1 bg-white">
@@ -210,14 +337,24 @@ function ProfileScreen({ spec }: { spec: SpecialistData }) {
             onChangeText={setMessage}
           />
           <Pressable
-            className={`mt-1 h-12 flex-row items-center justify-center gap-2 rounded-lg shadow-sm ${message.trim() ? 'bg-brandPrimary' : 'bg-gray-300'}`}
-            disabled={!message.trim()}
+            className={`mt-1 h-12 flex-row items-center justify-center gap-2 rounded-lg shadow-sm ${canSend ? 'bg-brandPrimary' : 'bg-gray-300'}`}
+            disabled={!canSend}
+            onPress={handleSendPress}
+            accessibilityLabel="Написать специалисту"
           >
             <Feather name="send" size={18} color="#FFFFFF" />
-            <Text className="text-base font-semibold text-white">Отправить</Text>
+            <Text className="text-base font-semibold text-white">Написать</Text>
           </Pressable>
         </View>
       </View>
+      <WriteSpecialistConfirm
+        visible={confirmVisible}
+        displayName={displayName}
+        onClose={() => { if (!submitting) { setConfirmVisible(false); setErrorText(null); } }}
+        onConfirm={handleConfirm}
+        submitting={submitting}
+        errorText={errorText}
+      />
     </ScrollView>
   );
 }

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -118,6 +118,14 @@ export const requests = {
     return client.post('/requests', data);
   },
 
+  /**
+   * POST /requests/quick — anonymous landing-page quick request.
+   * Public endpoint, does not require auth. Stores into the QuickRequest table.
+   */
+  createQuick(data: { description: string; serviceType: string; city?: string; ifnsId?: string; ifnsName?: string }) {
+    return client.post<{ id: string; status: string }>('/requests/quick', data);
+  },
+
   getRequest(id: string) {
     return client.get(`/requests/${id}`);
   },
@@ -190,6 +198,15 @@ export const threads = {
    */
   createForRequest(data: { requestId: string; firstMessage: string }) {
     return client.post<CreateThreadResponse>('/threads', data);
+  },
+
+  /**
+   * POST /threads — direct thread with another user (client → specialist).
+   * Body { otherUserId, requestId? }. Idempotent (upsert on sorted participant pair).
+   * Returns { threadId } (200 existing or 201 new).
+   */
+  startDirect(data: { otherUserId: string; requestId?: string }) {
+    return client.post<{ threadId: string }>('/threads', data);
   },
 
   /** PATCH /threads/:id/read — mark caller's side as read (204). */


### PR DESCRIPTION
## Summary

**Gap 1 — Landing inline quick request.** The hero form's "Отправить заявку" button redirected anonymous users to `/(auth)/role`, bleeding conversion from paid ads. The new flow keeps the user on the landing page:
1. User fills description + (optional) city/FNS/service, hits **Продолжить**.
2. Enters email → `POST /auth/request-otp`.
3. Enters 6-digit code → `POST /auth/verify-otp` → tokens stored, AuthContext synced.
4. `POST /requests/quick` fires with the fresh JWT attached.
5. Thank-you block with **Перейти в личный кабинет**.
If the visitor is already authed, steps 2–3 are skipped.

**Gap 2 — Dead "Написать" button on specialist profile.** The Pressable on `/specialists/[nick]` had no `onPress`. It now:
- For anon users, pushes to `/(auth)/email?role=CLIENT` (can't open a thread without a JWT).
- For authed users, opens a confirm modal → `POST /threads { otherUserId }` (existing idempotent `startThread` path) → sends the user's typed message if any → routes to `/chat/[id]`.

## Backend

No new endpoints. One minimal change: `specialists.getProfile` no longer strips `userId` from the response — it's needed to target the direct-thread endpoint, and it's already broadcast publicly in chat presence events (`user:online { userId }`).

## Files

- `app/index.tsx` — HeroSection rewritten around a `HeroStep` state machine (`idle → email → otp → done`).
- `app/specialists/[nick].tsx` — `WriteSpecialistConfirm` modal + wiring for the send Pressable.
- `lib/api/endpoints.ts` — `requests.createQuick()` and `threads.startDirect()` helpers.
- `api/src/specialists/specialists.service.ts` — keep `userId` in public profile response.

## Test plan

- [ ] Staging deploy success, `version.json` matches commit.
- [ ] Anon visitor on `/` — fill description, continue → email → OTP `000000` → thank-you → "Перейти в личный кабинет" lands in dashboard with auth.
- [ ] Logged-in user on `/` — skips OTP, submits, sees thank-you.
- [ ] Validation: description < 10 chars blocks "Продолжить".
- [ ] Invalid email blocks email step.
- [ ] `/specialists/<nick>` (anon) → "Написать" → redirects to login.
- [ ] `/specialists/<nick>` (authed client) → "Написать" → confirm → lands in `/chat/<id>` with typed message delivered.
- [ ] Second click on the same specialist reuses the existing thread (idempotent upsert).