### PR TITLE
fix(api): add missing settings table migration + fallback

### DIFF
--- a/api/prisma/migrations/20260416150000_add_settings_table/migration.sql
+++ b/api/prisma/migrations/20260416150000_add_settings_table/migration.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- Add settings table — fixes POST /api/requests 500 (missing public.settings)
+-- =============================================================================
+-- Schema had `model Setting` but no migration ever created it. RequestsService
+-- .getMaxRequests() + AdminService settings endpoints rely on this table.
+-- Seeds one default row so getMaxRequests() returns 5 immediately.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "settings" (
+  "id"    TEXT NOT NULL,
+  "key"   TEXT NOT NULL,
+  "value" TEXT NOT NULL,
+
+  CONSTRAINT "settings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "settings_key_key" ON "settings"("key");
+
+-- Seed default max requests per client (idempotent)
+INSERT INTO "settings" ("id", "key", "value")
+VALUES ('seed_max_requests_per_client', 'max_requests_per_client', '5')
+ON CONFLICT ("key") DO NOTHING;

--- a/api/src/requests/requests.service.ts
+++ b/api/src/requests/requests.service.ts
@@ -66,12 +66,20 @@ export class RequestsService {
   }
 
   private async getMaxRequests(): Promise<number> {
-    const setting = await this.prisma.setting.findUnique({
-      where: { key: 'max_requests_per_client' },
-    });
-    if (setting) {
-      const parsed = parseInt(setting.value, 10);
-      if (!isNaN(parsed) && parsed > 0) return parsed;
+    try {
+      const setting = await this.prisma.setting.findUnique({
+        where: { key: 'max_requests_per_client' },
+      });
+      if (setting) {
+        const parsed = parseInt(setting.value, 10);
+        if (!isNaN(parsed) && parsed > 0) return parsed;
+      }
+    } catch (err) {
+      // Fallback if settings table is missing (pending migration) or DB blip —
+      // never block request creation because of a config-lookup failure.
+      this.logger.warn(
+        `getMaxRequests: settings lookup failed, using DEFAULT_MAX_REQUESTS=${DEFAULT_MAX_REQUESTS}. ${(err as Error).message}`,
+      );
     }
     return DEFAULT_MAX_REQUESTS;
   }


### PR DESCRIPTION
## Summary
- `POST /api/requests` returns 500 on staging: `The table public.settings does not exist`.
- `model Setting` was in `schema.prisma` but no migration ever created the table.
- Adds migration `20260416150000_add_settings_table` (table + unique key index + seed row `max_requests_per_client=5`).
- Wraps `getMaxRequests()` in try/catch so config lookup failures degrade to `DEFAULT_MAX_REQUESTS` instead of crashing request creation.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] CI green
- [ ] Staging `POST /api/requests` returns 201 after merge+deploy