### PR TITLE
feat(api): POST /api/responses + lazy SpecialistProfile + axios 401 fix

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { StatsModule } from './stats/stats.module';
 import { ContentModule } from './content/content.module';
 import { ProtoModule } from './proto/proto.module';
 import { SearchModule } from './search/search.module';
+import { ResponsesModule } from './responses/responses.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { SearchModule } from './search/search.module';
     ContentModule,
     ProtoModule,
     SearchModule,
+    ResponsesModule,
   ],
   controllers: [AppController],
 })

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -178,6 +178,35 @@ export class AuthService {
       update: { lastLoginAt: new Date() },
     });
 
+    // Ensure a SpecialistProfile exists for users who signed up as SPECIALIST.
+    // Without this, PATCH /specialists/me 404s on first save. The profile is
+    // intentionally minimal (empty fields) — onboarding fills it in later.
+    if (isNewUser && user.role === Role.SPECIALIST) {
+      const existingProfile = await this.prisma.specialistProfile.findUnique({
+        where: { userId: user.id },
+      });
+      if (!existingProfile) {
+        // Nick must be unique; fall back to user.id (cuid) when username is null.
+        const candidateNick = user.username?.trim() || user.id;
+        const nickTaken = await this.prisma.specialistProfile.findUnique({
+          where: { nick: candidateNick },
+        });
+        const nick = nickTaken
+          ? `${candidateNick}-${Math.random().toString(36).slice(2, 6)}`
+          : candidateNick;
+        await this.prisma.specialistProfile.create({
+          data: {
+            userId: user.id,
+            nick,
+            cities: [],
+            services: [],
+            fnsOffices: [],
+            badges: [],
+          },
+        });
+      }
+    }
+
     const tokens = await this.generateTokens(user);
     return {
       ...tokens,

--- a/api/src/responses/dto/create-response.dto.ts
+++ b/api/src/responses/dto/create-response.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsNotEmpty, Length } from 'class-validator';
+
+/**
+ * Body for POST /api/responses — specialist responds to an open request.
+ *
+ * This is the core product action: a specialist sees a request in the feed
+ * and "отвечает" to it. Under the hood it creates a Thread (participants =
+ * client + specialist) and the first Message atomically. The operation is
+ * idempotent on (requestId, specialistId) — calling twice returns the same
+ * thread.
+ */
+export class CreateResponseDto {
+  @IsString()
+  @IsNotEmpty()
+  requestId!: string;
+
+  @IsString()
+  @Length(10, 1000, {
+    message: 'message должно быть от 10 до 1000 символов',
+  })
+  message!: string;
+}

--- a/api/src/responses/responses.controller.ts
+++ b/api/src/responses/responses.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { ChatService } from '../chat/chat.service';
+import { CreateResponseDto } from './dto/create-response.dto';
+
+/**
+ * POST /api/responses — specialist responds to a client request.
+ *
+ * The core product action. No separate "Response" Prisma model exists —
+ * responding means opening a Thread with the client and sending the first
+ * message. Delegates to ChatService.createThreadForRequest, which is
+ * idempotent on (requestId, specialistId).
+ *
+ * Also exposed as POST /api/requests/:id/respond for REST-shape callers.
+ */
+@Controller()
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ResponsesController {
+  constructor(private readonly chatService: ChatService) {}
+
+  /** POST /api/responses  body: { requestId, message } */
+  @Post('responses')
+  @Roles(Role.SPECIALIST)
+  @HttpCode(HttpStatus.CREATED)
+  async create(
+    @Request() req: { user: { id: string; role: Role } },
+    @Body() dto: CreateResponseDto,
+  ) {
+    const result = await this.chatService.createThreadForRequest(
+      req.user.id,
+      req.user.role,
+      dto.requestId,
+      dto.message,
+    );
+    return {
+      id: result.thread_id,
+      threadId: result.thread_id,
+      requestId: dto.requestId,
+      created: result.created,
+    };
+  }
+
+  /** POST /api/requests/:id/respond  body: { message } */
+  @Post('requests/:id/respond')
+  @Roles(Role.SPECIALIST)
+  @HttpCode(HttpStatus.CREATED)
+  async respondToRequest(
+    @Request() req: { user: { id: string; role: Role } },
+    @Param('id') requestId: string,
+    @Body() body: { message: string },
+  ) {
+    const result = await this.chatService.createThreadForRequest(
+      req.user.id,
+      req.user.role,
+      requestId,
+      body?.message ?? '',
+    );
+    return {
+      id: result.thread_id,
+      threadId: result.thread_id,
+      requestId,
+      created: result.created,
+    };
+  }
+}

