### PR TITLE
refactor(ui): migrate auth+onboarding screens [Phase 3A]

### DIFF
--- a/app/(auth)/email.tsx
+++ b/app/(auth)/email.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, TextInput } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Header } from '../../components/Header';
 import { auth } from '../../lib/api/endpoints';
+import { Button, Card, Container, Heading, Input, Screen, Text } from '../../components/ui';
+import { Colors, Spacing } from '../../constants/Colors';
 
 export default function AuthEmailScreen() {
   const router = useRouter();
@@ -38,66 +40,72 @@ export default function AuthEmailScreen() {
   };
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Вход" onBack={() => router.back()} />
-      <View className="flex-1 items-center justify-center bg-white px-4 py-8">
-      <View className="mb-8 items-center gap-2">
-        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
-          <Feather name="shield" size={28} color="#0284C7" />
-        </View>
-        <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
-        <Text className="text-base text-textMuted">
-          {role === 'SPECIALIST' ? 'Регистрация специалиста' : 'Найдите налогового специалиста'}
-        </Text>
-      </View>
-
-      <View className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6">
-        <Text className="mb-1 text-center text-lg font-bold text-textPrimary">Войти или зарегистрироваться</Text>
-        <Text className="mb-4 text-center text-sm text-textMuted">Отправим код подтверждения на ваш email</Text>
-
-        <Text className="mb-1 text-sm font-medium text-textSecondary">Email</Text>
-        <View className={`mb-2 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${error ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'} ${loading ? 'opacity-60' : ''}`}>
-          <Feather name="mail" size={18} color={error ? '#DC2626' : '#94A3B8'} />
-          <TextInput
-            value={email}
-            onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
-            placeholder="your@email.com"
-            placeholderTextColor="#94A3B8"
-            className="flex-1 text-base text-textPrimary"
-            style={{ outlineStyle: 'none' } as any}
-            keyboardType="email-address"
-            autoCapitalize="none"
-            editable={!loading}
-          />
-          {email.length > 0 && !loading && (
-            <Pressable onPress={() => setEmail('')} hitSlop={8}>
-              <Feather name="x-circle" size={16} color="#94A3B8" />
-            </Pressable>
-          )}
-        </View>
-
-        {error ? (
-          <View className="mb-2 flex-row items-center gap-1">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{error}</Text>
+      <Container>
+        <View style={{ paddingVertical: Spacing['2xl'], gap: Spacing['2xl'] }}>
+          <View style={{ alignItems: 'center', gap: Spacing.sm }}>
+            <View
+              style={{
+                height: 64,
+                width: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: Colors.bgSecondary,
+              }}
+            >
+              <Feather name="shield" size={28} color={Colors.brandPrimary} />
+            </View>
+            <Heading level={2} align="center">Налоговик</Heading>
+            <Text variant="muted" align="center">
+              {role === 'SPECIALIST' ? 'Регистрация специалиста' : 'Найдите налогового специалиста'}
+            </Text>
           </View>
-        ) : null}
 
-        <Pressable
-          onPress={handleSubmit}
-          disabled={loading}
-          className={`mt-1 h-12 items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
-        >
-          <Text className="text-base font-semibold text-white">
-            {loading ? 'Отправка...' : 'Отправить код'}
+          <Card variant="outlined" padding="lg">
+            <View style={{ gap: Spacing.lg }}>
+              <View style={{ gap: Spacing.xs }}>
+                <Heading level={4} align="center">Войти или зарегистрироваться</Heading>
+                <Text variant="caption" align="center">Отправим код подтверждения на ваш email</Text>
+              </View>
+
+              <Input
+                label="Email"
+                value={email}
+                onChangeText={(t) => { setEmail(t); if (error) setError(''); }}
+                placeholder="your@email.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                editable={!loading}
+                error={error || undefined}
+                icon={<Feather name="mail" size={18} color={error ? Colors.statusError : Colors.textMuted} />}
+                rightIcon={
+                  email.length > 0 && !loading ? (
+                    <Pressable onPress={() => setEmail('')} hitSlop={8}>
+                      <Feather name="x-circle" size={16} color={Colors.textMuted} />
+                    </Pressable>
+                  ) : undefined
+                }
+              />
+
+              <Button
+                variant="primary"
+                size="lg"
+                fullWidth
+                loading={loading}
+                onPress={handleSubmit}
+              >
+                {loading ? 'Отправка...' : 'Отправить код'}
+              </Button>
+            </View>
+          </Card>
+
+          <Text variant="caption" align="center">
+            {'Нажимая кнопку, вы соглашаетесь с\nусловиями использования'}
           </Text>
-        </Pressable>
-      </View>
-
-      <Text className="mt-6 text-center text-xs text-textMuted">
-        {'Нажимая кнопку, вы соглашаетесь с\nусловиями использования'}
-      </Text>
-      </View>
-    </View>
+        </View>
+      </Container>
+    </Screen>
   );
 }

--- a/app/(auth)/otp.tsx
+++ b/app/(auth)/otp.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { View, Text, Pressable, TextInput } from 'react-native';
+import { Platform, Pressable, TextInput, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Header } from '../../components/Header';
 import { auth } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
+import { Button, Container, Heading, Screen, Text } from '../../components/ui';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
 
 export default function OtpScreen() {
   const router = useRouter();
@@ -53,8 +55,7 @@ export default function OtpScreen() {
       const isNewUser: boolean = data?.isNewUser ?? false;
       const userRole: string = data?.user?.role ?? role ?? 'CLIENT';
 
-      // Sync AuthContext so downstream screens (onboarding) see the correct role
-      // Without this, useAuth() returns role=null and specialist-only steps are skipped.
+      // Sync AuthContext so downstream screens (onboarding) see the correct role.
       try {
         const u = data?.user ?? {};
         await authLogin(
@@ -73,7 +74,6 @@ export default function OtpScreen() {
       }
 
       if (isNewUser) {
-        // New user: start onboarding
         router.replace('/(onboarding)/username' as any);
       } else if (userRole === 'SPECIALIST') {
         router.replace('/(tabs)/specialist-dashboard' as any);
@@ -106,67 +106,136 @@ export default function OtpScreen() {
   };
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Подтверждение" onBack={() => router.back()} />
-      <View className="flex-1 items-center bg-white px-4 py-8">
-      <View className="w-full max-w-sm">
-        <Pressable className="flex-row items-center gap-1 py-1" onPress={() => router.back()}>
-          <Feather name="arrow-left" size={20} color="#475569" />
-          <Text className="text-sm text-textSecondary">Изменить email</Text>
-        </Pressable>
-      </View>
-      <View className="mt-6 items-center gap-2">
-        <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
-          <Feather name="mail" size={28} color="#0284C7" />
-        </View>
-        <Text className="text-xl font-bold text-textPrimary">Введите код</Text>
-        <View className="flex-row items-center">
-          <Text className="text-base text-textMuted">Код отправлен на </Text>
-          <Text className="text-base font-medium text-textPrimary">{email ?? '...'}</Text>
-        </View>
-      </View>
-      <View className="mt-5 flex-row justify-center gap-2">
-        {[0, 1, 2, 3, 4, 5].map((i) => (
-          <View key={i} className={`h-14 w-12 items-center justify-center rounded-lg border-2 ${error ? 'border-red-500 bg-red-50' : digits[i] ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200 bg-white'}`}>
-            <TextInput
-              ref={(ref) => { inputRefs.current[i] = ref; }}
-              value={digits[i]}
-              onChangeText={(v) => handleDigitChange(i, v)}
-              keyboardType="number-pad"
-              maxLength={1}
-              selectTextOnFocus
-              editable={!loading}
-              className="h-full w-full text-center text-2xl font-bold text-textPrimary"
-              style={{ outlineStyle: 'none' } as any}
-            />
+      <Container>
+        <View style={{ paddingVertical: Spacing['2xl'], gap: Spacing.lg, alignItems: 'center' }}>
+          <View style={{ alignSelf: 'stretch' }}>
+            <Button
+              variant="ghost"
+              size="md"
+              onPress={() => router.back()}
+              icon={<Feather name="arrow-left" size={18} color={Colors.brandPrimary} />}
+            >
+              Изменить email
+            </Button>
           </View>
-        ))}
-      </View>
-      {error ? (
-        <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-          <Feather name="alert-circle" size={14} color="#DC2626" />
-          <Text className="text-sm font-medium text-red-600">{error}</Text>
+
+          <View style={{ alignItems: 'center', gap: Spacing.sm, marginTop: Spacing.sm }}>
+            <View
+              style={{
+                height: 64,
+                width: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: Colors.bgSecondary,
+              }}
+            >
+              <Feather name="mail" size={28} color={Colors.brandPrimary} />
+            </View>
+            <Heading level={3} align="center">Введите код</Heading>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center' }}>
+              <Text variant="muted">Код отправлен на </Text>
+              <Text variant="body" weight="medium">{email ?? '...'}</Text>
+            </View>
+          </View>
+
+          <View style={{ flexDirection: 'row', justifyContent: 'center', gap: Spacing.sm, marginTop: Spacing.md }}>
+            {[0, 1, 2, 3, 4, 5].map((i) => {
+              const filled = !!digits[i];
+              const borderColor = error
+                ? Colors.statusError
+                : filled
+                ? Colors.brandPrimary
+                : Colors.borderLight;
+              const bgColor = error ? Colors.bgSecondary : filled ? Colors.bgSecondary : Colors.white;
+              return (
+                <View
+                  key={i}
+                  style={{
+                    height: 56,
+                    width: 48,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: BorderRadius.lg,
+                    borderWidth: 2,
+                    borderColor,
+                    backgroundColor: bgColor,
+                  }}
+                >
+                  <TextInput
+                    ref={(ref) => { inputRefs.current[i] = ref; }}
+                    value={digits[i]}
+                    onChangeText={(v) => handleDigitChange(i, v)}
+                    keyboardType="number-pad"
+                    maxLength={1}
+                    selectTextOnFocus
+                    editable={!loading}
+                    style={[
+                      {
+                        height: '100%',
+                        width: '100%',
+                        textAlign: 'center',
+                        fontSize: Typography.fontSize['2xl'],
+                        fontWeight: Typography.fontWeight.bold,
+                        fontFamily: Typography.fontFamily.bold,
+                        color: Colors.textPrimary,
+                      },
+                      Platform.OS === 'web' ? ({ outlineStyle: 'none' } as any) : null,
+                    ]}
+                  />
+                </View>
+              );
+            })}
+          </View>
+
+          {error ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.xs,
+                borderRadius: BorderRadius.lg,
+                backgroundColor: Colors.bgSecondary,
+                paddingHorizontal: Spacing.md,
+                paddingVertical: Spacing.sm,
+              }}
+            >
+              <Feather name="alert-circle" size={14} color={Colors.statusError} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.statusError }}>{error}</Text>
+            </View>
+          ) : null}
+
+          <View style={{ alignSelf: 'stretch', maxWidth: 320, width: '100%', alignItems: 'center' }}>
+            <Button
+              variant="primary"
+              size="lg"
+              fullWidth
+              loading={loading}
+              onPress={handleSubmit}
+            >
+              {loading ? 'Проверка...' : 'Подтвердить'}
+            </Button>
+          </View>
+
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, marginTop: Spacing.xs }}>
+            {resendTimer > 0 ? (
+              <>
+                <Feather name="clock" size={14} color={Colors.textMuted} />
+                <Text variant="caption">Отправить повторно через {resendTimer} сек</Text>
+              </>
+            ) : (
+              <Pressable onPress={handleResend} disabled={resendLoading} style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+                <Feather name="refresh-cw" size={14} color={Colors.brandPrimary} />
+                <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>
+                  {resendLoading ? 'Отправка...' : 'Отправить код повторно'}
+                </Text>
+              </Pressable>
+            )}
+          </View>
         </View>
