### PR TITLE
refactor(ui): admin + detail pages migration [Phase 3D]

### DIFF
--- a/app/(admin)/complaints.tsx
+++ b/app/(admin)/complaints.tsx
@@ -1,17 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  ActivityIndicator,
-  StyleSheet,
-  Alert,
-  Modal,
-  TextInput,
-} from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing } from '../../constants/Colors';
+import { Badge, BadgeVariant, Card, Container, EmptyState, Heading, Modal, Screen, Text } from '../../components/ui';
 import { Header } from '../../components/Header';
 import { useRouter } from 'expo-router';
 import * as api from '../../lib/api/endpoints';
@@ -22,10 +13,10 @@ const STATUS_LABELS: Record<string, string> = {
   DISMISSED: 'Отклонена',
 };
 
-const STATUS_COLORS: Record<string, string> = {
-  PENDING: Colors.statusWarning,
-  REVIEWED: Colors.statusSuccess,
-  DISMISSED: Colors.textMuted,
+const STATUS_VARIANTS: Record<string, BadgeVariant> = {
+  PENDING: 'warning',
+  REVIEWED: 'success',
+  DISMISSED: 'default',
 };
 
 const REASON_LABELS: Record<string, string> = {
@@ -42,34 +33,44 @@ function ComplaintRow({ item, onResolve }: { item: any; onResolve: (id: string) 
   const status = item.status as string;
 
   return (
-    <View style={s.row}>
-      <View style={s.rowMain}>
-        <View style={s.rowHeader}>
-          <View style={[s.statusBadge, { backgroundColor: STATUS_COLORS[status] + '20' }]}>
-            <Text style={[s.statusText, { color: STATUS_COLORS[status] }]}>
+    <Card variant="outlined" padding="md">
+      <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+        <View style={{ flex: 1, gap: Spacing.xs }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Badge variant={STATUS_VARIANTS[status] || 'default'}>
               {STATUS_LABELS[status] || status}
+            </Badge>
+            <Text variant="caption">{date}</Text>
+          </View>
+
+          <Text weight="semibold">{REASON_LABELS[item.reason] || item.reason}</Text>
+          {item.comment ? (
+            <Text variant="caption" numberOfLines={3} style={{ lineHeight: 20 }}>
+              {item.comment}
+            </Text>
+          ) : null}
+
+          <View style={{ gap: 2 }}>
+            <Text variant="caption">
+              От: <Text variant="caption" weight="semibold">{reporter}</Text>
+            </Text>
+            <Text variant="caption">
+              На: <Text variant="caption" weight="semibold">{target}</Text>
             </Text>
           </View>
-          <Text style={s.rowDate}>{date}</Text>
         </View>
 
-        <Text style={s.reason}>{REASON_LABELS[item.reason] || item.reason}</Text>
-        {item.comment && (
-          <Text style={s.comment} numberOfLines={3}>{item.comment}</Text>
-        )}
-
-        <View style={s.meta}>
-          <Text style={s.metaText}>От: <Text style={s.metaBold}>{reporter}</Text></Text>
-          <Text style={s.metaText}>На: <Text style={s.metaBold}>{target}</Text></Text>
-        </View>
+        {status === 'PENDING' ? (
+          <Pressable
+            onPress={() => onResolve(item.id)}
+            style={{ padding: Spacing.sm, alignSelf: 'flex-start' }}
+            accessibilityLabel="Разрешить жалобу"
+          >
+            <Feather name="check-circle" size={18} color={Colors.statusSuccess} />
+          </Pressable>
+        ) : null}
       </View>
-
-      {status === 'PENDING' && (
-        <Pressable onPress={() => onResolve(item.id)} style={s.resolveBtn}>
-          <Feather name="check-circle" size={18} color={Colors.statusSuccess} />
-        </Pressable>
-      )}
-    </View>
+    </Card>
   );
 }
 
@@ -102,43 +103,39 @@ function ResolveModal({
   }
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={s.overlay}>
-        <View style={s.modal}>
-          <Text style={s.modalTitle}>Обработать жалобу</Text>
-
-          <Text style={s.modalLabel}>Решение</Text>
-          <View style={s.statusRow}>
-            {(['REVIEWED', 'DISMISSED'] as const).map((opt) => (
-              <Pressable
-                key={opt}
-                style={[s.statusOption, status === opt && s.statusOptionActive]}
-                onPress={() => setStatus(opt)}
-              >
-                <Text style={[s.statusOptionText, status === opt && s.statusOptionTextActive]}>
-                  {STATUS_LABELS[opt]}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-
-          <View style={s.modalActions}>
-            <Pressable style={s.cancelBtn} onPress={onClose}>
-              <Text style={s.cancelText}>Отмена</Text>
-            </Pressable>
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      title="Обработать жалобу"
+      maxWidth={400}
+      primaryAction={{
+        label: 'Сохранить',
+        onPress: handleSubmit,
+        loading: submitting,
+        disabled: submitting,
+      }}
+      secondaryAction={{
+        label: 'Отмена',
+        onPress: onClose,
+        disabled: submitting,
+      }}
+    >
+      <Text variant="label">Решение</Text>
+      <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+        {(['REVIEWED', 'DISMISSED'] as const).map((opt) => {
+          const active = status === opt;
+          return (
             <Pressable
-              style={[s.confirmBtn, submitting && s.confirmDisabled]}
-              onPress={handleSubmit}
-              disabled={submitting}
+              key={opt}
+              onPress={() => setStatus(opt)}
+              style={{ flex: 1 }}
             >
-              {submitting ? (
-                <ActivityIndicator color="#fff" size="small" />
-              ) : (
-                <Text style={s.confirmText}>Сохранить</Text>
-              )}
+              <Badge variant={active ? 'info' : 'default'} style={{ alignSelf: 'stretch', alignItems: 'center' }}>
+                {STATUS_LABELS[opt]}
+              </Badge>
             </Pressable>
-          </View>
-        </View>
+          );
+        })}
       </View>
     </Modal>
   );
@@ -178,51 +175,79 @@ export default function AdminComplaintsScreen() {
   const totalPages = Math.ceil(total / 20);
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Жалобы" onBack={() => router.back()} />
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={s.scroll}>
-        <View style={s.pageHeader}>
-          <Text style={s.pageTitle}>Жалобы</Text>
-          <Text style={s.pageSubtitle}>Всего: {total}</Text>
-        </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ gap: Spacing.xs, marginBottom: Spacing.sm }}>
+              <Heading level={2}>Жалобы</Heading>
+              <Text variant="caption">Всего: {total}</Text>
+            </View>
 
-        {loading ? (
-          <View style={s.center}><ActivityIndicator size="large" color={Colors.brandPrimary} /></View>
-        ) : complaints.length === 0 ? (
-          <View style={s.empty}>
-            <Feather name="flag" size={32} color={Colors.border} />
-            <Text style={s.emptyText}>Жалоб нет</Text>
-          </View>
-        ) : (
-          <>
-            {complaints.map((c) => (
-              <ComplaintRow
-                key={c.id}
-                item={c}
-                onResolve={(id) => setResolveId(id)}
-              />
-            ))}
-            {totalPages > 1 && (
-              <View style={s.pagination}>
-                <Pressable
-                  style={[s.pageBtn, page <= 1 && s.pageBtnDisabled]}
-                  onPress={() => page > 1 && load(page - 1)}
-                  disabled={page <= 1}
-                >
-                  <Feather name="chevron-left" size={16} color={page <= 1 ? Colors.textMuted : Colors.brandPrimary} />
-                </Pressable>
-                <Text style={s.pageInfo}>{page} / {totalPages}</Text>
-                <Pressable
-                  style={[s.pageBtn, page >= totalPages && s.pageBtnDisabled]}
-                  onPress={() => page < totalPages && load(page + 1)}
-                  disabled={page >= totalPages}
-                >
-                  <Feather name="chevron-right" size={16} color={page >= totalPages ? Colors.textMuted : Colors.brandPrimary} />
-                </Pressable>
+            {loading ? (
+              <View style={{ paddingVertical: Spacing['3xl'], alignItems: 'center' }}>
+                <ActivityIndicator size="large" color={Colors.brandPrimary} />
               </View>
+            ) : complaints.length === 0 ? (
+              <EmptyState
+                icon={<Feather name="flag" size={32} color={Colors.border} />}
+                title="Жалоб нет"
+              />
+            ) : (
+              <>
+                {complaints.map((c) => (
+                  <ComplaintRow
+                    key={c.id}
+                    item={c}
+                    onResolve={(id) => setResolveId(id)}
+                  />
+                ))}
+                {totalPages > 1 ? (
+                  <View style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: Spacing.lg,
+                    marginTop: Spacing.md,
+                  }}>
+                    <Pressable
+                      onPress={() => page > 1 && load(page - 1)}
+                      disabled={page <= 1}
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 18,
+                        backgroundColor: Colors.bgSecondary,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        opacity: page <= 1 ? 0.4 : 1,
+                      }}
+                    >
+                      <Feather name="chevron-left" size={16} color={page <= 1 ? Colors.textMuted : Colors.brandPrimary} />
+                    </Pressable>
+                    <Text weight="semibold">{page} / {totalPages}</Text>
+                    <Pressable
+                      onPress={() => page < totalPages && load(page + 1)}
+                      disabled={page >= totalPages}
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 18,
+                        backgroundColor: Colors.bgSecondary,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        opacity: page >= totalPages ? 0.4 : 1,
+                      }}
+                    >
+                      <Feather name="chevron-right" size={16} color={page >= totalPages ? Colors.textMuted : Colors.brandPrimary} />
+                    </Pressable>
+                  </View>
+                ) : null}
+              </>
             )}
-          </>
-        )}
+          </View>
+        </Container>
       </ScrollView>
 
       <ResolveModal
@@ -231,124 +256,6 @@ export default function AdminComplaintsScreen() {
         onClose={() => setResolveId(null)}
         onResolved={handleResolved}
       />
-    </View>
+    </Screen>
   );
 }
-
-const s = StyleSheet.create({
-  scroll: { padding: Spacing.lg, gap: Spacing.md },
-  pageHeader: { gap: Spacing.xs, marginBottom: Spacing.sm },
-  pageTitle: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  pageSubtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  center: { paddingVertical: Spacing['3xl'], alignItems: 'center' },
-  empty: { alignItems: 'center', gap: Spacing.md, paddingVertical: Spacing['3xl'] },
-  emptyText: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
-
-  row: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.card,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    padding: Spacing.md,
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  rowMain: { flex: 1, gap: Spacing.xs },
-  rowHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  rowDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-
-  statusBadge: { borderRadius: 12, paddingHorizontal: Spacing.sm, paddingVertical: 2 },
-  statusText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold },
-
-  reason: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  comment: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
-  meta: { gap: 2 },
-  metaText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-  metaBold: { fontWeight: Typography.fontWeight.semibold, color: Colors.textSecondary },
-
-  resolveBtn: { padding: Spacing.sm, alignSelf: 'flex-start' },
-
-  pagination: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: Spacing.lg,
-    marginTop: Spacing.md,
-  },
-  pageBtn: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  pageBtnDisabled: { opacity: 0.4 },
-  pageInfo: { fontSize: Typography.fontSize.base, color: Colors.textPrimary, fontWeight: Typography.fontWeight.semibold },
-
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: Spacing.lg,
-  },
-  modal: {
-    backgroundColor: '#fff',
-    borderRadius: BorderRadius.card,
-    padding: Spacing.xl,
-    width: '100%',
-    maxWidth: 400,
-    gap: Spacing.md,
-    ...Shadows.lg,
-  },
-  modalTitle: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  modalLabel: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-  },
-  statusRow: { flexDirection: 'row', gap: Spacing.sm },
-  statusOption: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    paddingVertical: Spacing.sm,
-    alignItems: 'center',
-  },
-  statusOptionActive: {
-    borderColor: Colors.brandPrimary,
-    backgroundColor: Colors.bgSecondary,
-  },
-  statusOptionText: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-  statusOptionTextActive: { color: Colors.brandPrimary, fontWeight: Typography.fontWeight.semibold },
-
-  modalActions: { flexDirection: 'row', gap: Spacing.sm, marginTop: Spacing.sm },
-  cancelBtn: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cancelText: { fontSize: Typography.fontSize.base, color: Colors.textSecondary },
-  confirmBtn: {
-    flex: 1,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.md,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  confirmDisabled: { opacity: 0.5 },
-  confirmText: { fontSize: Typography.fontSize.base, color: '#fff', fontWeight: Typography.fontWeight.semibold },
-});

--- a/app/(admin)/index.tsx
+++ b/app/(admin)/index.tsx
@@ -1,31 +1,35 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, ActivityIndicator, StyleSheet, ScrollView } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { BorderRadius, Colors, Spacing, Typography } from '../../constants/Colors';
 import { admin } from '../../lib/api/endpoints';
 import { Header } from '../../components/Header';
-
-function SkeletonBlock({ width, height, radius }: { width: string | number; height: number; radius?: number }) {
-  return (
-    <View style={[s.skeleton, { width: width as any, height, borderRadius: radius || BorderRadius.md }]} />
-  );
-}
+import { Button, Card, Container, Heading, Screen, Text } from '../../components/ui';
 
 function StatCard({ label, value, color, trend, icon }: { label: string; value: string | number; color: string; trend?: string; icon: string }) {
   return (
-    <View style={s.statCard}>
-      <View style={[s.statIcon, { backgroundColor: color + '15' }]}>
+    <Card variant="outlined" padding="md" style={{ width: '48%', gap: Spacing.xs }}>
+      <View style={{
+        width: 36,
+        height: 36,
+        borderRadius: 18,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: color + '15',
+      }}>
         <Feather name={icon as any} size={18} color={color} />
       </View>
-      <Text style={s.statLabel}>{label}</Text>
-      <Text style={[s.statValue, { color }]}>{value}</Text>
-      {trend && (
-        <View style={s.trendRow}>
+      <Text variant="caption">{label}</Text>
+      <Text style={{ fontSize: 22, fontWeight: Typography.fontWeight.bold, color, fontFamily: Typography.fontFamily.bold }}>
+        {value}
+      </Text>
+      {trend ? (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
           <Feather name="trending-up" size={12} color={Colors.statusSuccess} />
-          <Text style={s.statTrend}>{trend}</Text>
+          <Text variant="caption" style={{ color: Colors.statusSuccess }}>{trend}</Text>
         </View>
-      )}
-    </View>
+      ) : null}
+    </Card>
   );
 }
 
@@ -50,39 +54,39 @@ function WeeklyChart({ title, data }: { title: string; data: WeeklyBucket[] }) {
   const allZero = totals.every((t) => t === 0);
 
   return (
-    <View style={s.chartCard}>
-      <Text style={s.chartTitle}>{title}</Text>
+    <Card variant="outlined" padding="lg" style={{ gap: Spacing.md }}>
+      <Heading level={4}>{title}</Heading>
       {allZero ? (
         <View style={{ paddingVertical: Spacing.xl, alignItems: 'center' }}>
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>
-            Нет активности за последние 7 дней
-          </Text>
+          <Text variant="caption">Нет активности за последние 7 дней</Text>
         </View>
       ) : (
-        <View style={s.chartArea}>
-          <View style={s.chartBars}>
+        <View style={{ gap: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'flex-end', gap: Spacing.sm, height: 100 }}>
             {totals.map((t, i) => {
               const h = Math.max(4, Math.round((t / max) * 100));
               const isLast = i === totals.length - 1;
               return (
                 <View
                   key={i}
-                  style={[
-                    s.chartBar,
-                    { height: h, backgroundColor: isLast ? Colors.brandPrimary : Colors.bgSecondary },
-                  ]}
+                  style={{
+                    flex: 1,
+                    borderRadius: BorderRadius.sm,
+                    height: h,
+                    backgroundColor: isLast ? Colors.brandPrimary : Colors.bgSecondary,
+                  }}
                 />
               );
             })}
           </View>
-          <View style={s.chartLabels}>
+          <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
             {labels.map((d, i) => (
-              <Text key={i} style={s.chartLabel}>{d}</Text>
+              <Text key={i} variant="caption" align="center" style={{ flex: 1 }}>{d}</Text>
             ))}
           </View>
         </View>
       )}
-    </View>
+    </Card>
   );
 }
 
