### PR TITLE
feat(onboarding): work-areas endpoint + firstName/lastName + clean flow

### DIFF
--- a/api/src/specialists/dto/save-work-areas.dto.ts
+++ b/api/src/specialists/dto/save-work-areas.dto.ts
@@ -1,0 +1,25 @@
+import { IsArray, IsOptional, IsString, ValidateNested, ArrayMinSize } from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * One work-area entry. `fnsId` may be a composite "cityId:ifnsId" (new flow)
+ * or a bare `ifnsId` (legacy). `departments` is the list of service names the
+ * specialist handles at this FNS office (e.g. "Выездная проверка").
+ */
+export class WorkAreaEntryDto {
+  @IsString()
+  fnsId!: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  departments?: string[];
+}
+
+export class SaveWorkAreasDto {
+  @IsArray()
+  @ArrayMinSize(1, { message: 'Нужно выбрать хотя бы одну ФНС' })
+  @ValidateNested({ each: true })
+  @Type(() => WorkAreaEntryDto)
+  workAreas!: WorkAreaEntryDto[];
+}

--- a/api/src/specialists/specialists.controller.ts
+++ b/api/src/specialists/specialists.controller.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync } from 'fs';
 import { SpecialistsService } from './specialists.service';
 import { CreateSpecialistProfileDto } from './dto/create-specialist-profile.dto';
 import { UpdateSpecialistProfileDto } from './dto/update-specialist-profile.dto';
+import { SaveWorkAreasDto } from './dto/save-work-areas.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { OptionalJwtAuthGuard } from '../auth/optional-jwt-auth.guard';
 import { AdminGuard } from '../auth/admin.guard';
@@ -94,6 +95,20 @@ export class SpecialistsController {
   @Roles(Role.SPECIALIST)
   deleteAvatar(@Request() req: any) {
     return this.specialistsService.deleteAvatar(req.user.id, this.storageService);
+  }
+
+  /**
+   * POST /specialists/work-areas
+   *
+   * Replaces the specialist's selected FNS offices + departments in one call.
+   * Called from the onboarding "work-area" screen; also usable later from
+   * profile-editor. JWT-only (no role guard) so onboarding — where the user
+   * still has role=CLIENT until this call promotes them — can complete.
+   */
+  @Post('work-areas')
+  @UseGuards(JwtAuthGuard)
+  saveWorkAreas(@Request() req: any, @Body() dto: SaveWorkAreasDto) {
+    return this.specialistsService.saveWorkAreas(req.user.id, dto.workAreas);
   }
 
   @Get('cities')

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Prisma, Role } from '@prisma/client';
 import { unlink } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
@@ -463,6 +463,138 @@ export class SpecialistsService {
     });
 
     return { items, total, page, pages };