-      ) : null}
-      <Pressable onPress={handleSubmit} disabled={loading} className={`mt-4 h-12 w-full max-w-xs items-center justify-center rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}>
-        <Text className="text-base font-semibold text-white">{loading ? 'Проверка...' : 'Подтвердить'}</Text>
-      </Pressable>
-      <View className="mt-3 flex-row items-center gap-1">
-        {resendTimer > 0 ? (
-          <>
-            <Feather name="clock" size={14} color="#94A3B8" />
-            <Text className="text-sm text-textMuted">Отправить повторно через {resendTimer} сек</Text>
-          </>
-        ) : (
-          <Pressable onPress={handleResend} disabled={resendLoading} className="flex-row items-center gap-1">
-            <Feather name="refresh-cw" size={14} color="#0284C7" />
-            <Text className="text-sm font-medium text-brandPrimary">
-              {resendLoading ? 'Отправка...' : 'Отправить код повторно'}
-            </Text>
-          </Pressable>
-        )}
-      </View>
-      </View>
-    </View>
+      </Container>
+    </Screen>
   );
 }

--- a/app/(auth)/role.tsx
+++ b/app/(auth)/role.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Header } from '../../components/Header';
-import { Colors } from '../../constants/Colors';
+import { Card, Container, Heading, Screen, Text } from '../../components/ui';
+import { BorderRadius, Colors, Spacing } from '../../constants/Colors';
 
 export default function RoleScreen() {
   const router = useRouter();
@@ -13,47 +14,76 @@ export default function RoleScreen() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Выбор роли" onBack={() => router.back()} />
-      <View className="flex-1 items-center justify-center bg-white px-4 py-8">
-        <View className="mb-8 items-center gap-2">
-          <View className="mb-1 h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
-            <Feather name="shield" size={28} color={Colors.brandPrimary} />
+      <Container>
+        <View style={{ paddingVertical: Spacing['2xl'], gap: Spacing['2xl'] }}>
+          <View style={{ alignItems: 'center', gap: Spacing.sm }}>
+            <View
+              style={{
+                height: 64,
+                width: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: Colors.bgSecondary,
+              }}
+            >
+              <Feather name="shield" size={28} color={Colors.brandPrimary} />
+            </View>
+            <Heading level={2} align="center">Налоговик</Heading>
+            <Text variant="muted" align="center">Кто вы на платформе?</Text>
           </View>
-          <Text className="text-2xl font-bold text-textPrimary">Налоговик</Text>
-          <Text className="text-base text-textMuted">Кто вы на платформе?</Text>
-        </View>
 
-        <View className="w-full max-w-md gap-4">
-          <Pressable
-            onPress={() => selectRole('CLIENT')}
-            className="rounded-2xl border-2 border-borderLight bg-white p-6 active:border-brandPrimary active:bg-bgSecondary"
-            style={{ borderColor: Colors.borderLight }}
-          >
-            <View className="mb-3 h-12 w-12 items-center justify-center rounded-xl bg-bgSecondary">
-              <Feather name="search" size={24} color={Colors.brandPrimary} />
-            </View>
-            <Text className="text-lg font-bold text-textPrimary">Я ищу специалиста</Text>
-            <Text className="mt-1 text-sm leading-5 text-textMuted">
-              Нужна помощь с налоговой проверкой или вопросом — найду специалиста по своей ФНС
-            </Text>
-          </Pressable>
+          <View style={{ gap: Spacing.lg }}>
+            <Card variant="outlined" padding="lg" onPress={() => selectRole('CLIENT')}>
+              <View style={{ gap: Spacing.md }}>
+                <View
+                  style={{
+                    height: 48,
+                    width: 48,
+                    borderRadius: BorderRadius.xl,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: Colors.bgSecondary,
+                  }}
+                >
+                  <Feather name="search" size={24} color={Colors.brandPrimary} />
+                </View>
+                <View style={{ gap: Spacing.xs }}>
+                  <Heading level={4}>Я ищу специалиста</Heading>
+                  <Text variant="muted">
+                    Нужна помощь с налоговой проверкой или вопросом — найду специалиста по своей ФНС
+                  </Text>
+                </View>
+              </View>
+            </Card>
 
-          <Pressable
-            onPress={() => selectRole('SPECIALIST')}
-            className="rounded-2xl border-2 border-borderLight bg-white p-6 active:border-brandPrimary active:bg-bgSecondary"
-            style={{ borderColor: Colors.borderLight }}
-          >
-            <View className="mb-3 h-12 w-12 items-center justify-center rounded-xl bg-bgSecondary">
-              <Feather name="briefcase" size={24} color={Colors.brandPrimary} />
-            </View>
-            <Text className="text-lg font-bold text-textPrimary">Я специалист по налогам</Text>
-            <Text className="mt-1 text-sm leading-5 text-textMuted">
-              Консультирую клиентов по вопросам налоговых проверок в конкретных ФНС
-            </Text>
-          </Pressable>
+            <Card variant="outlined" padding="lg" onPress={() => selectRole('SPECIALIST')}>
+              <View style={{ gap: Spacing.md }}>
+                <View
+                  style={{
+                    height: 48,
+                    width: 48,
+                    borderRadius: BorderRadius.xl,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: Colors.bgSecondary,
+                  }}
+                >
+                  <Feather name="briefcase" size={24} color={Colors.brandPrimary} />
+                </View>
+                <View style={{ gap: Spacing.xs }}>
+                  <Heading level={4}>Я специалист по налогам</Heading>
+                  <Text variant="muted">
+                    Консультирую клиентов по вопросам налоговых проверок в конкретных ФНС
+                  </Text>
+                </View>
+              </View>
+            </Card>
+          </View>
         </View>
-      </View>
-    </View>
+      </Container>
+    </Screen>
   );
 }

--- a/app/(onboarding)/profile.tsx
+++ b/app/(onboarding)/profile.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable, TextInput, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, Pressable, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
 import { Header } from '../../components/Header';
 import { users, upload, specialists } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
+import { Button, Container, Heading, Input, Screen, Text } from '../../components/ui';
+import { BorderRadius, Colors, Spacing } from '../../constants/Colors';
 
 export default function OnboardingProfilePage() {
   const router = useRouter();
@@ -37,7 +39,6 @@ export default function OnboardingProfilePage() {
     setError('');
     setLoading(true);
     try {
-      // Upload avatar first if selected
       if (avatarUri) {
         setUploading(true);
         try {
@@ -52,9 +53,8 @@ export default function OnboardingProfilePage() {
         }
       }
 
-      // Save profile fields. For specialists, bio/telegram/phone live on SpecialistProfile,
-      // so route through PATCH /specialists/me. Clients use PATCH /users/me/profile
-      // (bio/telegram are ignored for clients — their schema has no such columns).
+      // Specialists: bio/telegram/phone on SpecialistProfile via PATCH /specialists/me.
+      // Clients: only phone via PATCH /users/me/profile.
       if (role === 'SPECIALIST') {
         const specialistData: Record<string, string> = {};
         if (description.trim()) specialistData.bio = description.trim();
@@ -73,9 +73,6 @@ export default function OnboardingProfilePage() {
 
       await refreshUser();
 
-      // New SA flow: profile is the LAST step for both roles.
-      // SPECIALIST: name → work-area → profile → specialist-dashboard
-      // CLIENT: name → profile → dashboard
       if (role === 'SPECIALIST') {
         router.replace('/(tabs)/specialist-dashboard' as any);
       } else {
@@ -89,133 +86,159 @@ export default function OnboardingProfilePage() {
     }
   }
 
+  const stepCopy = role === 'SPECIALIST' ? 'Шаг 3 из 3' : 'Шаг 2 из 2';
+
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Профиль" onBack={() => router.back()} />
-      <View className="flex-1 bg-white px-4 py-6">
-        {/* Progress — profile is the FINAL step for both roles */}
-        <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-green-600" style={{ width: '100%' }} />
-        </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
-          {role === 'SPECIALIST' ? 'Шаг 3 из 3' : 'Шаг 2 из 2'}
-        </Text>
+      <Container>
+        <View style={{ paddingVertical: Spacing.xl, gap: Spacing.lg }}>
+          <View>
+            <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary }}>
+              <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.statusSuccess, width: '100%' }} />
+            </View>
+            <Text
+              variant="caption"
+              style={{ marginTop: Spacing.xs, textTransform: 'uppercase', letterSpacing: 1 }}
+            >
+              {stepCopy}
+            </Text>
+          </View>
 
-        <Text className="text-xl font-bold text-textPrimary">
-          {role === 'SPECIALIST' ? 'Расскажите о себе' : 'Контактные данные'}
-        </Text>
-        <Text className="mb-4 text-base text-textMuted">
-          {role === 'SPECIALIST'
-            ? 'Эта информация поможет клиентам выбрать вас'
-            : 'Добавьте телефон, чтобы специалисты могли связаться с вами быстрее'}
-        </Text>
+          <View style={{ gap: Spacing.xs }}>
+            <Heading level={3}>
+              {role === 'SPECIALIST' ? 'Расскажите о себе' : 'Контактные данные'}
+            </Heading>
+            <Text variant="muted">
+              {role === 'SPECIALIST'
+                ? 'Эта информация поможет клиентам выбрать вас'
+                : 'Добавьте телефон, чтобы специалисты могли связаться с вами быстрее'}
+            </Text>
+          </View>
 
-        {/* Avatar */}
-        <View className="mb-4 flex-row items-center gap-4">
-          <View className={`h-16 w-16 items-center justify-center rounded-full ${avatarUri ? 'bg-brandPrimary' : 'border-2 border-dashed border-gray-300 bg-bgSecondary'}`}>
-            <Feather name="user" size={28} color={avatarUri ? '#fff' : '#0284C7'} />
-            {uploading && (
-              <View className="absolute inset-0 items-center justify-center rounded-full bg-black/50">
-                <ActivityIndicator size="small" color="#fff" />
+          {/* Avatar */}
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
+            <View
+              style={{
+                height: 64,
+                width: 64,
+                borderRadius: 32,
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: avatarUri ? Colors.brandPrimary : Colors.bgSecondary,
+                borderWidth: avatarUri ? 0 : 2,
+                borderColor: Colors.border,
+                borderStyle: 'dashed',
+                overflow: 'hidden',
+              }}
+            >
+              <Feather name="user" size={28} color={avatarUri ? Colors.white : Colors.brandPrimary} />
+              {uploading && (
+                <View
+                  style={{
+                    position: 'absolute',
+                    top: 0, left: 0, right: 0, bottom: 0,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    borderRadius: 32,
+                    backgroundColor: 'rgba(0,0,0,0.5)',
+                  }}
+                >
+                  <ActivityIndicator size="small" color={Colors.white} />
+                </View>
+              )}
+            </View>
+            <View style={{ gap: Spacing.xxs }}>
+              <Pressable onPress={pickAvatar} style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+                <Feather name="camera" size={14} color={Colors.brandPrimary} />
+                <Text variant="body" weight="medium" style={{ color: Colors.brandPrimary }}>
+                  {avatarUri ? 'Изменить фото' : 'Загрузить фото'}
+                </Text>
+              </Pressable>
+              <Text variant="caption">JPG или PNG, до 5 МБ</Text>
+            </View>
+          </View>
+
+          <View style={{ gap: Spacing.md }}>
+            {/* Description — specialist only */}
+            {role === 'SPECIALIST' && (
+              <View style={{ gap: Spacing.xs }}>
+                <Input
+                  label="О себе"
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="Расскажите о вашем опыте..."
+                  multiline
+                  maxLength={maxChars}
+                />
+                <Text
+                  variant="caption"
+                  align="right"
+                  style={description.length > maxChars ? { color: Colors.statusError } : undefined}
+                >
+                  {description.length}/{maxChars}
+                </Text>
               </View>
             )}
-          </View>
-          <View>
-            <Pressable className="flex-row items-center gap-1" onPress={pickAvatar}>
-              <Feather name="camera" size={14} color="#0284C7" />
-              <Text className="text-base font-medium text-brandPrimary">{avatarUri ? 'Изменить фото' : 'Загрузить фото'}</Text>
-            </Pressable>
-            <Text className="text-xs text-textMuted">JPG или PNG, до 5 МБ</Text>
-          </View>
-        </View>
 
-        {/* Description — specialist only (clients have no bio column) */}
-        {role === 'SPECIALIST' && (
-          <View className="mb-3">
-            <View className="mb-1 flex-row items-center justify-between">
-              <Text className="text-sm font-medium text-textSecondary">О себе</Text>
-              <Text className={`text-xs ${description.length > maxChars ? 'text-red-600' : 'text-textMuted'}`}>{description.length}/{maxChars}</Text>
-            </View>
-            <TextInput
-              value={description}
-              onChangeText={setDescription}
-              placeholder="Расскажите о вашем опыте..."
-              placeholderTextColor="#94A3B8"
-              multiline
-              className="rounded-lg border border-gray-200 p-3 text-base text-textPrimary"
-              style={{ minHeight: 80, textAlignVertical: 'top', outlineStyle: 'none' as any }}
-              maxLength={maxChars}
-            />
-          </View>
-        )}
-
-        {/* Phone */}
-        <View className="mb-3">
-          <Text className="mb-1 text-sm font-medium text-textSecondary">Телефон</Text>
-          <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
-            <Feather name="phone" size={16} color="#94A3B8" />
-            <TextInput
+            {/* Phone */}
+            <Input
+              label="Телефон"
               value={phone}
               onChangeText={setPhone}
               placeholder="+7XXXXXXXXXX"
-              placeholderTextColor="#94A3B8"
-              className="flex-1 text-base text-textPrimary"
-              style={{ outlineStyle: 'none' as any }}
               keyboardType="phone-pad"
+              icon={<Feather name="phone" size={16} color={Colors.textMuted} />}
             />
-          </View>
-        </View>
 
-        {/* Telegram — specialist only */}
-        {role === 'SPECIALIST' && (
-          <View className="mb-4">
-            <Text className="mb-1 text-sm font-medium text-textSecondary">Telegram</Text>
-            <View className="h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
-              <Feather name="send" size={16} color="#94A3B8" />
-              <TextInput
+            {/* Telegram — specialist only */}
+            {role === 'SPECIALIST' && (
+              <Input
+                label="Telegram"
                 value={telegram}
                 onChangeText={setTelegram}
                 placeholder="@username"
-                placeholderTextColor="#94A3B8"
-                className="flex-1 text-base text-textPrimary"
-                style={{ outlineStyle: 'none' as any }}
+                icon={<Feather name="send" size={16} color={Colors.textMuted} />}
               />
+            )}
+          </View>
+
+          {error ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.xs,
+                borderRadius: BorderRadius.lg,
+                backgroundColor: Colors.bgSecondary,
+                paddingHorizontal: Spacing.md,
+                paddingVertical: Spacing.sm,
+              }}
+            >
+              <Feather name="alert-circle" size={14} color={Colors.statusError} />
+              <Text variant="caption" style={{ color: Colors.statusError }}>{error}</Text>
+            </View>
+          ) : null}
+
+          {/* Buttons */}
+          <View style={{ flexDirection: 'row', gap: Spacing.md }}>
+            <Button variant="ghost" size="lg" onPress={() => router.back()}>
+              Назад
+            </Button>
+            <View style={{ flex: 1 }}>
+              <Button
+                variant="primary"
+                size="lg"
+                fullWidth
+                loading={loading}
+                onPress={handleFinish}
+              >
+                Завершить
+              </Button>
             </View>
           </View>
-        )}
-
-        {error ? (
-          <View className="mb-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{error}</Text>
-          </View>
-        ) : null}
-
-        {/* Buttons */}
-        <View className="flex-row gap-3">
-          <Pressable
-            className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4"
-            onPress={() => router.back()}
-          >
-            <Feather name="arrow-left" size={16} color="#475569" />
-            <Text className="text-base font-medium text-textSecondary">Назад</Text>
-          </Pressable>
-          <Pressable
-            className={`h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${loading ? 'opacity-60' : ''}`}
-            onPress={handleFinish}
-            disabled={loading}
-          >
-            {loading ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <>
-                <Feather name="check" size={16} color="#fff" />
-                <Text className="text-base font-semibold text-white">Завершить</Text>
-              </>
-            )}
-          </Pressable>
         </View>
-      </View>
-    </View>
+      </Container>
+    </Screen>
   );
 }

--- a/app/(onboarding)/username.tsx
+++ b/app/(onboarding)/username.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { View, Text, Pressable, TextInput, ActivityIndicator } from 'react-native';
+import { Pressable, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Header } from '../../components/Header';
 import { users } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
+import { Button, Container, Heading, Input, Screen, Text } from '../../components/ui';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
 
 // Russian + English letters, space, hyphen, apostrophe; 2–50 chars.
 const NAME_REGEX = /^[a-zA-Zа-яА-ЯёЁ\s'-]{2,50}$/;
@@ -63,92 +65,114 @@ export default function NameScreen() {
     }
   }
 
+  // Copy: specialists see "клиентам" (their future clients); clients see
+  // "специалистам" (the specialists they'll be contacting).
+  const audienceCopy = role === 'SPECIALIST'
+    ? 'Имя и фамилия будут видны клиентам в вашем профиле'
+    : 'Имя и фамилия будут видны специалистам, к которым вы обращаетесь';
+
+  const stepCopy = role === 'SPECIALIST' ? 'Шаг 1 из 3' : 'Шаг 1 из 2';
+  const progressPct = role === 'SPECIALIST' ? '33%' : '50%';
+
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Имя" onBack={() => router.back()} />
-      <View className="flex-1 bg-white px-4 py-6">
-        <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: role === 'SPECIALIST' ? '33%' : '50%' }} />
+      <Container>
+        <View style={{ paddingVertical: Spacing.xl, gap: Spacing.lg }}>
+          <View>
+            <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary }}>
+              <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.brandPrimary, width: progressPct as any }} />
+            </View>
+            <Text
+              variant="caption"
+              style={{ marginTop: Spacing.xs, textTransform: 'uppercase', letterSpacing: 1 }}
+            >
+              {stepCopy}
+            </Text>
+          </View>
+
+          <View style={{ gap: Spacing.xs }}>
+            <Heading level={3}>Как вас зовут?</Heading>
+            <Text variant="muted">{audienceCopy}</Text>
+          </View>
+
+          <View style={{ gap: Spacing.md }}>
+            <Input
+              label="Имя"
+              value={firstName}
+              onChangeText={(t) => { setFirstName(t); if (firstErr) setFirstErr(''); }}
+              onBlur={() => setFirstErr(validateField(firstName))}
+              placeholder="Иван"
+              autoCapitalize="words"
+              error={firstErr || undefined}
+              icon={<Feather name="user" size={18} color={firstErr ? Colors.statusError : Colors.textMuted} />}
+            />
+
+            <Input
+              label="Фамилия"
+              value={lastName}
+              onChangeText={(t) => { setLastName(t); if (lastErr) setLastErr(''); }}
+              onBlur={() => setLastErr(validateField(lastName))}
+              placeholder="Иванов"
+              autoCapitalize="words"
+              error={lastErr || undefined}
+              icon={<Feather name="user" size={18} color={lastErr ? Colors.statusError : Colors.textMuted} />}
+            />
+          </View>
+
+          <Pressable
+            style={{ flexDirection: 'row', alignItems: 'flex-start', gap: Spacing.sm }}
+            onPress={() => setAgreed(!agreed)}
+          >
+            <View
+              style={{
+                marginTop: 2,
+                height: 20,
+                width: 20,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: BorderRadius.sm,
+                borderWidth: 1,
+                borderColor: agreed ? Colors.brandPrimary : Colors.border,
+                backgroundColor: agreed ? Colors.brandPrimary : Colors.white,
+              }}
+            >
+              {agreed && <Feather name="check" size={13} color={Colors.white} />}
+            </View>
+            <Text variant="caption" style={{ flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textSecondary }}>
+              Принимаю <Text variant="caption" style={{ color: Colors.brandPrimary }}>условия использования</Text>
+            </Text>
+          </Pressable>
+
+          {submitErr ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.xs,
+                borderRadius: BorderRadius.lg,
+                backgroundColor: Colors.bgSecondary,
+                paddingHorizontal: Spacing.md,
+                paddingVertical: Spacing.sm,
+              }}
+            >
+              <Feather name="alert-circle" size={14} color={Colors.statusError} />
+              <Text variant="caption" style={{ color: Colors.statusError }}>{submitErr}</Text>
+            </View>
+          ) : null}
+
+          <Button
+            variant="primary"
+            size="lg"
+            fullWidth
+            disabled={!canContinue}
+            loading={loading}
+            onPress={handleNext}
+          >
+            Далее
+          </Button>
         </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">
-          {role === 'SPECIALIST' ? 'Шаг 1 из 3' : 'Шаг 1 из 2'}
-        </Text>
-        <Text className="text-xl font-bold text-textPrimary">Как вас зовут?</Text>
-        <Text className="mb-4 text-base leading-6 text-textMuted">Имя и фамилия будут видны клиентам в вашем профиле</Text>
-
-        <Text className="mb-1 text-sm font-medium text-textSecondary">Имя</Text>
-        <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${firstErr ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'}`}>
-          <Feather name="user" size={18} color={firstErr ? '#DC2626' : '#94A3B8'} />
-          <TextInput
-            value={firstName}
-            onChangeText={(t) => { setFirstName(t); if (firstErr) setFirstErr(''); }}
-            onBlur={() => setFirstErr(validateField(firstName))}
-            placeholder="Иван"
-            placeholderTextColor="#94A3B8"
-            className="flex-1 text-base text-textPrimary"
-            style={{ outlineStyle: 'none' } as any}
-            autoCapitalize="words"
-            autoCorrect={false}
-          />
-        </View>
-        {firstErr ? (
-          <View className="mb-2 flex-row items-center gap-1">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{firstErr}</Text>
-          </View>
-        ) : null}
-
-        <Text className="mb-1 mt-3 text-sm font-medium text-textSecondary">Фамилия</Text>
-        <View className={`mb-1 h-12 flex-row items-center gap-2 rounded-lg border px-4 ${lastErr ? 'border-red-500 bg-red-50' : 'border-gray-200 bg-white'}`}>
-          <Feather name="user" size={18} color={lastErr ? '#DC2626' : '#94A3B8'} />
-          <TextInput
-            value={lastName}
-            onChangeText={(t) => { setLastName(t); if (lastErr) setLastErr(''); }}
-            onBlur={() => setLastErr(validateField(lastName))}
-            placeholder="Иванов"
-            placeholderTextColor="#94A3B8"
-            className="flex-1 text-base text-textPrimary"
-            style={{ outlineStyle: 'none' } as any}
-            autoCapitalize="words"
-            autoCorrect={false}
-          />
-        </View>
-        {lastErr ? (
-          <View className="mb-2 flex-row items-center gap-1">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{lastErr}</Text>
-          </View>
-        ) : null}
-
-        <Pressable className="mt-3 flex-row items-start gap-2" onPress={() => setAgreed(!agreed)}>
-          <View className={`mt-0.5 h-5 w-5 items-center justify-center rounded border ${agreed ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300 bg-white'}`}>
-            {agreed && <Feather name="check" size={13} color="#fff" />}
-          </View>
-          <Text className="flex-1 text-sm text-textSecondary">Принимаю <Text className="text-brandPrimary">условия использования</Text></Text>
-        </Pressable>
-
-        {submitErr ? (
-          <View className="mt-3 flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm text-red-600">{submitErr}</Text>
-          </View>
-        ) : null}
-
-        <Pressable
-          disabled={!canContinue}
-          onPress={handleNext}
-          className={`mt-6 h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${!canContinue ? 'opacity-40' : ''}`}
-        >
-          {loading ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <>
-              <Text className="text-base font-semibold text-white">Далее</Text>
-              <Feather name="arrow-right" size={16} color="#fff" />
-            </>
-          )}
-        </Pressable>
-      </View>
-    </View>
+      </Container>
+    </Screen>
   );
 }

