### PR TITLE
feat(ui): primitive component library [Phase 2]

### DIFF
--- a/app/_dev/ui.tsx
+++ b/app/_dev/ui.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, Spacing } from '../../constants/Colors';
+import {
+  Badge,
+  Button,
+  Card,
+  Container,
+  EmptyState,
+  Heading,
+  Input,
+  Modal,
+  Rating,
+  Screen,
+  Text,
+} from '../../components/ui';
+
+/**
+ * /_dev/ui — temporary demo of the components/ui/ primitive library.
+ * Not linked from navigation; for visual QA during Phase 3 migration.
+ * Remove after migration is complete.
+ */
+export default function UiDevPage() {
+  const [text, setText] = useState('');
+  const [textErr, setTextErr] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <Screen>
+      <ScrollView contentContainerStyle={{ paddingVertical: Spacing['2xl'] }}>
+        <Container>
+          <View style={{ gap: Spacing['2xl'] }}>
+            <Heading level={1}>UI primitives</Heading>
+            <Text variant="muted">
+              Demo page for the components/ui library. Not linked anywhere — accessible only
+              via /_dev/ui. Used for visual QA during Phase 3 screen migration.
+            </Text>
+
+            <Section title="Headings">
+              <Heading level={1}>Heading level 1 (display)</Heading>
+              <Heading level={2}>Heading level 2 (2xl)</Heading>
+              <Heading level={3}>Heading level 3 (xl)</Heading>
+              <Heading level={4}>Heading level 4 (lg)</Heading>
+            </Section>
+
+            <Section title="Text variants">
+              <Text variant="body">Body — default text, base 15, textPrimary.</Text>
+              <Text variant="muted">Muted — base 15, textSecondary.</Text>
+              <Text variant="caption">Caption — sm 13, textSecondary.</Text>
+              <Text variant="label">Label — sm 13, medium, textPrimary.</Text>
+              <Text weight="bold">Bold weight.</Text>
+              <Text weight="semibold">Semibold weight.</Text>
+              <Text weight="medium">Medium weight.</Text>
+              <Text weight="regular">Regular weight.</Text>
+            </Section>
+
+            <Section title="Buttons — variants (size md)">
+              <Row>
+                <Button onPress={() => { /* noop */ }}>Primary</Button>
+                <Button variant="secondary" onPress={() => { /* noop */ }}>Secondary</Button>
+                <Button variant="ghost" onPress={() => { /* noop */ }}>Ghost</Button>
+                <Button variant="danger" onPress={() => { /* noop */ }}>Danger</Button>
+              </Row>
+            </Section>
+
+            <Section title="Buttons — size lg">
+              <Row>
+                <Button size="lg" onPress={() => { /* noop */ }}>Primary lg</Button>
+                <Button size="lg" variant="secondary" onPress={() => { /* noop */ }}>Secondary lg</Button>
+              </Row>
+            </Section>
+
+            <Section title="Buttons — states">
+              <Row>
+                <Button loading onPress={() => { /* noop */ }}>Loading</Button>
+                <Button disabled onPress={() => { /* noop */ }}>Disabled</Button>
+                <Button
+                  icon={<Feather name="send" size={16} color={Colors.white} />}
+                  onPress={() => { /* noop */ }}
+                >
+                  With icon
+                </Button>
+                <Button fullWidth onPress={() => { /* noop */ }}>Full width</Button>
+              </Row>
+            </Section>
+
+            <Section title="Input">
+              <Input
+                label="Обычное поле"
+                value={text}
+                onChangeText={setText}
+                placeholder="Введите текст..."
+              />
+              <Input
+                label="С ошибкой"
+                value={textErr}
+                onChangeText={setTextErr}
+                placeholder="Ошибочное поле"
+                error="Это поле обязательно для заполнения"
+              />
+              <Input
+                label="С иконкой"
+                value={text}
+                onChangeText={setText}
+                placeholder="Поиск..."
+                icon={<Feather name="search" size={16} color={Colors.textMuted} />}
+              />
+              <Input
+                label="Отключено"
+                value="readonly value"
+                onChangeText={() => { /* noop */ }}
+                editable={false}
+              />
+              <Input
+                label="Многострочное"
+                value={text}
+                onChangeText={setText}
+                placeholder="Напишите длинный текст..."
+                multiline
+                numberOfLines={4}
+              />
+            </Section>
+
+            <Section title="Cards">
+              <Card>
+                <Heading level={4}>Elevated card</Heading>
+                <Text variant="muted">Default variant, shadow md.</Text>
+              </Card>
+              <Card variant="outlined">
+                <Heading level={4}>Outlined card</Heading>
+                <Text variant="muted">1px border, no shadow.</Text>
+              </Card>
+              <Card onPress={() => { /* noop */ }}>
+                <Heading level={4}>Pressable card</Heading>
+                <Text variant="muted">Click/tap me — scales 0.98 on press.</Text>
+              </Card>
+              <Card padding="sm">
+                <Text>Padding sm</Text>
+              </Card>
+              <Card padding="lg">
+                <Text>Padding lg</Text>
+              </Card>
+            </Section>
+
+            <Section title="Badges">
+              <Row>
+                <Badge>default</Badge>
+                <Badge variant="success">success</Badge>
+                <Badge variant="warning">warning</Badge>
+                <Badge variant="danger">danger</Badge>
+                <Badge variant="info">info</Badge>
+              </Row>
+            </Section>
+
+            <Section title="Rating">
+              <Rating value={4.5} reviewCount={127} />
+              <Rating value={3.2} reviewCount={12} size="sm" />
+              <Rating value={5} />
+              <Rating value={0} showNumeric={false} />
+            </Section>
+
+            <Section title="EmptyState">
+              <Card variant="outlined" padding="sm">
+                <EmptyState
+                  icon={<Feather name="inbox" size={40} color={Colors.textMuted} />}
+                  title="Ничего не найдено"
+                  description="Попробуйте изменить параметры поиска или сбросить фильтры."
+                  action={<Button variant="secondary" onPress={() => { /* noop */ }}>Сбросить</Button>}
+                />
+              </Card>
+            </Section>
+
+            <Section title="Modal">
+              <Button onPress={() => setModalOpen(true)}>Open modal</Button>
+            </Section>
+
+            <View style={{ height: Spacing['4xl'] }} />
+          </View>
+        </Container>
+      </ScrollView>
+
+      <Modal
+        visible={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title="Заголовок модалки"
+        primaryAction={{
+          label: 'Подтвердить',
+          onPress: () => setModalOpen(false),
+        }}
+        secondaryAction={{
+          label: 'Отмена',
+          onPress: () => setModalOpen(false),
+        }}
+      >
+        <Text>
+          Это содержимое модалки. Здесь может быть форма, текст, что угодно. Backdrop tap
+          закрывает.
+        </Text>
+        <Input
+          label="Поле внутри модалки"
+          value={text}
+          onChangeText={setText}
+          placeholder="Напишите что-нибудь"
+        />
+      </Modal>
+    </Screen>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={{ gap: Spacing.md }}>
+      <Heading level={2}>{title}</Heading>
+      <View style={{ gap: Spacing.md }}>{children}</View>
+    </View>
+  );
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return (
+    <View style={{ flexDirection: 'row', gap: Spacing.sm, flexWrap: 'wrap', alignItems: 'center' }}>
+      {children}
+    </View>
+  );
+}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
+import { Text } from './Text';
+
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+export interface BadgeProps {
+  variant?: BadgeVariant;
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+function variantColors(variant: BadgeVariant) {
+  switch (variant) {
+    case 'success':
+      return { bg: Colors.statusBg.success, text: Colors.statusSuccess };
+    case 'warning':
+      return { bg: Colors.statusBg.warning, text: Colors.statusWarning };
+    case 'danger':
+      return { bg: Colors.statusBg.error, text: Colors.statusError };
+    case 'info':
+      return { bg: Colors.statusBg.info, text: Colors.brandPrimary };
+    case 'default':
+    default:
+      return { bg: Colors.statusBg.neutral, text: Colors.textSecondary };
+  }
+}
+
+export function Badge({ variant = 'default', children, style }: BadgeProps) {
+  const colors = variantColors(variant);
+  return (
+    <View
+      style={[
+        {
+          alignSelf: 'flex-start',
+          paddingVertical: Spacing.xs,
+          paddingHorizontal: Spacing.sm,
+          borderRadius: BorderRadius.full,
+          backgroundColor: colors.bg,
+        },
+        style,
+      ]}
+    >
+      <Text
+        variant="caption"
+        style={{
+          color: colors.text,
+          fontSize: Typography.fontSize.xs,
+          fontWeight: Typography.fontWeight.semibold,
+          fontFamily: Typography.fontFamily.semibold,
+        }}
+      >
+        {children}
+      </Text>
+    </View>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  Text,
+  View,
+  type PressableStateCallbackType,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'md' | 'lg';
+
+export interface ButtonProps {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  disabled?: boolean;
+  onPress: () => void;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+  fullWidth?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+  accessibilityLabel?: string;
+}
+
+function variantColors(variant: ButtonVariant) {
+  switch (variant) {
+    case 'primary':
+      return { bg: Colors.brandPrimary, border: 'transparent', text: Colors.white };
+    case 'secondary':
+      return { bg: Colors.white, border: Colors.brandPrimary, text: Colors.brandPrimary };
+    case 'ghost':
+      return { bg: 'transparent', border: 'transparent', text: Colors.brandPrimary };
+    case 'danger':
+      return { bg: Colors.statusError, border: 'transparent', text: Colors.white };
+  }
+}
+
+function sizeMetrics(size: ButtonSize) {
+  if (size === 'lg') {
+    return {
+      paddingVertical: Spacing.md,
+      paddingHorizontal: Spacing.xl,
+      fontSize: Typography.fontSize.lg,
+      iconGap: Spacing.sm,
+    };
+  }
+  return {
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.lg,
+    fontSize: Typography.fontSize.base,
+    iconGap: Spacing.xs + Spacing.xxs, // 7 ≈ 8
+  };
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled = false,
+  onPress,
+  icon,
+  children,
+  fullWidth,
+  style,
+  testID,
+  accessibilityLabel,
+}: ButtonProps) {
+  const inactive = disabled || loading;
+  const colors = variantColors(variant);
+  const metrics = sizeMetrics(size);
+
+  const baseStyle: ViewStyle = {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: metrics.iconGap,
+    paddingVertical: metrics.paddingVertical,
+    paddingHorizontal: metrics.paddingHorizontal,
+    borderRadius: BorderRadius.btn,
+    backgroundColor: colors.bg,
+    borderWidth: variant === 'secondary' ? 1 : 0,
+    borderColor: colors.border,
+    opacity: disabled ? 0.5 : 1,
+    alignSelf: fullWidth ? 'stretch' : 'flex-start',
+    ...(Platform.OS === 'web' && !inactive ? ({ cursor: 'pointer' } as any) : null),
+  };
+
+  return (
+    <Pressable
+      onPress={inactive ? undefined : onPress}
+      disabled={inactive}
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !!disabled, busy: !!loading }}
+      accessibilityLabel={accessibilityLabel}
+      style={({ pressed }: PressableStateCallbackType) => [
+        baseStyle,
+        pressed && !inactive ? { opacity: 0.75 } : null,
+        style,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator size="small" color={colors.text} />
+      ) : icon ? (
+        <View style={{ alignItems: 'center', justifyContent: 'center' }}>{icon}</View>
+      ) : null}
+      <Text
+        style={{
+          color: colors.text,
+          fontSize: metrics.fontSize,
+          fontWeight: Typography.fontWeight.semibold,
+          fontFamily: Typography.fontFamily.semibold,
+        }}
+      >
+        {children}
+      </Text>
+    </Pressable>
+  );
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  Platform,
+  Pressable,
+  View,
+  type PressableStateCallbackType,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { BorderRadius, Colors, Shadows, Spacing } from '../../constants/Colors';
+
+export type CardVariant = 'elevated' | 'outlined';
+export type CardPadding = 'sm' | 'md' | 'lg';
+
+export interface CardProps {
+  children: React.ReactNode;
+  onPress?: () => void;
+  padding?: CardPadding;
+  variant?: CardVariant;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+const PADDING_MAP: Record<CardPadding, number> = {
+  sm: Spacing.md,
+  md: Spacing.lg,
+  lg: Spacing.xl,
+};
+
+export function Card({
+  children,
+  onPress,
+  padding = 'md',
+  variant = 'elevated',
+  style,
+  testID,
+}: CardProps) {
+  const baseStyle: ViewStyle = {
+    backgroundColor: Colors.white,
+    borderRadius: BorderRadius.card,
+    padding: PADDING_MAP[padding],
+    ...(variant === 'elevated' ? Shadows.md : null),
+    ...(variant === 'outlined'
+      ? { borderWidth: 1, borderColor: Colors.borderLight }
+      : null),
+  };
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        testID={testID}
+        style={({ pressed }: PressableStateCallbackType) => [
+          baseStyle,
+          pressed ? { transform: [{ scale: 0.98 }] } : null,
+          Platform.OS === 'web' ? ({ cursor: 'pointer' } as any) : null,
+          style,
+        ]}
+      >
+        {children}
+      </Pressable>
+    );
+  }
+
+  return <View style={[baseStyle, style]} testID={testID}>{children}</View>;
+}