@@ -141,56 +145,85 @@ function DefaultDashboard({
   activities: ActivityRow[];
 }) {
   return (
-    <ScrollView style={{ flex: 1 }} contentContainerStyle={s.container}>
-      <View style={s.pageHeader}>
-        <Text style={s.pageTitle}>Панель администратора</Text>
-        <Text style={s.pageSubtitle}>Обзор платформы</Text>
-      </View>
+    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+      <Container>
+        <View style={{ gap: Spacing.lg }}>
+          <View style={{ gap: Spacing.xs }}>
+            <Heading level={2}>Панель администратора</Heading>
+            <Text variant="caption">Обзор платформы</Text>
+          </View>
 
-      <View style={s.statsGrid}>
-        <StatCard label="Всего пользователей" value={st.totalUsers ?? '—'} color={Colors.textPrimary} icon="users" />
-        <StatCard label="Специалистов" value={st.totalSpecialists ?? '—'} color={Colors.brandPrimary} icon="briefcase" />
-        <StatCard label="Всего заявок" value={st.totalRequests ?? '—'} color={Colors.textPrimary} icon="file-text" />
-        <StatCard label="Открытые жалобы" value={st.openComplaints ?? '—'} color={Colors.statusWarning} icon="alert-triangle" />
-      </View>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm }}>
+            <StatCard label="Всего пользователей" value={st.totalUsers ?? '—'} color={Colors.textPrimary} icon="users" />
+            <StatCard label="Специалистов" value={st.totalSpecialists ?? '—'} color={Colors.brandPrimary} icon="briefcase" />
+            <StatCard label="Всего заявок" value={st.totalRequests ?? '—'} color={Colors.textPrimary} icon="file-text" />
+            <StatCard label="Открытые жалобы" value={st.openComplaints ?? '—'} color={Colors.statusWarning} icon="alert-triangle" />
+          </View>
 
-      <WeeklyChart title="Активность за неделю" data={weekly} />
+          <WeeklyChart title="Активность за неделю" data={weekly} />
 
-      <View style={s.recentSection}>
-        <View style={s.sectionHeader}>
-          <Text style={s.sectionTitle}>Последние действия</Text>
-          <View style={s.sectionBadge}>
-            <Text style={s.sectionBadgeText}>{activities.length}</Text>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+              <Heading level={3}>Последние действия</Heading>
+              <View style={{
+                backgroundColor: Colors.brandPrimary,
+                minWidth: 22,
+                height: 22,
+                borderRadius: 11,
+                alignItems: 'center',
+                justifyContent: 'center',
+                paddingHorizontal: 5,
+              }}>
+                <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.white, fontWeight: Typography.fontWeight.bold, fontFamily: Typography.fontFamily.bold }}>
+                  {activities.length}
+                </Text>
+              </View>
+            </View>
+            {activities.length === 0 ? (
+              <View style={{ paddingVertical: Spacing.xl, alignItems: 'center' }}>
+                <Text variant="caption">Пока нет активности</Text>
+              </View>
+            ) : (
+              activities.map((item, i) => {
+                const detailText = item.targetName
+                  ? `${item.actorName} — ${item.targetName}`
+                  : item.actorName;
+                return (
+                  <View
+                    key={i}
+                    style={{
+                      flexDirection: 'row',
+                      gap: Spacing.md,
+                      alignItems: 'center',
+                      paddingVertical: Spacing.sm,
+                      borderBottomWidth: 1,
+                      borderBottomColor: Colors.bgSecondary,
+                    }}
+                  >
+                    <View style={{
+                      width: 32,
+                      height: 32,
+                      borderRadius: 16,
+                      backgroundColor: Colors.brandPrimary + '15',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}>
+                      <Feather name={activityIconFor(item.type) as any} size={16} color={Colors.brandPrimary} />
+                    </View>
+                    <View style={{ flex: 1, gap: 1 }}>
+                      <Text weight="semibold" numberOfLines={1}>
+                        {item.action}: <Text>{detailText}</Text>
+                      </Text>
+                      <Text variant="caption">{formatRelativeTime(item.createdAt)}</Text>
+                    </View>
+                    <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+                  </View>
+                );
+              })
+            )}
           </View>
         </View>
-        {activities.length === 0 ? (
-          <View style={{ paddingVertical: Spacing.xl, alignItems: 'center' }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>
-              Пока нет активности
-            </Text>
-          </View>
-        ) : (
-          activities.map((item, i) => {
-            const detailText = item.targetName
-              ? `${item.actorName} — ${item.targetName}`
-              : item.actorName;
-            return (
-              <View key={i} style={s.activityRow}>
-                <View style={s.activityIconWrap}>
-                  <Feather name={activityIconFor(item.type) as any} size={16} color={Colors.brandPrimary} />
-                </View>
-                <View style={s.activityContent}>
-                  <Text style={s.activityAction} numberOfLines={1}>
-                    {item.action}: <Text style={s.activityDetail}>{detailText}</Text>
-                  </Text>
-                  <Text style={s.activityTime}>{formatRelativeTime(item.createdAt)}</Text>
-                </View>
-                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-              </View>
-            );
-          })
-        )}
-      </View>
+      </Container>
     </ScrollView>
   );
 }
@@ -222,83 +255,22 @@ export default function AdminDashboardPage() {
   useEffect(() => { load(); }, []);
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="auth" />
       {loading ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: Spacing.md }}>
           <ActivityIndicator color={Colors.brandPrimary} />
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Загрузка...</Text>
+          <Text variant="caption">Загрузка...</Text>
         </View>
       ) : error ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.xl, gap: Spacing.md }}>
           <Feather name="alert-circle" size={32} color={Colors.statusError} />
-          <Text style={{ fontSize: Typography.fontSize.base, color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
-          <Pressable
-            onPress={load}
-            style={{ paddingHorizontal: Spacing.lg, paddingVertical: Spacing.sm, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn }}
-          >
-            <Text style={{ color: Colors.white, fontWeight: Typography.fontWeight.semibold }}>Повторить</Text>
-          </Pressable>
+          <Text align="center" style={{ color: Colors.statusError }}>{error}</Text>
+          <Button onPress={load}>Повторить</Button>
         </View>
       ) : (
         <DefaultDashboard st={stats ?? {}} weekly={weekly} activities={activities} />
       )}
-    </View>
+    </Screen>
   );
 }
-
-const s = StyleSheet.create({
-  container: { padding: Spacing.lg, gap: Spacing.lg },
-
-  pageHeader: { gap: Spacing.xs },
-  pageTitle: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  pageSubtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  statsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm },
-  statCard: {
-    width: '48%', backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card,
-    padding: Spacing.md, borderWidth: 1, borderColor: Colors.border, gap: Spacing.xs, ...Shadows.sm,
-  },
-  statIcon: { width: 36, height: 36, borderRadius: 18, alignItems: 'center', justifyContent: 'center' },
-  statLabel: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-  statValue: { fontSize: 22, fontWeight: Typography.fontWeight.bold },
-  trendRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  statTrend: { fontSize: Typography.fontSize.xs, color: Colors.statusSuccess },
-
-  chartCard: {
-    backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg,
-    borderWidth: 1, borderColor: Colors.border, gap: Spacing.md, ...Shadows.sm,
-  },
-  chartTitle: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  chartArea: { gap: Spacing.sm },
-  chartBars: { flexDirection: 'row', alignItems: 'flex-end', gap: Spacing.sm, height: 100 },
-  chartBar: { flex: 1, borderRadius: BorderRadius.sm },
-  chartLabels: { flexDirection: 'row', gap: Spacing.sm },
-  chartLabel: { flex: 1, fontSize: Typography.fontSize.xs, color: Colors.textMuted, textAlign: 'center' },
-
-  recentSection: { gap: Spacing.md },
-  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: Spacing.sm },
-  sectionTitle: { fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  sectionBadge: {
-    backgroundColor: Colors.brandPrimary, minWidth: 22, height: 22, borderRadius: 11,
-    alignItems: 'center', justifyContent: 'center', paddingHorizontal: 5,
-  },
-  sectionBadgeText: { fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.bold, color: Colors.white },
-
-  activityRow: {
-    flexDirection: 'row', gap: Spacing.md, alignItems: 'center',
-    paddingVertical: Spacing.sm, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary,
-  },
-  activityIconWrap: {
-    width: 32, height: 32, borderRadius: 16, backgroundColor: Colors.brandPrimary + '15',
-    alignItems: 'center', justifyContent: 'center',
-  },
-  activityContent: { flex: 1, gap: 1 },
-  activityAction: { fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary },
-  activityDetail: { fontWeight: Typography.fontWeight.regular, color: Colors.textSecondary },
-  activityTime: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  // Loading
-  skeleton: { backgroundColor: Colors.bgSurface, opacity: 0.7 },
-  loadingText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: Spacing.sm },
-});

--- a/app/(admin)/reviews.tsx
+++ b/app/(admin)/reviews.tsx
@@ -1,28 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  ActivityIndicator,
-  StyleSheet,
-  Alert,
-} from 'react-native';
+import { ActivityIndicator, Alert, Pressable, ScrollView, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing } from '../../constants/Colors';
+import { Card, Container, EmptyState, Heading, Rating, Screen, Text } from '../../components/ui';
 import { Header } from '../../components/Header';
 import { useRouter } from 'expo-router';
 import * as api from '../../lib/api/endpoints';
-
-function StarDisplay({ rating }: { rating: number }) {
-  return (
-    <View style={{ flexDirection: 'row', gap: 2 }}>
-      {[1, 2, 3, 4, 5].map((n) => (
-        <Feather key={n} name="star" size={12} color={n <= rating ? '#F59E0B' : Colors.border} />
-      ))}
-    </View>
-  );
-}
 
 function ReviewRow({ item, onDelete }: { item: any; onDelete: (id: string) => void }) {
   const date = new Date(item.createdAt).toLocaleDateString('ru-RU');
@@ -37,26 +20,40 @@ function ReviewRow({ item, onDelete }: { item: any; onDelete: (id: string) => vo
   }
 
   return (
-    <View style={s.row}>
-      <View style={s.rowMain}>
-        <View style={s.rowHeader}>
-          <StarDisplay rating={item.rating} />
-          <Text style={s.rowDate}>{date}</Text>
+    <Card variant="outlined" padding="md">
+      <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+        <View style={{ flex: 1, gap: Spacing.xs }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Rating value={item.rating} size="sm" showNumeric={false} />
+            <Text variant="caption">{date}</Text>
+          </View>
+          {item.comment ? (
+            <Text variant="caption" numberOfLines={2} style={{ lineHeight: 20 }}>
+              {item.comment}
+            </Text>
+          ) : (
+            <Text variant="caption" style={{ fontStyle: 'italic' }}>
+              Без комментария
+            </Text>
+          )}
+          <View style={{ gap: 2 }}>
+            <Text variant="caption">
+              Специалист: <Text variant="caption" weight="semibold">{specialist}</Text>
+            </Text>
+            <Text variant="caption">
+              Клиент: <Text variant="caption" weight="semibold">{client}</Text>
+            </Text>
+          </View>
         </View>
-        {item.comment ? (
-          <Text style={s.rowComment} numberOfLines={2}>{item.comment}</Text>
-        ) : (
-          <Text style={s.rowNoComment}>Без комментария</Text>
-        )}
-        <View style={s.rowMeta}>
-          <Text style={s.metaText}>Специалист: <Text style={s.metaBold}>{specialist}</Text></Text>
-          <Text style={s.metaText}>Клиент: <Text style={s.metaBold}>{client}</Text></Text>
-        </View>
+        <Pressable
+          onPress={confirmDelete}
+          style={{ padding: Spacing.sm, alignSelf: 'flex-start' }}
+          accessibilityLabel="Удалить отзыв"
+        >
+          <Feather name="trash-2" size={16} color={Colors.statusError} />
+        </Pressable>
       </View>
-      <Pressable onPress={confirmDelete} style={s.deleteBtn}>
-        <Feather name="trash-2" size={16} color={Colors.statusError} />
-      </Pressable>
-    </View>
+    </Card>
   );
 }
 
@@ -101,105 +98,80 @@ export default function AdminReviewsScreen() {
   const totalPages = Math.ceil(total / 20);
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Отзывы" onBack={() => router.back()} />
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={s.scroll}>
-        <View style={s.pageHeader}>
-          <Text style={s.pageTitle}>Модерация отзывов</Text>
-          <Text style={s.pageSubtitle}>Всего: {total}</Text>
-        </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ gap: Spacing.xs, marginBottom: Spacing.sm }}>
+              <Heading level={2}>Модерация отзывов</Heading>
+              <Text variant="caption">Всего: {total}</Text>
+            </View>
 
-        {loading ? (
-          <View style={s.center}><ActivityIndicator size="large" color={Colors.brandPrimary} /></View>
-        ) : reviews.length === 0 ? (
-          <View style={s.empty}>
-            <Feather name="star" size={32} color={Colors.border} />
-            <Text style={s.emptyText}>Отзывов нет</Text>
-          </View>
-        ) : (
-          <>
-            {reviews.map((r) => (
-              <ReviewRow
-                key={r.id}
-                item={r}
-                onDelete={deleting ? () => {} : handleDelete}
-              />
-            ))}
-            {totalPages > 1 && (
-              <View style={s.pagination}>
-                <Pressable
-                  style={[s.pageBtn, page <= 1 && s.pageBtnDisabled]}
-                  onPress={() => page > 1 && load(page - 1)}
-                  disabled={page <= 1}
-                >
-                  <Feather name="chevron-left" size={16} color={page <= 1 ? Colors.textMuted : Colors.brandPrimary} />
-                </Pressable>
-                <Text style={s.pageInfo}>{page} / {totalPages}</Text>
-                <Pressable
-                  style={[s.pageBtn, page >= totalPages && s.pageBtnDisabled]}
-                  onPress={() => page < totalPages && load(page + 1)}
-                  disabled={page >= totalPages}
-                >
-                  <Feather name="chevron-right" size={16} color={page >= totalPages ? Colors.textMuted : Colors.brandPrimary} />
-                </Pressable>
+            {loading ? (
+              <View style={{ paddingVertical: Spacing['3xl'], alignItems: 'center' }}>
+                <ActivityIndicator size="large" color={Colors.brandPrimary} />
               </View>
+            ) : reviews.length === 0 ? (
+              <EmptyState
+                icon={<Feather name="star" size={32} color={Colors.border} />}
+                title="Отзывов нет"
+              />
+            ) : (
+              <>
+                {reviews.map((r) => (
+                  <ReviewRow
+                    key={r.id}
+                    item={r}
+                    onDelete={deleting ? () => {} : handleDelete}
+                  />
+                ))}
+                {totalPages > 1 ? (
+                  <View style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: Spacing.lg,
+                    marginTop: Spacing.md,
+                  }}>
+                    <Pressable
+                      onPress={() => page > 1 && load(page - 1)}
+                      disabled={page <= 1}
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 18,
+                        backgroundColor: Colors.bgSecondary,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        opacity: page <= 1 ? 0.4 : 1,
+                      }}
+                    >
+                      <Feather name="chevron-left" size={16} color={page <= 1 ? Colors.textMuted : Colors.brandPrimary} />
+                    </Pressable>
+                    <Text weight="semibold">{page} / {totalPages}</Text>
+                    <Pressable
+                      onPress={() => page < totalPages && load(page + 1)}
+                      disabled={page >= totalPages}
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 18,
+                        backgroundColor: Colors.bgSecondary,
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        opacity: page >= totalPages ? 0.4 : 1,
+                      }}
+                    >
+                      <Feather name="chevron-right" size={16} color={page >= totalPages ? Colors.textMuted : Colors.brandPrimary} />
+                    </Pressable>
+                  </View>
+                ) : null}
+              </>
             )}