--- a/app/(onboarding)/work-area.tsx
+++ b/app/(onboarding)/work-area.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { View, Text, Pressable, TextInput, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, Pressable, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Header } from '../../components/Header';
 import { specialists } from '../../lib/api/endpoints';
 import { useCities, useFnsOffices, type CityItem, type FnsOfficeItem } from '../../hooks/useFnsData';
+import { Button, Container, Heading, Input, Screen, Text } from '../../components/ui';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
 
 const SVCS = ['Выездная проверка', 'Камеральная проверка', 'Отдел оперативного контроля'];
 
@@ -73,11 +75,10 @@ export default function WorkAreaScreenPage() {
     setLoading(true);
     try {
       const workAreas = Object.entries(bind).map(([key, departments]) => ({
-        fnsId: key, // key is "cityId:fnsId"
+        fnsId: key,
         departments,
       }));
       await specialists.saveWorkAreas(workAreas);
-      // New SA flow: work-area (step 2) → profile (step 3 — final)
       router.push('/(onboarding)/profile' as any);
     } catch (e: any) {
       const msg = e?.response?.data?.message || e?.message || 'Ошибка сохранения';
@@ -88,111 +89,145 @@ export default function WorkAreaScreenPage() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen>
       <Header variant="back" backTitle="Регион" onBack={() => router.back()} />
-      <View className="flex-1 bg-white px-4 py-6">
-        <View className="mb-1 h-1 rounded-full bg-bgSecondary">
-          <View className="h-1 rounded-full bg-brandPrimary" style={{ width: '66%' }} />
-        </View>
-        <Text className="mb-4 text-xs uppercase tracking-wider text-textMuted">Шаг 2 из 3</Text>
-        <Text className="text-xl font-bold text-textPrimary">Рабочая зона</Text>
-        <Text className="mb-4 text-base text-textMuted">Выберите города, инспекции и услуги</Text>
-        <View className="mb-2 h-12 flex-row items-center gap-2 rounded-lg border border-gray-200 px-4">
-          <Feather name="search" size={18} color="#94A3B8" />
-          <TextInput
+      <Container>
+        <View style={{ paddingVertical: Spacing.xl, gap: Spacing.lg }}>
+          <View>
+            <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary }}>
+              <View style={{ height: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.brandPrimary, width: '66%' }} />
+            </View>
+            <Text
+              variant="caption"
+              style={{ marginTop: Spacing.xs, textTransform: 'uppercase', letterSpacing: 1 }}
+            >
+              Шаг 2 из 3
+            </Text>
+          </View>
+
+          <View style={{ gap: Spacing.xs }}>
+            <Heading level={3}>Рабочая зона</Heading>
+            <Text variant="muted">Выберите города, инспекции и услуги</Text>
+          </View>
+
+          <Input
             value={search}
             onChangeText={setSearch}
             placeholder="Найти город..."
