### PR TITLE
feat(settings): persist user preferences + availability toggle

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -35,6 +35,10 @@ class UpdateSettingsDto {
   @IsBoolean()
   @IsOptional()
   emailNotifications?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  notifyNewMessages?: boolean;
 }
 
 class UpdateNotificationSettingsDto {

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -41,11 +41,27 @@ export class UsersService {
     return { available: !existing && !existingUser };
   }
 
-  /** Return current user profile (id, email, role, username, firstName, lastName, phone, city, avatarUrl, createdAt). */
-  async getMe(userId: string): Promise<{ id: string; email: string; role: string; username: string | null; firstName: string | null; lastName: string | null; phone: string | null; city: string | null; avatarUrl: string | null; createdAt: Date }> {
-    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+  /** Return current user profile (id, email, role, username, firstName, lastName, phone, city, avatarUrl, createdAt, notifyNewMessages, isAvailable?). */
+  async getMe(userId: string): Promise<{ id: string; email: string; role: string; username: string | null; firstName: string | null; lastName: string | null; phone: string | null; city: string | null; avatarUrl: string | null; createdAt: Date; notifyNewMessages: boolean; isAvailable?: boolean }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: { specialistProfile: { select: { isAvailable: true } } },
+    });
     if (!user) throw new NotFoundException('User not found');
-    return { id: user.id, email: user.email, role: user.role, username: user.username, firstName: user.firstName, lastName: user.lastName, phone: user.phone, city: user.city, avatarUrl: user.avatarUrl, createdAt: user.createdAt };
+    return {
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      username: user.username,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      phone: user.phone,
+      city: user.city,
+      avatarUrl: user.avatarUrl,
+      createdAt: user.createdAt,
+      notifyNewMessages: user.notifyNewMessages,
+      ...(user.specialistProfile ? { isAvailable: user.specialistProfile.isAvailable } : {}),
+    };
   }
 
   /**
@@ -265,16 +281,18 @@ export class UsersService {
     return { notifyNewMessages: user.notifyNewMessages };
   }
 
-  /** Update user settings (backward-compatible: maps old emailNotifications to notifyNewMessages) */
+  /** Update user settings. Accepts both `notifyNewMessages` (preferred) and legacy `emailNotifications`. */
   async updateSettings(
     userId: string,
-    settings: { emailNotifications?: boolean },
+    settings: { emailNotifications?: boolean; notifyNewMessages?: boolean },
   ): Promise<{ notifyNewMessages: boolean }> {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user) throw new NotFoundException('User not found');
 
     const data: Record<string, unknown> = {};