-          </>
-        )}
+          </View>
+        </Container>
       </ScrollView>
-    </View>
+    </Screen>
   );
 }
-
-const s = StyleSheet.create({
-  scroll: { padding: Spacing.lg, gap: Spacing.md },
-  pageHeader: { gap: Spacing.xs, marginBottom: Spacing.sm },
-  pageTitle: { fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary },
-  pageSubtitle: { fontSize: Typography.fontSize.sm, color: Colors.textMuted },
-
-  center: { paddingVertical: Spacing['3xl'], alignItems: 'center' },
-  empty: { alignItems: 'center', gap: Spacing.md, paddingVertical: Spacing['3xl'] },
-  emptyText: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
-
-  row: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.card,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    padding: Spacing.md,
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  rowMain: { flex: 1, gap: Spacing.xs },
-  rowHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  rowDate: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-  rowComment: { fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 },
-  rowNoComment: { fontSize: Typography.fontSize.sm, color: Colors.textMuted, fontStyle: 'italic' },
-  rowMeta: { gap: 2 },
-  metaText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-  metaBold: { fontWeight: Typography.fontWeight.semibold, color: Colors.textSecondary },
-
-  deleteBtn: {
-    padding: Spacing.sm,
-    alignSelf: 'flex-start',
-  },
-
-  pagination: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: Spacing.lg,
-    marginTop: Spacing.md,
-  },
-  pageBtn: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  pageBtnDisabled: { opacity: 0.4 },
-  pageInfo: { fontSize: Typography.fontSize.base, color: Colors.textPrimary, fontWeight: Typography.fontWeight.semibold },
-});

--- a/app/(dashboard)/my-requests/[id].tsx
+++ b/app/(dashboard)/my-requests/[id].tsx
@@ -1,19 +1,28 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  Alert,
   ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  View,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Colors } from '../../../constants/Colors';
+import { BorderRadius, Colors, Spacing } from '../../../constants/Colors';
 import { requests, specialists as specialistsApi, threads as threadsApi } from '../../../lib/api/endpoints';
 import { useAuth } from '../../../lib/auth';
 import { Header } from '../../../components/Header';
 import { adaptThread } from '../../../lib/types/thread';
+import {
+  Badge,
+  BadgeVariant,
+  Button,
+  Card,
+  Container,
+  Heading,
+  Screen,
+  Text,
+} from '../../../components/ui';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -73,10 +82,10 @@ const STATUS_LABELS: Record<RequestStatus, string> = {
   CLOSED: 'Закрыта',
 };
 