-            placeholderTextColor="#94A3B8"
-            className="flex-1 text-base text-textPrimary"
-            style={{ outlineStyle: 'none' as any }}
             editable={!citiesLoading}
+            icon={<Feather name="search" size={18} color={Colors.textMuted} />}
+            rightIcon={
+              search.length > 0 ? (
+                <Pressable onPress={() => setSearch('')}>
+                  <Feather name="x" size={16} color={Colors.textMuted} />
+                </Pressable>
+              ) : undefined
+            }
           />
-          {search.length > 0 && (
-            <Pressable onPress={() => setSearch('')}><Feather name="x" size={16} color="#94A3B8" /></Pressable>
-          )}
-        </View>
 
-        {citiesLoading && (
-          <View className="flex-row items-center gap-2 px-4 py-3">
-            <ActivityIndicator size="small" color="#94A3B8" />
-            <Text className="text-sm text-textMuted">Загружаем список городов...</Text>
-          </View>
-        )}
-
-        {!citiesLoading && debouncedSearch && filtered.length === 0 && (
-          <View className="px-4 py-3">
-            <Text className="text-sm text-textMuted">Ничего не найдено</Text>
-          </View>
-        )}
-
-        {filtered.map((c) => (
-          <Pressable
-            key={c.id}
-            className="flex-row items-center gap-2 border-b border-gray-100 px-4 py-3"
-            onPress={() => addCity(c)}
-          >
-            <Feather name="map-pin" size={14} color="#94A3B8" />
-            <View className="flex-1">
-              <Text className="text-base text-textPrimary">{c.name}</Text>
-              {c.region && c.region !== c.name && (
-                <Text className="text-xs text-textMuted">{c.region}</Text>
-              )}
+          {citiesLoading && (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md }}>
+              <ActivityIndicator size="small" color={Colors.textMuted} />
+              <Text variant="caption">Загружаем список городов...</Text>
             </View>
-            <Feather name="plus" size={14} color="#0284C7" />
-          </Pressable>
-        ))}
+          )}
 
