### PR TITLE
fix(frontend): specialists mapping, missing routes, auth-aware guest header

### DIFF
--- a/app/(dashboard)/my-requests/index.tsx
+++ b/app/(dashboard)/my-requests/index.tsx
@@ -1,0 +1,8 @@
+import { Redirect } from 'expo-router';
+
+// /my-requests → /requests
+// Historical deep-links and notifications may point to /my-requests; the real
+// list lives in the tab bar at /requests. Redirect to keep URLs alive.
+export default function MyRequestsIndex() {
+  return <Redirect href="/requests" />;
+}

--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -119,7 +119,7 @@ export default function NewRequestScreen() {
   // Validation
   const titleError = title.length > 0 && title.length < 5 ? 'Минимум 5 символов' : null;
   const descError = description.length > 0 && description.length < 20 ? 'Минимум 20 символов' : null;
-  const isValid = title.length >= 5 && description.length >= 20 && !!service;
+  const isValid = title.length >= 5 && description.length >= 20 && !!city && !!service;
 
   // Load cities
   useEffect(() => {

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,0 +1,7 @@
+import { Redirect } from 'expo-router';
+
+// Deep-link / backlink / ad-landing entry point. Real auth flow lives at
+// /(auth)/role → /(auth)/email → /(auth)/otp. Forward to the role picker.
+export default function LoginRedirect() {
+  return <Redirect href="/(auth)/role" />;
+}

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -13,20 +13,31 @@ interface FnsService {
   services: string[];
 }
 
+interface SpecialistActivity {
+  responseCount?: number;
+  avgRating?: number | null;
+  reviewCount?: number | null;
+}
+
 interface SpecialistData {
-  id: string;
   userId?: string | null;
-  username?: string | null;
-  name?: string | null;
-  user?: { firstName?: string | null; lastName?: string | null } | null;
-  city?: string | null;
+  nick: string;
+  displayName?: string | null;
+  headline?: string | null;
+  bio?: string | null;
+  experience?: number | null;
+  hourlyRate?: number | null;
+  cities?: string[] | null;
+  services?: string[] | null;
+  fnsOffices?: string[] | null;
+  fnsGroupedByCity?: Array<{ city: string; fns: string[] }> | null;
   memberSince?: number | null;
   createdAt?: string | null;
+  activity?: SpecialistActivity | null;
   rating?: number | null;
   reviewCount?: number | null;
-  about?: string | null;
-  fnsServices?: FnsService[] | null;
   reviews?: Array<{ author?: string; date?: string; rating: number; text?: string }> | null;
+  avatarUrl?: string | null;
   [key: string]: unknown;
 }
 
@@ -170,9 +181,15 @@ function ProfileScreen({ spec }: { spec: SpecialistData }) {
   const [confirmVisible, setConfirmVisible] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [errorText, setErrorText] = useState<string | null>(null);
-  const fnsServices: FnsService[] = spec.fnsServices ?? [];
-  const displayName = spec.name
-    ?? ([spec.user?.firstName, spec.user?.lastName].filter(Boolean).join(' ') || '—');
+  // Backend returns fnsGroupedByCity = Array<{ city; fns: string[] }>. Map to flat FnsService list
+  // using the specialist's service names (same for all offices — no per-FNS mapping in current API).
+  const allServices = spec.services ?? [];
+  const fnsServices: FnsService[] = (spec.fnsOffices ?? []).map((fns) => ({ fns, services: allServices }));
+  const displayName = spec.displayName || spec.nick || '—';
+  const city = spec.cities?.[0] ?? null;
+  const rating = spec.rating ?? spec.activity?.avgRating ?? null;
+  const reviewCount = spec.reviewCount ?? spec.activity?.reviewCount ?? 0;
+  const about = spec.bio ?? spec.headline ?? null;
   const memberYear = spec.memberSince
     ?? (spec.createdAt ? new Date(spec.createdAt).getFullYear() : null);
 
@@ -241,16 +258,19 @@ function ProfileScreen({ spec }: { spec: SpecialistData }) {
             </View>
             <View className="flex-1 gap-1">
               <Text className="text-xl font-bold text-textPrimary">{displayName}</Text>
-              {spec.city && (
+              {spec.headline && (
+                <Text className="text-sm text-textSecondary">{spec.headline}</Text>
+              )}
+              {city && (
                 <View className="flex-row items-center gap-1">
                   <Feather name="map-pin" size={14} color="#94A3B8" />
-                  <Text className="text-base text-textMuted">{spec.city}</Text>
+                  <Text className="text-base text-textMuted">{city}</Text>
                 </View>
               )}
-              {spec.rating != null && (
+              {rating != null && (
                 <View className="flex-row items-center gap-1">
-                  <Stars rating={Math.round(spec.rating)} size={16} />
-                  <Text className="text-sm text-textMuted">{spec.rating} ({spec.reviewCount ?? 0} отзывов)</Text>
+                  <Stars rating={Math.round(rating)} size={16} />
+                  <Text className="text-sm text-textMuted">{rating} ({reviewCount} отзывов)</Text>
                 </View>
               )}
               {memberYear && (
@@ -261,7 +281,7 @@ function ProfileScreen({ spec }: { spec: SpecialistData }) {
               )}
             </View>
           </View>
-          {spec.about && <Text className="text-base leading-6 text-textSecondary">{spec.about}</Text>}
+          {about && <Text className="text-base leading-6 text-textSecondary">{about}</Text>}
         </View>
 
         {/* FNS preview (first 2 open) + "Подробнее" for rest */}

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -7,25 +7,27 @@ import { specialists as specialistsApi } from '../../lib/api/endpoints';
 import { Colors } from '../../constants/Colors';
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — matches GET /api/specialists response shape
 // ---------------------------------------------------------------------------
-interface FnsService {
-  fns: string;
-  services: string[];
+interface SpecialistActivity {
+  responseCount?: number;
+  avgRating?: number | null;
+  reviewCount?: number | null;
 }
 
 interface Specialist {
-  id: string;
-  username?: string | null;
-  name?: string | null;
-  user?: { firstName?: string | null; lastName?: string | null } | null;
-  city?: string | null;
-  rating?: number | null;
-  reviewCount?: number | null;
+  nick: string;
+  displayName?: string | null;
+  headline?: string | null;
+  experience?: number | null;
+  hourlyRate?: number | null;
+  cities?: string[] | null;
+  services?: string[] | null;
+  fnsOffices?: string[] | null;
   memberSince?: number | null;
   createdAt?: string | null;
-  fnsServices?: FnsService[] | null;
-  workAreas?: Array<{ fnsId?: string; departments?: string[] }> | null;
+  activity?: SpecialistActivity | null;
+  avatarUrl?: string | null;
   [key: string]: unknown;
 }
 
@@ -104,14 +106,17 @@ function SpecialistCard({ specialist, matchedFns }: {
   specialist: Specialist;
   matchedFns?: string;
 }) {
-  const fnsServices: FnsService[] = specialist.fnsServices ?? [];
-  const fnsToShow = matchedFns
-    ? fnsServices.filter(f => f.fns === matchedFns)
-    : fnsServices;
-  const displayName = specialist.name
-    ?? ([specialist.user?.firstName, specialist.user?.lastName].filter(Boolean).join(' ') || '—');
+  const displayName = specialist.displayName || specialist.nick || '—';
+  const city = specialist.cities?.[0] ?? null;
+  const services = specialist.services ?? [];
+  const fnsOffices = specialist.fnsOffices ?? [];
+  const rating = specialist.activity?.avgRating ?? null;
+  const reviewCount = specialist.activity?.reviewCount ?? null;
   const memberYear = specialist.memberSince
     ?? (specialist.createdAt ? new Date(specialist.createdAt).getFullYear() : null);
+  const fnsToShow = matchedFns
+    ? fnsOffices.filter(f => f === matchedFns)
+    : fnsOffices;
 
   return (
     <View className="flex-1 bg-white rounded-xl p-4 border border-sky-100 gap-3" style={{ minWidth: 280, shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}>
@@ -122,16 +127,19 @@ function SpecialistCard({ specialist, matchedFns }: {
         </View>
         <View className="flex-1 gap-0.5">
           <Text className="text-base font-semibold text-slate-900">{displayName}</Text>
+          {specialist.headline && (
+            <Text className="text-sm text-slate-500" numberOfLines={2}>{specialist.headline}</Text>
+          )}
           <View className="flex-row items-center gap-1">
             <Feather name="map-pin" size={12} color="#94A3B8" />
-            <Text className="text-sm text-slate-400">{specialist.city ?? '—'}</Text>
+            <Text className="text-sm text-slate-400">{city ?? '—'}</Text>
           </View>
-          {specialist.rating != null && (
+          {rating != null && (
             <View className="flex-row items-center gap-1 mt-0.5">
-              <Stars rating={specialist.rating} />
-              <Text className="text-sm font-bold text-slate-900">{specialist.rating}</Text>
-              {specialist.reviewCount != null && (
-                <Text className="text-xs text-slate-400">({specialist.reviewCount})</Text>
+              <Stars rating={rating} />
+              <Text className="text-sm font-bold text-slate-900">{rating}</Text>
+              {reviewCount != null && (
+                <Text className="text-xs text-slate-400">({reviewCount})</Text>
               )}
             </View>
           )}
@@ -146,25 +154,31 @@ function SpecialistCard({ specialist, matchedFns }: {
         </View>
       )}
 
-      {/* FNS blocks */}
-      {fnsToShow.map((entry) => (
-        <View key={entry.fns} className="gap-2">
-          <View className="flex-row items-center gap-1.5 bg-sky-50 rounded-lg px-2.5 py-1.5">
-            <Feather name="home" size={13} color="#0284C7" />
-            <Text className="text-xs font-semibold text-sky-600 flex-1" numberOfLines={1}>{entry.fns}</Text>
-          </View>
-          <View className="flex-row flex-wrap gap-1.5">
-            {entry.services.map((svc) => (
-              <View key={svc} className="bg-sky-50 px-2 py-1 rounded-full">
-                <Text className="text-xs font-medium text-sky-600">{svc}</Text>
-              </View>
-            ))}
-          </View>
+      {/* FNS offices */}
+      {fnsToShow.length > 0 && (
+        <View className="gap-1.5">
+          {fnsToShow.slice(0, 3).map((fns) => (
+            <View key={fns} className="flex-row items-center gap-1.5 bg-sky-50 rounded-lg px-2.5 py-1.5">
+              <Feather name="home" size={13} color="#0284C7" />
+              <Text className="text-xs font-semibold text-sky-600 flex-1" numberOfLines={1}>{fns}</Text>
+            </View>
+          ))}
         </View>
-      ))}
+      )}
+
+      {/* Services */}
+      {services.length > 0 && (
+        <View className="flex-row flex-wrap gap-1.5">
+          {services.map((svc) => (
+            <View key={svc} className="bg-sky-50 px-2 py-1 rounded-full">
+              <Text className="text-xs font-medium text-sky-600">{svc}</Text>
+            </View>
+          ))}
+        </View>
+      )}
 
       {/* Button */}
-      <Pressable className="h-10 rounded-xl items-center justify-center border border-sky-600 flex-row gap-1" onPress={() => router.push(`/specialists/${specialist.username ?? specialist.id}` as any)}>
+      <Pressable className="h-10 rounded-xl items-center justify-center border border-sky-600 flex-row gap-1" onPress={() => router.push(`/specialists/${specialist.nick}` as any)}>
         <Text className="text-sm font-medium text-sky-600">Подробнее</Text>
         <Feather name="chevron-right" size={16} color="#0284C7" />
       </Pressable>
@@ -200,14 +214,17 @@ function CatalogState() {
   }, []);
 
   // Derive cities from real data
-  const cities = useMemo(() => [...new Set(allSpecialists.map(s => s.city).filter(Boolean) as string[])], [allSpecialists]);
+  const cities = useMemo(() => {
+    const all = allSpecialists.flatMap(s => s.cities ?? []).filter(Boolean) as string[];
+    return [...new Set(all)];
+  }, [allSpecialists]);
 
   // Derive FNS options filtered by selected city
   const fnsOptions = useMemo(() => {
     if (!selectedCity) return [];
     const allFns = allSpecialists
-      .filter(s => s.city === selectedCity)
-      .flatMap(s => (s.fnsServices ?? []).map(f => f.fns));
+      .filter(s => (s.cities ?? []).includes(selectedCity))
+      .flatMap(s => s.fnsOffices ?? []);
     return [...new Set(allFns)];
   }, [selectedCity, allSpecialists]);
 
@@ -219,8 +236,8 @@ function CatalogState() {
   // Filter specialists
   const filtered = useMemo(() => {
     return allSpecialists.filter((sp) => {
-      if (selectedCity && sp.city !== selectedCity) return false;
-      if (selectedFns && !(sp.fnsServices ?? []).some(f => f.fns === selectedFns)) return false;
+      if (selectedCity && !(sp.cities ?? []).includes(selectedCity)) return false;
+      if (selectedFns && !(sp.fnsOffices ?? []).includes(selectedFns)) return false;
       return true;
     });
   }, [selectedCity, selectedFns, allSpecialists]);
@@ -307,7 +324,7 @@ function CatalogState() {
         <View className={`gap-3 ${isDesktop ? 'flex-row flex-wrap' : ''}`}>
           {filtered.map((sp) => (
             <SpecialistCard
-              key={sp.id}
+              key={sp.nick}
               specialist={sp}
               matchedFns={selectedFns || undefined}
             />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -22,7 +22,7 @@ function LogoBlock() {
   );
 }
 
-function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void }) {
+function BurgerDrawer({ open, onToggle, isAuthenticated }: { open: boolean; onToggle: () => void; isAuthenticated: boolean }) {
   if (!open) return null;
   return (
     <>
@@ -46,11 +46,15 @@ function BurgerDrawer({ open, onToggle }: { open: boolean; onToggle: () => void 
             <Text className="text-base text-textSecondary">{link.label}</Text>
           </Pressable>
         ))}
-        <View className="my-2 h-px bg-borderLight" />
-        <Pressable className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push('/(auth)/role' as any); }}>
-          <Feather name="log-in" size={18} color={Colors.brandPrimary} />
-          <Text className="text-base font-semibold text-brandPrimary">Войти</Text>
-        </Pressable>
+        {!isAuthenticated && (
+          <>
+            <View className="my-2 h-px bg-borderLight" />
+            <Pressable className="flex-row items-center gap-3 py-2.5" onPress={() => { onToggle(); router.push('/(auth)/role' as any); }}>
+              <Feather name="log-in" size={18} color={Colors.brandPrimary} />
+              <Text className="text-base font-semibold text-brandPrimary">Войти</Text>
+            </Pressable>
+          </>
+        )}
       </View>
     </>
   );
@@ -73,7 +77,7 @@ export function Header({
   const { user, isAuthenticated } = useAuth();
 
   useEffect(() => {
-    if (variant !== 'auth' || !isAuthenticated || hasNotif !== undefined) return;
+    if (variant === 'back' || !isAuthenticated || hasNotif !== undefined) return;
     let cancelled = false;
     const load = () => {
       notifications.unreadCount()
@@ -108,6 +112,12 @@ export function Header({
     );
   }
 
+  // variant === 'auth' OR (variant === 'guest' AND user is logged in — avoid
+  // stale "Войти" CTA on shared/public pages like /specialists).
+  const initials = user
+    ? ((user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '')).toUpperCase() || 'U'
+    : 'U';
+
   if (variant === 'guest') {
     return (
       <View className="relative" style={{ zIndex: 10 }}>
@@ -117,9 +127,27 @@ export function Header({
         >
           <LogoBlock />
           <View className="flex-row items-center gap-4">
-            <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4" onPress={() => router.push('/(auth)/role' as any)}>
-              <Text className="text-sm font-semibold text-white">Войти</Text>
-            </Pressable>
+            {isAuthenticated ? (
+              <>
+                <Pressable onPress={() => router.push('/notifications' as any)}>
+                  <Feather name="bell" size={20} color={Colors.textSecondary} />
+                  {showNotifDot && (
+                    <View className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-statusError" />
+                  )}
+                </Pressable>
+                <Pressable
+                  className="h-8 w-8 items-center justify-center rounded-full border bg-bgSecondary"
+                  style={{ borderColor: Colors.border }}
+                  onPress={() => router.push('/(tabs)/profile' as any)}
+                >
+                  <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
+                </Pressable>
+              </>
+            ) : (
+              <Pressable className="h-9 flex-row items-center gap-1.5 rounded-lg bg-brandPrimary px-4" onPress={() => router.push('/(auth)/role' as any)}>
+                <Text className="text-sm font-semibold text-white">Войти</Text>
+              </Pressable>
+            )}
             <Pressable onPress={() => setBurgerOpen(!burgerOpen)}>
               <Feather
                 name={burgerOpen ? 'x' : 'menu'}
@@ -129,15 +157,10 @@ export function Header({
             </Pressable>
           </View>
         </View>
-        <BurgerDrawer open={burgerOpen} onToggle={() => setBurgerOpen(false)} />
+        <BurgerDrawer open={burgerOpen} onToggle={() => setBurgerOpen(false)} isAuthenticated={isAuthenticated} />
       </View>
     );
   }
-
-  // variant === 'auth'
-  const initials = user
-    ? ((user.firstName?.[0] ?? '') + (user.lastName?.[0] ?? '')).toUpperCase() || 'U'
-    : 'U';
 
   return (
     <View


### PR DESCRIPTION
## Summary
- specialists list/detail: map to real API shape (nick/displayName/cities[0]/services/fnsOffices/activity.avgRating). Fixes all cards rendering dashes.
- specialist card link uses item.nick (matches detail route /specialists/[nick]).
- new request form: require city in isValid (DTO @IsNotEmpty).
- add /my-requests -> /requests redirect.
- add /login -> /(auth)/role redirect.
- Header guest variant: when authenticated, show bell + avatar instead of "Войти"; burger drops login entry when logged in.

## Test plan
- [ ] /specialists lists cards with real names + ratings
- [ ] Click card -> /specialists/<nick> loads, no 404
- [ ] /my-requests/new submit returns 201, redirects to request detail
- [ ] /my-requests -> /requests redirect works
- [ ] /login -> /(auth)/role redirect works
- [ ] /specialists while logged in -> no "Войти"