-const STATUS_COLORS: Record<RequestStatus, string> = {
-  ACTIVE: Colors.statusSuccess,
-  CLOSING_SOON: '#F97316',
-  CLOSED: Colors.textMuted,
+const STATUS_BADGE_VARIANT: Record<RequestStatus, BadgeVariant> = {
+  ACTIVE: 'success',
+  CLOSING_SOON: 'warning',
+  CLOSED: 'default',
 };
 
 function formatDate(iso: string) {
@@ -177,18 +186,18 @@ function RecommendedSpecialists({ request }: { request: RequestDetail }) {
   }, [writingTo, request.id]);
 
   return (
-    <View className="gap-3">
-      <Text className="text-base font-semibold text-textPrimary">Рекомендуемые специалисты</Text>
+    <View style={{ gap: Spacing.md }}>
+      <Heading level={4}>Рекомендуемые специалисты</Heading>
       {loading ? (
-        <View className="items-center py-6">
+        <View style={{ alignItems: 'center', paddingVertical: Spacing.xl }}>
           <ActivityIndicator color={Colors.brandPrimary} />
         </View>
       ) : error ? (
-        <Text className="text-sm text-statusError">{error}</Text>
+        <Text variant="caption" style={{ color: Colors.statusError }}>{error}</Text>
       ) : items.length === 0 ? (
-        <View className="rounded-xl border border-borderLight bg-bgCard p-4">
-          <Text className="text-sm text-textMuted">Пока никого не нашли по этим параметрам</Text>
-        </View>
+        <Card variant="outlined" padding="md">
+          <Text variant="caption">Пока никого не нашли по этим параметрам</Text>
+        </Card>
       ) : (
         items.map((s) => {
           const name = s.displayName ?? s.nick ?? 'Специалист';
@@ -196,45 +205,48 @@ function RecommendedSpecialists({ request }: { request: RequestDetail }) {
           const rating = s.activity?.avgRating;
           const city = (s.cities ?? [])[0];
           return (
-            <View
-              key={s.nick ?? name}
-              className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3"
-            >
-              <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
-                <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
-              </View>
-              <View className="flex-1">
-                <Text className="text-sm font-semibold text-textPrimary" numberOfLines={1}>{name}</Text>
-                <View className="mt-0.5 flex-row items-center gap-2">
-                  {rating != null && (
-                    <View className="flex-row items-center gap-1">
-                      <Feather name="star" size={11} color="#F59E0B" />
-                      <Text className="text-xs text-textMuted">{Number(rating).toFixed(1)}</Text>
-                    </View>
-                  )}
-                  {city && (
-                    <View className="flex-row items-center gap-1">
-                      <Feather name="map-pin" size={11} color={Colors.textMuted} />
-                      <Text className="text-xs text-textMuted" numberOfLines={1}>{city}</Text>
-                    </View>
-                  )}
+            <Card key={s.nick ?? name} variant="outlined" padding="sm">
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md }}>
+                <View style={{
+                  width: 40,
+                  height: 40,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: 9999,
+                  borderWidth: 1,
+                  borderColor: Colors.borderLight,
+                  backgroundColor: Colors.bgSurface,
+                }}>
+                  <Text weight="bold" style={{ color: Colors.brandPrimary, fontSize: 13 }}>{initials}</Text>
                 </View>
+                <View style={{ flex: 1 }}>
+                  <Text weight="semibold" numberOfLines={1}>{name}</Text>
+                  <View style={{ marginTop: 2, flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                    {rating != null ? (
+                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                        <Feather name="star" size={11} color={Colors.amber} />
+                        <Text variant="caption">{Number(rating).toFixed(1)}</Text>
+                      </View>
+                    ) : null}
+                    {city ? (
+                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                        <Feather name="map-pin" size={11} color={Colors.textMuted} />
+                        <Text variant="caption" numberOfLines={1}>{city}</Text>
+                      </View>
+                    ) : null}
+                  </View>
+                </View>
+                <Button
+                  size="md"
+                  onPress={() => s.nick && handleWrite(s.nick)}
+                  disabled={!s.nick || writingTo === s.nick}
+                  loading={writingTo === s.nick}
+                  icon={<Feather name="send" size={12} color={Colors.white} />}
+                >
+                  Написать
+                </Button>
               </View>
-              <Pressable
-                onPress={() => s.nick && handleWrite(s.nick)}
-                disabled={!s.nick || writingTo === s.nick}
-                className="h-9 flex-row items-center justify-center gap-1 rounded-lg bg-brandPrimary px-3"
-              >
-                {writingTo === s.nick ? (
-                  <ActivityIndicator size="small" color={Colors.white} />
-                ) : (
-                  <>
-                    <Feather name="send" size={12} color={Colors.white} />
-                    <Text className="text-xs font-semibold text-white">Написать</Text>
-                  </>
-                )}
-              </Pressable>
-            </View>
+            </Card>
           );
         })
       )}
@@ -256,8 +268,15 @@ function ReviewCTAList({
   if (threads.length === 0) return null;
 
   return (
-    <View className="gap-3 rounded-xl border border-brandPrimary/30 bg-brandPrimary/5 p-4">
-      <Text className="text-sm font-semibold text-brandPrimary">
+    <View style={{
+      gap: Spacing.md,
+      padding: Spacing.lg,
+      borderRadius: BorderRadius.xl,
+      borderWidth: 1,
+      borderColor: Colors.brandPrimary + '4D',
+      backgroundColor: Colors.brandPrimary + '0D',
+    }}>
+      <Text weight="semibold" style={{ color: Colors.brandPrimary }}>
         Заявка закрыта. Оставьте отзыв специалисту:
       </Text>
       {threads.map((thread) => {
@@ -274,14 +293,32 @@ function ReviewCTAList({
                 `/leave-review?requestId=${requestId}&specialistId=${specialist.id}${nick ? `&specialistNick=${nick}` : ''}` as any,
               )
             }
-            className="flex-row items-center gap-3 rounded-lg border border-borderLight bg-white p-3"
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: Spacing.md,
+              padding: Spacing.md,
+              borderRadius: BorderRadius.lg,
+              borderWidth: 1,
+              borderColor: Colors.borderLight,
+              backgroundColor: Colors.white,
+            }}
           >
-            <View className="h-9 w-9 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
-              <Text className="text-xs font-bold text-brandPrimary">{initials}</Text>
+            <View style={{
+              width: 36,
+              height: 36,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 9999,
+              borderWidth: 1,
+              borderColor: Colors.borderLight,
+              backgroundColor: Colors.bgSurface,
+            }}>
+              <Text weight="bold" style={{ color: Colors.brandPrimary, fontSize: 12 }}>{initials}</Text>
             </View>
-            <View className="flex-1">
-              <Text className="text-sm font-semibold text-textPrimary">{displayName}</Text>
-              {nick && <Text className="text-xs text-textMuted">@{nick}</Text>}
+            <View style={{ flex: 1 }}>
+              <Text weight="semibold">{displayName}</Text>
+              {nick ? <Text variant="caption">@{nick}</Text> : null}
             </View>
             <Feather name="star" size={16} color={Colors.brandPrimary} />
           </Pressable>
@@ -364,34 +401,32 @@ export default function RequestDetailScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-white">
+      <Screen bg={Colors.white}>
         <Header variant="back" onBack={() => router.back()} />
-        <View className="flex-1 items-center justify-center">
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator color={Colors.brandPrimary} />
         </View>
-      </View>
+      </Screen>
     );
   }
 
   if (error || !request) {
     return (
-      <View className="flex-1 bg-white">
+      <Screen bg={Colors.white}>
         <Header variant="back" onBack={() => router.back()} />
-        <View className="flex-1 items-center justify-center p-6">
-          <Text className="text-center text-base text-statusError">
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.xl, gap: Spacing.md }}>
+          <Text align="center" style={{ color: Colors.statusError }}>
             {error ?? 'Заявка не найдена'}
           </Text>
-          <Pressable onPress={fetchRequest} className="mt-4">
-            <Text className="text-sm text-brandPrimary">Повторить</Text>
-          </Pressable>
+          <Button variant="ghost" onPress={fetchRequest}>Повторить</Button>
         </View>
-      </View>
+      </Screen>
     );
   }
 
   const status = request.status as RequestStatus;
   const statusLabel = STATUS_LABELS[status] ?? status;
-  const statusColor = STATUS_COLORS[status] ?? Colors.textMuted;
+  const statusVariant = STATUS_BADGE_VARIANT[status] ?? 'default';
   const isOwner = user?.id === request.clientId;
   const canClose = isOwner && CLOSEABLE_STATUSES.includes(status);
   const isClosed = status === 'CLOSED';
@@ -400,135 +435,139 @@ export default function RequestDetailScreen() {
     isOwner && status === 'CLOSING_SOON' && extensionsCount < MAX_EXTENSIONS;
 
   return (
-    <View className="flex-1 bg-white">
-    <Header variant="back" backTitle={request.title} onBack={() => router.back()} />
-    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      {/* Request card */}
-      <View className="gap-4 rounded-xl border border-borderLight bg-white p-4">
-        <View className="flex-row items-start justify-between gap-2">
-          <Text className="flex-1 text-lg font-bold text-textPrimary">{request.title}</Text>
-          <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + '18' }}>
-            <Text className="text-xs font-semibold" style={{ color: statusColor }}>
-              {statusLabel}
-            </Text>
-          </View>
-        </View>
-
-        <Text className="text-base leading-6 text-textSecondary">{request.description}</Text>
-
-        <View className="gap-2">
-          <View className="flex-row items-center gap-2">
-            <Feather name="map-pin" size={14} color={Colors.textMuted} />
-            <Text className="text-sm text-textMuted">{request.city}</Text>
-          </View>
-          {request.ifnsName && (
-            <View className="flex-row items-center gap-2">
-              <Feather name="home" size={14} color={Colors.textMuted} />
-              <Text className="text-sm text-textMuted">{request.ifnsName}</Text>
-            </View>
-          )}
-          {request.serviceType && (
-            <View className="flex-row items-center gap-2">
-              <Feather name="briefcase" size={14} color={Colors.textMuted} />
-              <Text className="text-sm text-textMuted">{request.serviceType}</Text>
-            </View>
-          )}
-          <View className="flex-row items-center gap-2">
-            <Feather name="calendar" size={14} color={Colors.textMuted} />
-            <Text className="text-sm text-textMuted">{formatDate(request.createdAt)}</Text>
-          </View>
-        </View>
-
-        {/* Extend button — owner, CLOSING_SOON, extensionsCount < 3 */}
-        {canExtend && (
-          <Pressable
-            onPress={handleExtend}
-            disabled={extending}
-            className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-brandPrimary bg-brandPrimary/10"
-          >
-            {extending ? (
-              <ActivityIndicator size="small" color={Colors.brandPrimary} />
-            ) : (
-              <>
-                <Feather name="refresh-cw" size={14} color={Colors.brandPrimary} />
-                <Text className="text-sm font-medium text-brandPrimary">
-                  Продлить (осталось {MAX_EXTENSIONS - extensionsCount})
-                </Text>
-              </>
-            )}
-          </Pressable>
-        )}
-
-        {/* Close button — owner only, closeable statuses */}
-        {canClose && (
-          <Pressable
-            onPress={handleClose}
-            disabled={closing}
-            className="h-10 flex-row items-center justify-center gap-1.5 rounded-lg border border-statusError bg-statusError/10"
-          >
-            {closing ? (
-              <ActivityIndicator size="small" color={Colors.statusError} />
-            ) : (
-              <>
-                <Feather name="x-circle" size={14} color={Colors.statusError} />
-                <Text className="text-sm font-medium text-statusError">Закрыть заявку</Text>
-              </>
-            )}
-          </Pressable>
-        )}
-      </View>
-
-      {/* Recommended specialists — owner only, active / closing_soon */}
-      {isOwner && !isClosed && <RecommendedSpecialists request={request} />}
-
-      {/* Review CTAs — shown immediately after closing if threads exist */}
-      {isClosed && isOwner && request.threads.length > 0 && (
-        <ReviewCTAList
-          requestId={request.id}
-          threads={request.threads}
-          clientId={request.clientId}
-        />
-      )}
-
-      {/* Threads list */}
-      {request.threads.length > 0 && (
-        <View className="gap-3">
-          <Text className="text-base font-semibold text-textPrimary">
-            Сообщения ({request._count.threads})
-          </Text>
-          {request.threads.map((thread) => {
-            const specialist = getSpecialist(thread, request.clientId);
-            const displayName =
-              specialist.specialistProfile?.displayName ?? specialist.email;
-            const initials = getInitials(
-              specialist.specialistProfile?.displayName,
-              specialist.email,
-            );
-
-            return (
-              <Pressable
-                key={thread.id}
-                onPress={() => router.push(`/chat/${thread.id}` as any)}
-                className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3"
-              >
-                <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
-                  <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
+    <Screen bg={Colors.white}>
+      <Header variant="back" backTitle={request.title} onBack={() => router.back()} />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            {/* Request card */}
+            <Card variant="outlined" padding="md" style={{ gap: Spacing.lg }}>
+              <View style={{ flexDirection: 'row', alignItems: 'flex-start', justifyContent: 'space-between', gap: Spacing.sm }}>
+                <View style={{ flex: 1 }}>
+                  <Heading level={3}>{request.title}</Heading>
                 </View>
-                <View className="flex-1">
-                  <Text className="text-sm font-semibold text-textPrimary">{displayName}</Text>
-                  {specialist.specialistProfile?.nick && (
-                    <Text className="text-xs text-textMuted">
-                      @{specialist.specialistProfile.nick}
-                    </Text>
-                  )}
+                <Badge variant={statusVariant}>{statusLabel}</Badge>
+              </View>
+
+              <Text style={{ lineHeight: 24 }}>{request.description}</Text>
+
+              <View style={{ gap: Spacing.sm }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                  <Feather name="map-pin" size={14} color={Colors.textMuted} />
+                  <Text variant="caption">{request.city}</Text>
                 </View>
-                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-              </Pressable>
-            );
-          })}
-        </View>
-      )}
-    </ScrollView>
-    </View>
+                {request.ifnsName ? (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                    <Feather name="home" size={14} color={Colors.textMuted} />
+                    <Text variant="caption">{request.ifnsName}</Text>
+                  </View>
+                ) : null}
+                {request.serviceType ? (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                    <Feather name="briefcase" size={14} color={Colors.textMuted} />
+                    <Text variant="caption">{request.serviceType}</Text>
+                  </View>
+                ) : null}
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                  <Feather name="calendar" size={14} color={Colors.textMuted} />
+                  <Text variant="caption">{formatDate(request.createdAt)}</Text>
+                </View>
+              </View>
+
+              {/* Extend button — owner, CLOSING_SOON, extensionsCount < 3 */}
+              {canExtend ? (
+                <Button
+                  variant="secondary"
+                  onPress={handleExtend}
+                  disabled={extending}
+                  loading={extending}
+                  fullWidth
+                  icon={<Feather name="refresh-cw" size={14} color={Colors.brandPrimary} />}
+                >
+                  {`Продлить (осталось ${MAX_EXTENSIONS - extensionsCount})`}
+                </Button>
+              ) : null}
+
+              {/* Close button — owner only, closeable statuses */}
+              {canClose ? (
+                <Button
+                  variant="danger"
+                  onPress={handleClose}
+                  disabled={closing}
+                  loading={closing}
+                  fullWidth
+                  icon={<Feather name="x-circle" size={14} color={Colors.white} />}
+                >
+                  Закрыть заявку
+                </Button>
+              ) : null}
+            </Card>
+
+            {/* Recommended specialists — owner only, active / closing_soon */}
+            {isOwner && !isClosed ? <RecommendedSpecialists request={request} /> : null}
+
+            {/* Review CTAs — shown immediately after closing if threads exist */}
+            {isClosed && isOwner && request.threads.length > 0 ? (
+              <ReviewCTAList
+                requestId={request.id}
+                threads={request.threads}
+                clientId={request.clientId}
+              />
+            ) : null}
+
+            {/* Threads list */}
+            {request.threads.length > 0 ? (
+              <View style={{ gap: Spacing.md }}>
+                <Heading level={4}>
+                  {`Сообщения (${request._count.threads})`}
+                </Heading>
+                {request.threads.map((thread) => {
+                  const specialist = getSpecialist(thread, request.clientId);
+                  const displayName =
+                    specialist.specialistProfile?.displayName ?? specialist.email;
+                  const initials = getInitials(
+                    specialist.specialistProfile?.displayName,
+                    specialist.email,
+                  );
+
+                  return (
+                    <Card
+                      key={thread.id}
+                      onPress={() => router.push(`/chat/${thread.id}` as any)}
+                      variant="outlined"
+                      padding="sm"
+                    >
+                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md }}>
+                        <View style={{
+                          width: 40,
+                          height: 40,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          borderRadius: 9999,
+                          borderWidth: 1,
+                          borderColor: Colors.borderLight,
+                          backgroundColor: Colors.bgSurface,
+                        }}>
+                          <Text weight="bold" style={{ color: Colors.brandPrimary, fontSize: 13 }}>{initials}</Text>
+                        </View>
+                        <View style={{ flex: 1 }}>
+                          <Text weight="semibold">{displayName}</Text>
+                          {specialist.specialistProfile?.nick ? (
+                            <Text variant="caption">
+                              @{specialist.specialistProfile.nick}
+                            </Text>
+                          ) : null}
+                        </View>
+                        <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+                      </View>
+                    </Card>
+                  );
+                })}
+              </View>
+            ) : null}
+          </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }

--- a/app/leave-review.tsx
+++ b/app/leave-review.tsx
@@ -1,20 +1,18 @@
 import React, { useState } from 'react';
 import {
-  View,
-  Text,
-  TextInput,
-  Pressable,
-  ScrollView,
   Alert,
-  ActivityIndicator,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
+  ScrollView,
+  View,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router, useLocalSearchParams } from 'expo-router';
-import { Colors } from '../constants/Colors';
+import { Colors, Spacing } from '../constants/Colors';
 import { reviews } from '../lib/api/endpoints';
 import { Header } from '../components/Header';
+import { Button, Container, Heading, Input, Screen, Text } from '../components/ui';
 
 export default function LeaveReviewScreen() {
   const { requestId, specialistNick } = useLocalSearchParams<{
@@ -60,92 +58,99 @@ export default function LeaveReviewScreen() {
 
   if (submitted) {
     return (
-      <View className="flex-1 bg-white">
-      <Header variant="back" onBack={() => router.back()} />
-      <View className="flex-1 items-center justify-center p-8 gap-6">
-        <View className="h-16 w-16 items-center justify-center rounded-full bg-statusSuccess/10">
-          <Feather name="check-circle" size={32} color={Colors.statusSuccess} />
-        </View>
-        <Text className="text-center text-xl font-bold text-textPrimary">Отзыв отправлен</Text>
-        <Text className="text-center text-base text-textSecondary">
-          Спасибо за вашу оценку. Это помогает другим клиентам выбрать специалиста.
-        </Text>
-        <Pressable
-          onPress={() => router.replace('/(dashboard)/my-requests' as any)}
-          className="h-12 w-full items-center justify-center rounded-xl bg-brandPrimary"
-        >
-          <Text className="text-base font-semibold text-white">Вернуться к заявкам</Text>
-        </Pressable>
-      </View>
-      </View>
+      <Screen bg={Colors.white}>
+        <Header variant="back" onBack={() => router.back()} />
+        <Container>
+          <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', paddingVertical: Spacing['4xl'], gap: Spacing.xl }}>
+            <View style={{
+              width: 64,
+              height: 64,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 32,
+              backgroundColor: Colors.successBg,
+            }}>
+              <Feather name="check-circle" size={32} color={Colors.statusSuccess} />
+            </View>
+            <Heading level={2} align="center">Отзыв отправлен</Heading>
+            <Text align="center" variant="muted">
+              Спасибо за вашу оценку. Это помогает другим клиентам выбрать специалиста.
+            </Text>
+            <Button fullWidth onPress={() => router.replace('/(dashboard)/my-requests' as any)}>
+              Вернуться к заявкам
+            </Button>
+          </View>
+        </Container>
+      </Screen>
     );
   }
 
   return (
     <KeyboardAvoidingView
-      className="flex-1"
+      style={{ flex: 1 }}
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
     >
-      <Header variant="back" onBack={() => router.back()} />
-      <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 20 }}>
-        <Text className="text-xl font-bold text-textPrimary">Оставить отзыв</Text>
-        {specialistNick && (
-          <Text className="text-sm text-textMuted">Специалист: @{specialistNick}</Text>
-        )}
+      <Screen bg={Colors.white}>
+        <Header variant="back" onBack={() => router.back()} />
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+          <Container>
+            <View style={{ gap: Spacing.xl }}>
+              <Heading level={2}>Оставить отзыв</Heading>
+              {specialistNick ? (
+                <Text variant="caption">Специалист: @{specialistNick}</Text>
+              ) : null}
 
-        {/* Star rating */}
-        <View className="gap-2">
-          <Text className="text-sm font-semibold text-textPrimary">Оценка *</Text>
-          <View className="flex-row gap-3">
-            {[1, 2, 3, 4, 5].map((star) => (
-              <Pressable key={star} onPress={() => setRating(star)}>
-                <Feather
-                  name="star"
-                  size={36}
-                  color={star <= rating ? '#F59E0B' : Colors.borderLight ?? '#E5E7EB'}
+              {/* Star rating */}
+              <View style={{ gap: Spacing.sm }}>
+                <Text variant="label">Оценка *</Text>
+                <View style={{ flexDirection: 'row', gap: Spacing.md }}>
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <Pressable key={star} onPress={() => setRating(star)}>
+                      <Feather
+                        name="star"
+                        size={36}
+                        color={star <= rating ? Colors.amber : Colors.borderLight}
+                      />
+                    </Pressable>
+                  ))}
+                </View>
+                {rating > 0 ? (
+                  <Text variant="caption">
+                    {['', 'Плохо', 'Ниже среднего', 'Нормально', 'Хорошо', 'Отлично'][rating]}
+                  </Text>
+                ) : null}
+              </View>
+
+              {/* Comment */}
+              <View style={{ gap: Spacing.sm }}>
+                <Input
+                  label="Комментарий"
+                  value={comment}
+                  onChangeText={setComment}
+                  placeholder="Опишите ваш опыт работы со специалистом..."
+                  multiline
+                  numberOfLines={5}
+                  maxLength={1000}
                 />
+                <Text variant="caption" align="right">{comment.length}/1000</Text>
+              </View>
+
+              <Button
+                fullWidth
+                onPress={handleSubmit}
+                disabled={submitting || rating === 0}
+                loading={submitting}
+              >
+                Отправить отзыв
+              </Button>
+
+              <Pressable onPress={() => router.back()} style={{ alignItems: 'center', paddingVertical: Spacing.sm }}>
+                <Text variant="caption">Отмена</Text>
               </Pressable>
-            ))}
-          </View>
-          {rating > 0 && (
-            <Text className="text-xs text-textMuted">
-              {['', 'Плохо', 'Ниже среднего', 'Нормально', 'Хорошо', 'Отлично'][rating]}
-            </Text>
-          )}
-        </View>
-
-        {/* Comment */}
-        <View className="gap-2">
-          <Text className="text-sm font-semibold text-textPrimary">Комментарий</Text>
-          <TextInput
-            className="min-h-[120px] rounded-xl border border-borderLight bg-bgSurface p-3 text-base text-textPrimary"
-            placeholder="Опишите ваш опыт работы со специалистом..."
-            placeholderTextColor={Colors.textMuted}
-            value={comment}
-            onChangeText={setComment}
-            multiline
-            textAlignVertical="top"
-            maxLength={1000}
-          />
-          <Text className="text-right text-xs text-textMuted">{comment.length}/1000</Text>
-        </View>
-
-        <Pressable
-          onPress={handleSubmit}
-          disabled={submitting || rating === 0}
-          className="h-12 items-center justify-center rounded-xl bg-brandPrimary disabled:opacity-50"
-        >
-          {submitting ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text className="text-base font-semibold text-white">Отправить отзыв</Text>
-          )}
-        </Pressable>
-
-        <Pressable onPress={() => router.back()} className="items-center py-2">
-          <Text className="text-sm text-textMuted">Отмена</Text>
-        </Pressable>
-      </ScrollView>
+            </View>
+          </Container>
+        </ScrollView>
+      </Screen>
     </KeyboardAvoidingView>
   );
 }

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  View,
-  Text,
-  Pressable,
   ActivityIndicator,
-  ScrollView,
+  Pressable,
   RefreshControl,
+  ScrollView,
+  View,
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../constants/Colors';
+import { BorderRadius, Colors, Shadows, Spacing, Typography } from '../constants/Colors';
 import { Header } from '../components/Header';
 import { notifications as notificationsApi } from '../lib/api/endpoints';
+import { Container, EmptyState, Heading, Screen, Text } from '../components/ui';
 
 type NotifType = 'NEW_MESSAGE' | 'REQUEST_UPDATE' | 'REVIEW' | 'SYSTEM' | string;
 