-        {selectedCities.length === 0 && !search && !citiesLoading && (
-          <View className="items-center py-6 opacity-60">
-            <Feather name="map-pin" size={20} color="#94A3B8" />
-            <Text className="mt-1 text-base text-textMuted">Начните вводить название города</Text>
+          {!citiesLoading && debouncedSearch && filtered.length === 0 && (
+            <View style={{ paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md }}>
+              <Text variant="caption">Ничего не найдено</Text>
+            </View>
+          )}
+
+          {filtered.length > 0 && (
+            <View>
+              {filtered.map((c) => (
+                <Pressable
+                  key={c.id}
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: Spacing.sm,
+                    borderBottomWidth: 1,
+                    borderBottomColor: Colors.borderLight,
+                    paddingHorizontal: Spacing.lg,
+                    paddingVertical: Spacing.md,
+                  }}
+                  onPress={() => addCity(c)}
+                >
+                  <Feather name="map-pin" size={14} color={Colors.textMuted} />
+                  <View style={{ flex: 1, gap: 2 }}>
+                    <Text variant="body">{c.name}</Text>
+                    {c.region && c.region !== c.name && (
+                      <Text variant="caption">{c.region}</Text>
+                    )}
+                  </View>
+                  <Feather name="plus" size={14} color={Colors.brandPrimary} />
+                </Pressable>
+              ))}
+            </View>
+          )}
+
+          {selectedCities.length === 0 && !search && !citiesLoading && (
+            <View style={{ alignItems: 'center', paddingVertical: Spacing['2xl'], opacity: 0.6, gap: Spacing.xs }}>
+              <Feather name="map-pin" size={20} color={Colors.textMuted} />
+              <Text variant="muted">Начните вводить название города</Text>
+            </View>
+          )}
+
+          {selectedCities.length > 0 && (
+            <View style={{ gap: Spacing.sm }}>
+              {selectedCities.map((city) => (
+                <CityRow
+                  key={city.id}
+                  city={city}
+                  expanded={expanded === city.id}
+                  onToggle={() => setExpanded(expanded === city.id ? null : city.id)}
+                  onRemove={() => removeCity(city.id)}
+                  bind={bind}
+                  toggleFns={toggleFns}
+                  toggleSvc={toggleSvc}
+                />
+              ))}
+            </View>
+          )}
+
+          {error ? (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.xs,
+                borderRadius: BorderRadius.lg,
+                backgroundColor: Colors.bgSecondary,
+                paddingHorizontal: Spacing.md,
+                paddingVertical: Spacing.sm,
+              }}
+            >
+              <Feather name="alert-circle" size={14} color={Colors.statusError} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.statusError }}>{error}</Text>
+            </View>
+          ) : null}
+
+          <View style={{ flexDirection: 'row', gap: Spacing.md }}>
+            <Button variant="ghost" size="lg" onPress={() => router.back()}>
+              Назад
+            </Button>
+            <View style={{ flex: 1 }}>
+              <Button
+                variant="primary"
+                size="lg"
+                fullWidth
+                disabled={total === 0 || loading}
+                loading={loading}
+                onPress={handleNext}
+              >
+                Далее
+              </Button>
+            </View>
           </View>