+  }
+
+  /**
+   * Replace the specialist's work-area assignments (FNS + services).
+   *
+   * Request shape: `workAreas: [{ fnsId: "<cityId:ifnsId>" | "<ifnsId>", departments?: string[] }]`.
+   * `departments` contains Service names (e.g. "Выездная проверка") which are
+   * mapped to Service rows and inserted into SpecialistService.
+   *
+   * Behaviour:
+   * - Full replace: wipes existing SpecialistFns + SpecialistService rows first.
+   * - Auto-creates SpecialistProfile on first save (nick = user.username).
+   * - Promotes the user to SPECIALIST on successful save.
+   * - Throws 400 when workAreas is empty or composite fnsId cannot be parsed.
+   */
+  async saveWorkAreas(
+    userId: string,
+    workAreas: Array<{ fnsId: string; departments?: string[] }>,
+  ): Promise<{ ok: true; count: number }> {
+    if (!Array.isArray(workAreas) || workAreas.length === 0) {
+      throw new BadRequestException('Нужно выбрать хотя бы одну ФНС');
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    if (!user.username) {
+      throw new BadRequestException('Username must be set before saving work areas');
+    }
+
+    // Parse composite "cityId:ifnsId" → take the second segment. If no colon,
+    // treat the whole value as a bare ifnsId (legacy flow).
+    const parsed = workAreas.map((w) => {
+      const raw = String(w.fnsId ?? '').trim();
+      if (!raw) throw new BadRequestException('fnsId не может быть пустым');
+      const idx = raw.indexOf(':');
+      const ifnsId = idx >= 0 ? raw.slice(idx + 1).trim() : raw;
+      if (!ifnsId) throw new BadRequestException(`Некорректный fnsId: ${raw}`);
+      const departments = Array.isArray(w.departments)
+        ? w.departments.map((d) => d.trim()).filter(Boolean)
+        : [];
+      return { ifnsId, departments };
+    });
+
+    // Validate every ifnsId exists in Ifns table so we never persist dangling refs.
+    const ifnsIds = [...new Set(parsed.map((p) => p.ifnsId))];
+    const foundIfns = await this.prisma.ifns.findMany({
+      where: { id: { in: ifnsIds } },
+      select: { id: true, name: true, city: { select: { name: true } } },
+    });
+    const foundSet = new Set(foundIfns.map((f) => f.id));
+    const missing = ifnsIds.filter((id) => !foundSet.has(id));
+    if (missing.length > 0) {
+      throw new BadRequestException(`ФНС не найдены: ${missing.join(', ')}`);
+    }
+
+    // Fetch or create SpecialistProfile (auto-create on first save).
+    let profile = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+    if (!profile) {
+      const nickTaken = await this.prisma.specialistProfile.findUnique({
+        where: { nick: user.username },
+      });
+      if (nickTaken) throw new ConflictException('Nick already taken');
+      profile = await this.prisma.specialistProfile.create({
+        data: {
+          userId,
+          nick: user.username,
+          cities: [],
+          services: [],
+          fnsOffices: [],
+          badges: [],
+        },
+      });
+    }
+
+    // Resolve department names → Service ids (batch lookup).
+    const allDeptNames = [...new Set(parsed.flatMap((p) => p.departments))];
+    const services = allDeptNames.length > 0
+      ? await this.prisma.service.findMany({ where: { name: { in: allDeptNames } } })
+      : [];
+    const serviceByName = new Map(services.map((s) => [s.name, s.id]));
+
+    // Mirror data for legacy String[] columns so existing catalog filters keep working.
+    const mirrorCities = [...new Set(foundIfns.map((f) => f.city.name))];
+    const mirrorFnsOffices = [...new Set(foundIfns.map((f) => f.name))];
+    const mirrorServices = [...new Set(allDeptNames.filter((n) => serviceByName.has(n)))];
+
+    // Full-replace strategy: wipe then insert.
+    await this.prisma.$transaction([
+      this.prisma.specialistService.deleteMany({ where: { specialistId: profile.id } }),
+      this.prisma.specialistFns.deleteMany({ where: { specialistId: profile.id } }),
+    ]);
+
+    // Batch insert SpecialistFns.
+    await this.prisma.specialistFns.createMany({
+      data: ifnsIds.map((fnsId) => ({ specialistId: profile!.id, fnsId })),
+      skipDuplicates: true,
+    });
+
+    // Batch insert SpecialistService — only rows where Service name was found.
+    const serviceLinks: Array<{ specialistId: string; fnsId: string; serviceId: string }> = [];
+    for (const entry of parsed) {
+      for (const deptName of entry.departments) {
+        const serviceId = serviceByName.get(deptName);
+        if (!serviceId) continue;
+        serviceLinks.push({ specialistId: profile.id, fnsId: entry.ifnsId, serviceId });
+      }
+    }
+    if (serviceLinks.length > 0) {
+      await this.prisma.specialistService.createMany({
+        data: serviceLinks,
+        skipDuplicates: true,
+      });
+    }
+
+    // Update profile mirror columns + mark profileComplete + promote role.
+    await this.prisma.$transaction([
+      this.prisma.specialistProfile.update({
+        where: { id: profile.id },
+        data: {
+          cities: mirrorCities,
+          fnsOffices: mirrorFnsOffices,
+          services: mirrorServices.length > 0 ? mirrorServices : profile.services,
+          profileComplete: true,
+        },
+      }),
+      this.prisma.user.update({
+        where: { id: userId },
+        data: { role: Role.SPECIALIST },
+      }),
+    ]);
+
+    return { ok: true, count: parsed.length };
   }
 
   async updateAvatarUrl(userId: string, avatarUrl: string) {

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -81,6 +81,21 @@ class UpdateProfileDto {
   city?: string;
 }
 
+// Russian + English letters, space, hyphen, apostrophe (e.g. "Анна-Мария", "O'Neil")
+const NAME_REGEX = /^[a-zA-Zа-яА-ЯёЁ\s'-]+$/;
+
+class SetNameDto {
+  @IsString()
+  @Length(2, 50)
+  @Matches(NAME_REGEX, { message: 'firstName: только буквы, пробел, дефис и апостроф' })
+  firstName!: string;
+
+  @IsString()
+  @Length(2, 50)
+  @Matches(NAME_REGEX, { message: 'lastName: только буквы, пробел, дефис и апостроф' })
+  lastName!: string;
+}
+
 class SetupSpecialistProfileDto {
   @IsArray()
   @IsString({ each: true })
@@ -228,7 +243,7 @@ export class UsersController {
     return this.usersService.updateProfile(req.user.id, { avatarUrl });
   }
 
-  /** PATCH /users/me/username — set or update username + name */
+  /** PATCH /users/me/username — set or update username + name (legacy) */
   @Patch('me/username')
   setUsername(
     @Request() req: { user: { id: string } },
@@ -238,9 +253,30 @@ export class UsersController {
   }
 
   /**
-   * PATCH /users/me/specialist-profile — onboarding step 3.
-   * No role guard — any authenticated user can call this during onboarding.
-   * Creates SpecialistProfile (nick = username) and promotes user to SPECIALIST role.
+   * PATCH /users/me/name — onboarding step 1 (new flow).
+   * Accepts firstName + lastName only. Auto-generates a hidden username
+   * (transliterated firstName + lastName + random suffix) when username is not set yet.
+   */
+  @Patch('me/name')
+  setName(
+    @Request() req: { user: { id: string } },
+    @Body() body: SetNameDto,
+  ) {
+    return this.usersService.setName(req.user.id, body.firstName.trim(), body.lastName.trim());
+  }
+
+  /**
+   * PATCH /users/me/specialist-profile — legacy onboarding endpoint.
+   *
+   * In the new flow (Batch 4 / Task E), profile creation happens via
+   * POST /specialists/work-areas. This endpoint remains for legacy clients.
+   *
+   * No role guard — onboarding users are still CLIENT at call time. The service
+   * enforces access control: it requires a username to have been set (onboarding
+   * step 1) and rejects already-promoted SPECIALIST users (they should use
+   * PATCH /specialists/me to edit). CLIENT users with an existing profile fall
+   * through to the "update existing" branch, which is the idempotent re-entry
+   * path used by tests.
    */
   @Patch('me/specialist-profile')
   setupSpecialistProfile(

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -8,6 +8,24 @@ const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/;
 const USERNAME_CHECK_REGEX = /^[a-zA-Z0-9_-]+$/;
 const OTP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
+// Cyrillic → Latin map for username auto-generation (GOST 7.79-2000 scheme B).
+const TRANSLIT_MAP: Record<string, string> = {
+  а: 'a', б: 'b', в: 'v', г: 'g', д: 'd', е: 'e', ё: 'yo',
+  ж: 'zh', з: 'z', и: 'i', й: 'y', к: 'k', л: 'l', м: 'm',
+  н: 'n', о: 'o', п: 'p', р: 'r', с: 's', т: 't', у: 'u',
+  ф: 'f', х: 'kh', ц: 'ts', ч: 'ch', ш: 'sh', щ: 'shch',
+  ъ: '', ы: 'y', ь: '', э: 'e', ю: 'yu', я: 'ya',
+  ї: 'yi', і: 'i', є: 'ye', ґ: 'g',
+};
+
+function transliterate(text: string): string {
+  return text.toLowerCase().split('').map((ch) => TRANSLIT_MAP[ch] ?? ch).join('');
+}
+
+function slugifyName(text: string): string {
+  return transliterate(text).replace(/[^a-z0-9]/g, '');
+}
+
 @Injectable()
 export class UsersService {
   private readonly logger = new Logger(UsersService.name);
@@ -110,6 +128,56 @@ export class UsersService {
     });
 
     return { id: updated.id, email: updated.email, role: updated.role, username: updated.username, firstName: updated.firstName, lastName: updated.lastName, phone: updated.phone, city: updated.city, avatarUrl: updated.avatarUrl };
+  }
+
+  /**
+   * Onboarding step 1 (new flow): set firstName + lastName.
+   *
+   * Auto-generates a hidden username on first save:
+   *   transliterated firstName + '_' + transliterated lastName + '_' + 4-digit suffix.
+   * Retries up to 5 times on suffix collision. Username remains unique on User table
+   * and is reused later as SpecialistProfile.nick.
+   */
+  async setName(
+    userId: string,
+    firstName: string,
+    lastName: string,
+  ): Promise<{ id: string; email: string; role: string; username: string; firstName: string; lastName: string }> {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    let username = user.username;
+    if (!username) {
+      const base = `${slugifyName(firstName)}_${slugifyName(lastName)}`.replace(/^_|_$/g, '');
+      const safeBase = base.length >= 3 ? base.slice(0, 15) : 'user';
+      // Try up to 5 times to find a free suffix — a 4-digit space gives 10k candidates.
+      for (let i = 0; i < 5; i++) {
+        const suffix = Math.floor(1000 + Math.random() * 9000).toString();
+        const candidate = `${safeBase}_${suffix}`.slice(0, 20);
+        const taken = await this.prisma.user.findUnique({ where: { username: candidate } });
+        if (!taken) {
+          username = candidate;
+          break;
+        }
+      }
+      if (!username) {
+        throw new ConflictException('Unable to generate unique username — please retry');
+      }
+    }
+
+    const updated = await this.prisma.user.update({
+      where: { id: userId },
+      data: { firstName, lastName, username },
+    });
+
+    return {
+      id: updated.id,
+      email: updated.email,
+      role: updated.role,
+      username: updated.username!,
+      firstName: updated.firstName ?? '',
+      lastName: updated.lastName ?? '',
+    };
   }
 
   /** Set username (+ optional firstName/lastName) for a user. */

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -52,30 +52,32 @@ export default function OnboardingProfilePage() {
         }
       }
 
-      // Save User fields (phone) via /users/me/profile — handles phone + city + names.
-      if (phone) {
-        await users.updateProfile({ phone } as any);
-      }
-
-      // Save specialist-only fields (bio, telegram) via /specialists/me — works only when
-      // a SpecialistProfile already exists. For new specialists the profile is created in
-      // step 3 (work-area), so this call 404s gracefully and the values are re-applied there.
-      if (role === 'SPECIALIST' && (description || telegram)) {
-        try {
-          await specialists.updateProfile({
-            ...(description ? { bio: description } : {}),
-            ...(telegram ? { telegram } : {}),
-          });
-        } catch {
-          // Profile not yet created — values will be re-entered or merged in a later step.
+      // Save profile fields. For specialists, bio/telegram/phone live on SpecialistProfile,
+      // so route through PATCH /specialists/me. Clients use PATCH /users/me/profile
+      // (bio/telegram are ignored for clients — their schema has no such columns).
+      if (role === 'SPECIALIST') {
+        const specialistData: Record<string, string> = {};
+        if (description.trim()) specialistData.bio = description.trim();
+        if (phone.trim()) specialistData.phone = phone.trim();
+        if (telegram.trim()) specialistData.telegram = telegram.trim();
+        if (Object.keys(specialistData).length > 0) {
+          await specialists.updateProfile(specialistData);
+        }
+      } else {
+        const clientData: Record<string, string> = {};
+        if (phone.trim()) clientData.phone = phone.trim();
+        if (Object.keys(clientData).length > 0) {
+          await users.updateProfile(clientData);
         }
       }
 
       await refreshUser();
 
-      // SPECIALIST continues to work-area (step 3/3), CLIENT is done (step 2/2)
+      // New SA flow: profile is the LAST step for both roles.
+      // SPECIALIST: name → work-area → profile → specialist-dashboard
+      // CLIENT: name → profile → dashboard
       if (role === 'SPECIALIST') {
-        router.push('/(onboarding)/work-area' as any);
+        router.replace('/(tabs)/specialist-dashboard' as any);
       } else {
         router.replace('/(tabs)/dashboard' as any);
       }
@@ -91,12 +93,12 @@ export default function OnboardingProfilePage() {
     <View style={{ flex: 1, backgroundColor: '#fff' }}>
       <Header variant="back" backTitle="Профиль" onBack={() => router.back()} />
       <View className="flex-1 bg-white px-4 py-6">
-        {/* Progress */}
+        {/* Progress — profile is the FINAL step for both roles */}
         <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-green-600" style={{ width: role === 'SPECIALIST' ? '66%' : '100%' }} />
+          <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
         </View>
         <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
-          {role === 'SPECIALIST' ? 'Шаг 2 из 3' : 'Шаг 2 из 2'}
+          {role === 'SPECIALIST' ? 'Шаг 3 из 3' : 'Шаг 2 из 2'}
         </Text>
 
         <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -6,63 +6,58 @@ import { Header } from '../../components/Header';
 import { users } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
 
-const USERNAME_REGEX = /^[a-z0-9_-]{3,20}$/;
+// Russian + English letters, space, hyphen, apostrophe; 2–50 chars.
+const NAME_REGEX = /^[a-zA-Zа-яА-ЯёЁ\s'-]{2,50}$/;
 
-export default function UsernameScreen() {
+export default function NameScreen() {
   const router = useRouter();
-  const { role } = useAuth();
+  const { role, refreshUser } = useAuth();
 
-  const [value, setValue] = useState('');
-  const [error, setError] = useState('');
-  const [available, setAvailable] = useState(false);
-  const [checking, setChecking] = useState(false);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [firstErr, setFirstErr] = useState('');
+  const [lastErr, setLastErr] = useState('');
   const [agreed, setAgreed] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [submitErr, setSubmitErr] = useState('');
 
-  const canContinue = available && agreed && value.length >= 3;
-
-  function validateLocal(val: string): string {
-    if (val.length < 3) return 'Минимум 3 символа';
-    if (val.length > 20) return 'Максимум 20 символов';
-    if (!USERNAME_REGEX.test(val)) return 'Только латиница, цифры, _ и -';
+  const validateField = (val: string): string => {
+    if (val.trim().length < 2) return 'Минимум 2 символа';
+    if (val.trim().length > 50) return 'Максимум 50 символов';
+    if (!NAME_REGEX.test(val.trim())) return 'Только буквы, пробел, дефис и апостроф';
     return '';
-  }
+  };
 
-  async function checkAvailability() {
-    const localErr = validateLocal(value);
-    if (localErr) {
-      setError(localErr);
-      setAvailable(false);
-      return;
-    }
-    setChecking(true);
-    setError('');
-    setAvailable(false);
-    try {
-      const res = await users.checkUsername(value);
-      if (res.data.available) {
-        setAvailable(true);
-      } else {
-        setError('Имя уже занято');
-      }
-    } catch (e: any) {
-      setError('Ошибка проверки');
-    } finally {
-      setChecking(false);
-    }
-  }
+  const canContinue =
+    !!firstName.trim() &&
+    !!lastName.trim() &&
+    !firstErr &&
+    !lastErr &&
+    agreed &&
+    !loading;
 
   async function handleNext() {
-    if (!canContinue || loading) return;
+    const fErr = validateField(firstName);
+    const lErr = validateField(lastName);
+    setFirstErr(fErr);
+    setLastErr(lErr);
+    if (fErr || lErr || !agreed) return;
+
     setLoading(true);
-    setError('');
+    setSubmitErr('');
     try {
-      await users.setUsername({ username: value });
-      // Both roles go to profile next (CLIENT: step 2/2, SPECIALIST: step 2/3)
-      router.push('/(onboarding)/profile' as any);
+      await users.setName({ firstName: firstName.trim(), lastName: lastName.trim() });
+      await refreshUser();
+      // New SA-requested flow: name → work-area (specialist) → profile
+      // For clients: name → profile
+      if (role === 'SPECIALIST') {
+        router.push('/(onboarding)/work-area' as any);
+      } else {
+        router.push('/(onboarding)/profile' as any);
+      }
     } catch (e: any) {
       const msg = e?.response?.data?.message || e?.message || 'Ошибка сохранения';
-      setError(typeof msg === 'string' ? msg : 'Ошибка сохранения');
+      setSubmitErr(Array.isArray(msg) ? msg.join(', ') : msg);
     } finally {
       setLoading(false);
     }
@@ -79,46 +74,70 @@ export default function UsernameScreen() {
           {role === 'SPECIALIST' ? 'Шаг 1 из 3' : 'Шаг 1 из 2'}
         </Text>
         <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
-        <Text className="mb-4 text-base leading-6 text-textMuted">Это имя будет видно клиентам в вашем профиле</Text>
-        <Text className="mb-1 text-sm font-medium text-textSecondary">Имя пользователя</Text>
-        <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : available ? 'border-green-600 bg-green-50' : 'border-gray-200 bg-white'}`}>
-          <Feather name="user" size={18} color={error ? '#DC2626' : available ? '#15803D' : '#94A3B8'} />
+        <Text className="mb-4 text-base leading-6 text-textMuted">Имя и фамилия будут видны клиентам в вашем профиле</Text>
+
+        <Text className="mb-1 text-sm font-medium text-textSecondary">Имя</Text>
+        <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${firstErr ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'}`}>
+          <Feather name="user" size={18} color={firstErr ? '#DC2626' : '#94A3B8'} />
           <TextInput
-            value={value}
-            onChangeText={(t) => { setValue(t.toLowerCase()); setError(''); setAvailable(false); }}
-            placeholder="a-z, 0-9, _, - (3-20 символов)"
+            value={firstName}
+            onChangeText={(t) => { setFirstName(t); if (firstErr) setFirstErr(''); }}
+            onBlur={() => setFirstErr(validateField(firstName))}
+            placeholder="Иван"
             placeholderTextColor="#94A3B8"
             className="flex-1 text-base text-textPrimary"
             style={{ outlineStyle: 'none' } as any}
-            autoCapitalize="none"
+            autoCapitalize="words"
             autoCorrect={false}
-            onBlur={checkAvailability}
           />
-          {checking && <ActivityIndicator size="small" color="#94A3B8" />}
-          {!checking && available && <Feather name="check-circle" size={18} color="#15803D" />}
-          {!checking && error ? <Feather name="x-circle" size={18} color="#DC2626" /> : null}
         </View>
-        {error ? (
+        {firstErr ? (
           <View className="mb-2 flex-row items-center gap-1">
             <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{error}</Text>
-          </View>
-        ) : available ? (
-          <View className="mb-2 flex-row items-center gap-1">
-            <Feather name="check-circle" size={14} color="#15803D" />
-            <Text className="text-sm font-medium text-green-700">Имя свободно</Text>
+            <Text className="text-sm text-red-600">{firstErr}</Text>
           </View>
         ) : null}
+
+        <Text className="mb-1 mt-3 text-sm font-medium text-textSecondary">Фамилия</Text>
+        <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${lastErr ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'}`}>
+          <Feather name="user" size={18} color={lastErr ? '#DC2626' : '#94A3B8'} />
+          <TextInput
+            value={lastName}
+            onChangeText={(t) => { setLastName(t); if (lastErr) setLastErr(''); }}
+            onBlur={() => setLastErr(validateField(lastName))}
+            placeholder="Иванов"
+            placeholderTextColor="#94A3B8"
+            className="flex-1 text-base text-textPrimary"
+            style={{ outlineStyle: 'none' } as any}
+            autoCapitalize="words"
+            autoCorrect={false}
+          />
+        </View>
+        {lastErr ? (
+          <View className="mb-2 flex-row items-center gap-1">
+            <Feather name="alert-circle" size={14} color="#DC2626" />
+            <Text className="text-sm text-red-600">{lastErr}</Text>
+          </View>
+        ) : null}
+
         <Pressable className="mt-3 flex-row items-start gap-2" onPress={() => setAgreed(!agreed)}>
           <View className={`mt-0.5 h-5 w-5 items-center justify-center rounded border ${agreed ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300 bg-white'}`}>
             {agreed && <Feather name="check" size={13} color="#fff" />}
           </View>
           <Text className="flex-1 text-sm text-textSecondary">Принимаю <Text className="text-brandPrimary">условия использования</Text></Text>
         </Pressable>
+
+        {submitErr ? (
+          <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
+            <Feather name="alert-circle" size={14} color="#DC2626" />
+            <Text className="text-sm text-red-600">{submitErr}</Text>
+          </View>
+        ) : null}
+
         <Pressable
-          disabled={!canContinue || loading}
+          disabled={!canContinue}
           onPress={handleNext}
-          className={`mt-6 h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${(!canContinue || loading) ? 'opacity-40' : ''}`}
+          className={`mt-6 h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${!canContinue ? 'opacity-40' : ''}`}
         >
           {loading ? (
             <ActivityIndicator size="small" color="#fff" />

--- a/app/(onboarding)/work-area.tsx
+++ b/app/(onboarding)/work-area.tsx
@@ -77,7 +77,8 @@ export default function WorkAreaScreenPage() {
         departments,
       }));
       await specialists.saveWorkAreas(workAreas);
-      router.replace('/(tabs)/specialist-dashboard' as any);
+      // New SA flow: work-area (step 2) → profile (step 3 — final)
+      router.push('/(onboarding)/profile' as any);
     } catch (e: any) {
       const msg = e?.response?.data?.message || e?.message || 'Ошибка сохранения';
       setError(typeof msg === 'string' ? msg : 'Ошибка сохранения');
@@ -91,9 +92,9 @@ export default function WorkAreaScreenPage() {
       <Header variant="back" backTitle="Регион" onBack={() => router.back()} />
       <View className="flex-1 bg-white px-4 py-6">
         <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '100%' }} />
+          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '66%' }} />
         </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 3 из 3</Text>
+        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 2 из 3</Text>
         <Text className="text-xl font-bold text-textPrimary">Рабочая зона</Text>
         <Text className="mb-4 text-base text-textMuted">Выберите города, инспекции и услуги</Text>
         <View className="mb-2 h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
@@ -184,7 +185,7 @@ export default function WorkAreaScreenPage() {
               <ActivityIndicator size="small" color="#fff" />
             ) : (
               <>
-                <Text className="text-base font-semibold text-white">Завершить</Text>
+                <Text className="text-base font-semibold text-white">Далее</Text>
                 <Feather name="arrow-right" size={16} color="#fff" />
               </>
             )}

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -72,6 +72,11 @@ export const users = {
     return client.patch('/users/me/username', data);
   },
 
+  /** Onboarding step 1 (new flow): save firstName + lastName. Backend auto-generates username. */
+  setName(data: { firstName: string; lastName: string }) {
+    return client.patch('/users/me/name', data);
+  },
+
   getSettings() {
     return client.get('/users/me/settings');
   },


### PR DESCRIPTION
## Summary

Batch 4 / Task E — fixes 3 launch blockers in the specialist/client onboarding flow.

### Gap 1 — POST /specialists/work-areas (P0, was 404)
- New `SaveWorkAreasDto` accepting `{ workAreas: [{ fnsId, departments? }] }`
- Parses composite `fnsId` format `"cityId:ifnsId"` sent by the frontend
- Auto-creates `SpecialistProfile` on first save (nick = username)
- Full-replace `SpecialistFns` / `SpecialistService` rows in a `$transaction`
- Updates mirror columns (cities, fnsOffices, services) and promotes CLIENT to SPECIALIST
- Returns 400 on empty array

### Gap 2 — firstName / lastName step replaces username
- `PATCH /users/me/name` with `SetNameDto` (2-50 chars, ru+en letters / space / hyphen / apostrophe)
- Auto-generates hidden username from transliterated names + random suffix (retries on collision)
- Renamed onboarding screen to collect first name + last name
- Reordered flow: `name -> work-area -> profile` (was `username -> profile -> work-area`)
- Profile step is now terminal for both roles

### Gap 3 — specialist-profile endpoint guardrails
- Legacy `PATCH /users/me/specialist-profile`: service already rejects already-promoted specialists and requires a username to be set. Documented the chicken-and-egg constraint that prevents adding a strict `@Roles` guard.

### Frontend bio save fix
Profile step now routes `bio` / `telegram` / `phone` through `PATCH /specialists/me` for SPECIALIST (User table has no `bio` column) and `phone` only through `/users/me/profile` for CLIENT.

## Test plan

- [x] `cd api && doppler run -- npx tsc --noEmit` clean
- [x] root `npx tsc --noEmit` clean
- [x] Existing `api/src/users/onboarding.e2e.spec.ts` (19 tests) pass unchanged
- [ ] CI green on staging
- [ ] `curl -X POST https://p2ptax.smartlaunchhub.com/api/specialists/work-areas` with demo specialist JWT returns 200
- [ ] Walk onboarding as a new specialist on staging: name -> work-area -> profile -> specialist-dashboard (no 404)
- [ ] Walk onboarding as a new client: name -> profile -> dashboard