@@ -28,7 +28,7 @@ interface NotifItem {
 const TYPE_ICON: Record<string, { icon: string; color: string }> = {
   NEW_MESSAGE: { icon: 'message-circle', color: Colors.brandPrimary },
   REQUEST_UPDATE: { icon: 'file-text', color: Colors.statusSuccess },
-  REVIEW: { icon: 'star', color: '#F59E0B' },
+  REVIEW: { icon: 'star', color: Colors.amber },
   SYSTEM: { icon: 'info', color: Colors.textMuted },
 };
 
@@ -122,60 +122,56 @@ export default function NotificationsScreen() {
   const unreadCount = items.filter((n) => !n.isRead).length;
 
   return (
-    <View style={{ flex: 1, backgroundColor: Colors.white }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Уведомления" onBack={() => router.back()} />
       <ScrollView
         style={{ flex: 1 }}
-        contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}
+        contentContainerStyle={{ paddingVertical: Spacing.lg }}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={Colors.brandPrimary} />}
       >
-        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
-            Уведомления
-          </Text>
-          {unreadCount > 0 && (
-            <Pressable
-              onPress={handleMarkAll}
-              disabled={markingAll}
-              style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
-            >
-              {markingAll ? (
-                <ActivityIndicator size="small" color={Colors.brandPrimary} />
-              ) : (
-                <Feather name="check-circle" size={14} color={Colors.brandPrimary} />
-              )}
-              <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>
-                Прочитать все
-              </Text>
-            </Pressable>
-          )}
-        </View>
-
-        {loading ? (
-          <View style={{ alignItems: 'center', paddingVertical: 40 }}>
-            <ActivityIndicator color={Colors.brandPrimary} />
-          </View>
-        ) : error ? (
-          <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
-            <Feather name="alert-circle" size={28} color={Colors.statusError} />
-            <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
-            <Pressable onPress={fetchList}>
-              <Text style={{ color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>Повторить</Text>
-            </Pressable>
-          </View>
-        ) : items.length === 0 ? (
-          <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
-            <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
-              <Feather name="bell-off" size={28} color={Colors.textMuted} />
+        <Container>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Heading level={2}>Уведомления</Heading>
+              {unreadCount > 0 ? (
+                <Pressable
+                  onPress={handleMarkAll}
+                  disabled={markingAll}
+                  style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+                >
+                  {markingAll ? (
+                    <ActivityIndicator size="small" color={Colors.brandPrimary} />
+                  ) : (
+                    <Feather name="check-circle" size={14} color={Colors.brandPrimary} />
+                  )}
+                  <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>
+                    Прочитать все
+                  </Text>
+                </Pressable>
+              ) : null}
             </View>
-            <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }}>
-              Пока тихо
-            </Text>
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 260 }}>
-              Когда появятся новые сообщения или обновления по заявкам — вы увидите их здесь.
-            </Text>
-          </View>
-        ) : (
+
+            {loading ? (
+              <View style={{ alignItems: 'center', paddingVertical: 40 }}>
+                <ActivityIndicator color={Colors.brandPrimary} />
+              </View>
+            ) : error ? (
+              <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
+                <Feather name="alert-circle" size={28} color={Colors.statusError} />
+                <Text align="center" style={{ color: Colors.statusError }}>{error}</Text>
+                <Pressable onPress={fetchList}>
+                  <Text weight="medium" style={{ color: Colors.brandPrimary }}>Повторить</Text>
+                </Pressable>
+              </View>
+            ) : items.length === 0 ? (
+              <EmptyState
+                icon={<View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
+                  <Feather name="bell-off" size={28} color={Colors.textMuted} />
+                </View>}
+                title="Пока тихо"
+                description="Когда появятся новые сообщения или обновления по заявкам — вы увидите их здесь."
+              />
+            ) : (
           items.map((n) => {
             const meta = TYPE_ICON[n.type] ?? TYPE_ICON.SYSTEM;
             return (
@@ -209,27 +205,25 @@ export default function NotificationsScreen() {
                 <View style={{ flex: 1, gap: 2 }}>
                   <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
                     <Text
-                      style={{
-                        flex: 1,
-                        fontSize: Typography.fontSize.sm,
-                        fontWeight: n.isRead ? Typography.fontWeight.medium : Typography.fontWeight.bold,
-                        color: Colors.textPrimary,
-                      }}
+                      variant="caption"
+                      weight={n.isRead ? 'medium' : 'bold'}
                       numberOfLines={1}
+                      style={{ flex: 1, color: Colors.textPrimary }}
                     >
                       {n.title}
                     </Text>
-                    {!n.isRead && (
+                    {!n.isRead ? (
                       <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: Colors.brandPrimary }} />
-                    )}
+                    ) : null}
                   </View>
                   <Text
-                    style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 18 }}
+                    variant="caption"
                     numberOfLines={2}
+                    style={{ color: Colors.textSecondary, lineHeight: 18 }}
                   >
                     {n.body}
                   </Text>
-                  <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted, marginTop: 2 }}>
+                  <Text variant="caption" style={{ marginTop: 2 }}>
                     {formatTimeAgo(n.createdAt)}
                   </Text>
                 </View>
@@ -237,7 +231,9 @@ export default function NotificationsScreen() {
             );
           })
         )}
+          </View>
+        </Container>
       </ScrollView>
-    </View>
+    </Screen>
   );
 }

--- a/app/requests/[id].tsx
+++ b/app/requests/[id].tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Colors } from '../../constants/Colors';
+import { BorderRadius, Colors, Spacing } from '../../constants/Colors';
 import { Header } from '../../components/Header';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
 import { requests as requestsApi } from '../../lib/api/endpoints';
+import { Badge, Button, Card, Container, Heading, Screen, Text } from '../../components/ui';
 
 interface RequestDetail {
   id: string;
@@ -31,55 +32,72 @@ function RequestCard({ req }: { req: RequestDetail }) {
     : '—';
 
   return (
-    <View className="gap-3 rounded-xl border border-borderLight bg-white p-5">
-      {/* Status + date */}
-      <View className="flex-row items-center justify-between">
-        <View className="flex-row items-center gap-1.5 rounded-full bg-[#DCFCE7] px-2 py-0.5">
-          <View className="h-1.5 w-1.5 rounded-full bg-[#15803D]" />
-          <Text className="text-xs font-semibold text-[#15803D]">{req.status ?? 'Активна'}</Text>
+    <Card variant="outlined" padding="lg">
+      <View style={{ gap: Spacing.md }}>
+        {/* Status + date */}
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Badge variant="success">{req.status ?? 'Активна'}</Badge>
+          <Text variant="caption">{date}</Text>
         </View>
-        <Text className="text-xs text-textMuted">{date}</Text>
-      </View>
 
-      {/* Title */}
-      <Text className="text-xl font-bold leading-7 text-textPrimary">{req.title}</Text>
+        {/* Title */}
+        <Heading level={3}>{req.title}</Heading>
 
-      {/* Description */}
-      <Text className="text-base leading-6 text-textSecondary">{req.description ?? ''}</Text>
+        {/* Description */}
+        {req.description ? (
+          <Text style={{ lineHeight: 24 }}>{req.description}</Text>
+        ) : null}
 
-      {/* Tags */}
-      <View className="flex-row flex-wrap gap-2">
-        {req.city && (
-          <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
-            <Feather name="map-pin" size={12} color={Colors.brandPrimary} />
-            <Text className="text-xs font-medium text-brandPrimary">{req.city}</Text>
+        {/* Tags */}
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm }}>
+          {req.city ? (
+            <View style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 4,
+              borderRadius: BorderRadius.full,
+              backgroundColor: Colors.bgSecondary,
+              paddingHorizontal: Spacing.sm,
+              paddingVertical: Spacing.xs,
+            }}>
+              <Feather name="map-pin" size={12} color={Colors.brandPrimary} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>{req.city}</Text>
+            </View>
+          ) : null}
+          {req.serviceCategory ? (
+            <View style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 4,
+              borderRadius: BorderRadius.full,
+              backgroundColor: Colors.bgSecondary,
+              paddingHorizontal: Spacing.sm,
+              paddingVertical: Spacing.xs,
+            }}>
+              <Feather name="briefcase" size={12} color={Colors.brandPrimary} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>{req.serviceCategory}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        {/* Divider */}
+        <View style={{ height: 1, backgroundColor: Colors.borderLight }} />
+
+        {/* Meta */}
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.xl }}>
+          {req.ifnsCode ? (
+            <View style={{ gap: 2 }}>
+              <Text variant="caption" style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>ФНС</Text>
+              <Text weight="semibold">{req.ifnsCode}</Text>
+            </View>
+          ) : null}
+          <View style={{ gap: 2 }}>
+            <Text variant="caption" style={{ textTransform: 'uppercase', letterSpacing: 0.5 }}>Клиент</Text>
+            <Text weight="semibold">{clientName}</Text>
           </View>
-        )}
-        {req.serviceCategory && (
-          <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-1">
-            <Feather name="briefcase" size={12} color={Colors.brandPrimary} />
-            <Text className="text-xs font-medium text-brandPrimary">{req.serviceCategory}</Text>
-          </View>
-        )}
-      </View>
-
-      {/* Divider */}
-      <View className="h-px bg-borderLight" />
-
-      {/* Meta */}
-      <View className="flex-row flex-wrap gap-5">
-        {req.ifnsCode && (
-          <View className="gap-0.5">
-            <Text className="text-xs uppercase tracking-wide text-textMuted">ФНС</Text>
-            <Text className="text-base font-semibold text-textPrimary">{req.ifnsCode}</Text>
-          </View>
-        )}
-        <View className="gap-0.5">
-          <Text className="text-xs uppercase tracking-wide text-textMuted">Клиент</Text>
-          <Text className="text-base font-semibold text-textPrimary">{clientName}</Text>
         </View>
       </View>
-    </View>
+    </Card>
   );
 }
 
@@ -88,10 +106,19 @@ function RequestCard({ req }: { req: RequestDetail }) {
 // ---------------------------------------------------------------------------
 function ThreadCountBadge({ count }: { count: number }) {
   return (
-    <View className="flex-row items-center gap-2 rounded-lg bg-bgSecondary px-3 py-2">
+    <View style={{
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Spacing.sm,
+      borderRadius: BorderRadius.lg,
+      backgroundColor: Colors.bgSecondary,
+      paddingHorizontal: Spacing.md,
+      paddingVertical: Spacing.sm,
+    }}>
       <Feather name="users" size={14} color={Colors.brandPrimary} />
-      <Text className="text-sm text-textSecondary">
-        <Text className="font-semibold text-brandPrimary">{count} специалистов</Text> уже написали
+      <Text variant="caption" style={{ color: Colors.textSecondary }}>
+        <Text variant="caption" weight="semibold" style={{ color: Colors.brandPrimary }}>{count} специалистов</Text>
+        {' уже написали'}
       </Text>
     </View>
   );
@@ -102,17 +129,17 @@ function ThreadCountBadge({ count }: { count: number }) {
 // ---------------------------------------------------------------------------
 function WriteActionPanel({ onWrite }: { onWrite: () => void }) {
   return (
-    <View className="gap-2">
-      <Pressable
+    <View style={{ gap: Spacing.sm }}>
+      <Button
+        fullWidth
         onPress={onWrite}
-        className="h-12 flex-row items-center justify-center gap-2 rounded-lg bg-brandPrimary"
+        icon={<Feather name="send" size={16} color={Colors.white} />}
       >
-        <Feather name="send" size={16} color={Colors.white} />
-        <Text className="text-base font-semibold text-white">Написать</Text>
-      </Pressable>
-      <View className="flex-row items-center justify-center gap-1.5">
+        Написать
+      </Button>
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
         <Feather name="info" size={14} color={Colors.textMuted} />
-        <Text className="text-center text-sm text-textMuted">
+        <Text variant="caption" align="center">
           После первого сообщения откроется чат
         </Text>
       </View>
@@ -151,23 +178,27 @@ export default function PublicRequestDetailPage() {
   } : null;
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Заявка" onBack={() => router.back()} />
       {loading ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator color={Colors.brandPrimary} />
         </View>
       ) : error ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 }}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing['2xl'], gap: Spacing.md }}>
           <Feather name="alert-circle" size={28} color={Colors.statusError} />
-          <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+          <Text align="center" style={{ color: Colors.statusError }}>{error}</Text>
         </View>
       ) : reqData ? (
         <>
-          <ScrollView className="flex-1 bg-white" contentContainerStyle={{ padding: 16, gap: 16 }}>
-            <RequestCard req={reqData} />
-            <ThreadCountBadge count={reqData._count?.threads ?? 0} />
-            <WriteActionPanel onWrite={() => setWriteOpen(true)} />
+          <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+            <Container>
+              <View style={{ gap: Spacing.lg }}>
+                <RequestCard req={reqData} />
+                <ThreadCountBadge count={reqData._count?.threads ?? 0} />
+                <WriteActionPanel onWrite={() => setWriteOpen(true)} />
+              </View>
+            </Container>
           </ScrollView>
           <WriteConfirmModal
             visible={writeOpen && !!requestId}
@@ -180,6 +211,6 @@ export default function PublicRequestDetailPage() {
           />
         </>
       ) : null}
-    </View>
+    </Screen>
   );
 }

--- a/app/specialist/[id]/reviews.tsx
+++ b/app/specialist/[id]/reviews.tsx
@@ -1,31 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  ScrollView,
-  ActivityIndicator,
-  StyleSheet,
-} from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../../constants/Colors';
+import { Colors, Spacing } from '../../../constants/Colors';
+import { Card, Container, EmptyState, Heading, Rating, Screen, Text } from '../../../components/ui';
 import { Header } from '../../../components/Header';
 import * as api from '../../../lib/api/endpoints';
-
-function StarDisplay({ rating }: { rating: number }) {
-  return (
-    <View style={s.starRow}>
-      {[1, 2, 3, 4, 5].map((n) => (
-        <Feather
-          key={n}
-          name="star"
-          size={14}
-          color={n <= rating ? '#F59E0B' : Colors.border}
-        />
-      ))}
-    </View>
-  );
-}
 
 function ReviewCard({ item }: { item: any }) {
   const date = new Date(item.createdAt).toLocaleDateString('ru-RU', {
@@ -35,16 +15,18 @@ function ReviewCard({ item }: { item: any }) {
   });
 
   return (
-    <View style={s.card}>
-      <View style={s.cardHeader}>
-        <StarDisplay rating={item.rating} />
-        <Text style={s.dateText}>{date}</Text>
+    <Card variant="outlined" padding="md">
+      <View style={{ gap: Spacing.sm }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Rating value={item.rating} size="md" showNumeric={false} />
+          <Text variant="caption">{date}</Text>
+        </View>
+        {item.comment ? (
+          <Text style={{ lineHeight: 22, color: Colors.textSecondary }}>{item.comment}</Text>
+        ) : null}
+        <Text variant="caption" weight="semibold">{item.client?.username || 'Клиент'}</Text>
       </View>
-      {item.comment ? (
-        <Text style={s.comment}>{item.comment}</Text>
-      ) : null}
-      <Text style={s.clientName}>{item.client?.username || 'Клиент'}</Text>
-    </View>
+    </Card>
   );
 }
 
@@ -80,113 +62,54 @@ export default function SpecialistReviewsScreen() {
   }, [specialistId]);
 
   const avgRating = reviews.length
-    ? (reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length).toFixed(1)
+    ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
     : null;
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Отзывы" onBack={() => router.back()} />
       {loading ? (
-        <View style={s.center}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator size="large" color={Colors.brandPrimary} />
         </View>
       ) : (
-        <ScrollView style={{ flex: 1 }} contentContainerStyle={s.scroll}>
-          {avgRating && (
-            <View style={s.summary}>
-              <Text style={s.avgValue}>{avgRating}</Text>
-              <Feather name="star" size={20} color="#F59E0B" />
-              <Text style={s.totalText}>({total} отзывов)</Text>
-            </View>
-          )}
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+          <Container>
+            <View style={{ gap: Spacing.md }}>
+              {avgRating != null ? (
+                <Card variant="outlined" padding="md" style={{ backgroundColor: Colors.bgSecondary }}>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                    <Heading level={3}>{avgRating.toFixed(1)}</Heading>
+                    <Feather name="star" size={20} color={Colors.amber} />
+                    <Text variant="caption">({total} отзывов)</Text>
+                  </View>
+                </Card>
+              ) : null}
 
-          {reviews.length === 0 ? (
-            <View style={s.empty}>
-              <Feather name="star" size={32} color={Colors.border} />
-              <Text style={s.emptyText}>Отзывов пока нет</Text>
-            </View>
-          ) : (
-            reviews.map((r) => <ReviewCard key={r.id} item={r} />)
-          )}
-
-          {reviews.length < total && (
-            <View style={{ marginTop: Spacing.md, alignItems: 'center' }}>
-              {loadingMore ? (
-                <ActivityIndicator color={Colors.brandPrimary} />
+              {reviews.length === 0 ? (
+                <EmptyState
+                  icon={<Feather name="star" size={32} color={Colors.border} />}
+                  title="Отзывов пока нет"
+                />
               ) : (
-                <Text
-                  style={s.loadMore}
-                  onPress={() => load(page + 1, true)}
-                >
-                  Загрузить ещё
-                </Text>
+                reviews.map((r) => <ReviewCard key={r.id} item={r} />)
               )}
+
+              {reviews.length < total ? (
+                <View style={{ marginTop: Spacing.md, alignItems: 'center' }}>
+                  {loadingMore ? (
+                    <ActivityIndicator color={Colors.brandPrimary} />
+                  ) : (
+                    <Pressable onPress={() => load(page + 1, true)} style={{ paddingVertical: Spacing.sm }}>
+                      <Text weight="semibold" style={{ color: Colors.brandPrimary }}>Загрузить ещё</Text>
+                    </Pressable>
+                  )}
+                </View>
+              ) : null}
             </View>
-          )}
+          </Container>
         </ScrollView>
       )}
-    </View>
+    </Screen>
   );
 }
-
-const s = StyleSheet.create({
-  scroll: { padding: Spacing.lg, gap: Spacing.md },
-  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-
-  summary: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-    backgroundColor: Colors.bgSecondary,
-    borderRadius: BorderRadius.card,
-    padding: Spacing.md,
-    borderWidth: 1,
-    borderColor: Colors.border,
-  },
-  avgValue: {
-    fontSize: Typography.fontSize.xl,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-  totalText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-
-  card: {
-    backgroundColor: Colors.bgCard,
-    borderRadius: BorderRadius.card,
-    borderWidth: 1,
-    borderColor: Colors.borderLight,
-    padding: Spacing.md,
-    gap: Spacing.sm,
-    ...Shadows.sm,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  starRow: { flexDirection: 'row', gap: 2 },
-  dateText: { fontSize: Typography.fontSize.xs, color: Colors.textMuted },
-  comment: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    lineHeight: 22,
-  },
-  clientName: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-
-  empty: { alignItems: 'center', gap: Spacing.md, paddingVertical: Spacing['3xl'] },
-  emptyText: { fontSize: Typography.fontSize.base, color: Colors.textMuted },
-
-  loadMore: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.semibold,
-    paddingVertical: Spacing.sm,
-  },
-});