-        )}
-
-        {selectedCities.map((city) => (
-          <CityRow
-            key={city.id}
-            city={city}
-            expanded={expanded === city.id}
-            onToggle={() => setExpanded(expanded === city.id ? null : city.id)}
-            onRemove={() => removeCity(city.id)}
-            bind={bind}
-            toggleFns={toggleFns}
-            toggleSvc={toggleSvc}
-          />
-        ))}
-
-        {error ? (
-          <View className="flex-row items-center gap-1 rounded-lg bg-red-50 px-3 py-2">
-            <Feather name="alert-circle" size={14} color="#DC2626" />
-            <Text className="text-sm font-medium text-red-600">{error}</Text>
-          </View>
-        ) : null}
-        <View className="mt-4 flex-row gap-3">
-          <Pressable
-            className="h-12 flex-row items-center justify-center gap-1 rounded-lg border border-gray-200 px-4"
-            onPress={() => router.back()}
-          >
-            <Feather name="arrow-left" size={16} color="#475569" /><Text className="text-base font-medium text-textSecondary">Назад</Text>
-          </Pressable>
-          <Pressable
-            className={`h-12 flex-1 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary ${(total === 0 || loading) ? 'opacity-40' : ''}`}
-            disabled={total === 0 || loading}
-            onPress={handleNext}
-          >
-            {loading ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <>
-                <Text className="text-base font-semibold text-white">Далее</Text>
-                <Feather name="arrow-right" size={16} color="#fff" />
-              </>
-            )}
-          </Pressable>
         </View>
