### PR TITLE
fix(auth/onboarding): wire role through OTP + branch profile copy + allow test TLDs

### DIFF
--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,19 +1,28 @@
 import { Controller, Post, Body, UseGuards, Res, Req } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { IsEmail, IsString, Length, IsOptional, IsIn, Matches } from 'class-validator';
+import { IsString, Length, IsOptional, IsIn, Matches } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { Response, Request as ExpressRequest } from 'express';
 import { AuthService } from './auth.service';
 import { EmailThrottlerGuard } from './email-throttler.guard';
 import { IpThrottlerGuard } from './ip-throttler.guard';
 
+// Accept any reasonable email including test TLDs like .p2ptax / .test / .local.
+// Stricter than frontend .includes('@') but friendlier than validator.js @IsEmail
+// which rejects TLDs containing digits (breaks e2e and dev flows).
+const EMAIL_REGEX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z0-9]{2,}$/;
+
 class RequestOtpDto {
-  @IsEmail()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  @IsString({ message: 'Введите корректный email адрес' })
+  @Matches(EMAIL_REGEX, { message: 'Введите корректный email адрес' })
   email!: string;
 }
 
 class VerifyOtpDto {
-  @IsEmail()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  @IsString({ message: 'Введите корректный email адрес' })
+  @Matches(EMAIL_REGEX, { message: 'Введите корректный email адрес' })
   email!: string;
 
   @IsString({ message: 'code must be a string' })

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -4,9 +4,11 @@ import { Feather } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Header } from '../../components/Header';
 import { auth } from '../../lib/api/endpoints';