--- a/components/ui/Container.tsx
+++ b/components/ui/Container.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View, useWindowDimensions, type StyleProp, type ViewStyle } from 'react-native';
+import { Breakpoints, Spacing } from '../../constants/Colors';
+
+export interface ContainerProps {
+  children: React.ReactNode;
+  maxWidth?: number;
+  style?: StyleProp<ViewStyle>;
+  padded?: boolean;
+}
+
+/**
+ * Responsive max-width wrapper.
+ * - Mobile (<tablet breakpoint): full width
+ * - Tablet/Desktop: centered with maxWidth (default 800)
+ */
+export function Container({ children, maxWidth = 800, style, padded = true }: ContainerProps) {
+  const { width } = useWindowDimensions();
+  const shouldConstrain = width >= Breakpoints.tablet;
+
+  return (
+    <View
+      style={[
+        {
+          width: '100%',
+          alignSelf: 'center',
+          maxWidth: shouldConstrain ? maxWidth : undefined,
+          paddingHorizontal: padded ? Spacing.lg : 0,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { Spacing } from '../../constants/Colors';
+import { Heading } from './Heading';
+import { Text } from './Text';
+
+export interface EmptyStateProps {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function EmptyState({ icon, title, description, action, style }: EmptyStateProps) {
+  return (
+    <View
+      style={[
+        {
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: Spacing['3xl'],
+          gap: Spacing.md,
+        },
+        style,
+      ]}
+    >
+      {icon ? <View style={{ marginBottom: Spacing.xs }}>{icon}</View> : null}
+      <Heading level={3} align="center">
+        {title}
+      </Heading>
+      {description ? (
+        <Text variant="muted" align="center">
+          {description}
+        </Text>
+      ) : null}
+      {action ? <View style={{ marginTop: Spacing.md }}>{action}</View> : null}
+    </View>
+  );
+}

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Text as RNText, type StyleProp, type TextStyle } from 'react-native';
+import { Colors, Typography } from '../../constants/Colors';
+
+export type HeadingLevel = 1 | 2 | 3 | 4;
+export type HeadingAlign = 'left' | 'center' | 'right';
+
+export interface HeadingProps {
+  level: HeadingLevel;
+  children: React.ReactNode;
+  align?: HeadingAlign;
+  style?: StyleProp<TextStyle>;
+  numberOfLines?: number;
+}
+
+const LEVEL_SIZE: Record<HeadingLevel, number> = {
+  1: Typography.fontSize.display,
+  2: Typography.fontSize['2xl'],
+  3: Typography.fontSize.xl,
+  4: Typography.fontSize.lg,
+};
+
+const LEVEL_WEIGHT: Record<HeadingLevel, { w: TextStyle['fontWeight']; family: string }> = {
+  1: { w: Typography.fontWeight.bold, family: Typography.fontFamily.bold },
+  2: { w: Typography.fontWeight.semibold, family: Typography.fontFamily.semibold },
+  3: { w: Typography.fontWeight.semibold, family: Typography.fontFamily.semibold },
+  4: { w: Typography.fontWeight.semibold, family: Typography.fontFamily.semibold },
+};
+
+export function Heading({ level, children, align = 'left', style, numberOfLines }: HeadingProps) {
+  const { w, family } = LEVEL_WEIGHT[level];
+  return (
+    <RNText
+      numberOfLines={numberOfLines}
+      accessibilityRole="header"
+      style={[
+        {
+          color: Colors.textPrimary,
+          fontSize: LEVEL_SIZE[level],
+          fontWeight: w,
+          fontFamily: family,
+          textAlign: align,
+          lineHeight: Math.round(LEVEL_SIZE[level] * Typography.lineHeight.tight),
+        },
+        style,
+      ]}
+    >
+      {children}
+    </RNText>
+  );
+}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import {
+  Platform,
+  TextInput,
+  View,
+  type KeyboardTypeOptions,
+  type StyleProp,
+  type TextInputProps,
+  type ViewStyle,
+} from 'react-native';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
+import { Text } from './Text';
+
+export interface InputProps {
+  value: string;
+  onChangeText: (v: string) => void;
+  placeholder?: string;
+  label?: string;
+  error?: string;
+  icon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  secureTextEntry?: boolean;
+  keyboardType?: KeyboardTypeOptions;
+  autoCapitalize?: TextInputProps['autoCapitalize'];
+  multiline?: boolean;
+  numberOfLines?: number;
+  maxLength?: number;
+  editable?: boolean;
+  testID?: string;
+  style?: StyleProp<ViewStyle>;
+  onBlur?: () => void;
+  onFocus?: () => void;
+}
+
+export function Input({
+  value,
+  onChangeText,
+  placeholder,
+  label,
+  error,
+  icon,
+  rightIcon,
+  secureTextEntry,
+  keyboardType,
+  autoCapitalize,
+  multiline,
+  numberOfLines,
+  maxLength,
+  editable = true,
+  testID,
+  style,
+  onBlur,
+  onFocus,
+}: InputProps) {
+  const [focused, setFocused] = useState(false);
+
+  const borderColor = error
+    ? Colors.statusError
+    : focused
+    ? Colors.brandPrimary
+    : Colors.borderLight;
+
+  const fieldStyle: ViewStyle = {
+    flexDirection: 'row',
+    alignItems: multiline ? 'flex-start' : 'center',
+    gap: Spacing.sm,
+    borderWidth: 1,
+    borderColor,
+    backgroundColor: Colors.white,
+    borderRadius: BorderRadius.input,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: multiline ? Spacing.md : Spacing.sm + Spacing.xxs, // 11
+    opacity: editable ? 1 : 0.6,
+  };
+
+  return (
+    <View style={[{ gap: Spacing.xs + Spacing.xxs }, style]}>
+      {label ? (
+        <Text variant="label">{label}</Text>
+      ) : null}
+      <View style={fieldStyle}>
+        {icon ? <View style={{ alignItems: 'center', justifyContent: 'center' }}>{icon}</View> : null}
+        <TextInput
+          testID={testID}
+          value={value}
+          onChangeText={onChangeText}
+          placeholder={placeholder}
+          placeholderTextColor={Colors.textMuted}
+          secureTextEntry={secureTextEntry}
+          keyboardType={keyboardType}
+          autoCapitalize={autoCapitalize}
+          multiline={multiline}
+          numberOfLines={numberOfLines}
+          maxLength={maxLength}
+          editable={editable}
+          onFocus={() => { setFocused(true); onFocus?.(); }}
+          onBlur={() => { setFocused(false); onBlur?.(); }}
+          style={[
+            {
+              flex: 1,
+              fontSize: Typography.fontSize.base,
+              fontFamily: Typography.fontFamily.regular,
+              color: Colors.textPrimary,
+              textAlignVertical: multiline ? 'top' : 'center',
+              minHeight: multiline ? 96 : undefined,
+            },
+            Platform.OS === 'web' ? ({ outlineStyle: 'none' } as any) : null,
+          ]}
+        />
+        {rightIcon ? (
+          <View style={{ alignItems: 'center', justifyContent: 'center' }}>{rightIcon}</View>
+        ) : null}
+      </View>
+      {error ? (
+        <Text variant="caption" style={{ color: Colors.statusError }}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {
+  Modal as RNModal,
+  Platform,
+  Pressable,
+  ScrollView,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { BorderRadius, Colors, Spacing } from '../../constants/Colors';
+import { Button } from './Button';
+import { Heading } from './Heading';
+
+export interface ModalAction {
+  label: string;
+  onPress: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export interface ModalProps {
+  visible: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  primaryAction?: ModalAction;
+  secondaryAction?: ModalAction;
+  /** Max width of the content panel (px). */
+  maxWidth?: number;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function Modal({
+  visible,
+  onClose,
+  title,
+  children,
+  primaryAction,
+  secondaryAction,
+  maxWidth = 480,
+  style,
+}: ModalProps) {
+  const animationType = Platform.OS === 'web' ? 'fade' : 'slide';
+
+  return (
+    <RNModal
+      visible={visible}
+      transparent
+      animationType={animationType}
+      onRequestClose={onClose}
+    >
+      {/* Backdrop */}
+      <Pressable
+        onPress={onClose}
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(12, 26, 46, 0.5)',
+          justifyContent: Platform.OS === 'web' ? 'center' : 'flex-end',
+          alignItems: 'center',
+          padding: Platform.OS === 'web' ? Spacing.lg : 0,
+        }}
+      >
+        {/* Panel — stop propagation by wrapping in its own Pressable */}
+        <Pressable
+          onPress={(e) => e.stopPropagation()}
+          style={[
+            {
+              width: '100%',
+              maxWidth: Platform.OS === 'web' ? maxWidth : undefined,
+              maxHeight: '90%',
+              backgroundColor: Colors.white,
+              borderTopLeftRadius: BorderRadius.xl,
+              borderTopRightRadius: BorderRadius.xl,
+              borderBottomLeftRadius: Platform.OS === 'web' ? BorderRadius.xl : 0,
+              borderBottomRightRadius: Platform.OS === 'web' ? BorderRadius.xl : 0,
+              padding: Spacing.xl,
+              gap: Spacing.lg,
+            },
+            style,
+          ]}
+        >
+          {title ? (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+              <View style={{ flex: 1 }}>
+                <Heading level={3}>{title}</Heading>
+              </View>
+              <Pressable
+                onPress={onClose}
+                hitSlop={8}
+                accessibilityLabel="Закрыть"
+                accessibilityRole="button"
+                style={{ padding: Spacing.xs }}
+              >
+                <Feather name="x" size={20} color={Colors.textMuted} />
+              </Pressable>
+            </View>
+          ) : null}
+
+          <ScrollView
+            style={{ flexGrow: 0 }}
+            contentContainerStyle={{ gap: Spacing.md }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {children}
+          </ScrollView>
+
+          {(primaryAction || secondaryAction) && (
+            <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+              {secondaryAction ? (
+                <View style={{ flex: 1 }}>
+                  <Button
+                    variant="secondary"
+                    onPress={secondaryAction.onPress}
+                    disabled={secondaryAction.disabled}
+                    loading={secondaryAction.loading}
+                    fullWidth
+                  >
+                    {secondaryAction.label}
+                  </Button>
+                </View>
+              ) : null}
+              {primaryAction ? (
+                <View style={{ flex: 1 }}>
+                  <Button
+                    variant="primary"
+                    onPress={primaryAction.onPress}
+                    disabled={primaryAction.disabled}
+                    loading={primaryAction.loading}
+                    fullWidth
+                  >
+                    {primaryAction.label}
+                  </Button>
+                </View>
+              ) : null}
+            </View>
+          )}
+        </Pressable>
+      </Pressable>
+    </RNModal>
+  );
+}

--- a/components/ui/Rating.tsx
+++ b/components/ui/Rating.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, Spacing, Typography } from '../../constants/Colors';
+import { Text } from './Text';
+
+export type RatingSize = 'sm' | 'md';
+
+export interface RatingProps {
+  value: number;
+  reviewCount?: number;
+  size?: RatingSize;
+  showNumeric?: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+const STAR_COUNT = 5;
+
+function iconSize(size: RatingSize) {
+  return size === 'sm' ? 12 : 16;
+}
+
+function textSize(size: RatingSize) {
+  return size === 'sm' ? Typography.fontSize.xs : Typography.fontSize.sm;
+}
+
+/**
+ * Rating row: star icons + numeric value + optional review count.
+ * `value` may be fractional (0–5). Stars render as full when >= i+1, otherwise empty.
+ * (Half-star uses Feather which lacks `star-half` — we round-to-nearest for simplicity;
+ * fractional numeric is still shown.)
+ */
+export function Rating({ value, reviewCount, size = 'md', showNumeric = true, style }: RatingProps) {
+  const clamped = Math.max(0, Math.min(STAR_COUNT, value));
+  const iSize = iconSize(size);
+  const tSize = textSize(size);
+
+  return (
+    <View
+      style={[
+        { flexDirection: 'row', alignItems: 'center', gap: Spacing.xs + Spacing.xxs },
+        style,
+      ]}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 2 }}>
+        {Array.from({ length: STAR_COUNT }).map((_, i) => {
+          const filled = clamped >= i + 0.5;
+          return (
+            <Feather
+              key={i}
+              name="star"
+              size={iSize}
+              color={filled ? Colors.amber : Colors.borderLight}
+            />
+          );
+        })}
+      </View>
+      {showNumeric ? (
+        <Text
+          style={{
+            fontSize: tSize,
+            color: Colors.textPrimary,
+            fontWeight: Typography.fontWeight.semibold,
+            fontFamily: Typography.fontFamily.semibold,
+          }}
+        >
+          {clamped.toFixed(1)}
+        </Text>
+      ) : null}
+      {typeof reviewCount === 'number' ? (
+        <Text style={{ fontSize: tSize, color: Colors.textMuted }}>
+          ({reviewCount})
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/components/ui/Screen.tsx
+++ b/components/ui/Screen.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { type StyleProp, type ViewStyle } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Colors } from '../../constants/Colors';
+
+export interface ScreenProps {
+  children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
+  bg?: string;
+}
+
+export function Screen({ children, style, bg }: ScreenProps) {
+  return (
+    <SafeAreaView style={[{ flex: 1, backgroundColor: bg ?? Colors.bgPrimary }, style]}>
+      {children}
+    </SafeAreaView>
+  );
+}

--- a/components/ui/Text.tsx
+++ b/components/ui/Text.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Text as RNText, type StyleProp, type TextStyle } from 'react-native';
+import { Colors, Typography } from '../../constants/Colors';
+
+export type TextVariant = 'body' | 'muted' | 'caption' | 'label';
+export type TextWeight = 'regular' | 'medium' | 'semibold' | 'bold';
+export type TextAlign = 'left' | 'center' | 'right';
+
+export interface TextProps {
+  variant?: TextVariant;
+  weight?: TextWeight;
+  align?: TextAlign;
+  children: React.ReactNode;
+  style?: StyleProp<TextStyle>;
+  numberOfLines?: number;
+  selectable?: boolean;
+}
+
+function variantStyle(variant: TextVariant): TextStyle {
+  switch (variant) {
+    case 'body':
+      return { fontSize: Typography.fontSize.base, color: Colors.textPrimary };
+    case 'muted':
+      return { fontSize: Typography.fontSize.base, color: Colors.textSecondary };
+    case 'caption':
+      return { fontSize: Typography.fontSize.sm, color: Colors.textSecondary };
+    case 'label':
+      return {
+        fontSize: Typography.fontSize.sm,
+        color: Colors.textPrimary,
+        fontWeight: Typography.fontWeight.medium,
+        fontFamily: Typography.fontFamily.medium,
+      };
+  }
+}
+
+function weightStyle(weight: TextWeight): TextStyle {
+  return {
+    fontWeight: Typography.fontWeight[weight],
+    fontFamily: Typography.fontFamily[weight],
+  };
+}
+
+export function Text({
+  variant = 'body',
+  weight,
+  align,
+  children,
+  style,
+  numberOfLines,
+  selectable,
+}: TextProps) {
+  return (
+    <RNText
+      numberOfLines={numberOfLines}
+      selectable={selectable}
+      style={[
+        variantStyle(variant),
+        weight ? weightStyle(weight) : null,
+        align ? { textAlign: align } : null,
+        style,
+      ]}
+    >
+      {children}
+    </RNText>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -1,0 +1,32 @@
+export { Button } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+
+export { Input } from './Input';
+export type { InputProps } from './Input';
+
+export { Heading } from './Heading';
+export type { HeadingProps, HeadingLevel, HeadingAlign } from './Heading';
+
+export { Text } from './Text';
+export type { TextProps, TextVariant, TextWeight, TextAlign } from './Text';
+
+export { Card } from './Card';
+export type { CardProps, CardVariant, CardPadding } from './Card';
+
+export { Screen } from './Screen';
+export type { ScreenProps } from './Screen';
+
+export { Container } from './Container';
+export type { ContainerProps } from './Container';
+
+export { EmptyState } from './EmptyState';
+export type { EmptyStateProps } from './EmptyState';
+
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeVariant } from './Badge';
+
+export { Rating } from './Rating';
+export type { RatingProps, RatingSize } from './Rating';
+
+export { Modal } from './Modal';
+export type { ModalProps, ModalAction } from './Modal';

--- a/hooks/useBreakpoint.ts
+++ b/hooks/useBreakpoint.ts
@@ -1,0 +1,34 @@
+import { useWindowDimensions } from 'react-native';
+
+/**
+ * Thin generic breakpoint hook for primitives in components/ui/.
+ * Project-specific helpers (numColumns, sidebarWidth, contentMaxWidth) live
+ * in `useBreakpoints` (plural) — keep them decoupled.
+ */
+export const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+} as const;
+
+export type BreakpointKey = keyof typeof BREAKPOINTS;
+
+export interface BreakpointInfo {
+  width: number;
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+  atLeast: (bp: BreakpointKey) => boolean;
+}
+
+export function useBreakpoint(): BreakpointInfo {
+  const { width } = useWindowDimensions();
+  return {
+    width,
+    isMobile: width < BREAKPOINTS.md,
+    isTablet: width >= BREAKPOINTS.md && width < BREAKPOINTS.lg,
+    isDesktop: width >= BREAKPOINTS.lg,
+    atLeast: (bp: BreakpointKey) => width >= BREAKPOINTS[bp],
+  };
+}


### PR DESCRIPTION
Phase 2 of UI overhaul.

Pure additions: new components/ui/ directory + useBreakpoint hook. Existing screens untouched — they migrate in Phase 3.

## New primitives
- Button, Input, Heading, Text, Card, Screen, Container
- EmptyState, Badge, Rating, Modal
- hooks/useBreakpoint

## Tokens compliance
- 0 raw hex literals
- 0 raw fontSize numbers
- 0 StyleSheet.create (nativewind where possible)

## Demo
/_dev/ui renders all variants for visual QA.