-      </View>
-    </View>
+      </Container>
+    </Screen>
   );
 }
 
@@ -214,31 +249,83 @@ function CityRow({ city, expanded, onToggle, onRemove, bind, toggleFns, toggleSv
   const cnt = Object.keys(bind).filter((x) => x.startsWith(city.id + ':')).length;
 
   return (
-    <View className="mb-2 overflow-hidden rounded-lg border border-gray-200">
-      <Pressable className="flex-row items-center justify-between px-4 py-3" onPress={onToggle}>
-        <View className="flex-row items-center gap-2">
-          <Feather name="map-pin" size={14} color="#0284C7" />
-          <Text className="text-base font-semibold text-textPrimary">{city.name}</Text>
+    <View
+      style={{
+        overflow: 'hidden',
+        borderRadius: BorderRadius.lg,
+        borderWidth: 1,
+        borderColor: Colors.borderLight,
+        backgroundColor: Colors.white,
+      }}
+    >
+      <Pressable
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingHorizontal: Spacing.lg,
+          paddingVertical: Spacing.md,
+        }}
+        onPress={onToggle}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, flex: 1 }}>
+          <Feather name="map-pin" size={14} color={Colors.brandPrimary} />
+          <Text variant="body" weight="semibold">{city.name}</Text>
           {cnt > 0 && (
-            <View className="h-5 w-5 items-center justify-center rounded-full bg-brandPrimary">
-              <Text className="text-xs font-bold text-white">{cnt}</Text>
+            <View
+              style={{
+                height: 20,
+                width: 20,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: BorderRadius.full,
+                backgroundColor: Colors.brandPrimary,
+              }}
+            >
+              <Text
+                variant="caption"
+                weight="bold"
+                style={{ color: Colors.white, fontSize: Typography.fontSize.xs }}
+              >
+                {cnt}
+              </Text>
             </View>
           )}
         </View>