--- a/app/specialists/[nick].tsx
+++ b/app/specialists/[nick].tsx
@@ -1,12 +1,23 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, TextInput, Pressable, ScrollView, Modal, ActivityIndicator } from 'react-native';
+import { ActivityIndicator, Pressable, ScrollView, View } from 'react-native';
 import axios from 'axios';
 import { Feather } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Header } from '../../components/Header';
 import { specialists as specialistsApi, threads as threadsApi } from '../../lib/api/endpoints';
-import { Colors } from '../../constants/Colors';
+import { BorderRadius, Colors, Spacing } from '../../constants/Colors';
 import { useAuth } from '../../lib/auth/AuthContext';
+import {
+  Button,
+  Card,
+  Container,
+  Heading,
+  Input,
+  Modal,
+  Rating,
+  Screen,
+  Text,
+} from '../../components/ui';
 
 interface FnsService {
   fns: string;
@@ -41,69 +52,68 @@ interface SpecialistData {
   [key: string]: unknown;
 }
 
-function Stars({ rating, size = 14 }: { rating: number; size?: number }) {
-  return (
-    <View className="flex-row gap-0.5">
-      {[1, 2, 3, 4, 5].map(i => (
-        <Feather key={i} name="star" size={size} color={i <= rating ? '#F59E0B' : '#E2E8F0'} />
-      ))}
-    </View>
-  );
-}
-
 function ReviewItem({ author, rating, text, date }: { author: string; rating: number; text: string; date: string }) {
   return (
-    <View className="gap-1 border-b border-bgSecondary py-3">
-      <View className="flex-row justify-between">
-        <View className="flex-row items-center gap-1">
-          <Feather name="user" size={14} color="#94A3B8" />
-          <Text className="text-base font-semibold text-textPrimary">{author}</Text>
+    <View style={{
+      gap: Spacing.xs,
+      borderBottomWidth: 1,
+      borderBottomColor: Colors.bgSecondary,
+      paddingVertical: Spacing.md,
+    }}>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+          <Feather name="user" size={14} color={Colors.textMuted} />
+          <Text weight="semibold">{author}</Text>
         </View>
-        <View className="flex-row items-center gap-1">
-          <Feather name="calendar" size={12} color="#94A3B8" />
-          <Text className="text-sm text-textMuted">{date}</Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+          <Feather name="calendar" size={12} color={Colors.textMuted} />
+          <Text variant="caption">{date}</Text>
         </View>
       </View>
-      <Stars rating={rating} />
-      <Text className="text-base leading-6 text-textSecondary">{text}</Text>
+      <Rating value={rating} size="sm" showNumeric={false} />
+      <Text style={{ lineHeight: 24 }}>{text}</Text>
     </View>
   );
 }
 
 function FnsModal({ visible, onClose, fnsServices }: { visible: boolean; onClose: () => void; fnsServices: FnsService[] }) {
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View className="flex-1 items-center justify-center bg-black/50 px-4">
-        <View className="w-full max-w-lg rounded-2xl bg-white">
-          <View className="flex-row items-center justify-between border-b border-gray-200 px-5 py-4">
-            <View className="flex-row items-center gap-2">
-              <Feather name="briefcase" size={18} color="#0284C7" />
-              <Text className="text-lg font-bold text-textPrimary">ФНС и услуги</Text>
-            </View>
-            <Pressable onPress={onClose} className="rounded-full p-1">
-              <Feather name="x" size={22} color="#64748B" />
-            </Pressable>
+    <Modal visible={visible} onClose={onClose} title="ФНС и услуги" maxWidth={520}>
+      {fnsServices.map((group, idx) => (
+        <View
+          key={group.fns}
+          style={{
+            gap: Spacing.sm,
+            paddingVertical: Spacing.md,
+            borderTopWidth: idx > 0 ? 1 : 0,
+            borderTopColor: Colors.borderLight,
+          }}
+        >
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+            <Feather name="home" size={14} color={Colors.textMuted} />
+            <Text weight="semibold">{group.fns}</Text>
           </View>
-          <ScrollView className="max-h-96 px-5 py-3">
-            {fnsServices.map((group, idx) => (
-              <View key={group.fns} className={`gap-2 py-3 ${idx < fnsServices.length - 1 ? 'border-b border-gray-100' : ''}`}>
-                <View className="flex-row items-center gap-2">
-                  <Feather name="home" size={14} color="#64748B" />
-                  <Text className="text-base font-semibold text-textPrimary">{group.fns}</Text>
-                </View>
-                <View className="flex-row flex-wrap gap-2 pl-6">
-                  {group.services.map((svc) => (
-                    <View key={svc} className="flex-row items-center gap-1 rounded-full bg-sky-50 px-3 py-1.5">
-                      <Feather name="check" size={12} color="#0284C7" />
-                      <Text className="text-sm text-brandPrimary">{svc}</Text>
-                    </View>
-                  ))}
-                </View>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm, paddingLeft: Spacing['2xl'] }}>
+            {group.services.map((svc) => (
+              <View
+                key={svc}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 4,
+                  borderRadius: BorderRadius.full,
+                  paddingHorizontal: Spacing.md,
+                  paddingVertical: 6,
+                  backgroundColor: Colors.statusBg.info,
+                }}
+              >
+                <Feather name="check" size={12} color={Colors.brandPrimary} />
+                <Text variant="caption" style={{ color: Colors.brandPrimary }}>{svc}</Text>
               </View>
             ))}
-          </ScrollView>
+          </View>
         </View>
-      </View>
+      ))}
     </Modal>
   );
 }
@@ -124,51 +134,40 @@ function WriteSpecialistConfirm({
   errorText: string | null;
 }) {
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={{ flex: 1, backgroundColor: 'rgba(12,26,46,0.5)', justifyContent: 'center', alignItems: 'center', padding: 16 }}>
-        <View style={{ width: '100%', maxWidth: 420, backgroundColor: Colors.white, borderRadius: 16, padding: 20, gap: 14 }}>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-            <View style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
-              <Feather name="send" size={16} color={Colors.brandPrimary} />
-            </View>
-            <Text style={{ flex: 1, fontSize: 18, fontWeight: '700', color: Colors.textPrimary }}>Написать специалисту</Text>
-            <Pressable onPress={onClose} hitSlop={8} style={{ padding: 4 }} accessibilityLabel="Закрыть">
-              <Feather name="x" size={20} color={Colors.textMuted} />
-            </Pressable>
-          </View>
-          <Text style={{ fontSize: 15, color: Colors.textSecondary, lineHeight: 21 }}>
-            Открыть чат с <Text style={{ fontWeight: '600', color: Colors.textPrimary }}>{displayName}</Text>?
-            Ваше первое сообщение будет отправлено, и специалист получит уведомление.
-          </Text>
-          {errorText ? (
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, padding: 10, borderRadius: 8, backgroundColor: Colors.statusBg?.error ?? '#FEE2E2' }}>
-              <Feather name="alert-circle" size={14} color={Colors.statusError} />
-              <Text style={{ flex: 1, fontSize: 13, color: Colors.statusError }}>{errorText}</Text>
-            </View>
-          ) : null}
-          <View style={{ flexDirection: 'row', gap: 8 }}>
-            <Pressable
-              onPress={onClose}
-              disabled={submitting}
-              style={{ flex: 1, height: 44, borderRadius: 10, borderWidth: 1, borderColor: Colors.borderLight, alignItems: 'center', justifyContent: 'center', opacity: submitting ? 0.5 : 1 }}
-            >
-              <Text style={{ fontSize: 15, fontWeight: '500', color: Colors.textSecondary }}>Отмена</Text>
-            </Pressable>
-            <Pressable
-              onPress={onConfirm}
-              disabled={submitting}
-              style={{ flex: 1, height: 44, borderRadius: 10, backgroundColor: Colors.brandPrimary, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, opacity: submitting ? 0.7 : 1 }}
-            >
-              {submitting ? (
-                <ActivityIndicator size="small" color={Colors.white} />
-              ) : (
-                <Feather name="send" size={15} color={Colors.white} />
-              )}
-              <Text style={{ fontSize: 15, fontWeight: '600', color: Colors.white }}>Написать</Text>
-            </Pressable>
-          </View>
+    <Modal
+      visible={visible}
+      onClose={onClose}
+      title="Написать специалисту"
+      maxWidth={420}
+      primaryAction={{
+        label: 'Написать',
+        onPress: onConfirm,
+        loading: submitting,
+        disabled: submitting,
+      }}
+      secondaryAction={{
+        label: 'Отмена',
+        onPress: onClose,
+        disabled: submitting,
+      }}
+    >
+      <Text style={{ lineHeight: 21 }}>
+        Открыть чат с <Text weight="semibold">{displayName}</Text>?
+        Ваше первое сообщение будет отправлено, и специалист получит уведомление.
+      </Text>
+      {errorText ? (
+        <View style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: Spacing.sm,
+          padding: Spacing.md,
+          borderRadius: BorderRadius.md,
+          backgroundColor: Colors.statusBg.error,
+        }}>
+          <Feather name="alert-circle" size={14} color={Colors.statusError} />
+          <Text variant="caption" style={{ flex: 1, color: Colors.statusError }}>{errorText}</Text>
         </View>
-      </View>
+      ) : null}
     </Modal>
   );
 }