+import { useAuth } from '../../lib/auth';
 
 export default function OtpScreen() {
   const router = useRouter();
+  const { login: authLogin } = useAuth();
   const { email, role } = useLocalSearchParams<{ email: string; role?: string }>();
   const [digits, setDigits] = useState<string[]>(['', '', '', '', '', '']);
   const [error, setError] = useState('');
@@ -50,6 +52,25 @@ export default function OtpScreen() {
       const data = (res as any).data ?? res;
       const isNewUser: boolean = data?.isNewUser ?? false;
       const userRole: string = data?.user?.role ?? role ?? 'CLIENT';
+
+      // Sync AuthContext so downstream screens (onboarding) see the correct role
+      // Without this, useAuth() returns role=null and specialist-only steps are skipped.
+      try {
+        const u = data?.user ?? {};
+        await authLogin(
+          data.accessToken,
+          data.refreshToken,
+          {
+            id: u.userId ?? u.id ?? '',
+            email: u.email ?? email,
+            role: (u.role ?? userRole) as 'CLIENT' | 'SPECIALIST' | 'ADMIN',
+            username: u.username ?? undefined,
+            isNewUser,
+          },
+        );
+      } catch {
+        // Non-critical — tokens are already stored by verifyOtp
+      }
 
       if (isNewUser) {
         // New user: start onboarding

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -101,8 +101,14 @@ export default function OnboardingProfilePage() {
           {role === 'SPECIALIST' ? 'Шаг 3 из 3' : 'Шаг 2 из 2'}
         </Text>
 
-        <Text className="text-xl font-bold text-textPrimary">Расскажите о себе</Text>
-        <Text className="mb-4 text-base text-textMuted">Эта информация поможет клиентам выбрать вас</Text>
+        <Text className="text-xl font-bold text-textPrimary">
+          {role === 'SPECIALIST' ? 'Расскажите о себе' : 'Контактные данные'}
+        </Text>
+        <Text className="mb-4 text-base text-textMuted">
+          {role === 'SPECIALIST'
+            ? 'Эта информация поможет клиентам выбрать вас'
+            : 'Добавьте телефон, чтобы специалисты могли связаться с вами быстрее'}
+        </Text>
 
         {/* Avatar */}
         <View className="mb-4 flex-row items-center gap-4">
@@ -123,23 +129,25 @@ export default function OnboardingProfilePage() {
           </View>
         </View>
 
-        {/* Description */}
-        <View className="mb-3">
-          <View className="mb-1 flex-row items-center justify-between">
-            <Text className="text-sm font-medium text-textSecondary">О себе</Text>
-            <Text className={`text-xs ${description.length > maxChars ? 'text-red-600' : 'text-textMuted'}`}>{description.length}/{maxChars}</Text>
+        {/* Description — specialist only (clients have no bio column) */}
+        {role === 'SPECIALIST' && (
+          <View className="mb-3">
+            <View className="mb-1 flex-row items-center justify-between">
+              <Text className="text-sm font-medium text-textSecondary">О себе</Text>
+              <Text className={`text-xs ${description.length > maxChars ? 'text-red-600' : 'text-textMuted'}`}>{description.length}/{maxChars}</Text>
+            </View>
+            <TextInput
+              value={description}
+              onChangeText={setDescription}
+              placeholder="Расскажите о вашем опыте..."
+              placeholderTextColor="#94A3B8"
+              multiline
+              className="rounded-lg border border-gray-200 p-3 text-base text-textPrimary"
+              style={{ minHeight: 80, textAlignVertical: 'top', outlineStyle: 'none' as any }}
+              maxLength={maxChars}
+            />
           </View>
-          <TextInput
-            value={description}
-            onChangeText={setDescription}
-            placeholder="Расскажите о вашем опыте..."
-            placeholderTextColor="#94A3B8"
-            multiline
-            className="rounded-lg border border-gray-200 p-3 text-base text-textPrimary"
-            style={{ minHeight: 80, textAlignVertical: 'top', outlineStyle: 'none' as any }}
-            maxLength={maxChars}
-          />
-        </View>
+        )}
 
         {/* Phone */}
         <View className="mb-3">
@@ -158,21 +166,23 @@ export default function OnboardingProfilePage() {
           </View>
         </View>
 
-        {/* Telegram */}
-        <View className="mb-4">
-          <Text className="mb-1 text-sm font-medium text-textSecondary">Telegram</Text>
-          <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
-            <Feather name="send" size={16} color="#94A3B8" />
-            <TextInput
-              value={telegram}
-              onChangeText={setTelegram}
-              placeholder="@username"
-              placeholderTextColor="#94A3B8"
-              className="flex-1 text-base text-textPrimary"
-              style={{ outlineStyle: 'none' as any }}
-            />
+        {/* Telegram — specialist only */}
+        {role === 'SPECIALIST' && (
+          <View className="mb-4">
+            <Text className="mb-1 text-sm font-medium text-textSecondary">Telegram</Text>
+            <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
+              <Feather name="send" size={16} color="#94A3B8" />
+              <TextInput
+                value={telegram}
+                onChangeText={setTelegram}
+                placeholder="@username"
+                placeholderTextColor="#94A3B8"
+                className="flex-1 text-base text-textPrimary"
+                style={{ outlineStyle: 'none' as any }}
+              />
+            </View>
           </View>
-        </View>
+        )}
 
         {error ? (
           <View className="mb-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">


### PR DESCRIPTION
## Summary
- **Bug 1 (role discarded)**: OTP screen now calls `authLogin()` from AuthContext after successful verify, so downstream onboarding screens read the correct role. Without this, `useAuth()` returned null and specialist-only steps were silently skipped. Frontend was already sending role — backend DTO already accepted it — but the in-memory AuthContext was never notified.
- **Bug 2 (work-area step missing)**: fixed as a side-effect of bug 1. `username.tsx` already routes to `/work-area` when `role === 'SPECIALIST'`; now that role propagates correctly through AuthContext, the step actually triggers.
- **Bug 3 (client onboarding uses specialist copy)**: `profile.tsx` now branches title, description, and fields by role. Specialist keeps bio + telegram; client gets "Контактные данные" with only phone (bio/telegram have no client column anyway).
- **Bug 4 (email validation rejects `.p2ptax` with raw 400)**: replaced `@IsEmail()` on request-otp / verify-otp with a regex + localized Russian message. `validator.js` rejects TLDs containing digits, which broke the e2e test domain. Other email DTOs in users controller untouched (out of scope).

## Test plan
- [ ] On staging, call `POST /api/auth/request-otp` with `{email: "e2e-role-check@test.p2ptax"}` — should return 200, not 400.
- [ ] Verify OTP with `role: "specialist"` → user.role in response = SPECIALIST.
- [ ] Onboarding: specialist sees `username → work-area → profile` (3 steps), client sees `username → profile` (2 steps).
- [ ] Client profile step shows "Контактные данные" title and only the phone field.