--- a/api/src/responses/responses.module.ts
+++ b/api/src/responses/responses.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ResponsesController } from './responses.controller';
+import { ChatModule } from '../chat/chat.module';
+
+@Module({
+  imports: [ChatModule],
+  controllers: [ResponsesController],
+})
+export class ResponsesModule {}

--- a/api/src/specialists/specialists.service.ts
+++ b/api/src/specialists/specialists.service.ts
@@ -107,7 +107,45 @@ export class SpecialistsService {
     return profile;
   }
 
+  /**
+   * Lazy-create an empty SpecialistProfile for a user that doesn't have one yet.
+   * Called from getMyProfile / updateProfile so /specialists/me never 404s for
+   * a user with role=SPECIALIST (they may have signed up before onboarding
+   * filled in work-areas, or been promoted by admin).
+   *
+   * Returns the existing profile if present, creates a minimal one otherwise.
+   * Nick is derived from user.username (unique) or falls back to user id.
+   */
+  private async ensureProfile(userId: string) {
+    const existing = await this.prisma.specialistProfile.findUnique({ where: { userId } });
+    if (existing) return existing;
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+
+    // Pick a unique nick: prefer user.username, fall back to user id (cuid,
+    // collision-free). If somehow the derived nick is already taken, append
+    // a short random suffix.
+    let nick = user.username?.trim() || user.id;
+    const taken = await this.prisma.specialistProfile.findUnique({ where: { nick } });
+    if (taken) {
+      nick = `${nick}-${Math.random().toString(36).slice(2, 6)}`;
+    }
+
+    return this.prisma.specialistProfile.create({
+      data: {
+        userId,
+        nick,
+        cities: [],
+        services: [],
+        fnsOffices: [],
+        badges: [],
+      },
+    });
+  }
+
   async getMyProfile(userId: string) {
+    await this.ensureProfile(userId);
     const profile = await this.prisma.specialistProfile.findUnique({
       where: { userId },
       include: {
@@ -123,8 +161,7 @@ export class SpecialistsService {
   }
 
   async updateProfile(userId: string, dto: UpdateSpecialistProfileDto) {
-    const profile = await this.prisma.specialistProfile.findUnique({ where: { userId } });
-    if (!profile) throw new NotFoundException('Profile not found');
+    const profile = await this.ensureProfile(userId);
 
     // Validate badges against allowed list
     const data: any = { ...dto };

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -81,23 +81,37 @@ function processQueue(error: unknown, token: string | null = null) {
 }
 
 // ---------------------------------------------------------------------------
-// Response interceptor — error toasts for non-401 errors
+// Response interceptor — error toasts + label normalization.
+// Runs LAST on errors (axios invokes response error interceptors in reverse
+// registration order, so the refresh interceptor below runs first; only when
+// refresh gives up or the error is not a 401 do we arrive here).
 // ---------------------------------------------------------------------------
 client.interceptors.response.use(
   undefined,
   (error: AxiosError) => {
     const status = error.response?.status;
 
-    if (status && status !== 401) {
-      if (status >= 500) {
-        toast.error('Ошибка сервера, попробуйте позже');
-      } else if (status >= 400) {
-        const data = error.response?.data as { message?: string } | undefined;
-        const message = data?.message || 'Произошла ошибка запроса';
-        toast.error(message);
-      }
-    } else if (status === 401) {
-      // 401 is handled by the refresh interceptor below — skip toast
+    // Normalize 401 errors so downstream code never sees a stale message from
+    // a previous response. Bug: before this, error.message sometimes carried
+    // the "Not Found" text from the preceding 404 request on the same axios
+    // instance (axios reuses the Error object in the refresh-retry path),
+    // leading the UI to say "404" for what was really an auth failure.
+    if (status === 401) {
+      const data = error.response?.data as { message?: string } | undefined;
+      error.message = data?.message || 'Unauthorized';
+      // 401 toast is intentionally suppressed — the refresh interceptor
+      // (registered after this one, therefore runs first) handles UX: it
+      // either retries the request or emits the unauthorized event which
+      // triggers logout.
+      return Promise.reject(error);
+    }
+
+    if (status && status >= 500) {
+      toast.error('Ошибка сервера, попробуйте позже');
+    } else if (status && status >= 400) {
+      const data = error.response?.data as { message?: string } | undefined;
+      const message = data?.message || 'Произошла ошибка запроса';
+      toast.error(message);
     } else if (!error.response && error.message !== 'canceled') {
       // Network error (no response at all)
       toast.error('Нет соединения с сервером');

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -236,6 +236,30 @@ export const threads = {
 };
 
 // ---------------------------------------------------------------------------
+// Responses — specialist replies to a client request (core product action).
+// Thin alias over POST /api/threads, kept as a separate namespace because
+// "respond to a request" is the language the UI uses.
+// ---------------------------------------------------------------------------
+export interface CreateResponseResult {
+  id: string;
+  threadId: string;
+  requestId: string;
+  created: boolean;
+}
+
+export const responses = {
+  /** POST /api/responses — body { requestId, message } */
+  create(data: { requestId: string; message: string }) {
+    return client.post<CreateResponseResult>('/responses', data);
+  },
+
+  /** POST /api/requests/:id/respond — body { message } (REST-shape alias) */
+  respondToRequest(requestId: string, message: string) {
+    return client.post<CreateResponseResult>(`/requests/${requestId}/respond`, { message });
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Specialist portal (post-W-1: returns threads with request info)
 // ---------------------------------------------------------------------------
 export const specialistPortal = {


### PR DESCRIPTION
## Summary

Three P0 backend fixes enabling the core specialist flow end-to-end.

- **POST /api/responses** — new endpoint (aliased as `POST /api/requests/:id/respond`). Specialists can finally respond to a client request; under the hood it delegates to the existing `ChatService.createThreadForRequest`, which creates Thread + first Message atomically and is already idempotent on `(requestId, specialistId)` with a 20-threads/24h rate limit. No new Prisma model — schema has no explicit Response/Offer/Application model, so the "response" is the first chat message on a new Thread.
- **SpecialistProfile lazy/auto-create** — created at sign-up (`AuthService.verifyOtp`) when `role=SPECIALIST`, and lazy-created on `GET`/`PATCH /specialists/me` via a new `ensureProfile()` helper. Stops the 404 loop where a freshly-signed-up specialist couldn't edit any profile field.
- **Axios 401 normalization** — the error-toast interceptor in `lib/api/client.ts` now sets `error.message` to the 401 response's own message (or `"Unauthorized"`), preventing stale messages from the previous request (often 404) leaking through.

## Test plan

- [x] `npx tsc --noEmit` clean in `api/`
- [x] existing jest suite (`onboarding.e2e.spec.ts` — 19 tests) still passes
- [ ] after deploy: `POST /api/responses` returns 201 for specialist + open request
- [ ] after deploy: fresh specialist signup → `PATCH /specialists/me` returns 200 (not 404)
- [ ] after deploy: 401 error on the web UI shows "Unauthorized" (or server-provided message), not a leftover 404 text