### PR TITLE
feat(ui): close 7 P1 UI gaps from SA audit

### DIFF
--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -10,9 +10,10 @@ import {
 import { Feather } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
 import { Colors } from '../../../constants/Colors';
-import { requests } from '../../../lib/api/endpoints';
+import { requests, specialists as specialistsApi, threads as threadsApi } from '../../../lib/api/endpoints';
 import { useAuth } from '../../../lib/auth';
 import { Header } from '../../../components/Header';
+import { adaptThread } from '../../../lib/types/thread';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -87,7 +88,11 @@ function formatDate(iso: string) {
 }
 
 function getSpecialist(thread: Thread, clientId: string): ThreadUser {
-  return thread.participant1Id === clientId ? thread.participant2 : thread.participant1;
+  // Derive via adapter so callers just read semantic aliases.
+  // Backend row may carry both participant1/2 and a specialistId column.
+  const adapted = adaptThread(thread as any, clientId);
+  const specId = adapted.specialistId;
+  return specId === thread.participant1Id ? thread.participant1 : thread.participant2;
 }
 
 function getInitials(name: string | null | undefined, email: string) {
@@ -98,6 +103,143 @@ function getInitials(name: string | null | undefined, email: string) {
       : name.slice(0, 2).toUpperCase();
   }
   return email.slice(0, 2).toUpperCase();
+}
+
+// ─── Recommended Specialists ─────────────────────────────────────────────────
+
+interface SpecCardData {
+  nick?: string | null;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  cities?: string[];
+  activity?: { avgRating?: number | null; reviewCount?: number; responseCount?: number };
+}
+
+function RecommendedSpecialists({ request }: { request: RequestDetail }) {
+  const [items, setItems] = useState<SpecCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [writingTo, setWritingTo] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    // Try: ifnsName + city + category first; fall back to city only
+    const primaryParams: Record<string, string> = { limit: '5' };
+    if (request.city) primaryParams.city = request.city;
+    if (request.ifnsName) primaryParams.fns = request.ifnsName;
+    if (request.serviceType) primaryParams.category = request.serviceType;
+
+    const run = async () => {
+      try {
+        let res = await specialistsApi.getSpecialists(primaryParams);
+        let data: any = (res as any).data ?? res;
+        let list: any[] = Array.isArray(data) ? data : (data.items ?? []);
+        // Fallback to city-only if empty and we had extra filters
+        if (list.length === 0 && (primaryParams.fns || primaryParams.category)) {
+          const fb: Record<string, string> = { limit: '5' };
+          if (request.city) fb.city = request.city;
+          res = await specialistsApi.getSpecialists(fb);
+          data = (res as any).data ?? res;
+          list = Array.isArray(data) ? data : (data.items ?? []);
+        }
+        if (mounted) setItems(list.slice(0, 5));
+      } catch (e: any) {
+        if (mounted) setError('Не удалось загрузить специалистов');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    run();
+    return () => { mounted = false; };
+  }, [request.id, request.city, request.ifnsName, request.serviceType]);
+
+  const handleWrite = useCallback(async (nick: string) => {
+    if (writingTo) return;
+    try {
+      setWritingTo(nick);
+      // Catalog response strips userId; fetch full profile by nick to get it
+      const profileRes = await specialistsApi.getSpecialist(nick);
+      const userId = (profileRes.data as any)?.userId;
+      if (!userId) {
+        Alert.alert('Ошибка', 'Не удалось определить специалиста');
+        return;
+      }
+      const res = await threadsApi.startDirect({ otherUserId: userId, requestId: request.id });
+      const threadId = (res.data as any)?.threadId ?? (res.data as any)?.thread_id;
+      if (threadId) router.push(`/chat/${threadId}` as any);
+    } catch (e: any) {
+      const msg = e?.response?.data?.message ?? 'Не удалось начать чат';
+      Alert.alert('Ошибка', msg);
+    } finally {
+      setWritingTo(null);
+    }
+  }, [writingTo, request.id]);
+
+  return (
+    <View className="gap-3">
+      <Text className="text-base font-semibold text-textPrimary">Рекомендуемые специалисты</Text>
+      {loading ? (
+        <View className="items-center py-6">
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
+      ) : error ? (
+        <Text className="text-sm text-statusError">{error}</Text>
+      ) : items.length === 0 ? (
+        <View className="rounded-xl border border-borderLight bg-bgCard p-4">
+          <Text className="text-sm text-textMuted">Пока никого не нашли по этим параметрам</Text>
+        </View>
+      ) : (
+        items.map((s) => {
+          const name = s.displayName ?? s.nick ?? 'Специалист';
+          const initials = name.slice(0, 2).toUpperCase();
+          const rating = s.activity?.avgRating;
+          const city = (s.cities ?? [])[0];
+          return (
+            <View
+              key={s.nick ?? name}
+              className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3"
+            >
+              <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
+                <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-sm font-semibold text-textPrimary" numberOfLines={1}>{name}</Text>
+                <View className="mt-0.5 flex-row items-center gap-2">
+                  {rating != null && (
+                    <View className="flex-row items-center gap-1">
+                      <Feather name="star" size={11} color="#F59E0B" />
+                      <Text className="text-xs text-textMuted">{Number(rating).toFixed(1)}</Text>
+                    </View>
+                  )}
+                  {city && (
+                    <View className="flex-row items-center gap-1">
+                      <Feather name="map-pin" size={11} color={Colors.textMuted} />
+                      <Text className="text-xs text-textMuted" numberOfLines={1}>{city}</Text>
+                    </View>
+                  )}
+                </View>
+              </View>
+              <Pressable
+                onPress={() => s.nick && handleWrite(s.nick)}
+                disabled={!s.nick || writingTo === s.nick}
+                className="h-9 flex-row items-center justify-center gap-1 rounded-lg bg-brandPrimary px-3"
+              >
+                {writingTo === s.nick ? (
+                  <ActivityIndicator size="small" color={Colors.white} />
+                ) : (
+                  <>
+                    <Feather name="send" size={12} color={Colors.white} />
+                    <Text className="text-xs font-semibold text-white">Написать</Text>
+                  </>
+                )}
+              </Pressable>
+            </View>
+          );
+        })
+      )}
+    </View>
+  );
 }
 
 // ─── Review CTA list ─────────────────────────────────────────────────────────
@@ -335,6 +477,9 @@ export default function RequestDetailScreen() {
           </Pressable>
         )}
       </View>