@@ -248,125 +247,153 @@ function ProfileScreen({ spec }: { spec: SpecialistData }) {
   };
 
   return (
-    <ScrollView className="flex-1 bg-white">
-      <View className="gap-4 p-4">
-        {/* Profile card */}
-        <View className="gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-          <View className="flex-row gap-4">
-            <View className="h-20 w-20 items-center justify-center rounded-full bg-bgSecondary">
-              <Feather name="user" size={32} color="#94A3B8" />
-            </View>
-            <View className="flex-1 gap-1">
-              <Text className="text-xl font-bold text-textPrimary">{displayName}</Text>
-              {spec.headline && (
-                <Text className="text-sm text-textSecondary">{spec.headline}</Text>
-              )}
-              {city && (
-                <View className="flex-row items-center gap-1">
-                  <Feather name="map-pin" size={14} color="#94A3B8" />
-                  <Text className="text-base text-textMuted">{city}</Text>
+    <ScrollView style={{ flex: 1, backgroundColor: Colors.white }}>
+      <Container>
+        <View style={{ gap: Spacing.lg, paddingVertical: Spacing.lg }}>
+          {/* Profile card */}
+          <Card variant="outlined" padding="md">
+            <View style={{ gap: Spacing.md }}>
+              <View style={{ flexDirection: 'row', gap: Spacing.lg }}>
+                <View style={{
+                  width: 80,
+                  height: 80,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: 9999,
+                  backgroundColor: Colors.bgSecondary,
+                }}>
+                  <Feather name="user" size={32} color={Colors.textMuted} />
                 </View>
-              )}
-              {rating != null && (
-                <View className="flex-row items-center gap-1">
-                  <Stars rating={Math.round(rating)} size={16} />
-                  <Text className="text-sm text-textMuted">{rating} ({reviewCount} отзывов)</Text>
-                </View>
-              )}
-              {memberYear && (
-                <View className="mt-1 flex-row items-center gap-1">
-                  <Feather name="clock" size={13} color="#94A3B8" />
-                  <Text className="text-sm text-textMuted">На сайте с {memberYear} г.</Text>
-                </View>
-              )}
-            </View>
-          </View>
-          {about && <Text className="text-base leading-6 text-textSecondary">{about}</Text>}
-        </View>
-
-        {/* FNS preview (first 2 open) + "Подробнее" for rest */}
-        {fnsServices.length > 0 && (
-          <View className="gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <View className="flex-row items-center gap-2">
-              <Feather name="briefcase" size={16} color="#0284C7" />
-              <Text className="text-lg font-semibold text-textPrimary">ФНС и услуги</Text>
-            </View>
-            {fnsServices.slice(0, 2).map((group, idx) => (
-              <View key={group.fns} className={`gap-2 ${idx > 0 ? 'border-t border-gray-100 pt-3' : ''}`}>
-                <View className="flex-row items-center gap-2">
-                  <Feather name="home" size={14} color="#64748B" />
-                  <Text className="text-base font-medium text-textPrimary">{group.fns}</Text>
-                </View>
-                <View className="flex-row flex-wrap gap-2 pl-6">
-                  {group.services.map((svc) => (
-                    <View key={svc} className="flex-row items-center gap-1 rounded-full bg-sky-50 px-3 py-1.5">
-                      <Feather name="check" size={12} color="#0284C7" />
-                      <Text className="text-sm text-brandPrimary">{svc}</Text>
+                <View style={{ flex: 1, gap: Spacing.xs }}>
+                  <Heading level={3}>{displayName}</Heading>
+                  {spec.headline ? (
+                    <Text variant="caption">{spec.headline}</Text>
+                  ) : null}
+                  {city ? (
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+                      <Feather name="map-pin" size={14} color={Colors.textMuted} />
+                      <Text variant="muted">{city}</Text>
                     </View>
-                  ))}
+                  ) : null}
+                  {rating != null ? (
+                    <Rating value={Number(rating)} reviewCount={reviewCount} size="md" />
+                  ) : null}
+                  {memberYear ? (
+                    <View style={{ marginTop: 4, flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+                      <Feather name="clock" size={13} color={Colors.textMuted} />
+                      <Text variant="caption">На сайте с {memberYear} г.</Text>
+                    </View>
+                  ) : null}
                 </View>
               </View>
-            ))}
-            {fnsServices.length > 2 && (
-              <Pressable
-                onPress={() => setFnsModalVisible(true)}
-                className="mt-1 flex-row items-center justify-center gap-2 rounded-lg border border-brandPrimary py-2.5"
-              >
-                <Text className="text-sm font-semibold text-brandPrimary">Все ФНС и услуги ({fnsServices.length})</Text>
-                <Feather name="chevron-right" size={16} color="#0284C7" />
-              </Pressable>
-            )}
-          </View>
-        )}
-
-        <FnsModal visible={fnsModalVisible} onClose={() => setFnsModalVisible(false)} fnsServices={fnsServices} />
-
-        {/* Reviews */}
-        {(spec.reviews ?? []).length > 0 && (
-          <View className="gap-3">
-            <View className="flex-row items-center gap-2">
-              <Feather name="message-square" size={16} color="#0284C7" />
-              <Text className="text-lg font-semibold text-textPrimary">Отзывы</Text>
+              {about ? <Text style={{ lineHeight: 24 }}>{about}</Text> : null}
             </View>
-            {(spec.reviews ?? []).map((r, i) => (
-              <ReviewItem
-                key={i}
-                author={r.author ?? '—'}
-                rating={r.rating}
-                text={r.text ?? ''}
-                date={r.date ?? ''}
-              />
-            ))}
-          </View>
-        )}
+          </Card>
 
-        {/* Message textarea */}
-        <View className="gap-2">
-          <View className="flex-row items-center gap-2">
-            <Feather name="edit-3" size={16} color="#0284C7" />
-            <Text className="text-lg font-semibold text-textPrimary">Написать специалисту</Text>
+          {/* FNS preview (first 2 open) + "Подробнее" for rest */}
+          {fnsServices.length > 0 ? (
+            <Card variant="outlined" padding="md">
+              <View style={{ gap: Spacing.md }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                  <Feather name="briefcase" size={16} color={Colors.brandPrimary} />
+                  <Heading level={4}>ФНС и услуги</Heading>
+                </View>
+                {fnsServices.slice(0, 2).map((group, idx) => (
+                  <View
+                    key={group.fns}
+                    style={{
+                      gap: Spacing.sm,
+                      borderTopWidth: idx > 0 ? 1 : 0,
+                      borderTopColor: Colors.borderLight,
+                      paddingTop: idx > 0 ? Spacing.md : 0,
+                    }}
+                  >
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                      <Feather name="home" size={14} color={Colors.textMuted} />
+                      <Text weight="medium">{group.fns}</Text>
+                    </View>
+                    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm, paddingLeft: Spacing['2xl'] }}>
+                      {group.services.map((svc) => (
+                        <View
+                          key={svc}
+                          style={{
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            gap: 4,
+                            borderRadius: BorderRadius.full,
+                            paddingHorizontal: Spacing.md,
+                            paddingVertical: 6,
+                            backgroundColor: Colors.statusBg.info,
+                          }}
+                        >
+                          <Feather name="check" size={12} color={Colors.brandPrimary} />
+                          <Text variant="caption" style={{ color: Colors.brandPrimary }}>{svc}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  </View>
+                ))}
+                {fnsServices.length > 2 ? (
+                  <Button
+                    variant="secondary"
+                    fullWidth
+                    onPress={() => setFnsModalVisible(true)}
+                    icon={<Feather name="chevron-right" size={16} color={Colors.brandPrimary} />}
+                  >
+                    {`Все ФНС и услуги (${fnsServices.length})`}
+                  </Button>
+                ) : null}
+              </View>
+            </Card>
+          ) : null}
+
+          <FnsModal visible={fnsModalVisible} onClose={() => setFnsModalVisible(false)} fnsServices={fnsServices} />
+
+          {/* Reviews */}
+          {(spec.reviews ?? []).length > 0 ? (
+            <View style={{ gap: Spacing.md }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                <Feather name="message-square" size={16} color={Colors.brandPrimary} />
+                <Heading level={4}>Отзывы</Heading>
+              </View>
+              {(spec.reviews ?? []).map((r, i) => (
+                <ReviewItem
+                  key={i}
+                  author={r.author ?? '—'}
+                  rating={r.rating}
+                  text={r.text ?? ''}
+                  date={r.date ?? ''}
+                />
+              ))}
+            </View>
+          ) : null}
+
+          {/* Message textarea */}
+          <View style={{ gap: Spacing.sm }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+              <Feather name="edit-3" size={16} color={Colors.brandPrimary} />
+              <Heading level={4}>Написать специалисту</Heading>
+            </View>
+            <Input
+              value={message}
+              onChangeText={setMessage}
+              placeholder="Опишите вашу задачу или задайте вопрос..."
+              multiline
+              numberOfLines={4}
+            />
+            <Button
+              fullWidth
+              disabled={!canSend}
+              onPress={handleSendPress}
+              icon={<Feather name="send" size={18} color={Colors.white} />}
+              accessibilityLabel="Написать специалисту"
+            >
+              Написать
+            </Button>
           </View>
-          <TextInput
-            className="min-h-[100px] rounded-lg bg-white p-3 text-base text-textPrimary"
-            style={{ borderWidth: 1, borderColor: '#E5E7EB', outlineStyle: 'none' } as any}
-            placeholder="Опишите вашу задачу или задайте вопрос..."
-            placeholderTextColor="#94A3B8"
-            multiline
-            textAlignVertical="top"
-            value={message}
-            onChangeText={setMessage}
-          />
-          <Pressable
-            className={`mt-1 h-12 flex-row items-center justify-center gap-2 rounded-lg shadow-sm ${canSend ? 'bg-brandPrimary' : 'bg-gray-300'}`}
-            disabled={!canSend}
-            onPress={handleSendPress}
-            accessibilityLabel="Написать специалисту"
-          >
-            <Feather name="send" size={18} color="#FFFFFF" />
-            <Text className="text-base font-semibold text-white">Написать</Text>
-          </Pressable>
         </View>
-      </View>
+      </Container>
+
       <WriteSpecialistConfirm
         visible={confirmVisible}
         displayName={displayName}
@@ -401,20 +428,20 @@ export default function SpecialistProfileScreen() {
   }, [nick]);
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="back" backTitle="Специалист" onBack={() => router.back()} />
       {loading ? (
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator color={Colors.brandPrimary} />
         </View>
       ) : error ? (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 }}>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing['2xl'], gap: Spacing.md }}>
           <Feather name="alert-circle" size={28} color={Colors.statusError} />
-          <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
+          <Text align="center" style={{ color: Colors.statusError }}>{error}</Text>
         </View>
       ) : specData ? (
         <ProfileScreen spec={specData} />
       ) : null}
-    </View>
+    </Screen>
   );
 }

--- a/app/terms.tsx
+++ b/app/terms.tsx
@@ -1,146 +1,74 @@
 import React from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { Feather } from '@expo/vector-icons';
-import { Colors, Spacing, Typography, BorderRadius } from '../constants/Colors';
+import { ScrollView, View } from 'react-native';
+import { Colors, Spacing } from '../constants/Colors';
+import { Container, Heading, Screen, Text } from '../components/ui';
 import { Header } from '../components/Header';
 
-// ---------------------------------------------------------------------------
-// LOADED state — terms content rendered
-// ---------------------------------------------------------------------------
-function LoadedState() {
-  return (
-    <View style={s.container}>
-      {/* Header */}
-      <View style={s.header}>
-        <Pressable style={s.closeBtn}>
-          <Feather name="x" size={20} color={Colors.textPrimary} />
-        </Pressable>
-        <Text style={s.headerTitle}>Условия использования</Text>
-        <View style={{ width: 32 }} />
-      </View>
-
-      {/* Content */}
-      <View style={s.content}>
-        <Text style={s.sectionTitle}>1. Общие положения</Text>
-        <Text style={s.paragraph}>
-          Настоящие Условия использования (далее — «Условия») регулируют порядок использования
-          платформы «Налоговик» (далее — «Платформа»), предоставляющей услуги по поиску и подбору
-          налоговых специалистов.
-        </Text>
-        <Text style={s.paragraph}>
-          Используя Платформу, вы подтверждаете, что ознакомились с настоящими Условиями и принимаете
-          их в полном объёме.
-        </Text>
-
-        <Text style={s.sectionTitle}>2. Регистрация и учётная запись</Text>
-        <Text style={s.paragraph}>
-          Для использования функций Платформы необходимо пройти регистрацию, указав действующий
-          адрес электронной почты. Авторизация осуществляется посредством одноразового кода (OTP),
-          направляемого на указанный email.
-        </Text>
-        <Text style={s.paragraph}>
-          Пользователь несёт ответственность за сохранность доступа к своей электронной почте и
-          учётной записи на Платформе.
-        </Text>
-
-        <Text style={s.sectionTitle}>3. Роли пользователей</Text>
-        <Text style={s.paragraph}>
-          На Платформе предусмотрены следующие роли: Клиент и Специалист. Клиент может создавать
-          заявки на налоговые услуги. Специалист может откликаться на заявки и оказывать услуги.
-        </Text>
-
-        <Text style={s.sectionTitle}>4. Ограничение ответственности</Text>
-        <Text style={s.paragraph}>
-          Платформа является информационным посредником и не несёт ответственности за качество
-          услуг, оказываемых специалистами. Все финансовые расчёты между клиентами и специалистами
-          осуществляются напрямую, без участия Платформы.
-        </Text>
-
-        <Text style={s.sectionTitle}>5. Конфиденциальность</Text>
-        <Text style={s.paragraph}>
-          Платформа обрабатывает персональные данные пользователей в соответствии с Политикой
-          конфиденциальности. Данные не передаются третьим лицам без согласия пользователя, за
-          исключением случаев, предусмотренных законодательством.
-        </Text>
-
-        <Text style={s.sectionTitle}>6. Изменение условий</Text>
-        <Text style={s.paragraph}>
-          Администрация Платформы оставляет за собой право вносить изменения в настоящие Условия.
-          Актуальная версия всегда доступна на данной странице.
-        </Text>
-
-        <Text style={s.updated}>Последнее обновление: 01.04.2026</Text>
-      </View>
-    </View>
-  );
-}
+const SECTIONS: Array<{ title: string; paragraphs: string[] }> = [
+  {
+    title: '1. Общие положения',
+    paragraphs: [
+      'Настоящие Условия использования (далее — «Условия») регулируют порядок использования платформы «Налоговик» (далее — «Платформа»), предоставляющей услуги по поиску и подбору налоговых специалистов.',
+      'Используя Платформу, вы подтверждаете, что ознакомились с настоящими Условиями и принимаете их в полном объёме.',
+    ],
+  },
+  {
+    title: '2. Регистрация и учётная запись',
+    paragraphs: [
+      'Для использования функций Платформы необходимо пройти регистрацию, указав действующий адрес электронной почты. Авторизация осуществляется посредством одноразового кода (OTP), направляемого на указанный email.',
+      'Пользователь несёт ответственность за сохранность доступа к своей электронной почте и учётной записи на Платформе.',
+    ],
+  },
+  {
+    title: '3. Роли пользователей',
+    paragraphs: [
+      'На Платформе предусмотрены следующие роли: Клиент и Специалист. Клиент может создавать заявки на налоговые услуги. Специалист может откликаться на заявки и оказывать услуги.',
+    ],
+  },
+  {
+    title: '4. Ограничение ответственности',
+    paragraphs: [
+      'Платформа является информационным посредником и не несёт ответственности за качество услуг, оказываемых специалистами. Все финансовые расчёты между клиентами и специалистами осуществляются напрямую, без участия Платформы.',
+    ],
+  },
+  {
+    title: '5. Конфиденциальность',
+    paragraphs: [
+      'Платформа обрабатывает персональные данные пользователей в соответствии с Политикой конфиденциальности. Данные не передаются третьим лицам без согласия пользователя, за исключением случаев, предусмотренных законодательством.',
+    ],
+  },
+  {
+    title: '6. Изменение условий',
+    paragraphs: [
+      'Администрация Платформы оставляет за собой право вносить изменения в настоящие Условия. Актуальная версия всегда доступна на данной странице.',
+    ],
+  },
+];
 
 export default function TermsPage() {
   return (
-    <View style={{ flex: 1, backgroundColor: '#fff' }}>
+    <Screen bg={Colors.white}>
       <Header variant="guest" />
-      <LoadedState />
-    </View>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.xl }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            <Heading level={1}>Условия использования</Heading>
+
+            {SECTIONS.map((section) => (
+              <View key={section.title} style={{ gap: Spacing.sm, marginTop: Spacing.sm }}>
+                <Heading level={4}>{section.title}</Heading>
+                {section.paragraphs.map((p, i) => (
+                  <Text key={i} variant="muted" style={{ lineHeight: 22 }}>{p}</Text>
+                ))}
+              </View>
+            ))}
+
+            <Text variant="caption" align="center" style={{ marginTop: Spacing.lg }}>
+              Последнее обновление: 01.04.2026
+            </Text>
+          </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }
-
-// ---------------------------------------------------------------------------
-// STYLES
-// ---------------------------------------------------------------------------
-const s = StyleSheet.create({
-  container: { gap: 0 },
-
-  // Header
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: Spacing.lg,
-    paddingVertical: Spacing.md,
-    borderBottomWidth: 1,
-    borderBottomColor: Colors.borderLight,
-  },
-  closeBtn: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: Colors.bgSecondary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  headerTitle: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textPrimary,
-  },
-
-  // Content
-  content: {
-    padding: Spacing.xl,
-    gap: Spacing.md,
-  },
-  sectionTitle: {
-    fontSize: Typography.fontSize.md,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-    marginTop: Spacing.sm,
-  },
-  paragraph: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-    lineHeight: 22,
-  },
-  updated: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-    marginTop: Spacing.lg,
-    textAlign: 'center',
-  },
-
-  // Skeleton
-  skelLine: {
-    height: 12,
-    borderRadius: 4,
-    backgroundColor: Colors.bgSecondary,
-  },
-});

--- a/components/ComplaintButton.tsx
+++ b/components/ComplaintButton.tsx
@@ -1,16 +1,8 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  Modal,
-  StyleSheet,
-  TextInput,
-  ActivityIndicator,
-  Alert,
-} from 'react-native';
+import { Alert, Pressable, View } from 'react-native';
 import { Feather } from '@expo/vector-icons';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../constants/Colors';
+import { Colors, Spacing } from '../constants/Colors';
+import { Badge, Input, Modal, Text } from './ui';
 import * as api from '../lib/api/endpoints';
 
 type TargetType = 'user' | 'request' | 'thread';