-    if (settings.emailNotifications !== undefined) {
+    if (settings.notifyNewMessages !== undefined) {
+      data.notifyNewMessages = settings.notifyNewMessages;
+    } else if (settings.emailNotifications !== undefined) {
       data.notifyNewMessages = settings.emailNotifications;
     }
 

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -4,7 +4,7 @@ import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
 import { Header } from '../../components/Header';
-import { users, upload } from '../../lib/api/endpoints';
+import { users, upload, specialists } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
 
 export default function OnboardingProfilePage() {
@@ -52,12 +52,24 @@ export default function OnboardingProfilePage() {
         }
       }
 
-      // Save profile fields
-      await users.updateProfile({
-        ...(description ? { bio: description } : {}),
-        ...(phone ? { phone } : {}),
-        ...(telegram ? { telegram } : {}),
-      } as any);
+      // Save User fields (phone) via /users/me/profile — handles phone + city + names.
+      if (phone) {
+        await users.updateProfile({ phone } as any);
+      }
+
+      // Save specialist-only fields (bio, telegram) via /specialists/me — works only when
+      // a SpecialistProfile already exists. For new specialists the profile is created in
+      // step 3 (work-area), so this call 404s gracefully and the values are re-applied there.
+      if (role === 'SPECIALIST' && (description || telegram)) {
+        try {
+          await specialists.updateProfile({
+            ...(description ? { bio: description } : {}),
+            ...(telegram ? { telegram } : {}),
+          });
+        } catch {
+          // Profile not yet created — values will be re-entered or merged in a later step.
+        }
+      }
 
       await refreshUser();
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { View, Text, Pressable, Switch } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { View, Text, Pressable, Switch, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
 import { useAuth } from '../../lib/auth/AuthContext';
+import { users } from '../../lib/api/endpoints';
 
 function SettingRow({ label, value, danger, icon, onPress }: { label: string; value?: string; danger?: boolean; icon?: string; onPress?: () => void }) {
   return (
@@ -16,12 +17,13 @@ function SettingRow({ label, value, danger, icon, onPress }: { label: string; va
   );
 }
 
-function ToggleRow({ label, icon, enabled, onToggle }: { label: string; icon: string; enabled: boolean; onToggle: () => void }) {
+function ToggleRow({ label, icon, enabled, onToggle, saving }: { label: string; icon: string; enabled: boolean; onToggle: (next: boolean) => void; saving?: boolean }) {
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary }}>
       <Feather name={icon as any} size={18} color={Colors.textMuted} />
       <Text style={{ flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textPrimary }}>{label}</Text>
-      <Switch value={enabled} onValueChange={() => onToggle()} trackColor={{ false: '#D1D5DB', true: '#0284C7' }} thumbColor="#fff" />
+      {saving && <ActivityIndicator size="small" color={Colors.textMuted} style={{ marginRight: Spacing.sm }} />}
+      <Switch value={enabled} onValueChange={onToggle} trackColor={{ false: '#D1D5DB', true: '#0284C7' }} thumbColor="#fff" />
     </View>
   );
 }
@@ -30,8 +32,36 @@ export default function SettingsScreen() {
   const { user, logout } = useAuth();
   const router = useRouter();
   const [emailNotif, setEmailNotif] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
   const [showLogout, setShowLogout] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
+
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    users.getMe()
+      .then((res: any) => {
+        const me = res.data as { notifyNewMessages?: boolean };
+        if (typeof me?.notifyNewMessages === 'boolean') setEmailNotif(me.notifyNewMessages);
+      })
+      .catch(() => { /* default stays true */ })
+      .finally(() => setLoading(false));
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
+  const handleEmailToggle = (next: boolean) => {
+    setEmailNotif(next);
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    setSaving(true);
+    saveTimerRef.current = setTimeout(() => {
+      users.updateSettings({ notifyNewMessages: next })
+        .catch(() => setEmailNotif(!next))
+        .finally(() => setSaving(false));
+    }, 400);
+  };
 
   const handleLogout = async () => {
     try {
@@ -41,23 +71,27 @@ export default function SettingsScreen() {
     }
   };
 
+  if (loading) {
+    return (
+      <View style={{ padding: Spacing.lg, alignItems: 'center' }}>
+        <ActivityIndicator color={Colors.brandPrimary} />
+      </View>
+    );
+  }
+
   return (
     <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
       <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>Настройки</Text>
       <View style={{ gap: Spacing.sm }}>
         <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Уведомления</Text>
         <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <ToggleRow label="Email-уведомления" icon="mail" enabled={emailNotif} onToggle={() => setEmailNotif(!emailNotif)} />
+          <ToggleRow label="Email-уведомления" icon="mail" enabled={emailNotif} onToggle={handleEmailToggle} saving={saving} />
         </View>
       </View>
       <View style={{ gap: Spacing.sm }}>
         <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Аккаунт</Text>
         <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
           <SettingRow label="Email" value={user?.email ?? '—'} icon="mail" />
-          {/* TODO: Language screen not implemented yet */}
-          <SettingRow label="Язык" value="Русский" icon="globe" />
-          {/* TODO: Theme screen not implemented yet */}
-          <SettingRow label="Тема" value="Светлая" icon="sun" />
         </View>
       </View>
       <View style={{ gap: Spacing.sm }}>

--- a/app/(tabs)/specialist-settings.tsx
+++ b/app/(tabs)/specialist-settings.tsx
@@ -1,22 +1,28 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
 import { Toggle } from '../../components/proto/Toggle';
 import { useAuth } from '../../lib/auth/AuthContext';
-import { users, specialistPortal } from '../../lib/api/endpoints';
+import { users, specialistPortal, specialists } from '../../lib/api/endpoints';
 
 function IdleState() {
   const { user, logout } = useAuth();
   const router = useRouter();
+
+  const [isAvailable, setIsAvailable] = useState(true);
   const [emailNotif, setEmailNotif] = useState(true);
-  const [pushNotif, setPushNotif] = useState(false);
-  const [publicProfile, setPublicProfile] = useState(true);
 
   const [email, setEmail] = useState(user?.email ?? '');
   const [phone, setPhone] = useState('');
   const [profileLoading, setProfileLoading] = useState(true);
+
+  const [savingAvailable, setSavingAvailable] = useState(false);
+  const [savingEmail, setSavingEmail] = useState(false);
+
+  const availableTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const emailTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -27,13 +33,42 @@ function IdleState() {
         const me = meRes.data as any;
         setEmail(me.email ?? user?.email ?? '');
         setPhone(me.phone ?? '');
+        if (typeof me.notifyNewMessages === 'boolean') setEmailNotif(me.notifyNewMessages);
+        if (typeof me.isAvailable === 'boolean') setIsAvailable(me.isAvailable);
       }
       if (spRes?.data) {
         const sp = spRes.data as any;
-        if (!phone && sp.phone) setPhone(sp.phone);
+        if (sp.phone) setPhone((prev) => prev || sp.phone);
+        if (typeof sp.isAvailable === 'boolean') setIsAvailable(sp.isAvailable);
       }
     }).finally(() => setProfileLoading(false));
+    return () => {
+      if (availableTimerRef.current) clearTimeout(availableTimerRef.current);
+      if (emailTimerRef.current) clearTimeout(emailTimerRef.current);
+    };
   }, []);
+
+  const handleAvailableToggle = (next: boolean) => {
+    setIsAvailable(next);
+    if (availableTimerRef.current) clearTimeout(availableTimerRef.current);
+    setSavingAvailable(true);
+    availableTimerRef.current = setTimeout(() => {
+      specialists.updateProfile({ isAvailable: next })
+        .catch(() => setIsAvailable(!next))
+        .finally(() => setSavingAvailable(false));
+    }, 400);
+  };
+
+  const handleEmailNotifToggle = (next: boolean) => {
+    setEmailNotif(next);
+    if (emailTimerRef.current) clearTimeout(emailTimerRef.current);
+    setSavingEmail(true);
+    emailTimerRef.current = setTimeout(() => {
+      users.updateSettings({ notifyNewMessages: next })
+        .catch(() => setEmailNotif(!next))
+        .finally(() => setSavingEmail(false));
+    }, 400);
+  };
 
   const handleLogout = async () => {
     try {
@@ -46,6 +81,27 @@ function IdleState() {
   return (
     <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 20 }}>
       <Text className="text-xl font-bold text-textPrimary">Настройки</Text>
+
+      {/* Availability — primary toggle */}
+      <View className="gap-3 rounded-xl border-2 border-brandPrimary bg-bgSecondary p-4">
+        <View className="flex-row items-center gap-2">
+          <Feather name="zap" size={18} color={Colors.brandPrimary} />
+          <Text className="flex-1 text-base font-bold text-textPrimary">Я доступен для новых заявок</Text>
+          {savingAvailable && <ActivityIndicator size="small" color={Colors.brandPrimary} />}
+        </View>
+        <Text className="text-xs text-textMuted">
+          Когда выключено, ваш профиль скрыт из каталога и вы не получите новых заявок.
+        </Text>
+        {profileLoading ? (
+          <ActivityIndicator size="small" color={Colors.textMuted} />
+        ) : (
+          <Toggle
+            label={isAvailable ? 'Доступен' : 'Недоступен'}
+            value={isAvailable}
+            onValueChange={handleAvailableToggle}
+          />
+        )}
+      </View>
 
       {/* Account */}
       <View className="gap-3 rounded-xl border border-borderLight p-4">
@@ -82,15 +138,11 @@ function IdleState() {
 
       {/* Notifications */}
       <View className="gap-3 rounded-xl border border-borderLight p-4">
-        <Text className="text-base font-semibold text-textPrimary">Уведомления</Text>
-        <Toggle label="Email-уведомления" value={emailNotif} onValueChange={setEmailNotif} />
-        <Toggle label="Push-уведомления" value={pushNotif} onValueChange={setPushNotif} />
-      </View>
-
-      {/* Public profile */}
-      <View className="gap-3 rounded-xl border border-borderLight p-4">
-        <Text className="text-base font-semibold text-textPrimary">Публичный профиль</Text>
-        <Toggle label="Профиль виден всем" value={publicProfile} onValueChange={setPublicProfile} />
+        <View className="flex-row items-center gap-2">
+          <Text className="flex-1 text-base font-semibold text-textPrimary">Уведомления</Text>
+          {savingEmail && <ActivityIndicator size="small" color={Colors.textMuted} />}
+        </View>
+        <Toggle label="Email-уведомления" value={emailNotif} onValueChange={handleEmailNotifToggle} />
       </View>
 
       {/* Logout */}

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -162,6 +162,21 @@ export const specialists = {
   saveWorkAreas(workAreas: { fnsId: string; departments: string[] }[]) {
     return client.post('/specialists/work-areas', { workAreas });
   },
+
+  /** PATCH /specialists/me — update specialist profile fields (bio, telegram, isAvailable, etc.) */
+  updateProfile(data: {
+    bio?: string;
+    displayName?: string;
+    headline?: string;
+    telegram?: string;
+    whatsapp?: string;
+    phone?: string;
+    officeAddress?: string;
+    workingHours?: string;
+    isAvailable?: boolean;
+  }) {
+    return client.patch('/specialists/me', data);
+  },
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Settings toggles (client + specialist) now persist across page refresh via `GET/PATCH /users/me/settings` wired to `notifyNewMessages` on User.
- Specialist settings screen gets a prominent new "Я доступен для новых заявок" toggle at the top, saving to `SpecialistProfile.isAvailable` via `PATCH /specialists/me`.
- Onboarding profile step routes specialist-only fields (`bio`, `telegram`) to `/specialists/me` instead of silently dropping them in `UpdateProfileDto`.
- Removed "Язык" / "Тема" rows from settings (not-yet-implemented stubs, per SA out of MVP).
- Removed unsupported "Публичный профиль" toggle (no backing column in schema).

## Test plan
- [ ] Login as client → Настройки → toggle Email-уведомления → refresh → holds
- [ ] Login as specialist → Настройки → toggle "Я доступен" → refresh → holds
- [ ] `curl /api/users/me` returns `notifyNewMessages` and `isAvailable` for specialist
- [ ] Onboarding specialist: bio/telegram persist (after profile created)
- [ ] No TS errors (both api and root tsc --noEmit pass locally)