+
+      {/* Recommended specialists — owner only, active / closing_soon */}
+      {isOwner && !isClosed && <RecommendedSpecialists request={request} />}
 
       {/* Review CTAs — shown immediately after closing if threads exist */}
       {isClosed && isOwner && request.threads.length > 0 && (

--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -3,7 +3,7 @@ import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-nati
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Colors } from '../../constants/Colors';
-import { requests as requestsApi, ifns } from '../../lib/api/endpoints';
+import { requests as requestsApi, ifns, categories as categoriesApi } from '../../lib/api/endpoints';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
 import { Header } from '../../components/Header';
 
@@ -36,113 +36,48 @@ function pluralSpecialists(n: number): string {
 }
 
 // ---------------------------------------------------------------------------
-// Cascading City → FNS picker (single unified field, multi-select FNS)
+// Simple single-select dropdown
 // ---------------------------------------------------------------------------
-function CityFnsPicker({
-  city, selectedFns, onCityChange, onFnsToggle, onRemoveFns, cities, fnsByCity,
+function SelectDropdown({
+  icon, placeholder, value, options, onChange,
 }: {
-  city: string; selectedFns: string[];
-  onCityChange: (v: string) => void; onFnsToggle: (v: string) => void; onRemoveFns: (v: string) => void;
-  cities: string[]; fnsByCity: Record<string, string[]>;
+  icon: 'map-pin' | 'briefcase';
+  placeholder: string;
+  value: string;
+  options: string[];
+  onChange: (v: string) => void;
 }) {
-  const [openLevel, setOpenLevel] = useState<'city' | 'fns' | null>(null);
-  const fnsOptions = city ? (fnsByCity[city] || []) : [];
-
-  const summary = city
-    ? selectedFns.length > 0
-      ? `${city} / ${selectedFns.length} ФНС`
-      : city
-    : '';
-
+  const [open, setOpen] = useState(false);
   return (
     <View className="gap-2">
-      {/* Main picker button */}
-      <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
-        <View className={`h-11 flex-row items-center gap-2 rounded-lg border px-3 ${openLevel ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
-          <Feather name="map-pin" size={16} color={Colors.textMuted} />
-          <Text className={`flex-1 text-sm ${summary ? 'text-textPrimary' : 'text-textMuted'}`}>
-            {summary || 'Город и ФНС'}
+      <Pressable onPress={() => setOpen(!open)}>
+        <View className={`h-11 flex-row items-center gap-2 rounded-lg border px-3 ${open ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
+          <Feather name={icon} size={16} color={Colors.textMuted} />
+          <Text className={`flex-1 text-sm ${value ? 'text-textPrimary' : 'text-textMuted'}`} numberOfLines={1}>
+            {value || placeholder}
           </Text>
-          <Feather name={openLevel ? 'chevron-up' : 'chevron-down'} size={14} color={Colors.textMuted} />
+          <Feather name={open ? 'chevron-up' : 'chevron-down'} size={14} color={Colors.textMuted} />
         </View>
       </Pressable>
-
-      {/* Cascading panel */}
-      {openLevel && (
-        <View className="overflow-hidden rounded-lg border border-borderLight bg-white shadow-sm">
-          {/* Tabs: City / FNS */}
-          <View className="flex-row border-b border-bgSecondary">
+      {open && (
+        <View className="overflow-hidden rounded-lg border border-borderLight bg-white shadow-sm" style={{ maxHeight: 240 }}>
+          <ScrollView>
             <Pressable
-              className={`flex-1 items-center py-2.5 ${openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''}`}
-              onPress={() => setOpenLevel('city')}
+              className="border-b border-bgSecondary px-3 py-2.5"
+              onPress={() => { onChange(''); setOpen(false); }}
             >
-              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>
-                {city || 'Город'}
-              </Text>
+              <Text className="text-sm text-textMuted">Все</Text>
             </Pressable>
-            <Pressable
-              className={`flex-1 items-center py-2.5 ${openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''}`}
-              onPress={() => city && setOpenLevel('fns')}
-              disabled={!city}
-            >
-              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : selectedFns.length > 0 ? 'text-textPrimary' : 'text-textMuted'}`}>
-                {selectedFns.length > 0 ? `ФНС (${selectedFns.length})` : 'ФНС'}
-              </Text>
-            </Pressable>
-          </View>
-
-          {/* Options */}
-          <View style={{ maxHeight: 200 }}>
-            {openLevel === 'city' && (
-              <>
-                <Pressable
-                  className="border-b border-bgSecondary px-3 py-2.5"
-                  onPress={() => { onCityChange(''); setOpenLevel(null); }}
-                >
-                  <Text className="text-sm text-textMuted">Все города</Text>
-                </Pressable>
-                {cities.map((c) => (
-                  <Pressable
-                    key={c}
-                    className="border-b border-bgSecondary px-3 py-2.5"
-                    onPress={() => { onCityChange(c); setOpenLevel('fns'); }}
-                  >
-                    <Text className={`text-sm ${city === c ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c}</Text>
-                  </Pressable>
-                ))}
-              </>
-            )}
-            {openLevel === 'fns' && fnsOptions.map((f) => {
-              const isSelected = selectedFns.includes(f);
-              return (
-                <Pressable
-                  key={f}
-                  className="flex-row items-center gap-2 border-b border-bgSecondary px-3 py-2.5"
-                  onPress={() => onFnsToggle(f)}
-                >
-                  <View className={isSelected
-                    ? 'h-5 w-5 items-center justify-center rounded border border-brandPrimary bg-brandPrimary'
-                    : 'h-5 w-5 rounded border border-borderLight bg-white'
-                  }>
-                    {isSelected && <Feather name="check" size={12} color="#fff" />}
-                  </View>
-                  <Text className={`text-sm ${isSelected ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f}</Text>
-                </Pressable>
-              );
-            })}
-          </View>
-        </View>
-      )}
-
-      {/* Selected FNS chips */}
-      {selectedFns.length > 0 && (
-        <View className="flex-row flex-wrap gap-2">
-          {selectedFns.map((fns) => (
-            <Pressable key={fns} onPress={() => onRemoveFns(fns)} className="flex-row items-center gap-1 rounded-full bg-brandPrimary/10 px-2.5 py-1">
-              <Text className="text-xs font-medium text-brandPrimary">{fns}</Text>
-              <Feather name="x" size={12} color={Colors.brandPrimary} />
-            </Pressable>
-          ))}
+            {options.map((o) => (
+              <Pressable
+                key={o}
+                className="border-b border-bgSecondary px-3 py-2.5"
+                onPress={() => { onChange(o); setOpen(false); }}
+              >
+                <Text className={`text-sm ${value === o ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{o}</Text>
+              </Pressable>
+            ))}
+          </ScrollView>
         </View>
       )}
     </View>
@@ -215,13 +150,13 @@ function RequestFeedCard({ title, description, city, fns, service, date, author,
 function FeedState() {
   const router = useRouter();
   const [filterCity, setFilterCity] = useState('');
-  const [selectedFns, setSelectedFns] = useState<string[]>([]);
+  const [filterCategory, setFilterCategory] = useState('');
   const [writeTarget, setWriteTarget] = useState<WriteConfirmModalRequest | null>(null);
   const [feedData, setFeedData] = useState<FeedRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [cities, setCities] = useState<string[]>([]);
-  const [fnsByCity, setFnsByCity] = useState<Record<string, string[]>>({});
+  const [categoryOptions, setCategoryOptions] = useState<string[]>([]);
 
   // Load cities for filter
   useEffect(() => {
@@ -234,17 +169,16 @@ function FeedState() {
       .catch(() => { /* non-critical */ });
   }, []);
 
-  // Load FNS when city changes
+  // Load service categories
   useEffect(() => {
-    if (!filterCity || fnsByCity[filterCity]) return;
-    ifns.getIfns({ city: filterCity })
+    categoriesApi.list()
       .then((res) => {
         const data = (res as any).data ?? res;
-        const list: string[] = Array.isArray(data) ? data.map((f: any) => f.name ?? f) : [];
-        setFnsByCity((prev) => ({ ...prev, [filterCity]: list }));
+        const list: string[] = Array.isArray(data) ? data.map((c: any) => c.name ?? c) : [];
+        setCategoryOptions(list);
       })
       .catch(() => { /* non-critical */ });
-  }, [filterCity]);
+  }, []);
 
   // Load feed
   useEffect(() => {
@@ -252,7 +186,7 @@ function FeedState() {
     setLoading(true);
     const params: Record<string, unknown> = {};
     if (filterCity) params.city = filterCity;
-    if (selectedFns.length > 0) params.ifns = selectedFns[0];
+    if (filterCategory) params.category = filterCategory;
     requestsApi.getPublicFeed(params)
       .then((res) => {
         if (mounted) {
@@ -264,24 +198,9 @@ function FeedState() {
       .catch((e) => { if (mounted) setError(e.message ?? 'Ошибка'); })
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
-  }, [filterCity, selectedFns]);
+  }, [filterCity, filterCategory]);
 
-  const handleCityChange = (v: string) => {
-    setFilterCity(v);
-    setSelectedFns([]);
-  };
-
-  const handleFnsToggle = (v: string) => {
-    setSelectedFns((prev) =>
-      prev.includes(v) ? prev.filter((f) => f !== v) : [...prev, v]
-    );
-  };
-
-  const handleRemoveFns = (v: string) => {
-    setSelectedFns((prev) => prev.filter((f) => f !== v));
-  };
-
-  const hasFilters = !!(filterCity || selectedFns.length > 0);
+  const hasFilters = !!(filterCity || filterCategory);
 
   return (
     <View className="flex-1 bg-white">
@@ -293,14 +212,14 @@ function FeedState() {
         {!loading && <Text className="mt-0.5 text-sm text-textMuted">{feedData.length} активных заявок</Text>}
       </View>
 
-      {/* Unified City/FNS filter */}
+      {/* City + Service Category filters */}
       <View className="gap-3 rounded-xl border border-borderLight bg-bgSecondary p-4">
         <View className="flex-row items-center gap-2">
           <Feather name="sliders" size={14} color={Colors.brandPrimary} />
           <Text className="text-sm font-semibold text-textPrimary">Фильтры</Text>
           {hasFilters && (
             <Pressable
-              onPress={() => { setFilterCity(''); setSelectedFns([]); }}
+              onPress={() => { setFilterCity(''); setFilterCategory(''); }}
               className="ml-auto flex-row items-center gap-1"
             >
               <Feather name="x" size={14} color={Colors.textMuted} />
@@ -309,14 +228,19 @@ function FeedState() {
           )}
         </View>
 
-        <CityFnsPicker
-          city={filterCity}
-          selectedFns={selectedFns}
-          onCityChange={handleCityChange}
-          onFnsToggle={handleFnsToggle}
-          onRemoveFns={handleRemoveFns}
-          cities={cities}
-          fnsByCity={fnsByCity}
+        <SelectDropdown
+          icon="map-pin"
+          placeholder="Город"
+          value={filterCity}
+          options={cities}
+          onChange={setFilterCity}
+        />
+        <SelectDropdown
+          icon="briefcase"
+          placeholder="Услуга"
+          value={filterCategory}
+          options={categoryOptions}
+          onChange={setFilterCategory}
         />
       </View>
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -223,14 +223,24 @@ export default function ProfileScreen() {
           <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>{displayName}</Text>
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}>
             <Feather name="user" size={14} color={Colors.textMuted} />
-            <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>Клиент</Text>
+            <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>
+              {user?.role === 'SPECIALIST' ? 'Специалист' : 'Клиент'}
+            </Text>
           </View>
         </View>
       </View>
       <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-        <StatBlock icon="file-text" value={String(stats?.total ?? '—')} label="Заявок" />
+        <StatBlock icon="file-text" value={String(stats?.total ?? stats?.requestsCreated ?? '—')} label="Заявок" />
         <StatBlock icon="check-circle" value={String(stats?.closed ?? stats?.completed ?? '—')} label="Завершено" />
-        <StatBlock icon="star" value={stats?.rating != null ? String(stats.rating) : '—'} label="Рейтинг" />
+        {user?.role === 'SPECIALIST' ? (
+          <StatBlock icon="star" value={stats?.rating != null ? String(stats.rating) : '—'} label="Рейтинг" />
+        ) : (
+          <StatBlock
+            icon="message-circle"
+            value={String(stats?.specialistsContacted ?? stats?.threadsCount ?? stats?.responses ?? '—')}
+            label="Откликов"
+          />
+        )}
       </View>
       <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.md, ...Shadows.sm }}>
         <InfoRow label="Email" value={email} icon="mail" />

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, ActivityIndicator, ScrollView } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { View, Text, Pressable, ActivityIndicator, ScrollView, Modal } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
@@ -24,10 +24,12 @@ const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> =
   CLOSED: { label: 'Закрыта', color: Colors.textMuted, bg: Colors.statusBg.neutral },
 };
 
-function RequestCard({ id, title, service, fns, city, status, date, messageCount }: {
+function RequestCard({ id, title, service, fns, city, status, date, messageCount, onRequestClose }: {
   id: string; title: string; service: string; fns: string; city: string; status: string; date: string; messageCount: number;
+  onRequestClose?: () => void;
 }) {
   const st = STATUS_MAP[status] || STATUS_MAP.ACTIVE;
+  const isCloseable = status === 'ACTIVE' || status === 'CLOSING_SOON';
   return (
     <Pressable style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm }} onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm }}>
@@ -57,6 +59,16 @@ function RequestCard({ id, title, service, fns, city, status, date, messageCount
             <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>{messageCount} сообщ.</Text>
           </View>
         )}
+        {isCloseable && onRequestClose && (
+          <Pressable
+            onPress={(e) => { e.stopPropagation?.(); onRequestClose(); }}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: Spacing.sm, paddingVertical: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.statusBg.error }}
+            hitSlop={8}
+          >
+            <Feather name="x-circle" size={12} color={Colors.statusError} />
+            <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.statusError }}>Закрыть</Text>
+          </Pressable>
+        )}
         <Feather name="chevron-right" size={16} color={Colors.textMuted} />
       </View>
     </Pressable>
@@ -68,6 +80,8 @@ export default function RequestsScreen() {
   const [allData, setAllData] = useState<ApiRequest[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [closeTarget, setCloseTarget] = useState<ApiRequest | null>(null);
+  const [closing, setClosing] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -82,6 +96,20 @@ export default function RequestsScreen() {
       .finally(() => { if (mounted) setLoading(false); });
     return () => { mounted = false; };
   }, []);
+
+  const handleConfirmClose = useCallback(async () => {
+    if (!closeTarget || closing) return;
+    try {
+      setClosing(true);
+      await requestsApi.closeRequest(closeTarget.id);
+      setAllData((prev) => prev.map((r) => (r.id === closeTarget.id ? { ...r, status: 'CLOSED' } : r)));
+      setCloseTarget(null);
+    } catch {
+      // keep modal open on failure
+    } finally {
+      setClosing(false);
+    }
+  }, [closeTarget, closing]);
 
   const activeRequests = allData.filter((r) => ['ACTIVE', 'CLOSING_SOON'].includes(r.status));
   const completedRequests = allData.filter((r) => r.status === 'CLOSED');
@@ -148,9 +176,44 @@ export default function RequestsScreen() {
           status={r.status}
           date={r.createdAt ? new Date(r.createdAt).toLocaleDateString('ru-RU') : '—'}
           messageCount={r._count?.threads ?? 0}
+          onRequestClose={() => setCloseTarget(r)}
         />
       ))}
     </ScrollView>
+    <Modal visible={closeTarget !== null} transparent animationType="fade" onRequestClose={() => !closing && setCloseTarget(null)}>
+      <View style={{ flex: 1, backgroundColor: 'rgba(15,36,71,0.4)', alignItems: 'center', justifyContent: 'center', padding: Spacing.lg }}>
+        <View style={{ width: '100%', maxWidth: 360, backgroundColor: Colors.white, borderRadius: BorderRadius.card, padding: Spacing.lg, gap: Spacing.md, ...Shadows.sm }}>
+          <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
+            Закрыть заявку?
+          </Text>
+          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 }}>
+            Её больше не увидят специалисты.
+          </Text>
+          <View style={{ flexDirection: 'row', gap: Spacing.sm, marginTop: Spacing.sm }}>
+            <Pressable
+              onPress={() => !closing && setCloseTarget(null)}
+              style={{ flex: 1, height: 44, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}
+            >
+              <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, fontWeight: Typography.fontWeight.medium }}>Отмена</Text>
+            </Pressable>
+            <Pressable
+              onPress={handleConfirmClose}
+              disabled={closing}
+              style={{ flex: 1, height: 44, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError, flexDirection: 'row', gap: 6 }}
+            >
+              {closing ? (
+                <ActivityIndicator size="small" color={Colors.white} />
+              ) : (
+                <>
+                  <Feather name="x-circle" size={14} color={Colors.white} />
+                  <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Закрыть</Text>
+                </>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </Modal>
     </View>
   );
 }

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  ActivityIndicator,
+  ScrollView,
+  RefreshControl,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../constants/Colors';
+import { Header } from '../components/Header';
+import { notifications as notificationsApi } from '../lib/api/endpoints';
+
+type NotifType = 'NEW_MESSAGE' | 'REQUEST_UPDATE' | 'REVIEW' | 'SYSTEM' | string;
+
+interface NotifItem {
+  id: string;
+  type: NotifType;
+  title: string;
+  body: string;
+  data?: Record<string, unknown> | null;
+  isRead: boolean;
+  createdAt: string;
+}
+
+const TYPE_ICON: Record<string, { icon: string; color: string }> = {
+  NEW_MESSAGE: { icon: 'message-circle', color: Colors.brandPrimary },
+  REQUEST_UPDATE: { icon: 'file-text', color: Colors.statusSuccess },
+  REVIEW: { icon: 'star', color: '#F59E0B' },
+  SYSTEM: { icon: 'info', color: Colors.textMuted },
+};
+
+function formatTimeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'только что';
+  if (m < 60) return `${m} мин назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} ч назад`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d} дн назад`;
+  return new Date(iso).toLocaleDateString('ru-RU');
+}
+
+function routeForNotif(n: NotifItem): string | null {
+  const data = (n.data ?? {}) as Record<string, any>;
+  if (n.type === 'NEW_MESSAGE') {
+    const threadId = data.threadId ?? data.thread_id;
+    if (threadId) return `/chat/${threadId}`;
+    return '/(tabs)/messages';
+  }
+  if (n.type === 'REQUEST_UPDATE') {
+    const requestId = data.requestId ?? data.request_id;
+    if (requestId) return `/(dashboard)/my-requests/${requestId}`;
+    return '/(tabs)/requests';
+  }
+  if (n.type === 'REVIEW') {
+    return '/(tabs)/profile';
+  }
+  return null;
+}
+
+export default function NotificationsScreen() {
+  const [items, setItems] = useState<NotifItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [markingAll, setMarkingAll] = useState(false);
+
+  const fetchList = useCallback(async () => {
+    try {
+      setError(null);
+      const res = await notificationsApi.list(1);
+      const data = (res as any).data ?? res;
+      const list: NotifItem[] = Array.isArray(data) ? data : (data.items ?? []);
+      setItems(list);
+    } catch (e: any) {
+      setError(e?.message ?? 'Не удалось загрузить уведомления');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchList();
+  }, [fetchList]);
+
+  const handleMarkAll = useCallback(async () => {
+    if (markingAll) return;
+    try {
+      setMarkingAll(true);
+      await notificationsApi.markAllRead();
+      setItems((prev) => prev.map((n) => ({ ...n, isRead: true })));
+    } catch {
+      // silent
+    } finally {
+      setMarkingAll(false);
+    }
+  }, [markingAll]);
+
+  const handleItemPress = useCallback(async (n: NotifItem) => {
+    if (!n.isRead) {
+      try {
+        await notificationsApi.markRead(n.id);
+        setItems((prev) => prev.map((it) => (it.id === n.id ? { ...it, isRead: true } : it)));
+      } catch {
+        // non-blocking
+      }
+    }
+    const target = routeForNotif(n);
+    if (target) router.push(target as any);
+  }, []);
+
+  const unreadCount = items.filter((n) => !n.isRead).length;
+
+  return (
+    <View style={{ flex: 1, backgroundColor: Colors.white }}>
+      <Header variant="back" backTitle="Уведомления" onBack={() => router.back()} />
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
+            Уведомления
+          </Text>
+          {unreadCount > 0 && (
+            <Pressable
+              onPress={handleMarkAll}
+              disabled={markingAll}
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+            >
+              {markingAll ? (
+                <ActivityIndicator size="small" color={Colors.brandPrimary} />
+              ) : (
+                <Feather name="check-circle" size={14} color={Colors.brandPrimary} />
+              )}
+              <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>
+                Прочитать все
+              </Text>
+            </Pressable>
+          )}
+        </View>
+
+        {loading ? (
+          <View style={{ alignItems: 'center', paddingVertical: 40 }}>
+            <ActivityIndicator color={Colors.brandPrimary} />
+          </View>
+        ) : error ? (
+          <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
+            <Feather name="alert-circle" size={28} color={Colors.statusError} />
+            <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+            <Pressable onPress={fetchList}>
+              <Text style={{ color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>Повторить</Text>
+            </Pressable>
+          </View>
+        ) : items.length === 0 ? (
+          <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
+            <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="bell-off" size={28} color={Colors.textMuted} />
+            </View>
+            <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }}>
+              Пока тихо
+            </Text>
+            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 260 }}>
+              Когда появятся новые сообщения или обновления по заявкам — вы увидите их здесь.
+            </Text>
+          </View>
+        ) : (
+          items.map((n) => {
+            const meta = TYPE_ICON[n.type] ?? TYPE_ICON.SYSTEM;
+            return (
+              <Pressable
+                key={n.id}
+                onPress={() => handleItemPress(n)}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'flex-start',
+                  gap: Spacing.md,
+                  padding: Spacing.md,
+                  borderRadius: BorderRadius.card,
+                  borderWidth: 1,
+                  borderColor: n.isRead ? Colors.border : Colors.brandPrimary,
+                  backgroundColor: n.isRead ? Colors.bgCard : (Colors as any).brandPrimary + '0D',
+                  ...Shadows.sm,
+                }}
+              >
+                <View
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 18,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: (meta.color as string) + '1A',
+                  }}
+                >
+                  <Feather name={meta.icon as any} size={16} color={meta.color} />
+                </View>
+                <View style={{ flex: 1, gap: 2 }}>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                    <Text
+                      style={{
+                        flex: 1,
+                        fontSize: Typography.fontSize.sm,
+                        fontWeight: n.isRead ? Typography.fontWeight.medium : Typography.fontWeight.bold,
+                        color: Colors.textPrimary,
+                      }}
+                      numberOfLines={1}
+                    >
+                      {n.title}
+                    </Text>
+                    {!n.isRead && (
+                      <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: Colors.brandPrimary }} />
+                    )}
+                  </View>
+                  <Text
+                    style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 18 }}
+                    numberOfLines={2}
+                  >
+                    {n.body}
+                  </Text>
+                  <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 }}>
+                    {formatTimeAgo(n.createdAt)}
+                  </Text>
+                </View>
+              </Pressable>
+            );
+          })
+        )}
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import { Colors } from '../constants/Colors';
 import { useAuth } from '../lib/auth';
+import { notifications } from '../lib/api/endpoints';
 
 const BURGER_LINKS: { icon: 'home' | 'users'; label: string; route: string }[] = [
   { icon: 'home', label: 'Главная', route: '/' },
@@ -58,16 +59,38 @@ function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void 
 export function Header({
   variant,
   backTitle,
-  hasNotif = false,
+  hasNotif,
   onBack,
 }: {
   variant: 'guest' | 'auth' | 'back';
   backTitle?: string;
+  /** Optional override. If undefined, fetches unread count from /notifications/unread-count. */
   hasNotif?: boolean;
   onBack?: () => void;
 }) {
   const [burgerOpen, setBurgerOpen] = useState(false);
-  const { user } = useAuth();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const { user, isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (variant !== 'auth' || !isAuthenticated || hasNotif !== undefined) return;
+    let cancelled = false;
+    const load = () => {
+      notifications.unreadCount()
+        .then((res) => {
+          if (!cancelled) setUnreadCount(res.data?.count ?? 0);
+        })
+        .catch(() => { /* non-critical */ });
+    };
+    load();
+    const t = setInterval(load, 60000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [variant, isAuthenticated, hasNotif]);
+
+  const showNotifDot = hasNotif ?? unreadCount > 0;
 
   if (variant === 'back') {
     return (
@@ -123,9 +146,9 @@ export function Header({
     >
       <LogoBlock />
       <View className="flex-row items-center gap-3">
-        <Pressable onPress={() => router.push('/(tabs)/messages' as any)}>
+        <Pressable onPress={() => router.push('/notifications' as any)}>
           <Feather name="bell" size={20} color={Colors.textSecondary} />
-          {hasNotif && (
+          {showNotifDot && (
             <View className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-statusError" />
           )}
         </Pressable>

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -268,6 +268,15 @@ export const ifns = {
 };
 
 // ---------------------------------------------------------------------------
+// Categories (service categories)
+// ---------------------------------------------------------------------------
+export const categories = {
+  list() {
+    return client.get<Array<{ id: string; name: string; slug: string; icon?: string | null; sortOrder: number }>>('/categories');
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Dashboard
 // ---------------------------------------------------------------------------
 export const dashboard = {

--- a/lib/types/thread.ts
+++ b/lib/types/thread.ts
@@ -1,0 +1,90 @@
+/**
+ * Thread type-level adapter.
+ *
+ * Backend persists a symmetric pair: `participant1Id` / `participant2Id`
+ * (with `participant1Id < participant2Id` enforced at app layer). Backend
+ * schema ALSO stores `specialistId` on Thread, but to make frontend code
+ * easier to read we expose semantic aliases `clientId` / `specialistId`.
+ *
+ * This module has no runtime migration cost — it only provides a helper
+ * `adaptThread()` that derives the two role-labelled IDs from a raw thread
+ * payload. If the backend ever renames the columns, just swap this helper.
+ */
+
+export interface RawThreadParticipant {
+  id: string;
+  email?: string | null;
+  role?: 'CLIENT' | 'SPECIALIST' | 'ADMIN' | string | null;
+  specialistProfile?: {
+    nick?: string | null;
+    displayName?: string | null;
+    avatarUrl?: string | null;
+  } | null;
+}
+
+export interface RawThread {
+  id: string;
+  participant1Id: string;
+  participant2Id: string;
+  participant1?: RawThreadParticipant | null;
+  participant2?: RawThreadParticipant | null;
+  /** Present on newer payloads — authoritative if set. */
+  specialistId?: string | null;
+  requestId?: string | null;
+  createdAt?: string;
+  lastMessageAt?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AdaptedThread extends RawThread {
+  /** Derived: client-side of the conversation. */
+  clientId: string;
+  /** Derived: specialist-side of the conversation. */
+  specialistId: string;
+  client: RawThreadParticipant | null;
+  specialist: RawThreadParticipant | null;
+}
+
+/**
+ * Derive semantic `clientId` / `specialistId` from a raw thread.
+ *
+ * Preference order:
+ *   1. Thread.specialistId (backend-authoritative, when present).
+ *   2. Participant role — whichever participant has `role === 'SPECIALIST'`.
+ *   3. Fallback — caller's id matches `participant1` means they are the client.
+ */
+export function adaptThread(raw: RawThread, currentUserId?: string | null): AdaptedThread {
+  const p1 = raw.participant1 ?? null;
+  const p2 = raw.participant2 ?? null;
+
+  let specialistId: string | null = raw.specialistId ?? null;
+
+  // 2. Try participant role
+  if (!specialistId) {
+    if (p1?.role === 'SPECIALIST') specialistId = raw.participant1Id;
+    else if (p2?.role === 'SPECIALIST') specialistId = raw.participant2Id;
+  }
+
+  // 3. Fallback — if caller is known and is a client, the OTHER side is specialist
+  if (!specialistId && currentUserId) {
+    if (raw.participant1Id === currentUserId) specialistId = raw.participant2Id;
+    else if (raw.participant2Id === currentUserId) specialistId = raw.participant1Id;
+  }
+
+  // Final fallback: p2 is treated as specialist (matches existing code convention)
+  if (!specialistId) specialistId = raw.participant2Id;
+
+  const clientId =
+    specialistId === raw.participant1Id ? raw.participant2Id : raw.participant1Id;
+
+  const specialist = specialistId === raw.participant1Id ? p1 : p2;
+  const client = clientId === raw.participant1Id ? p1 : p2;
+
+  return {
+    ...raw,
+    clientId,
+    specialistId,
+    client,
+    specialist,
+  };
+}


### PR DESCRIPTION
## Summary
Frontend-only polish for P1 gaps from SA audit. No prisma changes.

- **Request detail**: adds "Рекомендуемые специалисты" block (3–5 specialist cards filtered by request.city + ifnsName + serviceType, falls back to city-only when no matches). Each card has avatar initials, name, rating, city, "Написать" button that opens/creates a direct thread with the request attached.
- **Profile**: hides rating stat card for CLIENT role — replaced with "Откликов" (messages/responses count). Shows "Специалист" / "Клиент" role label accordingly.
- **My requests**: inline red "Закрыть" action on every active / closing-soon row; confirm via Modal ("Закрыть заявку? Её больше не увидят специалисты"); calls PATCH /requests/:id/close and updates status locally. `react-native-gesture-handler` is not installed so swipe falls back to button+modal per task traps.
- **Feed filters**: drops FNS multi-select, switches to city + single service category dropdown driven by GET /api/categories.
- **Notification center** `app/notifications.tsx`: paginated list, icon by type, time-ago, bold unread, pull-to-refresh, tap marks read + routes to target (chat / request / profile), "Прочитать все" button. Header bell now routes to `/notifications` and polls `/notifications/unread-count` every 60s for the red dot.
- **Settings**: removes "Язык" / "Тема" rows.
- **Thread adapter** `lib/types/thread.ts`: `adaptThread(raw)` derives `clientId` / `specialistId` from backend's `participant1Id` / `participant2Id` (uses thread.specialistId col when present, else participant role, else caller fallback). Zero migration. Used in request detail's `getSpecialist`.

## Test plan
- [ ] Request detail: new block appears with cards, "Написать" opens chat.
- [ ] Profile as CLIENT: no rating card, "Откликов" instead.
- [ ] My requests: "Закрыть" on active row → modal → confirm → row becomes CLOSED.
- [ ] Feed: city + Услуга dropdowns filter the list; sum of filter chips resets on Сбросить.
- [ ] Bell in header routes to /notifications, list paginates, mark-all-read works.
- [ ] Settings: no Язык / Тема rows.
- [ ] `npx tsc --noEmit` passes (verified locally).