@@ -59,186 +51,53 @@ export function ComplaintButton({ targetId, targetType = 'user', label = 'Пож
 
   return (
     <>
-      <Pressable onPress={open} style={s.trigger}>
+      <Pressable
+        onPress={open}
+        style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, paddingVertical: Spacing.xs }}
+      >
         <Feather name="flag" size={14} color={Colors.textMuted} />
-        <Text style={s.triggerText}>{label}</Text>
+        <Text variant="caption" style={{ color: Colors.textMuted }}>{label}</Text>
       </Pressable>
 
-      <Modal visible={visible} transparent animationType="fade" onRequestClose={() => setVisible(false)}>
-        <View style={s.overlay}>
-          <View style={s.modal}>
-            <View style={s.modalHeader}>
-              <Text style={s.modalTitle}>Отправить жалобу</Text>
-              <Pressable onPress={() => setVisible(false)}>
-                <Feather name="x" size={20} color={Colors.textMuted} />
+      <Modal
+        visible={visible}
+        onClose={() => setVisible(false)}
+        title="Отправить жалобу"
+        maxWidth={420}
+        primaryAction={{
+          label: 'Отправить',
+          onPress: handleSubmit,
+          loading: submitting,
+          disabled: submitting,
+        }}
+        secondaryAction={{
+          label: 'Отмена',
+          onPress: () => setVisible(false),
+          disabled: submitting,
+        }}
+      >
+        <Text variant="label">Причина</Text>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm }}>
+          {REASON_OPTIONS.map((opt) => {
+            const active = reason === opt.value;
+            return (
+              <Pressable key={opt.value} onPress={() => setReason(opt.value)}>
+                <Badge variant={active ? 'info' : 'default'}>{opt.label}</Badge>
               </Pressable>
-            </View>
-
-            <Text style={s.label}>Причина</Text>
-            <View style={s.reasonGrid}>
-              {REASON_OPTIONS.map((opt) => (
-                <Pressable
-                  key={opt.value}
-                  style={[s.reasonOption, reason === opt.value && s.reasonOptionActive]}
-                  onPress={() => setReason(opt.value)}
-                >
-                  <Text style={[s.reasonText, reason === opt.value && s.reasonTextActive]}>
-                    {opt.label}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-
-            <Text style={s.label}>Комментарий <Text style={s.optional}>(необязательно)</Text></Text>
-            <TextInput
-              style={s.textArea}
-              placeholder="Опишите проблему подробнее..."
-              placeholderTextColor={Colors.textMuted}
-              multiline
-              numberOfLines={4}
-              value={comment}
-              onChangeText={setComment}
-              maxLength={500}
-            />
-
-            <View style={s.actions}>
-              <Pressable style={s.cancelBtn} onPress={() => setVisible(false)}>
-                <Text style={s.cancelText}>Отмена</Text>
-              </Pressable>
-              <Pressable
-                style={[s.submitBtn, submitting && s.submitDisabled]}
-                onPress={handleSubmit}
-                disabled={submitting}
-              >
-                {submitting ? (
-                  <ActivityIndicator color="#fff" size="small" />
-                ) : (
-                  <Text style={s.submitText}>Отправить</Text>
-                )}
-              </Pressable>
-            </View>
-          </View>
+            );
+          })}
         </View>
+
+        <Input
+          label="Комментарий (необязательно)"
+          value={comment}
+          onChangeText={setComment}
+          placeholder="Опишите проблему подробнее..."
+          multiline
+          numberOfLines={4}
+          maxLength={500}
+        />
       </Modal>
     </>
   );
 }
-
-const s = StyleSheet.create({
-  trigger: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-    paddingVertical: Spacing.xs,
-  },
-  triggerText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-
-  overlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: Spacing.lg,
-  },
-  modal: {
-    backgroundColor: '#fff',
-    borderRadius: BorderRadius.card,
-    padding: Spacing.xl,
-    width: '100%',
-    maxWidth: 420,
-    gap: Spacing.md,
-    ...Shadows.lg,
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  modalTitle: {
-    fontSize: Typography.fontSize.lg,
-    fontWeight: Typography.fontWeight.bold,
-    color: Colors.textPrimary,
-  },
-
-  label: {
-    fontSize: Typography.fontSize.sm,
-    fontWeight: Typography.fontWeight.semibold,
-    color: Colors.textSecondary,
-  },
-  optional: {
-    fontWeight: Typography.fontWeight.regular,
-    color: Colors.textMuted,
-  },
-
-  reasonGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Spacing.sm,
-  },
-  reasonOption: {
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    paddingHorizontal: Spacing.md,
-    paddingVertical: Spacing.sm,
-  },
-  reasonOptionActive: {
-    borderColor: Colors.brandPrimary,
-    backgroundColor: Colors.bgSecondary,
-  },
-  reasonText: {
-    fontSize: Typography.fontSize.sm,
-    color: Colors.textMuted,
-  },
-  reasonTextActive: {
-    color: Colors.brandPrimary,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-
-  textArea: {
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    padding: Spacing.md,
-    fontSize: Typography.fontSize.base,
-    color: Colors.textPrimary,
-    minHeight: 100,
-    textAlignVertical: 'top',
-  },
-
-  actions: {
-    flexDirection: 'row',
-    gap: Spacing.sm,
-    marginTop: Spacing.sm,
-  },
-  cancelBtn: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: Colors.border,
-    borderRadius: BorderRadius.md,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  cancelText: {
-    fontSize: Typography.fontSize.base,
-    color: Colors.textSecondary,
-  },
-  submitBtn: {
-    flex: 1,
-    backgroundColor: Colors.brandPrimary,
-    borderRadius: BorderRadius.md,
-    height: 44,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  submitDisabled: { opacity: 0.5 },
-  submitText: {
-    color: '#fff',
-    fontSize: Typography.fontSize.base,
-    fontWeight: Typography.fontWeight.semibold,
-  },
-});

--- a/components/WriteConfirmModal.tsx
+++ b/components/WriteConfirmModal.tsx
@@ -1,19 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  Text,
-  TextInput,
-  View,
-  ActivityIndicator,
-  Platform,
-} from 'react-native';
+import { View } from 'react-native';
 import axios, { AxiosError } from 'axios';
 import { Feather } from '@expo/vector-icons';
-import { Colors } from '../constants/Colors';
+import { BorderRadius, Colors, Spacing } from '../constants/Colors';
 import { threads } from '../lib/api/endpoints';
 import { toast } from '../lib/toast';
+import { Input, Modal, Text } from './ui';
 
 const MIN_LEN = 10;
 const MAX_LEN = 1000;
@@ -103,211 +95,97 @@ export function WriteConfirmModal({ visible, request, onClose, onSuccess }: Prop
   return (
     <Modal
       visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={onClose}
+      onClose={onClose}
+      title="Написать по заявке"
+      maxWidth={480}
+      primaryAction={{
+        label: 'Отправить',
+        onPress: handleSubmit,
+        loading: submitting,
+        disabled: !canSend,
+      }}
+      secondaryAction={{
+        label: 'Отмена',
+        onPress: onClose,
+        disabled: submitting,
+      }}
     >
-      <View
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(12, 26, 46, 0.5)',
-          justifyContent: 'center',
-          alignItems: 'center',
-          padding: 16,
-        }}
-      >
+      {/* Request summary */}
+      {request ? (
         <View
           style={{
-            width: '100%',
-            maxWidth: 480,
-            maxHeight: '90%',
-            backgroundColor: Colors.white,
-            borderRadius: 16,
-            padding: 20,
-            gap: 16,
+            gap: 6,
+            padding: Spacing.md,
+            borderRadius: BorderRadius.btn,
+            borderWidth: 1,
+            borderColor: Colors.borderLight,
+            backgroundColor: Colors.bgSecondary,
           }}
         >
-          {/* Header */}
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-            <View
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: 16,
-                backgroundColor: Colors.bgSecondary,
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Feather name="send" size={16} color={Colors.brandPrimary} />
-            </View>
-            <Text
-              style={{
-                flex: 1,
-                fontSize: 18,
-                fontWeight: '700',
-                color: Colors.textPrimary,
-              }}
-            >
-              Написать по заявке
+          <Text weight="semibold" numberOfLines={2}>
+            {request.title}
+          </Text>
+          {request.description ? (
+            <Text variant="caption" numberOfLines={3}>
+              {request.description}
             </Text>
-            <Pressable
-              onPress={onClose}
-              hitSlop={8}
-              style={{ padding: 4 }}
-              accessibilityLabel="Закрыть"
-            >
-              <Feather name="x" size={20} color={Colors.textMuted} />
-            </Pressable>
-          </View>
-
-          <ScrollView
-            style={{ flexGrow: 0 }}
-            contentContainerStyle={{ gap: 12 }}
-            keyboardShouldPersistTaps="handled"
-          >
-            {/* Request summary */}
-            {request && (
-              <View
-                style={{
-                  gap: 6,
-                  padding: 12,
-                  borderRadius: 12,
-                  borderWidth: 1,
-                  borderColor: Colors.borderLight,
-                  backgroundColor: Colors.bgSecondary,
-                }}
-              >
-                <Text style={{ fontSize: 14, fontWeight: '600', color: Colors.textPrimary }} numberOfLines={2}>
-                  {request.title}
-                </Text>
-                {request.description ? (
-                  <Text style={{ fontSize: 13, color: Colors.textSecondary }} numberOfLines={3}>
-                    {request.description}
-                  </Text>
-                ) : null}
-                {(request.city || request.service) && (
-                  <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 2 }}>
-                    {request.city ? (
-                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                        <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
-                        <Text style={{ fontSize: 12, color: Colors.brandPrimary }}>{request.city}</Text>
-                      </View>
-                    ) : null}
-                    {request.service ? (
-                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-                        <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
-                        <Text style={{ fontSize: 12, color: Colors.brandPrimary }}>{request.service}</Text>
-                      </View>
-                    ) : null}
-                  </View>
-                )}
-              </View>
-            )}
-
-            {/* Message input */}
-            <View style={{ gap: 6 }}>
-              <Text style={{ fontSize: 13, fontWeight: '500', color: Colors.textSecondary }}>
-                Первое сообщение клиенту
-              </Text>
-              <TextInput
-                value={message}
-                onChangeText={setMessage}
-                multiline
-                placeholder="Здравствуйте! Я могу помочь с..."
-                placeholderTextColor={Colors.textMuted}
-                editable={!submitting}
-                maxLength={MAX_LEN}
-                style={{
-                  minHeight: 110,
-                  borderRadius: 10,
-                  borderWidth: 1,
-                  borderColor: Colors.borderLight,
-                  backgroundColor: Colors.white,
-                  padding: 12,
-                  fontSize: 15,
-                  color: Colors.textPrimary,
-                  textAlignVertical: 'top',
-                  ...(Platform.OS === 'web' ? ({ outlineStyle: 'none' } as any) : null),
-                }}
-              />
-              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-                <Text style={{ fontSize: 11, color: Colors.textMuted }}>
-                  Минимум {MIN_LEN} символов
-                </Text>
-                <Text style={{ fontSize: 11, color: counterColor }}>
-                  {trimmedLen} / {MAX_LEN}
-                </Text>
-              </View>
+          ) : null}
+          {(request.city || request.service) ? (
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm, marginTop: 2 }}>
+              {request.city ? (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                  <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
+                  <Text variant="caption" style={{ color: Colors.brandPrimary }}>{request.city}</Text>
+                </View>
+              ) : null}
+              {request.service ? (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                  <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
+                  <Text variant="caption" style={{ color: Colors.brandPrimary }}>{request.service}</Text>
+                </View>
+              ) : null}
             </View>
+          ) : null}
+        </View>
+      ) : null}
 
-            {errorText ? (
-              <View
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  gap: 8,
-                  padding: 10,
-                  borderRadius: 8,
-                  backgroundColor: Colors.statusBg.error,
-                }}
-              >
-                <Feather name="alert-circle" size={14} color={Colors.statusError} />
-                <Text style={{ flex: 1, fontSize: 13, color: Colors.statusError }}>{errorText}</Text>
-              </View>
-            ) : null}
-          </ScrollView>
-
-          {/* Actions */}
-          <View style={{ flexDirection: 'row', gap: 8 }}>
-            <Pressable
-              onPress={onClose}
-              disabled={submitting}
-              style={{
-                flex: 1,
-                height: 44,
-                borderRadius: 10,
-                borderWidth: 1,
-                borderColor: Colors.borderLight,
-                alignItems: 'center',
-                justifyContent: 'center',
-                opacity: submitting ? 0.5 : 1,
-              }}
-            >
-              <Text style={{ fontSize: 15, fontWeight: '500', color: Colors.textSecondary }}>Отмена</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleSubmit}
-              disabled={!canSend}
-              style={{
-                flex: 1,
-                height: 44,
-                borderRadius: 10,
-                backgroundColor: canSend ? Colors.brandPrimary : Colors.borderLight,
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 6,
-              }}
-            >
-              {submitting ? (
-                <ActivityIndicator size="small" color={Colors.white} />
-              ) : (
-                <Feather name="send" size={15} color={canSend ? Colors.white : Colors.textMuted} />
-              )}
-              <Text
-                style={{
-                  fontSize: 15,
-                  fontWeight: '600',
-                  color: canSend ? Colors.white : Colors.textMuted,
-                }}
-              >
-                Отправить
-              </Text>
-            </Pressable>
-          </View>
+      {/* Message input */}
+      <View style={{ gap: 6 }}>
+        <Input
+          label="Первое сообщение клиенту"
+          value={message}
+          onChangeText={setMessage}
+          multiline
+          numberOfLines={5}
+          placeholder="Здравствуйте! Я могу помочь с..."
+          editable={!submitting}
+          maxLength={MAX_LEN}
+        />
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Text variant="caption">
+            Минимум {MIN_LEN} символов
+          </Text>
+          <Text variant="caption" style={{ color: counterColor }}>
+            {trimmedLen} / {MAX_LEN}
+          </Text>
         </View>
       </View>
+
+      {errorText ? (
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: Spacing.sm,
+            padding: Spacing.md,
+            borderRadius: BorderRadius.md,
+            backgroundColor: Colors.statusBg.error,
+          }}
+        >
+          <Feather name="alert-circle" size={14} color={Colors.statusError} />
+          <Text variant="caption" style={{ flex: 1, color: Colors.statusError }}>{errorText}</Text>
+        </View>
+      ) : null}
     </Modal>
   );
 }


### PR DESCRIPTION
Phase 3D of UI overhaul. Largest parallel PR - kills StyleSheet.create holdouts.

## Scope
- app/(admin)/complaints.tsx, reviews.tsx, index.tsx
- app/(dashboard)/my-requests/[id].tsx
- app/specialists/[nick].tsx, app/specialist/[id]/reviews.tsx
- app/requests/[id].tsx
- app/terms.tsx, app/notifications.tsx, app/leave-review.tsx
- components/ComplaintButton.tsx, components/WriteConfirmModal.tsx

## Before -> After
- StyleSheet.create: 6 files -> 0 (in scope)
- Inline hex (#F97316, #F59E0B, #DCFCE7, #15803D, #E5E7EB, #94A3B8, #64748B, #0284C7, #E2E8F0, sky-50): N -> 0
- Hand-rolled Modals: replaced with <Modal> primitive (ComplaintButton, WriteConfirmModal, Specialist profile, AdminComplaints)

## LOC deltas
- ComplaintButton: 244 -> 103 (-58%)
- WriteConfirmModal: 313 -> 191 (-39%)
- complaints.tsx: 354 -> 261
- reviews.tsx: 205 -> 177
- terms.tsx: 146 -> 74

## Verification
- `tsc --noEmit` passes with 0 errors
- 0 StyleSheet.create in scope files
- 0 raw hex literals in scope files (all mapped to Colors tokens)

## Notes
- app/chat/[id].tsx already compliant (0 StyleSheet.create, 0 hex) - left untouched to avoid risk on high-value chat flow
- app/(admin)/_layout.tsx is a 5-line Stack wrapper, nothing to migrate
- Parallel with Phase 3A/B/C.