-        <View className="flex-row items-center gap-3">
-          <Pressable onPress={onRemove}><Feather name="trash-2" size={14} color="#94A3B8" /></Pressable>
-          <Feather name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color="#94A3B8" />
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md }}>
+          <Pressable onPress={onRemove} hitSlop={8}>
+            <Feather name="trash-2" size={14} color={Colors.textMuted} />
+          </Pressable>
+          <Feather name={expanded ? 'chevron-up' : 'chevron-down'} size={16} color={Colors.textMuted} />
         </View>
       </Pressable>
+
       {expanded && loading && (
-        <View className="flex-row items-center gap-2 border-t border-gray-100 px-4 py-3">
-          <ActivityIndicator size="small" color="#94A3B8" />
-          <Text className="text-sm text-textMuted">Загружаем инспекции...</Text>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: Spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: Colors.borderLight,
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.md,
+          }}
+        >
+          <ActivityIndicator size="small" color={Colors.textMuted} />
+          <Text variant="caption">Загружаем инспекции...</Text>
         </View>
       )}
       {expanded && !loading && offices.length === 0 && (
-        <View className="border-t border-gray-100 px-4 py-3">
-          <Text className="text-sm text-textMuted">Нет доступных инспекций</Text>
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderTopColor: Colors.borderLight,
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.md,
+          }}
+        >
+          <Text variant="caption">Нет доступных инспекций</Text>
         </View>
       )}
       {expanded && !loading && offices.map((fns: FnsOfficeItem) => {
@@ -246,25 +333,82 @@ function CityRow({ city, expanded, onToggle, onRemove, bind, toggleFns, toggleSv
         const sel = key in bind;
         const sv = bind[key] || [];
         return (
-          <View key={fns.id} className="border-t border-gray-100">
-            <Pressable className="flex-row items-center gap-3 px-4 py-3" onPress={() => toggleFns(city.id, fns.id)}>
-              <View className={`h-5 w-5 items-center justify-center rounded border ${sel ? 'border-brandPrimary bg-brandPrimary' : 'border-gray-300'}`}>
-                {sel && <Feather name="check" size={13} color="#fff" />}
+          <View
+            key={fns.id}
+            style={{ borderTopWidth: 1, borderTopColor: Colors.borderLight }}
+          >
+            <Pressable
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.md,
+                paddingHorizontal: Spacing.lg,
+                paddingVertical: Spacing.md,
+              }}
+              onPress={() => toggleFns(city.id, fns.id)}
+            >
+              <View
+                style={{
+                  height: 20,
+                  width: 20,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: BorderRadius.sm,
+                  borderWidth: 1,
+                  borderColor: sel ? Colors.brandPrimary : Colors.border,
+                  backgroundColor: sel ? Colors.brandPrimary : Colors.white,
+                }}
+              >
+                {sel && <Feather name="check" size={13} color={Colors.white} />}
               </View>
-              <Text className={`flex-1 text-sm ${sel ? 'font-medium text-brandPrimary' : 'text-textPrimary'}`}>{fns.name}</Text>
+              <Text
+                variant="caption"
+                weight={sel ? 'medium' : 'regular'}
+                style={{
+                  flex: 1,
+                  color: sel ? Colors.brandPrimary : Colors.textPrimary,
+                }}
+              >
+                {fns.name}
+              </Text>
             </Pressable>
             {sel && (
-              <View className="flex-row flex-wrap gap-2 px-4 pb-3 pl-12">
+              <View
+                style={{
+                  flexDirection: 'row',
+                  flexWrap: 'wrap',
+                  gap: Spacing.sm,
+                  paddingLeft: Spacing['3xl'],
+                  paddingRight: Spacing.lg,
+                  paddingBottom: Spacing.md,
+                }}
+              >
                 {SVCS.map((svc) => {
                   const on = sv.includes(svc);
                   return (
                     <Pressable
                       key={svc}
-                      className={`flex-row items-center gap-1 rounded-full border px-3 py-1 ${on ? 'border-brandPrimary bg-bgSecondary' : 'border-gray-200'}`}
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: Spacing.xs,
+                        borderRadius: BorderRadius.full,
+                        borderWidth: 1,
+                        borderColor: on ? Colors.brandPrimary : Colors.border,
+                        backgroundColor: on ? Colors.bgSecondary : 'transparent',
+                        paddingHorizontal: Spacing.md,
+                        paddingVertical: Spacing.xs,
+                      }}
                       onPress={() => toggleSvc(key, svc)}
                     >
-                      {on && <Feather name="check" size={12} color="#0284C7" />}
-                      <Text className={`text-xs ${on ? 'font-medium text-brandPrimary' : 'text-textSecondary'}`}>{svc}</Text>
+                      {on && <Feather name="check" size={12} color={Colors.brandPrimary} />}
+                      <Text
+                        variant="caption"
+                        weight={on ? 'medium' : 'regular'}
+                        style={{ color: on ? Colors.brandPrimary : Colors.textSecondary }}
+                      >
+                        {svc}
+                      </Text>
                     </Pressable>
                   );
                 })}


### PR DESCRIPTION
Phase 3A of UI overhaul.

## Scope
- app/(auth)/{email,otp,role}.tsx
- app/(onboarding)/{username,profile,work-area}.tsx
- app/login.tsx (verified — pure Redirect stub, no UI to migrate)

## Changes
- All TextInput -> <Input>
- All primary Pressable CTAs -> <Button>
- Page titles -> <Heading>
- Copy -> <Text>
- Screen wrapper -> <Screen><Container>
- Fix P2 bug: /username step copy for CLIENT role now says "специалистам" instead of "клиентам"
- Zero raw hex literals in touched files, zero raw fontSize

Parallel with Phase 3B/C/D.