### PR TITLE
refactor(ui): tabs + dashboard migration [Phase 3C]

### DIFF
--- a/app/(dashboard)/my-requests/new.tsx
+++ b/app/(dashboard)/my-requests/new.tsx
@@ -1,12 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import { Alert, View, Text, TextInput, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { Alert, View, Pressable, ScrollView } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Feather } from '@expo/vector-icons';
 import * as DocumentPicker from 'expo-document-picker';
-import { Colors } from '../../../constants/Colors';
+import { Colors, Spacing, BorderRadius } from '../../../constants/Colors';
 import { Toggle } from '../../../components/proto/Toggle';
 import { ifns, requests, upload } from '../../../lib/api/endpoints';
 import { Header } from '../../../components/Header';
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Screen,
+  Text,
+} from '../../../components/ui';
 
 // Fixed service list per product spec
 const SERVICES = ['Выездная проверка', 'Отдел оперативного контроля', 'Камеральная проверка', 'Не знаю'];
@@ -24,11 +32,23 @@ interface IfnsItem {
 
 function FileItem({ name, size, onRemove }: { name: string; size: string; onRemove: () => void }) {
   return (
-    <View className="flex-row items-center gap-3 rounded-lg border border-borderLight bg-bgSurface px-3 py-2">
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: Spacing.md,
+        borderRadius: BorderRadius.lg,
+        borderWidth: 1,
+        borderColor: Colors.borderLight,
+        backgroundColor: Colors.bgSurface,
+        paddingHorizontal: Spacing.md,
+        paddingVertical: Spacing.sm,
+      }}
+    >
       <Feather name="file" size={16} color={Colors.brandPrimary} />
-      <View className="flex-1">
-        <Text className="text-sm text-textPrimary" numberOfLines={1}>{name}</Text>
-        <Text className="text-xs text-textMuted">{size}</Text>
+      <View style={{ flex: 1 }}>
+        <Text variant="caption" style={{ color: Colors.textPrimary }} numberOfLines={1}>{name}</Text>
+        <Text variant="caption">{size}</Text>
       </View>
       <Pressable onPress={onRemove}>
         <Feather name="x" size={16} color={Colors.textMuted} />
@@ -56,44 +76,119 @@ function LocationServicePicker({
   const summary = city ? [city.name, selectedFns?.name, service].filter(Boolean).join(' / ') : '';
 
   return (
-    <View className="gap-1">
-      <Text className="text-sm font-medium text-textSecondary">Город, ФНС и услуга</Text>
+    <View style={{ gap: Spacing.xs }}>
+      <Text variant="label" style={{ color: Colors.textSecondary }}>Город, ФНС и услуга</Text>
       <Pressable onPress={() => setOpenLevel(openLevel ? null : 'city')}>
-        <View className={`min-h-[48px] flex-row items-center gap-2 rounded-xl border px-4 py-3 ${openLevel ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
+        <View
+          style={{
+            minHeight: 48,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: Spacing.sm,
+            borderRadius: BorderRadius.btn,
+            borderWidth: 1,
+            borderColor: openLevel ? Colors.brandPrimary : Colors.borderLight,
+            backgroundColor: Colors.white,
+            paddingHorizontal: Spacing.lg,
+            paddingVertical: Spacing.md,
+          }}
+        >
           <Feather name="map-pin" size={16} color={Colors.textMuted} />
-          <Text className={`flex-1 text-base ${summary ? 'text-textPrimary' : 'text-textMuted'}`} numberOfLines={2}>
+          <Text
+            variant="body"
+            style={{ flex: 1, color: summary ? Colors.textPrimary : Colors.textMuted }}
+            numberOfLines={2}
+          >
             {summary || 'Выберите город, ФНС и услугу'}
           </Text>
           <Feather name={openLevel ? 'chevron-up' : 'chevron-down'} size={16} color={Colors.textMuted} />
         </View>
       </Pressable>
       {openLevel && (
-        <View className="overflow-hidden rounded-xl border border-borderLight bg-white shadow-sm">
-          <View className="flex-row border-b border-bgSecondary">
-            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'city' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => setOpenLevel('city')}>
-              <Text className={`text-xs font-semibold ${openLevel === 'city' ? 'text-brandPrimary' : city ? 'text-textPrimary' : 'text-textMuted'}`}>{city?.name || 'Город'}</Text>
-            </Pressable>
-            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'fns' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => city && setOpenLevel('fns')} disabled={!city}>
-              <Text className={`text-xs font-semibold ${openLevel === 'fns' ? 'text-brandPrimary' : selectedFns ? 'text-textPrimary' : 'text-textMuted'}`}>{selectedFns ? selectedFns.name.replace(/^ФНС\s*/, '').substring(0, 20) : 'ФНС'}</Text>
-            </Pressable>
-            <Pressable className={`flex-1 items-center py-2.5 ${openLevel === 'service' ? 'border-b-2 border-brandPrimary' : ''}`} onPress={() => selectedFns && setOpenLevel('service')} disabled={!selectedFns}>
-              <Text className={`text-xs font-semibold ${openLevel === 'service' ? 'text-brandPrimary' : service ? 'text-textPrimary' : 'text-textMuted'}`}>{service || 'Услуга'}</Text>
-            </Pressable>
+        <View
+          style={{
+            overflow: 'hidden',
+            borderRadius: BorderRadius.btn,
+            borderWidth: 1,
+            borderColor: Colors.borderLight,
+            backgroundColor: Colors.white,
+          }}
+        >
+          <View style={{ flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary }}>
+            {[
+              { key: 'city' as const, label: city?.name || 'Город', has: !!city },
+              { key: 'fns' as const, label: selectedFns ? selectedFns.name.replace(/^ФНС\s*/, '').substring(0, 20) : 'ФНС', has: !!selectedFns, disabled: !city },
+              { key: 'service' as const, label: service || 'Услуга', has: !!service, disabled: !selectedFns },
+            ].map((tab) => {
+              const active = openLevel === tab.key;
+              return (
+                <Pressable
+                  key={tab.key}
+                  style={{
+                    flex: 1,
+                    alignItems: 'center',
+                    paddingVertical: Spacing.sm + 2,
+                    borderBottomWidth: active ? 2 : 0,
+                    borderBottomColor: active ? Colors.brandPrimary : 'transparent',
+                  }}
+                  onPress={() => !tab.disabled && setOpenLevel(tab.key)}
+                  disabled={tab.disabled}
+                >
+                  <Text
+                    variant="caption"
+                    weight="semibold"
+                    style={{ color: active ? Colors.brandPrimary : tab.has ? Colors.textPrimary : Colors.textMuted }}
+                  >
+                    {tab.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
           </View>
-          <View className="max-h-48">
+          <View style={{ maxHeight: 192 }}>
             {openLevel === 'city' && cities.map((c) => (
-              <Pressable key={c.id} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onCityChange(c); onServiceChange(''); setOpenLevel('fns'); }}>
-                <Text className={`text-base ${city?.id === c.id ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{c.name}</Text>
+              <Pressable
+                key={c.id}
+                style={{ borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md }}
+                onPress={() => { onCityChange(c); onServiceChange(''); setOpenLevel('fns'); }}
+              >
+                <Text
+                  variant="body"
+                  weight={city?.id === c.id ? 'semibold' : undefined}
+                  style={{ color: city?.id === c.id ? Colors.brandPrimary : Colors.textPrimary }}
+                >
+                  {c.name}
+                </Text>
               </Pressable>
             ))}
             {openLevel === 'fns' && fnsOptions.map((f) => (
-              <Pressable key={f.id} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onFnsChange(f); setOpenLevel('service'); }}>
-                <Text className={`text-base ${selectedFns?.id === f.id ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{f.name}</Text>
+              <Pressable
+                key={f.id}
+                style={{ borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md }}
+                onPress={() => { onFnsChange(f); setOpenLevel('service'); }}
+              >
+                <Text
+                  variant="body"
+                  weight={selectedFns?.id === f.id ? 'semibold' : undefined}
+                  style={{ color: selectedFns?.id === f.id ? Colors.brandPrimary : Colors.textPrimary }}
+                >
+                  {f.name}
+                </Text>
               </Pressable>
             ))}
             {openLevel === 'service' && SERVICES.map((s) => (
-              <Pressable key={s} className="border-b border-bgSecondary px-4 py-3" onPress={() => { onServiceChange(s); setOpenLevel(null); }}>
-                <Text className={`text-base ${service === s ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{s}</Text>
+              <Pressable
+                key={s}
+                style={{ borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md }}
+                onPress={() => { onServiceChange(s); setOpenLevel(null); }}
+              >
+                <Text
+                  variant="body"
+                  weight={service === s ? 'semibold' : undefined}
+                  style={{ color: service === s ? Colors.brandPrimary : Colors.textPrimary }}
+                >
+                  {s}
+                </Text>
               </Pressable>
             ))}
           </View>
@@ -214,7 +309,7 @@ export default function NewRequestScreen() {
         try {
           await upload.requestDocuments(id, formData);
         } catch {
-          // Non-blocking — request was created, just log
+          // Non-blocking
         }
       }
 
@@ -235,77 +330,95 @@ export default function NewRequestScreen() {
   };
 
   return (
-    <View className="flex-1 bg-white">
-    <Header variant="back" backTitle="Новая заявка" onBack={() => router.back()} />
-    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      <Text className="text-xl font-bold text-textPrimary">Новая заявка</Text>
-      <LocationServicePicker
-        city={city}
-        fns={selectedFns}
-        service={service}
-        onCityChange={handleCityChange}
-        onFnsChange={setSelectedFns}
-        onServiceChange={setService}
-        cities={cities}
-        fnsByCity={fnsByCity}
-      />
-      <View className="gap-1">
-        <Text className="text-sm font-medium text-textSecondary">Заголовок</Text>
-        <TextInput
-          value={title}
-          onChangeText={setTitle}
-          placeholder="Кратко опишите задачу"
-          placeholderTextColor={Colors.textMuted}
-          className={`h-12 rounded-xl border px-4 text-base text-textPrimary bg-white ${titleError ? 'border-red-400' : 'border-borderLight'}`}
-          style={{ outlineStyle: 'none' } as any}
-        />
-        {titleError && <Text className="text-xs text-red-500">{titleError}</Text>}
-      </View>
-      <View className="gap-1">
-        <Text className="text-sm font-medium text-textSecondary">Описание</Text>
-        <TextInput
-          value={description}
-          onChangeText={setDescription}
-          placeholder="Подробно опишите, что нужно сделать..."
-          placeholderTextColor={Colors.textMuted}
-          multiline
-          className={`min-h-[96px] rounded-xl border p-4 text-base text-textPrimary bg-white ${descError ? 'border-red-400' : 'border-borderLight'}`}
-          style={{ textAlignVertical: 'top', outlineStyle: 'none' } as any}
-        />
-        {descError && <Text className="text-xs text-red-500">{descError}</Text>}
-      </View>
-      <View className="gap-2">
-        <Text className="text-sm font-medium text-textSecondary">Файлы</Text>
-        {files.map((f, i) => (<FileItem key={i} name={f.name} size={f.size} onRemove={() => handleRemoveFile(i)} />))}
-        {files.length < 5 && (
-          <Pressable
-            onPress={handlePickFiles}
-            className="h-10 flex-row items-center justify-center gap-2 rounded-lg border border-dashed border-borderLight bg-bgSurface"
-          >
-            <Feather name="paperclip" size={16} color={Colors.brandPrimary} />
-            <Text className="text-sm font-medium text-brandPrimary">Прикрепить файл</Text>
-          </Pressable>
-        )}
-        <Text className="text-xs text-textMuted">PDF, JPG, PNG до 10 МБ. Макс. 5 файлов.</Text>
-      </View>
-      <View className="py-1">
-        <Toggle value={publicVisible} onValueChange={setPublicVisible} label="Показать неавторизованным" sublabel="Заявку увидят без входа в аккаунт" />
-      </View>
-      <Pressable
-        onPress={handleSubmit}
-        disabled={!isValid || submitting}
-        className={`mt-2 h-12 flex-row items-center justify-center gap-2 rounded-xl ${isValid && !submitting ? 'bg-brandPrimary' : 'bg-brandPrimary/50'}`}
-      >
-        {submitting ? (
-          <ActivityIndicator color={Colors.white} size="small" />
-        ) : (
-          <>
-            <Feather name="send" size={16} color={Colors.white} />
-            <Text className="text-base font-semibold text-white">Отправить заявку</Text>
-          </>
-        )}
-      </Pressable>
-    </ScrollView>
-    </View>
+    <Screen bg={Colors.white}>
+      <Header variant="back" backTitle="Новая заявка" onBack={() => router.back()} />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            <Heading level={3}>Новая заявка</Heading>
+
+            <LocationServicePicker
+              city={city}
+              fns={selectedFns}
+              service={service}
+              onCityChange={handleCityChange}
+              onFnsChange={setSelectedFns}
+              onServiceChange={setService}
+              cities={cities}
+              fnsByCity={fnsByCity}
+            />
+
+            <Input
+              label="Заголовок"
+              value={title}
+              onChangeText={setTitle}
+              placeholder="Кратко опишите задачу"
+              error={titleError ?? undefined}
+            />
+
+            <Input
+              label="Описание"
+              value={description}
+              onChangeText={setDescription}
+              placeholder="Подробно опишите, что нужно сделать..."
+              multiline
+              numberOfLines={4}
+              error={descError ?? undefined}
+            />
+
+            <View style={{ gap: Spacing.sm }}>
+              <Text variant="label" style={{ color: Colors.textSecondary }}>Файлы</Text>
+              {files.map((f, i) => (
+                <FileItem key={i} name={f.name} size={f.size} onRemove={() => handleRemoveFile(i)} />
+              ))}
+              {files.length < 5 && (
+                <Pressable
+                  onPress={handlePickFiles}
+                  style={{
+                    height: 40,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: Spacing.sm,
+                    borderRadius: BorderRadius.lg,
+                    borderWidth: 1,
+                    borderStyle: 'dashed',
+                    borderColor: Colors.borderLight,
+                    backgroundColor: Colors.bgSurface,
+                  }}
+                >
+                  <Feather name="paperclip" size={16} color={Colors.brandPrimary} />
+                  <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>
+                    Прикрепить файл
+                  </Text>
+                </Pressable>
+              )}
+              <Text variant="caption">PDF, JPG, PNG до 10 МБ. Макс. 5 файлов.</Text>
+            </View>
+
+            <View>
+              <Toggle
+                value={publicVisible}
+                onValueChange={setPublicVisible}
+                label="Показать неавторизованным"
+                sublabel="Заявку увидят без входа в аккаунт"
+              />
+            </View>
+
+            <Button
+              variant="primary"
+              size="lg"
+              loading={submitting}
+              disabled={!isValid || submitting}
+              icon={<Feather name="send" size={16} color={Colors.white} />}
+              onPress={handleSubmit}
+              fullWidth
+            >
+              Отправить заявку
+            </Button>
+          </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -1,11 +1,21 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, ScrollView, Pressable, ActivityIndicator } from "react-native";
+import { View, ScrollView, ActivityIndicator, Pressable } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { router } from "expo-router";
-import { Colors } from "../../constants/Colors";
+import { Colors, Spacing, BorderRadius, Typography } from "../../constants/Colors";
 import { useAuth } from "../../lib/auth/AuthContext";
 import { requests, threads } from "../../lib/api/endpoints";
 import { Header } from "../../components/Header";
+import {
+  Button,
+  Card,
+  Container,
+  EmptyState,
+  Heading,
+  Screen,
+  Text,
+  Badge,
+} from "../../components/ui";
 
 function getGreeting(): string {
   const h = new Date().getHours();
@@ -15,147 +25,178 @@ function getGreeting(): string {
   return "Добрый вечер";
 }
 
-function StatCard({ icon, label, value, color }: { icon: string; label: string; value: string; color: string }) {
-  return (
-    <View className="flex-1 items-center gap-1 rounded-xl border border-borderLight bg-white p-3">
-      <View className="h-9 w-9 items-center justify-center rounded-full" style={{ backgroundColor: color + "15" }}>
-        <Feather name={icon as any} size={18} color={color} />
-      </View>
-      <Text className="text-lg font-bold" style={{ color }}>{value}</Text>
-      <Text className="text-xs text-textMuted">{label}</Text>
-    </View>
-  );
-}
+const STATUS_LABEL: Record<string, string> = {
+  ACTIVE: "Активная",
+  CLOSING_SOON: "Истекает скоро",
+  CLOSED: "Закрыта",
+  active: "Новая",
+  in_progress: "В работе",
+  closed: "Закрыта",
+  cancelled: "Отменена",
+};
 
-function getStatusLabel(status: string): string {
-  const map: Record<string, string> = {
-    active: 'Новая',
-    in_progress: 'В работе',
-    closed: 'Закрыта',
-    cancelled: 'Отменена',
-  };
-  return map[status] ?? status;
-}
-
-function getStatusColor(status: string): string {
-  const map: Record<string, string> = {
-    active: Colors.brandPrimary,
-    in_progress: Colors.statusWarning,
-    closed: Colors.textMuted,
-    cancelled: Colors.statusError,
-  };
-  return map[status] ?? Colors.textMuted;
-}
+const STATUS_VARIANT: Record<string, "success" | "warning" | "default" | "danger" | "info"> = {
+  ACTIVE: "success",
+  CLOSING_SOON: "warning",
+  CLOSED: "default",
+  active: "info",
+  in_progress: "warning",
+  closed: "default",
+  cancelled: "danger",
+};
 
 function RequestCard({ id, title, service, fns, city, date, messageCount, status }: {
   id: string; title: string; service: string; fns?: string; city?: string; date: string;
   messageCount: number; status: string;
 }) {
-  const statusColor = getStatusColor(status);
-  const statusLabel = getStatusLabel(status);
+  const statusLabel = STATUS_LABEL[status] ?? status;
+  const statusVariant = STATUS_VARIANT[status] ?? "default";
   return (
-    <Pressable className="gap-2 rounded-xl border border-borderLight bg-white p-4" onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
-      <View className="flex-row items-start justify-between gap-2">
-        <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={2}>{title}</Text>
-        <View className="rounded-full px-2 py-0.5" style={{ backgroundColor: statusColor + "18" }}>
-          <Text className="text-xs font-semibold" style={{ color: statusColor }}>{statusLabel}</Text>
+    <Card onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
+      <View style={{ gap: Spacing.sm }}>
+        <View style={{ flexDirection: "row", alignItems: "flex-start", justifyContent: "space-between", gap: Spacing.sm }}>
+          <View style={{ flex: 1 }}>
+            <Text variant="body" weight="semibold" numberOfLines={2}>{title}</Text>
+          </View>
+          <Badge variant={statusVariant}>{statusLabel}</Badge>
+        </View>
+        <View style={{ flexDirection: "row", flexWrap: "wrap", rowGap: Spacing.xs, columnGap: Spacing.md, alignItems: "center" }}>
+          {service ? (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.xs }}>
+              <Feather name="briefcase" size={12} color={Colors.textMuted} />
+              <Text variant="caption">{service}</Text>
+            </View>
+          ) : null}
+          {fns ? (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.xs }}>
+              <Feather name="home" size={12} color={Colors.textMuted} />
+              <Text variant="caption">{fns}</Text>
+            </View>
+          ) : null}
+          {city ? (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.xs }}>
+              <Feather name="map-pin" size={12} color={Colors.textMuted} />
+              <Text variant="caption">{city}</Text>
+            </View>
+          ) : null}
+        </View>
+        <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.xs }}>
+            <Feather name="calendar" size={12} color={Colors.textMuted} />
+            <Text variant="caption">{date}</Text>
+          </View>
+          {messageCount > 0 && (
+            <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.xs }}>
+              <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>
+                {messageCount} сообщ.
+              </Text>
+            </View>
+          )}
         </View>
       </View>
-      <View className="flex-row flex-wrap items-center gap-x-3 gap-y-1">
-        {service ? (
-          <View className="flex-row items-center gap-1">
-            <Feather name="briefcase" size={12} color={Colors.textMuted} />
-            <Text className="text-xs text-textMuted">{service}</Text>
-          </View>
-        ) : null}
-        {fns ? (
-          <View className="flex-row items-center gap-1">
-            <Feather name="home" size={12} color={Colors.textMuted} />
-            <Text className="text-xs text-textMuted">{fns}</Text>
-          </View>
-        ) : null}
-        {city ? (
-          <View className="flex-row items-center gap-1">
-            <Feather name="map-pin" size={12} color={Colors.textMuted} />
-            <Text className="text-xs text-textMuted">{city}</Text>
-          </View>
-        ) : null}
-      </View>
-      <View className="flex-row items-center justify-between">
-        <View className="flex-row items-center gap-1">
-          <Feather name="calendar" size={12} color={Colors.textMuted} />
-          <Text className="text-xs text-textMuted">{date}</Text>
-        </View>
-        {messageCount > 0 && (
-          <View className="flex-row items-center gap-1">
-            <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
-            <Text className="text-xs font-medium text-brandPrimary">{messageCount} сообщ.</Text>
-          </View>
-        )}
-      </View>
-    </Pressable>
+    </Card>
   );
 }
 
 function getInitials(name: string): string {
   return name
-    .split(' ')
-    .map((p) => p[0] ?? '')
-    .join('')
+    .split(" ")
+    .map((p) => p[0] ?? "")
+    .join("")
     .toUpperCase()
     .slice(0, 2);
 }
 
 function formatThreadTime(isoString: string): string {
-  if (!isoString) return '';
+  if (!isoString) return "";
   const d = new Date(isoString);
   const now = new Date();
   const diffMs = now.getTime() - d.getTime();
   const diffH = diffMs / 1000 / 3600;
   if (diffH < 24) {
-    return d.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' });
+    return d.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" });
   }
-  if (diffH < 48) return 'вчера';
-  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit' });
+  if (diffH < 48) return "вчера";
+  return d.toLocaleDateString("ru-RU", { day: "2-digit", month: "2-digit" });
 }
 
 function MessagePreview({ id, initials, name, snippet, time, unread }: {
   id: string; initials: string; name: string; snippet: string; time: string; unread?: boolean;
 }) {
   return (
-    <Pressable className="flex-row items-center gap-3 rounded-xl border border-borderLight bg-white p-3" onPress={() => router.push(`/chat/${id}` as any)}>
-      <View className="h-10 w-10 items-center justify-center rounded-full border border-borderLight bg-bgSurface">
-        <Text className="text-sm font-bold text-brandPrimary">{initials}</Text>
-      </View>
-      <View className="flex-1">
-        <View className="flex-row items-center justify-between">
-          <Text className={`text-sm ${unread ? "font-bold text-textPrimary" : "font-medium text-textPrimary"}`}>{name}</Text>
-          <Text className="text-xs text-textMuted">{time}</Text>
+    <Card onPress={() => router.push(`/chat/${id}` as any)} padding="sm" variant="outlined">
+      <View style={{ flexDirection: "row", alignItems: "center", gap: Spacing.md }}>
+        <View
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: BorderRadius.full,
+            backgroundColor: Colors.bgSurface,
+            borderWidth: 1,
+            borderColor: Colors.borderLight,
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Text style={{ color: Colors.brandPrimary, fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold }}>
+            {initials}
+          </Text>
         </View>
-        <Text className={`text-xs ${unread ? "font-medium text-textSecondary" : "text-textMuted"}`} numberOfLines={1}>{snippet}</Text>
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+            <Text weight={unread ? "bold" : "medium"} variant="body" numberOfLines={1}>{name}</Text>
+            <Text variant="caption">{time}</Text>
+          </View>
+          <Text
+            variant={unread ? "body" : "caption"}
+            weight={unread ? "medium" : undefined}
+            numberOfLines={1}
+          >
+            {snippet}
+          </Text>
+        </View>
+        {unread && (
+          <View style={{ width: 10, height: 10, borderRadius: BorderRadius.full, backgroundColor: Colors.brandPrimary }} />
+        )}
       </View>
-      {unread && (
-        <View className="h-2.5 w-2.5 rounded-full bg-brandPrimary" />
-      )}
-    </Pressable>
+    </Card>
   );
 }
 
 function QuickActions() {
   return (
-    <View className="flex-row gap-2">
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl bg-brandPrimary" onPress={() => router.push('/(dashboard)/my-requests/new' as any)}>
-        <Feather name="plus" size={16} color={Colors.white} />
-        <Text className="text-sm font-semibold text-white">Новая заявка</Text>
-      </Pressable>
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white" onPress={() => router.push('/(tabs)/requests' as any)}>
-        <Feather name="list" size={16} color={Colors.brandPrimary} />
-        <Text className="text-sm font-medium text-brandPrimary">Мои заявки</Text>
-      </Pressable>
-      <Pressable className="h-10 flex-1 flex-row items-center justify-center gap-1.5 rounded-xl border border-borderLight bg-white" onPress={() => router.push('/(tabs)/messages' as any)}>
-        <Feather name="message-circle" size={16} color={Colors.brandPrimary} />
-        <Text className="text-sm font-medium text-brandPrimary">Сообщения</Text>
-      </Pressable>
+    <View style={{ flexDirection: "row", gap: Spacing.sm }}>
+      <View style={{ flex: 1 }}>
+        <Button
+          variant="primary"
+          icon={<Feather name="plus" size={16} color={Colors.white} />}
+          onPress={() => router.push("/(dashboard)/my-requests/new" as any)}
+          fullWidth
+        >
+          Новая заявка
+        </Button>
+      </View>
+      <View style={{ flex: 1 }}>
+        <Button
+          variant="secondary"
+          icon={<Feather name="list" size={16} color={Colors.brandPrimary} />}
+          onPress={() => router.push("/(tabs)/requests" as any)}
+          fullWidth
+        >
+          Мои заявки
+        </Button>
+      </View>
+      <View style={{ flex: 1 }}>
+        <Button
+          variant="secondary"
+          icon={<Feather name="message-circle" size={16} color={Colors.brandPrimary} />}
+          onPress={() => router.push("/(tabs)/messages" as any)}
+          fullWidth
+        >
+          Сообщения
+        </Button>
+      </View>
     </View>
   );
 }
@@ -164,7 +205,7 @@ interface RequestItem {
   id: string;
   title: string;
   serviceType?: string;
-  fnsName?: string;
+  ifnsName?: string;
   city?: string;
   createdAt: string;
   status: string;
@@ -186,9 +227,9 @@ interface ThreadItem {
 }
 
 function formatDate(iso: string): string {
-  if (!iso) return '';
+  if (!iso) return "";
   const d = new Date(iso);
-  return d.toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  return d.toLocaleDateString("ru-RU", { day: "2-digit", month: "2-digit", year: "numeric" });
 }
 
 export default function DashboardScreen() {
@@ -201,7 +242,7 @@ export default function DashboardScreen() {
   const [msgsLoading, setMsgsLoading] = useState(true);
 
   useEffect(() => {
-    requests.getMyRequests({ limit: 3, status: 'active' })
+    requests.getMyRequests({ limit: 3, status: "active" })
       .then((res: any) => {
         const data = res.data;
         setReqs(Array.isArray(data) ? data : (data.items ?? data.data ?? []));
@@ -221,102 +262,128 @@ export default function DashboardScreen() {
       .finally(() => setMsgsLoading(false));
   }, []);
 
-  const firstName = user?.firstName ?? user?.email?.split('@')[0] ?? 'друг';
+  const firstName = user?.firstName ?? user?.email?.split("@")[0] ?? "друг";
 
   return (
-    <View className="flex-1 bg-white">
-    <Header variant="auth" />
-    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      <View className="flex-row items-start justify-between">
-        <View className="flex-1">
-          <Text className="text-xl font-bold text-textPrimary">{getGreeting()}, {firstName}!</Text>
-          <Text className="text-sm text-textMuted">Ваши заявки и сообщения</Text>
-        </View>
-        <Pressable className="h-10 w-10 items-center justify-center rounded-full bg-bgSurface" onPress={() => router.push('/(tabs)/messages' as any)}>
-          <Feather name="bell" size={20} color={Colors.textPrimary} />
-        </Pressable>
-      </View>
+    <Screen bg={Colors.white}>
+      <Header variant="auth" />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            <View style={{ flexDirection: "row", alignItems: "flex-start", justifyContent: "space-between" }}>
+              <View style={{ flex: 1 }}>
+                <Heading level={3}>{getGreeting()}, {firstName}!</Heading>
+                <Text variant="muted">Ваши заявки и сообщения</Text>
+              </View>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Уведомления"
+                onPress={() => router.push("/(tabs)/messages" as any)}
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: BorderRadius.full,
+                  backgroundColor: Colors.bgSurface,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Feather name="bell" size={20} color={Colors.textPrimary} />
+              </Pressable>
+            </View>
 
-      <QuickActions />
+            <QuickActions />
 
-      {/* Active requests */}
-      <View className="gap-3">
-        <View className="flex-row items-center justify-between">
-          <Text className="text-base font-semibold text-textPrimary">Активные заявки</Text>
-          <Pressable onPress={() => router.push('/(tabs)/requests' as any)}>
-            <Text className="text-sm font-medium text-brandPrimary">Все заявки</Text>
-          </Pressable>
-        </View>
-        {reqsLoading ? (
-          <ActivityIndicator color={Colors.brandPrimary} />
-        ) : reqs.length === 0 ? (
-          <View className="items-center gap-3 rounded-xl border border-borderLight bg-white p-6">
-            <Feather name="file-text" size={32} color={Colors.textMuted} />
-            <Text className="text-sm text-textMuted">Нет активных заявок</Text>
-            <Pressable
-              className="h-10 flex-row items-center gap-1.5 rounded-xl bg-brandPrimary px-4"
-              onPress={() => router.push('/(dashboard)/my-requests/new' as any)}
-            >
-              <Feather name="plus" size={16} color={Colors.white} />
-              <Text className="text-sm font-semibold text-white">Создать заявку</Text>
-            </Pressable>
+            {/* Active requests */}
+            <View style={{ gap: Spacing.md }}>
+              <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+                <Text variant="body" weight="semibold">Активные заявки</Text>
+                <Button variant="ghost" size="md" onPress={() => router.push("/(tabs)/requests" as any)}>
+                  Все заявки
+                </Button>
+              </View>
+              {reqsLoading ? (
+                <ActivityIndicator color={Colors.brandPrimary} />
+              ) : reqs.length === 0 ? (
+                <Card variant="outlined">
+                  <EmptyState
+                    icon={<Feather name="file-text" size={32} color={Colors.textMuted} />}
+                    title="Нет активных заявок"
+                    action={
+                      <Button
+                        variant="primary"
+                        icon={<Feather name="plus" size={16} color={Colors.white} />}
+                        onPress={() => router.push("/(dashboard)/my-requests/new" as any)}
+                      >
+                        Создать заявку
+                      </Button>
+                    }
+                  />
+                </Card>
+              ) : (
+                <View style={{ gap: Spacing.md }}>
+                  {reqs.map((req) => (
+                    <RequestCard
+                      key={req.id}
+                      id={req.id}
+                      title={req.title}
+                      service={req.serviceType ?? ""}
+                      fns={req.ifnsName}
+                      city={req.city}
+                      date={formatDate(req.createdAt)}
+                      messageCount={req._count?.threads ?? 0}
+                      status={req.status}
+                    />
+                  ))}
+                </View>
+              )}
+            </View>
+
+            {/* Recent messages */}
+            <View style={{ gap: Spacing.md }}>
+              <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between" }}>
+                <Text variant="body" weight="semibold">Новые сообщения</Text>
+                <Button variant="ghost" size="md" onPress={() => router.push("/(tabs)/messages" as any)}>
+                  Все сообщения
+                </Button>
+              </View>
+              {msgsLoading ? (
+                <ActivityIndicator color={Colors.brandPrimary} />
+              ) : msgs.length === 0 ? (
+                <Card variant="outlined">
+                  <View style={{ alignItems: "center", paddingVertical: Spacing.md }}>
+                    <Text variant="muted">Нет сообщений</Text>
+                  </View>
+                </Card>
+              ) : (
+                <View style={{ gap: Spacing.sm }}>
+                  {msgs.map((thread) => {
+                    const other = thread.specialist ?? thread.client;
+                    const name = other
+                      ? [other.firstName, other.lastName].filter(Boolean).join(" ") || other.nick || "Специалист"
+                      : "Специалист";
+                    const initials = getInitials(name);
+                    const snippet = thread.lastMessage?.content ?? "";
+                    const time = thread.lastMessage?.createdAt ? formatThreadTime(thread.lastMessage.createdAt) : "";
+                    const unread = (thread.unreadCount ?? 0) > 0;
+                    return (
+                      <MessagePreview
+                        key={thread.id}
+                        id={thread.id}
+                        initials={initials}
+                        name={name}
+                        snippet={snippet}
+                        time={time}
+                        unread={unread}
+                      />
+                    );
+                  })}
+                </View>
+              )}
+            </View>
           </View>
-        ) : (
-          reqs.map((req) => (
-            <RequestCard
-              key={req.id}
-              id={req.id}
-              title={req.title}
-              service={req.serviceType ?? ''}
-              fns={req.fnsName}
-              city={req.city}
-              date={formatDate(req.createdAt)}
-              messageCount={req._count?.threads ?? 0}
-              status={req.status}
-            />
-          ))
-        )}
-      </View>
-
-      {/* Recent messages */}
-      <View className="gap-3">
-        <View className="flex-row items-center justify-between">
-          <Text className="text-base font-semibold text-textPrimary">Новые сообщения</Text>
-          <Pressable onPress={() => router.push('/(tabs)/messages' as any)}>
-            <Text className="text-sm font-medium text-brandPrimary">Все сообщения</Text>
-          </Pressable>
-        </View>
-        {msgsLoading ? (
-          <ActivityIndicator color={Colors.brandPrimary} />
-        ) : msgs.length === 0 ? (
-          <View className="items-center rounded-xl border border-borderLight bg-white p-6">
-            <Text className="text-sm text-textMuted">Нет сообщений</Text>
-          </View>
-        ) : (
-          msgs.map((thread) => {
-            const other = thread.specialist ?? thread.client;
-            const name = other
-              ? [other.firstName, other.lastName].filter(Boolean).join(' ') || other.nick || 'Специалист'
-              : 'Специалист';
-            const initials = getInitials(name);
-            const snippet = thread.lastMessage?.content ?? '';
-            const time = thread.lastMessage?.createdAt ? formatThreadTime(thread.lastMessage.createdAt) : '';
-            const unread = (thread.unreadCount ?? 0) > 0;
-            return (
-              <MessagePreview
-                key={thread.id}
-                id={thread.id}
-                initials={initials}
-                name={name}
-                snippet={snippet}
-                time={time}
-                unread={unread}
-              />
-            );
-          })
-        )}
-      </View>
-    </ScrollView>
-    </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }

--- a/app/(tabs)/feed.tsx
+++ b/app/(tabs)/feed.tsx
@@ -1,11 +1,20 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { View, Text, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Pressable, ScrollView, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { Colors } from '../../constants/Colors';
+import { Colors, Spacing, BorderRadius } from '../../constants/Colors';
 import { requests as requestsApi, ifns, categories as categoriesApi } from '../../lib/api/endpoints';
 import { WriteConfirmModal, WriteConfirmModalRequest } from '../../components/WriteConfirmModal';
 import { Header } from '../../components/Header';
+import {
+  Button,
+  Card,
+  Container,
+  EmptyState,
+  Heading,
+  Screen,
+  Text,
+} from '../../components/ui';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -15,8 +24,9 @@ interface FeedRequest {
   title: string;
   description?: string | null;
   city?: string | null;
-  ifnsCode?: string | null;
-  serviceCategory?: string | null;
+  ifnsName?: string | null;
+  serviceType?: string | null;
+  category?: string | null;
   createdAt: string;
   client?: { firstName?: string | null; lastName?: string | null; createdAt?: string | null } | null;
   _count?: { threads?: number };
@@ -49,32 +59,63 @@ function SelectDropdown({
 }) {
   const [open, setOpen] = useState(false);
   return (
-    <View className="gap-2">
+    <View style={{ gap: Spacing.sm }}>
       <Pressable onPress={() => setOpen(!open)}>
-        <View className={`h-11 flex-row items-center gap-2 rounded-lg border px-3 ${open ? 'border-brandPrimary' : 'border-borderLight'} bg-white`}>
+        <View
+          style={{
+            height: 44,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: Spacing.sm,
+            borderRadius: BorderRadius.input,
+            borderWidth: 1,
+            borderColor: open ? Colors.brandPrimary : Colors.borderLight,
+            backgroundColor: Colors.white,
+            paddingHorizontal: Spacing.md,
+          }}
+        >
           <Feather name={icon} size={16} color={Colors.textMuted} />
-          <Text className={`flex-1 text-sm ${value ? 'text-textPrimary' : 'text-textMuted'}`} numberOfLines={1}>
+          <Text
+            variant="caption"
+            style={{ flex: 1, color: value ? Colors.textPrimary : Colors.textMuted }}
+            numberOfLines={1}
+          >
             {value || placeholder}
           </Text>
           <Feather name={open ? 'chevron-up' : 'chevron-down'} size={14} color={Colors.textMuted} />
         </View>
       </Pressable>
       {open && (
-        <View className="overflow-hidden rounded-lg border border-borderLight bg-white shadow-sm" style={{ maxHeight: 240 }}>
+        <View
+          style={{
+            overflow: 'hidden',
+            borderRadius: BorderRadius.input,
+            borderWidth: 1,
+            borderColor: Colors.borderLight,
+            backgroundColor: Colors.white,
+            maxHeight: 240,
+          }}
+        >
           <ScrollView>
             <Pressable
-              className="border-b border-bgSecondary px-3 py-2.5"
+              style={{ borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm + 2 }}
               onPress={() => { onChange(''); setOpen(false); }}
             >
-              <Text className="text-sm text-textMuted">Все</Text>
+              <Text variant="caption" style={{ color: Colors.textMuted }}>Все</Text>
             </Pressable>
             {options.map((o) => (
               <Pressable
                 key={o}
-                className="border-b border-bgSecondary px-3 py-2.5"
+                style={{ borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm + 2 }}
                 onPress={() => { onChange(o); setOpen(false); }}
               >
-                <Text className={`text-sm ${value === o ? 'font-semibold text-brandPrimary' : 'text-textPrimary'}`}>{o}</Text>
+                <Text
+                  variant="caption"
+                  weight={value === o ? 'semibold' : undefined}
+                  style={{ color: value === o ? Colors.brandPrimary : Colors.textPrimary }}
+                >
+                  {o}
+                </Text>
               </Pressable>
             ))}
           </ScrollView>
@@ -92,55 +133,62 @@ function RequestFeedCard({ title, description, city, fns, service, date, author,
   onWrite: () => void;
 }) {
   return (
-    <View className="gap-2 rounded-xl border border-borderLight bg-white p-4" style={{ shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 2, elevation: 2 }}>
-      <View className="flex-row items-center justify-between">
-        <Text className="flex-1 text-base font-semibold text-textPrimary" numberOfLines={1}>{title}</Text>
-        <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-      </View>
-      <Text className="text-sm leading-5 text-textSecondary" numberOfLines={2}>{description}</Text>
-      <View className="flex-row flex-wrap gap-2">
-        <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-0.5">
-          <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
-          <Text className="text-xs font-medium text-brandPrimary">{city}</Text>
-        </View>
-        <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-0.5">
-          <Feather name="home" size={11} color={Colors.brandPrimary} />
-          <Text className="text-xs font-medium text-brandPrimary">{fns}</Text>
-        </View>
-        <View className="flex-row items-center gap-1 rounded-full bg-bgSecondary px-2 py-0.5">
-          <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
-          <Text className="text-xs font-medium text-brandPrimary">{service}</Text>
-        </View>
-      </View>
-      {/* Author + date row */}
-      <View className="mt-1 flex-row items-center justify-between border-t border-borderLight pt-2">
-        <View className="flex-row items-center gap-2">
-          <View className="h-7 w-7 items-center justify-center rounded-full bg-bgSecondary">
-            <Feather name="user" size={14} color={Colors.textMuted} />
+    <Card variant="elevated">
+      <View style={{ gap: Spacing.sm }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <View style={{ flex: 1 }}>
+            <Text variant="body" weight="semibold" numberOfLines={1}>{title}</Text>
           </View>
-          <View>
-            <Text className="text-sm font-medium text-textPrimary">{author}</Text>
+          <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+        </View>
+        <Text variant="caption" style={{ color: Colors.textSecondary, lineHeight: 20 }} numberOfLines={2}>{description}</Text>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 2 }}>
+            <Feather name="map-pin" size={11} color={Colors.brandPrimary} />
+            <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>{city}</Text>
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 2 }}>
+            <Feather name="home" size={11} color={Colors.brandPrimary} />
+            <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>{fns}</Text>
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary, paddingHorizontal: Spacing.sm, paddingVertical: 2 }}>
+            <Feather name="briefcase" size={11} color={Colors.brandPrimary} />
+            <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>{service}</Text>
           </View>
         </View>
-        <Text className="text-xs text-textMuted">{date}</Text>
-      </View>
-      {/* Message count + Write CTA */}
-      <View className="mt-1 flex-row items-center justify-between gap-2">
-        <View className="flex-row items-center gap-1.5">
-          <Feather name="message-circle" size={12} color={messageCount > 0 ? Colors.brandPrimary : Colors.textMuted} />
-          <Text className={messageCount > 0 ? 'text-xs font-semibold text-brandPrimary' : 'text-xs text-textMuted'}>
-            {pluralSpecialists(messageCount)}
-          </Text>
+        {/* Author + date */}
+        <View style={{ marginTop: Spacing.xxs, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderTopWidth: 1, borderTopColor: Colors.borderLight, paddingTop: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+            <View style={{ width: 28, height: 28, borderRadius: BorderRadius.full, backgroundColor: Colors.bgSecondary, alignItems: 'center', justifyContent: 'center' }}>
+              <Feather name="user" size={14} color={Colors.textMuted} />
+            </View>
+            <Text variant="caption" weight="medium">{author}</Text>
+          </View>
+          <Text variant="caption">{date}</Text>
         </View>
-        <Pressable
-          onPress={onWrite}
-          className="h-9 flex-row items-center justify-center gap-1.5 rounded-lg bg-brandPrimary px-4"
-        >
-          <Feather name="send" size={13} color={Colors.white} />
-          <Text className="text-xs font-semibold text-white">Написать</Text>
-        </Pressable>
+        {/* Message count + Write CTA */}
+        <View style={{ marginTop: Spacing.xxs, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+            <Feather name="message-circle" size={12} color={messageCount > 0 ? Colors.brandPrimary : Colors.textMuted} />
+            <Text
+              variant="caption"
+              weight={messageCount > 0 ? 'semibold' : undefined}
+              style={{ color: messageCount > 0 ? Colors.brandPrimary : Colors.textMuted }}
+            >
+              {pluralSpecialists(messageCount)}
+            </Text>
+          </View>
+          <Button
+            variant="primary"
+            size="md"
+            icon={<Feather name="send" size={13} color={Colors.white} />}
+            onPress={onWrite}
+          >
+            Написать
+          </Button>
+        </View>
       </View>
-    </View>
+    </Card>
   );
 }
 
@@ -203,106 +251,119 @@ function FeedState() {
   const hasFilters = !!(filterCity || filterCategory);
 
   return (
-    <View className="flex-1 bg-white">
-    <Header variant="auth" />
-    <ScrollView className="flex-1" contentContainerStyle={{ padding: 16, gap: 16 }}>
-      {/* Page title */}
-      <View>
-        <Text className="text-xl font-bold text-textPrimary">Заявки</Text>
-        {!loading && <Text className="mt-0.5 text-sm text-textMuted">{feedData.length} активных заявок</Text>}
-      </View>
+    <Screen bg={Colors.white}>
+      <Header variant="auth" />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            {/* Page title */}
+            <View>
+              <Heading level={3}>Заявки</Heading>
+              {!loading && <Text variant="caption" style={{ marginTop: 2 }}>{feedData.length} активных заявок</Text>}
+            </View>
 
-      {/* City + Service Category filters */}
-      <View className="gap-3 rounded-xl border border-borderLight bg-bgSecondary p-4">
-        <View className="flex-row items-center gap-2">
-          <Feather name="sliders" size={14} color={Colors.brandPrimary} />
-          <Text className="text-sm font-semibold text-textPrimary">Фильтры</Text>
-          {hasFilters && (
-            <Pressable
-              onPress={() => { setFilterCity(''); setFilterCategory(''); }}
-              className="ml-auto flex-row items-center gap-1"
+            {/* Filters */}
+            <View
+              style={{
+                gap: Spacing.md,
+                borderRadius: BorderRadius.card,
+                borderWidth: 1,
+                borderColor: Colors.borderLight,
+                backgroundColor: Colors.bgSecondary,
+                padding: Spacing.lg,
+              }}
             >
-              <Feather name="x" size={14} color={Colors.textMuted} />
-              <Text className="text-xs text-textMuted">Сбросить</Text>
-            </Pressable>
-          )}
-        </View>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                <Feather name="sliders" size={14} color={Colors.brandPrimary} />
+                <Text variant="body" weight="semibold">Фильтры</Text>
+                {hasFilters && (
+                  <Pressable
+                    onPress={() => { setFilterCity(''); setFilterCategory(''); }}
+                    style={{ marginLeft: 'auto', flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}
+                  >
+                    <Feather name="x" size={14} color={Colors.textMuted} />
+                    <Text variant="caption">Сбросить</Text>
+                  </Pressable>
+                )}
+              </View>
 
-        <SelectDropdown
-          icon="map-pin"
-          placeholder="Город"
-          value={filterCity}
-          options={cities}
-          onChange={setFilterCity}
-        />
-        <SelectDropdown
-          icon="briefcase"
-          placeholder="Услуга"
-          value={filterCategory}
-          options={categoryOptions}
-          onChange={setFilterCategory}
-        />
-      </View>
-
-      {/* Request cards */}
-      {loading ? (
-        <View className="items-center py-10">
-          <ActivityIndicator color={Colors.brandPrimary} />
-        </View>
-      ) : error ? (
-        <View className="items-center gap-3 py-10">
-          <Feather name="alert-circle" size={28} color={Colors.statusError} />
-          <Text className="text-sm text-statusError">{error}</Text>
-        </View>
-      ) : feedData.length === 0 ? (
-        <View className="items-center gap-3 py-10">
-          <View className="h-16 w-16 items-center justify-center rounded-full bg-bgSecondary">
-            <Feather name="inbox" size={32} color={Colors.textMuted} />
-          </View>
-          <Text className="text-lg font-semibold text-textPrimary">Нет заявок</Text>
-          <Text className="max-w-[260px] text-center text-sm text-textMuted">Попробуйте изменить параметры фильтров</Text>
-        </View>
-      ) : (
-        <View className="gap-3">
-          {feedData.map((r) => {
-            const authorName = r.client
-              ? [r.client.firstName, r.client.lastName].filter(Boolean).join(' ') || '—'
-              : '—';
-            return (
-              <RequestFeedCard
-                key={r.id}
-                title={r.title}
-                description={r.description ?? ''}
-                city={r.city ?? '—'}
-                fns={r.ifnsCode ?? '—'}
-                service={r.serviceCategory ?? '—'}
-                date={r.createdAt ? new Date(r.createdAt).toLocaleDateString('ru-RU') : '—'}
-                author={authorName}
-                messageCount={r._count?.threads ?? 0}
-                onWrite={() => setWriteTarget({
-                  id: String(r.id),
-                  title: r.title,
-                  description: r.description ?? '',
-                  city: r.city ?? '',
-                  service: r.serviceCategory ?? '',
-                })}
+              <SelectDropdown
+                icon="map-pin"
+                placeholder="Город"
+                value={filterCity}
+                options={cities}
+                onChange={setFilterCity}
               />
-            );
-          })}
-        </View>
-      )}
+              <SelectDropdown
+                icon="briefcase"
+                placeholder="Услуга"
+                value={filterCategory}
+                options={categoryOptions}
+                onChange={setFilterCategory}
+              />
+            </View>
 
-      <WriteConfirmModal
-        visible={writeTarget !== null}
-        request={writeTarget}
-        onClose={() => setWriteTarget(null)}
-        onSuccess={(threadId) => {
-          setWriteTarget(null);
-          router.push(`/chat/${threadId}` as any);
-        }}
-      />
-    </ScrollView>
-    </View>
+            {/* Request cards */}
+            {loading ? (
+              <View style={{ alignItems: 'center', paddingVertical: Spacing['3xl'] }}>
+                <ActivityIndicator color={Colors.brandPrimary} />
+              </View>
+            ) : error ? (
+              <EmptyState
+                icon={<Feather name="alert-circle" size={28} color={Colors.statusError} />}
+                title="Ошибка"
+                description={error}
+              />
+            ) : feedData.length === 0 ? (
+              <EmptyState
+                icon={<Feather name="inbox" size={32} color={Colors.textMuted} />}
+                title="Нет заявок"
+                description="Попробуйте изменить параметры фильтров"
+              />
+            ) : (
+              <View style={{ gap: Spacing.md }}>
+                {feedData.map((r) => {
+                  const authorName = r.client
+                    ? [r.client.firstName, r.client.lastName].filter(Boolean).join(' ') || '—'
+                    : '—';
+                  const serviceLabel = r.serviceType ?? r.category ?? '—';
+                  return (
+                    <RequestFeedCard
+                      key={r.id}
+                      title={r.title}
+                      description={r.description ?? ''}
+                      city={r.city ?? '—'}
+                      fns={r.ifnsName ?? '—'}
+                      service={serviceLabel}
+                      date={r.createdAt ? new Date(r.createdAt).toLocaleDateString('ru-RU') : '—'}
+                      author={authorName}
+                      messageCount={r._count?.threads ?? 0}
+                      onWrite={() => setWriteTarget({
+                        id: String(r.id),
+                        title: r.title,
+                        description: r.description ?? '',
+                        city: r.city ?? '',
+                        service: serviceLabel !== '—' ? serviceLabel : '',
+                      })}
+                    />
+                  );
+                })}
+              </View>
+            )}
+          </View>
+        </Container>
+
+        <WriteConfirmModal
+          visible={writeTarget !== null}
+          request={writeTarget}
+          onClose={() => setWriteTarget(null)}
+          onSuccess={(threadId) => {
+            setWriteTarget(null);
+            router.push(`/chat/${threadId}` as any);
+          }}
+        />
+      </ScrollView>
+    </Screen>
   );
 }
 

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,14 +1,24 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { View, Text, TextInput, Pressable, ScrollView, ActivityIndicator } from 'react-native';
+import { View, Pressable, ScrollView, ActivityIndicator } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { threads as threadsApi } from '../../lib/api/endpoints';
 import { useAuth } from '../../lib/auth';
 import { Header } from '../../components/Header';
+import {
+  Button,
+  Card,
+  Container,
+  EmptyState,
+  Heading,
+  Input,
+  Screen,
+  Text,
+} from '../../components/ui';
 
 // ---------------------------------------------------------------------------
-// Types — shape from GET /threads?grouped_by=request
+// Types
 // ---------------------------------------------------------------------------
 interface LastMessage {
   id: string;
@@ -121,74 +131,60 @@ function ThreadRow({
   const unread = isUnreadForMe(thread, currentUserId);
 
   return (
-    <Pressable
-      onPress={onPress}
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        gap: Spacing.md,
-        paddingVertical: Spacing.md,
-        paddingHorizontal: Spacing.sm,
-        backgroundColor: Colors.bgCard,
-        borderRadius: BorderRadius.card,
-        borderWidth: 1,
-        borderColor: Colors.border,
-        ...Shadows.sm,
-      }}
-    >
-      <View
-        style={{
-          width: 44,
-          height: 44,
-          borderRadius: 22,
-          backgroundColor: Colors.bgSurface,
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderWidth: 1,
-          borderColor: Colors.border,
-        }}
-      >
-        <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>{initials}</Text>
-      </View>
-      <View style={{ flex: 1, gap: 2 }}>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+    <Card onPress={onPress} padding="sm" variant="outlined">
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md }}>
+        <View
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: 22,
+            backgroundColor: Colors.bgSurface,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderWidth: 1,
+            borderColor: Colors.border,
+          }}
+        >
           <Text
             style={{
-              fontSize: Typography.fontSize.base,
-              fontWeight: unread ? Typography.fontWeight.bold : Typography.fontWeight.medium,
-              color: Colors.textPrimary,
-            }}
-          >
-            {name}
-          </Text>
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{when}</Text>
-        </View>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
-          <Text
-            style={{
-              flex: 1,
               fontSize: Typography.fontSize.sm,
-              color: unread ? Colors.textPrimary : Colors.textMuted,
-              fontWeight: unread ? Typography.fontWeight.medium : undefined,
+              fontWeight: Typography.fontWeight.bold,
+              color: Colors.brandPrimary,
+              fontFamily: Typography.fontFamily.bold,
             }}
-            numberOfLines={1}
           >
-            {preview}
+            {initials}
           </Text>
-          {unread && (
-            <View
-              style={{
-                backgroundColor: Colors.brandPrimary,
-                minWidth: 10,
-                height: 10,
-                borderRadius: 5,
-              }}
-            />
-          )}
         </View>
+        <View style={{ flex: 1, gap: 2 }}>
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text variant="body" weight={unread ? 'bold' : 'medium'} numberOfLines={1}>{name}</Text>
+            <Text variant="caption">{when}</Text>
+          </View>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+            <Text
+              variant="caption"
+              weight={unread ? 'medium' : undefined}
+              style={{ flex: 1, color: unread ? Colors.textPrimary : Colors.textMuted }}
+              numberOfLines={1}
+            >
+              {preview}
+            </Text>
+            {unread && (
+              <View
+                style={{
+                  backgroundColor: Colors.brandPrimary,
+                  minWidth: 10,
+                  height: 10,
+                  borderRadius: 5,
+                }}
+              />
+            )}
+          </View>
+        </View>
+        <Feather name="chevron-right" size={16} color={Colors.textMuted} />
       </View>
-      <Feather name="chevron-right" size={16} color={Colors.textMuted} />
-    </Pressable>
+    </Card>
   );
 }
 
@@ -205,17 +201,15 @@ function GroupSection({
   return (
     <View style={{ gap: Spacing.sm }}>
       <View style={{ gap: 2 }}>
-        <Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }} numberOfLines={2}>
-          {group.request.title}
-        </Text>
+        <Text variant="body" weight="semibold" numberOfLines={2}>{group.request.title}</Text>
         <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
           {group.request.city ? (
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
               <Feather name="map-pin" size={11} color={Colors.textMuted} />
-              <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>{group.request.city}</Text>
+              <Text variant="caption">{group.request.city}</Text>
             </View>
           ) : null}
-          <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>
+          <Text variant="caption">
             {count} {count === 1 ? 'специалист' : count >= 2 && count <= 4 ? 'специалиста' : 'специалистов'}
           </Text>
         </View>
@@ -236,81 +230,74 @@ function GroupSection({
 
 function LoadingState() {
   return (
-    <View style={{ padding: Spacing.lg, gap: Spacing.md }}>
-      <View style={{ height: 28, width: '40%', backgroundColor: Colors.bgSurface, borderRadius: BorderRadius.md }} />
-      {[0, 1, 2].map((i) => (
-        <View key={i} style={{ height: 72, backgroundColor: Colors.bgSurface, borderRadius: BorderRadius.card }} />
-      ))}
-      <View style={{ alignItems: 'center', paddingTop: Spacing.sm }}>
-        <ActivityIndicator size="small" color={Colors.brandPrimary} />
+    <Container>
+      <View style={{ gap: Spacing.md, paddingVertical: Spacing.lg }}>
+        <View style={{ height: 28, width: '40%', backgroundColor: Colors.bgSurface, borderRadius: BorderRadius.md }} />
+        {[0, 1, 2].map((i) => (
+          <View key={i} style={{ height: 72, backgroundColor: Colors.bgSurface, borderRadius: BorderRadius.card }} />
+        ))}
+        <View style={{ alignItems: 'center', paddingTop: Spacing.sm }}>
+          <ActivityIndicator size="small" color={Colors.brandPrimary} />
+        </View>
       </View>
-    </View>
+    </Container>
   );
 }
 
-function EmptyState() {
+function MessagesEmpty() {
   return (
-    <View style={{ alignItems: 'center', gap: Spacing.md, paddingVertical: Spacing['3xl'] }}>
-      <View
-        style={{
-          width: 72,
-          height: 72,
-          borderRadius: 36,
-          backgroundColor: Colors.bgSurface,
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderWidth: 1,
-          borderColor: Colors.border,
-        }}
-      >
-        <Feather name="message-circle" size={36} color={Colors.brandPrimary} />
-      </View>
-      <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }}>
-        У вас пока нет сообщений
-      </Text>
-      <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, textAlign: 'center', maxWidth: 300 }}>
-        Когда специалисты напишут по вашим заявкам, диалоги появятся здесь.
-      </Text>
-    </View>
+    <EmptyState
+      icon={
+        <View
+          style={{
+            width: 72,
+            height: 72,
+            borderRadius: 36,
+            backgroundColor: Colors.bgSurface,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderWidth: 1,
+            borderColor: Colors.border,
+          }}
+        >
+          <Feather name="message-circle" size={36} color={Colors.brandPrimary} />
+        </View>
+      }
+      title="У вас пока нет сообщений"
+      description="Когда специалисты напишут по вашим заявкам, диалоги появятся здесь."
+    />
   );
 }
 
 function ErrorState({ onRetry }: { onRetry: () => void }) {
   return (
-    <View style={{ alignItems: 'center', gap: Spacing.md, paddingVertical: Spacing['3xl'] }}>
-      <View
-        style={{
-          width: 72,
-          height: 72,
-          borderRadius: 36,
-          backgroundColor: Colors.statusBg.error,
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Feather name="alert-triangle" size={36} color={Colors.statusError} />
-      </View>
-      <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }}>
-        Ошибка загрузки
-      </Text>
-      <Pressable
-        onPress={onRetry}
-        style={{
-          height: 44,
-          paddingHorizontal: Spacing['2xl'],
-          borderRadius: BorderRadius.btn,
-          backgroundColor: Colors.brandPrimary,
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: Spacing.sm,
-        }}
-      >
-        <Feather name="refresh-cw" size={16} color={Colors.white} />
-        <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>
+    <EmptyState
+      icon={
+        <View
+          style={{
+            width: 72,
+            height: 72,
+            borderRadius: 36,
+            backgroundColor: Colors.statusBg.error,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Feather name="alert-triangle" size={36} color={Colors.statusError} />
+        </View>
+      }
+      title="Ошибка загрузки"
+      action={
+        <Button
+          variant="primary"
+          size="lg"
+          icon={<Feather name="refresh-cw" size={16} color={Colors.white} />}
+          onPress={onRetry}
+        >
           Повторить
-        </Text>
-      </Pressable>
-    </View>
+        </Button>
+      }
+    />
   );
 }
 
@@ -363,81 +350,85 @@ export default function MessagesScreen() {
     return sum;
   }, [groups, user?.id]);
 
-  if (loading) return <View style={{ flex: 1 }}><Header variant="auth" /><LoadingState /></View>;
-  if (error) return <View style={{ flex: 1 }}><Header variant="auth" /><ErrorState onRetry={load} /></View>;
+  if (loading) return <Screen><Header variant="auth" /><LoadingState /></Screen>;
+  if (error) {
+    return (
+      <Screen>
+        <Header variant="auth" />
+        <Container>
+          <ErrorState onRetry={load} />
+        </Container>
+      </Screen>
+    );
+  }
 
   return (
-    <View style={{ flex: 1 }}>
-    <Header variant="auth" />
-    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
-        <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
-          Сообщения
-        </Text>
-        {totalUnread > 0 && (
-          <View
-            style={{
-              backgroundColor: Colors.brandPrimary,
-              minWidth: 24,
-              height: 24,
-              borderRadius: 12,
-              alignItems: 'center',
-              justifyContent: 'center',
-              paddingHorizontal: 6,
-            }}
-          >
-            <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.bold, color: Colors.white }}>{totalUnread}</Text>
+    <Screen>
+      <Header variant="auth" />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+              <Heading level={3}>Сообщения</Heading>
+              {totalUnread > 0 && (
+                <View
+                  style={{
+                    backgroundColor: Colors.brandPrimary,
+                    minWidth: 24,
+                    height: 24,
+                    borderRadius: 12,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    paddingHorizontal: 6,
+                  }}
+                >
+                  <Text
+                    style={{
+                      fontSize: Typography.fontSize.xs,
+                      fontWeight: Typography.fontWeight.bold,
+                      color: Colors.white,
+                      fontFamily: Typography.fontFamily.bold,
+                    }}
+                  >
+                    {totalUnread}
+                  </Text>
+                </View>
+              )}
+            </View>
+
+            {(groups?.length ?? 0) > 0 ? (
+              <Input
+                value={search}
+                onChangeText={setSearch}
+                placeholder="Поиск по сообщениям..."
+                icon={<Feather name="search" size={16} color={Colors.textMuted} />}
+                rightIcon={search.length > 0 ? (
+                  <Pressable onPress={() => setSearch('')}>
+                    <Feather name="x" size={16} color={Colors.textMuted} />
+                  </Pressable>
+                ) : undefined}
+              />
+            ) : null}
+
+            {(groups?.length ?? 0) === 0 ? (
+              <MessagesEmpty />
+            ) : filtered.length === 0 ? (
+              <View style={{ alignItems: 'center', paddingVertical: Spacing['2xl'] }}>
+                <Text variant="muted">Ничего не найдено</Text>
+              </View>
+            ) : (
+              filtered.map((g) => (
+                <GroupSection
+                  key={g.request.id}
+                  group={g}
+                  currentUserId={user?.id}
+                  onOpenThread={(id) => router.push(`/chat/${id}` as any)}
+                />
+              ))
+            )}
           </View>
-        )}
-      </View>
-
-      {(groups?.length ?? 0) > 0 ? (
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: Spacing.sm,
-            height: 40,
-            backgroundColor: Colors.bgCard,
-            borderWidth: 1,
-            borderColor: Colors.border,
-            borderRadius: BorderRadius.card,
-            paddingHorizontal: Spacing.md,
-          }}
-        >
-          <Feather name="search" size={16} color={Colors.textMuted} />
-          <TextInput
-            value={search}
-            onChangeText={setSearch}
-            placeholder="Поиск по сообщениям..."
-            placeholderTextColor={Colors.textMuted}
-            style={{ flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textPrimary, paddingVertical: 0, outlineStyle: 'none' } as any}
-          />
-          {search.length > 0 && (
-            <Pressable onPress={() => setSearch('')}>
-              <Feather name="x" size={16} color={Colors.textMuted} />
-            </Pressable>
-          )}
-        </View>
-      ) : null}
-
-      {(groups?.length ?? 0) === 0 ? (
-        <EmptyState />
-      ) : filtered.length === 0 ? (
-        <View style={{ alignItems: 'center', paddingVertical: Spacing['2xl'] }}>
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Ничего не найдено</Text>
-        </View>
-      ) : (
-        filtered.map((g) => (
-          <GroupSection
-            key={g.request.id}
-            group={g}
-            currentUserId={user?.id}
-            onOpenThread={(id) => router.push(`/chat/${id}` as any)}
-          />
-        ))
-      )}
-    </ScrollView>
-    </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,29 +1,40 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, TextInput, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { View, ActivityIndicator, Alert, ScrollView } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing, Typography, BorderRadius } from '../../constants/Colors';
 import { useAuth } from '../../lib/auth/AuthContext';
 import { users, upload } from '../../lib/api/endpoints';
+import {
+  Button,
+  Card,
+  Container,
+  Heading,
+  Input,
+  Screen,
+  Text,
+} from '../../components/ui';
 
 function InfoRow({ label, value, icon }: { label: string; value: string; icon: string }) {
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
       <Feather name={icon as any} size={16} color={Colors.textMuted} />
-      <Text style={{ flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{label}</Text>
-      <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textPrimary }}>{value}</Text>
+      <Text variant="caption" style={{ flex: 1 }}>{label}</Text>
+      <Text variant="caption" weight="medium" style={{ color: Colors.textPrimary }}>{value}</Text>
     </View>
   );
 }
 
 function StatBlock({ icon, value, label }: { icon: string; value: string; label: string }) {
   return (
-    <View style={{ flex: 1, backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.md, alignItems: 'center', gap: Spacing.xs, borderWidth: 1, borderColor: Colors.border, ...Shadows.sm }}>
-      <Feather name={icon as any} size={18} color={Colors.brandPrimary} />
-      <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>{value}</Text>
-      <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>{label}</Text>
-    </View>
+    <Card style={{ flex: 1 }} padding="sm" variant="outlined">
+      <View style={{ alignItems: 'center', gap: Spacing.xs }}>
+        <Feather name={icon as any} size={18} color={Colors.brandPrimary} />
+        <Text variant="body" weight="bold">{value}</Text>
+        <Text variant="caption">{label}</Text>
+      </View>
+    </Card>
   );
 }
 
@@ -38,10 +49,37 @@ function formatDate(iso?: string): string {
   return new Date(iso).toLocaleDateString('ru-RU', { day: '2-digit', month: '2-digit', year: 'numeric' });
 }
 
+function Avatar({ initials, size = 64 }: { initials: string; size?: number }) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: Colors.bgSurface,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderWidth: 1,
+        borderColor: Colors.borderLight,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: Typography.fontSize.xl,
+          fontWeight: Typography.fontWeight.bold,
+          color: Colors.brandPrimary,
+          fontFamily: Typography.fontFamily.bold,
+        }}
+      >
+        {initials}
+      </Text>
+    </View>
+  );
+}
+
 export default function ProfileScreen() {
   const { user, refreshUser } = useAuth();
 
-  // Profile data from API
   const [profile, setProfile] = useState<{
     firstName?: string;
     lastName?: string;
@@ -70,7 +108,6 @@ export default function ProfileScreen() {
         setCity(d.city ?? d.profile?.city ?? '');
       })
       .catch(() => {
-        // Fallback to cached auth user
         if (user) {
           setFirstName(user.firstName ?? '');
           setLastName(user.lastName ?? '');
@@ -135,9 +172,11 @@ export default function ProfileScreen() {
 
   if (profileLoading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <ActivityIndicator color={Colors.brandPrimary} />
-      </View>
+      <Screen>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
+      </Screen>
     );
   }
 
@@ -148,114 +187,138 @@ export default function ProfileScreen() {
 
   if (editMode) {
     return (
-      <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
-          <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-            <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>{initials}</Text>
-          </View>
-          <Pressable
-            style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}
-            onPress={handleChangePicture}
-            disabled={avatarLoading}
-          >
-            {avatarLoading ? (
-              <ActivityIndicator size="small" color={Colors.brandPrimary} />
-            ) : (
-              <>
-                <Feather name="camera" size={14} color={Colors.brandPrimary} />
-                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>Изменить фото</Text>
-              </>
-            )}
-          </Pressable>
-        </View>
-        <View style={{ gap: Spacing.lg }}>
-          <View style={{ gap: Spacing.xs }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Имя</Text>
-            <TextInput value={firstName} onChangeText={setFirstName} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
-          </View>
-          <View style={{ gap: Spacing.xs }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Фамилия</Text>
-            <TextInput value={lastName} onChangeText={setLastName} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
-          </View>
-          <View style={{ gap: Spacing.xs }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Email</Text>
-            <TextInput value={email} editable={false} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, opacity: 0.5, outlineStyle: 'none' } as any} />
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-              <Feather name="lock" size={12} color={Colors.textMuted} />
-              <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.textMuted }}>Email нельзя изменить</Text>
+      <Screen>
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+          <Container>
+            <View style={{ gap: Spacing.lg }}>
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
+                <Avatar initials={initials} />
+                <Button
+                  variant="ghost"
+                  size="md"
+                  icon={avatarLoading
+                    ? <ActivityIndicator size="small" color={Colors.brandPrimary} />
+                    : <Feather name="camera" size={14} color={Colors.brandPrimary} />}
+                  onPress={handleChangePicture}
+                  disabled={avatarLoading}
+                >
+                  Изменить фото
+                </Button>
+              </View>
+
+              <View style={{ gap: Spacing.lg }}>
+                <Input
+                  label="Имя"
+                  value={firstName}
+                  onChangeText={setFirstName}
+                />
+                <Input
+                  label="Фамилия"
+                  value={lastName}
+                  onChangeText={setLastName}
+                />
+                <View style={{ gap: Spacing.xs }}>
+                  <Input
+                    label="Email"
+                    value={email}
+                    onChangeText={() => { /* noop, not editable */ }}
+                    editable={false}
+                  />
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+                    <Feather name="lock" size={12} color={Colors.textMuted} />
+                    <Text variant="caption">Email нельзя изменить</Text>
+                  </View>
+                </View>
+                <Input
+                  label="Город"
+                  value={city}
+                  onChangeText={setCity}
+                />
+              </View>
+
+              <View style={{ gap: Spacing.sm }}>
+                <Button
+                  variant="primary"
+                  size="lg"
+                  loading={saving}
+                  disabled={saving}
+                  icon={<Feather name="check" size={16} color={Colors.white} />}
+                  onPress={handleSave}
+                  fullWidth
+                >
+                  Сохранить
+                </Button>
+                <Button variant="secondary" size="lg" onPress={handleCancel} fullWidth>
+                  Отмена
+                </Button>
+              </View>
             </View>
-          </View>
-          <View style={{ gap: Spacing.xs }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.medium, color: Colors.textSecondary }}>Город</Text>
-            <TextInput value={city} onChangeText={setCity} style={{ height: 48, backgroundColor: Colors.bgCard, borderWidth: 1, borderColor: Colors.border, borderRadius: BorderRadius.card, paddingHorizontal: Spacing.lg, fontSize: Typography.fontSize.base, color: Colors.textPrimary, outlineStyle: 'none' } as any} />
-          </View>
-        </View>
-        <View style={{ gap: Spacing.sm }}>
-          <Pressable
-            onPress={handleSave}
-            disabled={saving}
-            style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}
-          >
-            {saving ? (
-              <ActivityIndicator color={Colors.white} />
-            ) : (
-              <>
-                <Feather name="check" size={16} color={Colors.white} />
-                <Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Сохранить</Text>
-              </>
-            )}
-          </Pressable>
-          <Pressable onPress={handleCancel} style={{ height: 48, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-            <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>Отмена</Text>
-          </Pressable>
-        </View>
-      </View>
+          </Container>
+        </ScrollView>
+      </Screen>
     );
   }
 
   return (
-    <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
-        <View style={{ width: 64, height: 64, borderRadius: 32, backgroundColor: Colors.bgSurface, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.brandPrimary }}>{initials}</Text>
-        </View>
-        <View>
-          <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>{displayName}</Text>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 }}>
-            <Feather name="user" size={14} color={Colors.textMuted} />
-            <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textMuted }}>
-              {user?.role === 'SPECIALIST' ? 'Специалист' : 'Клиент'}
-            </Text>
+    <Screen>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.lg }}>
+              <Avatar initials={initials} />
+              <View>
+                <Heading level={3}>{displayName}</Heading>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, marginTop: 2 }}>
+                  <Feather name="user" size={14} color={Colors.textMuted} />
+                  <Text variant="muted">
+                    {user?.role === 'SPECIALIST' ? 'Специалист' : 'Клиент'}
+                  </Text>
+                </View>
+              </View>
+            </View>
+
+            <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+              <StatBlock icon="file-text" value={String(stats?.total ?? stats?.requestsCreated ?? '—')} label="Заявок" />
+              <StatBlock icon="check-circle" value={String(stats?.closed ?? stats?.completed ?? '—')} label="Завершено" />
+              {user?.role === 'SPECIALIST' ? (
+                <StatBlock icon="star" value={stats?.rating != null ? String(stats.rating) : '—'} label="Рейтинг" />
+              ) : (
+                <StatBlock
+                  icon="message-circle"
+                  value={String(stats?.specialistsContacted ?? stats?.threadsCount ?? stats?.responses ?? '—')}
+                  label="Откликов"
+                />
+              )}
+            </View>
+
+            <Card variant="outlined">
+              <View style={{ gap: Spacing.md }}>
+                <InfoRow label="Email" value={email} icon="mail" />
+                <InfoRow label="Город" value={profile.city ?? '—'} icon="map-pin" />
+                <InfoRow label="Регистрация" value={formatDate((profile as any).createdAt)} icon="calendar" />
+              </View>
+            </Card>
+
+            <Button
+              variant="primary"
+              size="lg"
+              icon={<Feather name="edit-2" size={16} color={Colors.white} />}
+              onPress={() => setEditMode(true)}
+              fullWidth
+            >
+              Редактировать
+            </Button>
+
+            <Card onPress={() => router.push('/(tabs)/settings' as any)} variant="outlined">
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+                <Feather name="settings" size={16} color={Colors.textMuted} />
+                <Text variant="body" style={{ flex: 1 }}>Настройки</Text>
+                <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+              </View>
+            </Card>
           </View>
-        </View>
-      </View>
-      <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-        <StatBlock icon="file-text" value={String(stats?.total ?? stats?.requestsCreated ?? '—')} label="Заявок" />
-        <StatBlock icon="check-circle" value={String(stats?.closed ?? stats?.completed ?? '—')} label="Завершено" />
-        {user?.role === 'SPECIALIST' ? (
-          <StatBlock icon="star" value={stats?.rating != null ? String(stats.rating) : '—'} label="Рейтинг" />
-        ) : (
-          <StatBlock
-            icon="message-circle"
-            value={String(stats?.specialistsContacted ?? stats?.threadsCount ?? stats?.responses ?? '—')}
-            label="Откликов"
-          />
-        )}
-      </View>
-      <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.md, ...Shadows.sm }}>
-        <InfoRow label="Email" value={email} icon="mail" />
-        <InfoRow label="Город" value={profile.city ?? '—'} icon="map-pin" />
-        <InfoRow label="Регистрация" value={formatDate((profile as any).createdAt)} icon="calendar" />
-      </View>
-      <Pressable onPress={() => setEditMode(true)} style={{ height: 48, backgroundColor: Colors.brandPrimary, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', flexDirection: 'row', gap: Spacing.sm, ...Shadows.sm }}>
-        <Feather name="edit-2" size={16} color={Colors.white} />
-        <Text style={{ fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Редактировать</Text>
-      </Pressable>
-      <Pressable style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm, backgroundColor: Colors.bgCard, padding: Spacing.lg, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border }} onPress={() => router.push('/(tabs)/settings' as any)}>
-        <Feather name="settings" size={16} color={Colors.textMuted} />
-        <Text style={{ fontSize: Typography.fontSize.base, color: Colors.textPrimary }}>Настройки</Text>
-        <Feather name="chevron-right" size={16} color={Colors.textMuted} style={{ marginLeft: 'auto' }} />
-      </Pressable>
-    </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -1,16 +1,28 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { View, Text, Pressable, ActivityIndicator, ScrollView, Modal } from 'react-native';
+import { View, Pressable, ActivityIndicator, ScrollView } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { router } from 'expo-router';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing, BorderRadius } from '../../constants/Colors';
 import { requests as requestsApi } from '../../lib/api/endpoints';
 import { Header } from '../../components/Header';
+import {
+  Badge,
+  Button,
+  Card,
+  Container,
+  EmptyState,
+  Heading,
+  Modal,
+  Screen,
+  Text,
+} from '../../components/ui';
+import type { BadgeVariant } from '../../components/ui';
 
 interface ApiRequest {
   id: string;
   title: string;
-  serviceCategory?: string | null;
-  ifnsCode?: string | null;
+  serviceType?: string | null;
+  ifnsName?: string | null;
   city?: string | null;
   status: string;
   createdAt: string;
@@ -18,10 +30,10 @@ interface ApiRequest {
   [key: string]: unknown;
 }
 
-const STATUS_MAP: Record<string, { label: string; color: string; bg: string }> = {
-  ACTIVE: { label: 'Активная', color: Colors.statusSuccess, bg: Colors.statusBg.success },
-  CLOSING_SOON: { label: 'Истекает скоро', color: Colors.statusWarning, bg: Colors.statusBg.warning },
-  CLOSED: { label: 'Закрыта', color: Colors.textMuted, bg: Colors.statusBg.neutral },
+const STATUS_MAP: Record<string, { label: string; variant: BadgeVariant }> = {
+  ACTIVE: { label: 'Активная', variant: 'success' },
+  CLOSING_SOON: { label: 'Истекает скоро', variant: 'warning' },
+  CLOSED: { label: 'Закрыта', variant: 'default' },
 };
 
 function RequestCard({ id, title, service, fns, city, status, date, messageCount, onRequestClose }: {
@@ -31,47 +43,65 @@ function RequestCard({ id, title, service, fns, city, status, date, messageCount
   const st = STATUS_MAP[status] || STATUS_MAP.ACTIVE;
   const isCloseable = status === 'ACTIVE' || status === 'CLOSING_SOON';
   return (
-    <Pressable style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.border, gap: Spacing.sm, ...Shadows.sm }} onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)}>
-      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm }}>
-        <Text style={{ flex: 1, fontSize: Typography.fontSize.base, fontWeight: Typography.fontWeight.semibold, color: Colors.textPrimary }} numberOfLines={2}>{title}</Text>
-        <View style={{ paddingHorizontal: Spacing.sm, paddingVertical: 2, borderRadius: BorderRadius.full, backgroundColor: st.bg }}>
-          <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: st.color }}>{st.label}</Text>
-        </View>
-      </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
-        <Feather name="briefcase" size={12} color={Colors.textMuted} />
-        <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{service}</Text>
-        <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.border }}>{'·'}</Text>
-        <Feather name="home" size={12} color={Colors.textMuted} />
-        <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{fns}</Text>
-        <Text style={{ fontSize: Typography.fontSize.xs, color: Colors.border }}>{'·'}</Text>
-        <Feather name="map-pin" size={12} color={Colors.textMuted} />
-        <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{city}</Text>
-      </View>
-      <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, flex: 1 }}>
-          <Feather name="calendar" size={12} color={Colors.textMuted} />
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>{date}</Text>
-        </View>
-        {messageCount > 0 && (
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-            <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.brandPrimary, fontWeight: Typography.fontWeight.medium }}>{messageCount} сообщ.</Text>
+    <Card onPress={() => router.push(`/(dashboard)/my-requests/${id}` as any)} variant="outlined">
+      <View style={{ gap: Spacing.sm }}>
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start', gap: Spacing.sm }}>
+          <View style={{ flex: 1 }}>
+            <Text variant="body" weight="semibold" numberOfLines={2}>{title}</Text>
           </View>
-        )}
-        {isCloseable && onRequestClose && (
-          <Pressable
-            onPress={(e) => { e.stopPropagation?.(); onRequestClose(); }}
-            style={{ flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: Spacing.sm, paddingVertical: 4, borderRadius: BorderRadius.full, backgroundColor: Colors.statusBg.error }}
-            hitSlop={8}
-          >
-            <Feather name="x-circle" size={12} color={Colors.statusError} />
-            <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.statusError }}>Закрыть</Text>
-          </Pressable>
-        )}
-        <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+          <Badge variant={st.variant}>{st.label}</Badge>
+        </View>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', rowGap: Spacing.xs, columnGap: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+            <Feather name="briefcase" size={12} color={Colors.textMuted} />
+            <Text variant="caption">{service}</Text>
+          </View>
+          <Text variant="caption" style={{ color: Colors.border }}>·</Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+            <Feather name="home" size={12} color={Colors.textMuted} />
+            <Text variant="caption">{fns}</Text>
+          </View>
+          <Text variant="caption" style={{ color: Colors.border }}>·</Text>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+            <Feather name="map-pin" size={12} color={Colors.textMuted} />
+            <Text variant="caption">{city}</Text>
+          </View>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.sm }}>
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs, flex: 1 }}>
+            <Feather name="calendar" size={12} color={Colors.textMuted} />
+            <Text variant="caption">{date}</Text>
+          </View>
+          {messageCount > 0 && (
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }}>
+              <Feather name="message-circle" size={12} color={Colors.brandPrimary} />
+              <Text variant="caption" weight="medium" style={{ color: Colors.brandPrimary }}>
+                {messageCount} сообщ.
+              </Text>
+            </View>
+          )}
+          {isCloseable && onRequestClose && (
+            <Pressable
+              onPress={(e) => { e.stopPropagation?.(); onRequestClose(); }}
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: Spacing.xs,
+                paddingHorizontal: Spacing.sm,
+                paddingVertical: Spacing.xs,
+                borderRadius: BorderRadius.full,
+                backgroundColor: Colors.statusBg.error,
+              }}
+              hitSlop={8}
+            >
+              <Feather name="x-circle" size={12} color={Colors.statusError} />
+              <Text variant="caption" weight="semibold" style={{ color: Colors.statusError }}>Закрыть</Text>
+            </Pressable>
+          )}
+          <Feather name="chevron-right" size={16} color={Colors.textMuted} />
+        </View>
       </View>
-    </Pressable>
+    </Card>
   );
 }
 
@@ -117,103 +147,121 @@ export default function RequestsScreen() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1 }}>
+      <Screen>
         <Header variant="auth" />
         <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
           <ActivityIndicator color={Colors.brandPrimary} />
         </View>
-      </View>
+      </Screen>
     );
   }
 
   if (error) {
     return (
-      <View style={{ flex: 1 }}>
+      <Screen>
         <Header variant="auth" />
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: Spacing.xl, gap: Spacing.md }}>
-          <Feather name="alert-circle" size={28} color={Colors.statusError} />
-          <Text style={{ color: Colors.statusError, textAlign: 'center' }}>{error}</Text>
-        </View>
-      </View>
+        <Container>
+          <EmptyState
+            icon={<Feather name="alert-circle" size={28} color={Colors.statusError} />}
+            title="Ошибка"
+            description={error}
+          />
+        </Container>
+      </Screen>
     );
   }
 
   return (
-    <View style={{ flex: 1 }}>
-    <Header variant="auth" />
-    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ padding: Spacing.lg, gap: Spacing.md }}>
-      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>Мои заявки</Text>
-        <Pressable style={{ backgroundColor: Colors.brandPrimary, paddingHorizontal: Spacing.md, paddingVertical: Spacing.sm, borderRadius: BorderRadius.btn, flexDirection: 'row', alignItems: 'center', gap: Spacing.xs }} onPress={() => router.push('/(dashboard)/my-requests/new' as any)}>
-          <Feather name="plus" size={16} color={Colors.white} />
-          <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Новая</Text>
-        </Pressable>
-      </View>
-      <View style={{ flexDirection: 'row', gap: Spacing.xs }}>
-        {([
-          { key: 'active' as const, label: `Активные (${activeRequests.length})` },
-          { key: 'completed' as const, label: `Завершённые (${completedRequests.length})` },
-          { key: 'all' as const, label: `Все (${allData.length})` },
-        ]).map((t) => (
-          <Pressable key={t.key} onPress={() => setTab(t.key)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: tab === t.key ? Colors.brandPrimary : Colors.border, backgroundColor: tab === t.key ? Colors.brandPrimary : Colors.bgCard }}>
-            <Text style={{ fontSize: Typography.fontSize.xs, color: tab === t.key ? Colors.white : Colors.textMuted, fontWeight: tab === t.key ? Typography.fontWeight.semibold : Typography.fontWeight.medium }}>{t.label}</Text>
-          </Pressable>
-        ))}
-      </View>
-      {visibleRequests.length === 0 ? (
-        <View style={{ alignItems: 'center', paddingVertical: 40, gap: Spacing.md }}>
-          <Feather name="inbox" size={32} color={Colors.textMuted} />
-          <Text style={{ color: Colors.textMuted }}>Заявок нет</Text>
-        </View>
-      ) : visibleRequests.map((r) => (
-        <RequestCard
-          key={r.id}
-          id={r.id}
-          title={r.title}
-          service={r.serviceCategory ?? '—'}
-          fns={r.ifnsCode ?? '—'}
-          city={r.city ?? '—'}
-          status={r.status}
-          date={r.createdAt ? new Date(r.createdAt).toLocaleDateString('ru-RU') : '—'}
-          messageCount={r._count?.threads ?? 0}
-          onRequestClose={() => setCloseTarget(r)}
-        />
-      ))}
-    </ScrollView>
-    <Modal visible={closeTarget !== null} transparent animationType="fade" onRequestClose={() => !closing && setCloseTarget(null)}>
-      <View style={{ flex: 1, backgroundColor: 'rgba(15,36,71,0.4)', alignItems: 'center', justifyContent: 'center', padding: Spacing.lg }}>
-        <View style={{ width: '100%', maxWidth: 360, backgroundColor: Colors.white, borderRadius: BorderRadius.card, padding: Spacing.lg, gap: Spacing.md, ...Shadows.sm }}>
-          <Text style={{ fontSize: Typography.fontSize.lg, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>
-            Закрыть заявку?
-          </Text>
-          <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, lineHeight: 20 }}>
-            Её больше не увидят специалисты.
-          </Text>
-          <View style={{ flexDirection: 'row', gap: Spacing.sm, marginTop: Spacing.sm }}>
-            <Pressable
-              onPress={() => !closing && setCloseTarget(null)}
-              style={{ flex: 1, height: 44, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}
-            >
-              <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, fontWeight: Typography.fontWeight.medium }}>Отмена</Text>
-            </Pressable>
-            <Pressable
-              onPress={handleConfirmClose}
-              disabled={closing}
-              style={{ flex: 1, height: 44, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError, flexDirection: 'row', gap: 6 }}
-            >
-              {closing ? (
-                <ActivityIndicator size="small" color={Colors.white} />
-              ) : (
-                <>
-                  <Feather name="x-circle" size={14} color={Colors.white} />
-                  <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Закрыть</Text>
-                </>
-              )}
-            </Pressable>
+    <Screen>
+      <Header variant="auth" />
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.md }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+              <Heading level={3}>Мои заявки</Heading>
+              <Button
+                variant="primary"
+                size="md"
+                icon={<Feather name="plus" size={16} color={Colors.white} />}
+                onPress={() => router.push('/(dashboard)/my-requests/new' as any)}
+              >
+                Новая
+              </Button>
+            </View>
+            <View style={{ flexDirection: 'row', gap: Spacing.xs }}>
+              {([
+                { key: 'active' as const, label: `Активные (${activeRequests.length})` },
+                { key: 'completed' as const, label: `Завершённые (${completedRequests.length})` },
+                { key: 'all' as const, label: `Все (${allData.length})` },
+              ]).map((t) => {
+                const selected = tab === t.key;
+                return (
+                  <Pressable
+                    key={t.key}
+                    onPress={() => setTab(t.key)}
+                    style={{
+                      flex: 1,
+                      height: 40,
+                      borderRadius: BorderRadius.btn,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      borderWidth: 1,
+                      borderColor: selected ? Colors.brandPrimary : Colors.border,
+                      backgroundColor: selected ? Colors.brandPrimary : Colors.bgCard,
+                    }}
+                  >
+                    <Text
+                      variant="caption"
+                      weight={selected ? 'semibold' : 'medium'}
+                      style={{ color: selected ? Colors.white : Colors.textMuted }}
+                    >
+                      {t.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            {visibleRequests.length === 0 ? (
+              <EmptyState
+                icon={<Feather name="inbox" size={32} color={Colors.textMuted} />}
+                title="Заявок нет"
+              />
+            ) : visibleRequests.map((r) => (
+              <RequestCard
+                key={r.id}
+                id={r.id}
+                title={r.title}
+                service={r.serviceType ?? '—'}
+                fns={r.ifnsName ?? '—'}
+                city={r.city ?? '—'}
+                status={r.status}
+                date={r.createdAt ? new Date(r.createdAt).toLocaleDateString('ru-RU') : '—'}
+                messageCount={r._count?.threads ?? 0}
+                onRequestClose={() => setCloseTarget(r)}
+              />
+            ))}
           </View>
-        </View>
-      </View>
-    </Modal>
-    </View>
+        </Container>
+      </ScrollView>
+
+      <Modal
+        visible={closeTarget !== null}
+        onClose={() => !closing && setCloseTarget(null)}
+        title="Закрыть заявку?"
+        primaryAction={{
+          label: 'Закрыть',
+          onPress: handleConfirmClose,
+          loading: closing,
+          disabled: closing,
+        }}
+        secondaryAction={{
+          label: 'Отмена',
+          onPress: () => !closing && setCloseTarget(null),
+          disabled: closing,
+        }}
+      >
+        <Text variant="muted">Её больше не увидят специалисты.</Text>
+      </Modal>
+    </Screen>
   );
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,17 +1,41 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, Pressable, Switch, ActivityIndicator } from 'react-native';
+import { View, Pressable, Switch, ActivityIndicator, ScrollView } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import { Colors, Spacing, Typography, BorderRadius, Shadows } from '../../constants/Colors';
+import { Colors, Spacing, BorderRadius } from '../../constants/Colors';
 import { useAuth } from '../../lib/auth/AuthContext';
 import { users } from '../../lib/api/endpoints';
+import {
+  Button,
+  Card,
+  Container,
+  Heading,
+  Screen,
+  Text,
+} from '../../components/ui';
 
 function SettingRow({ label, value, danger, icon, onPress }: { label: string; value?: string; danger?: boolean; icon?: string; onPress?: () => void }) {
   return (
-    <Pressable onPress={onPress} style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary }}>
+    <Pressable
+      onPress={onPress}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: Spacing.md,
+        paddingHorizontal: Spacing.lg,
+        paddingVertical: Spacing.md,
+        borderBottomWidth: 1,
+        borderBottomColor: Colors.bgSecondary,
+      }}
+    >
       {icon && <Feather name={icon as any} size={18} color={danger ? Colors.statusError : Colors.textMuted} />}
-      <Text style={{ flex: 1, fontSize: Typography.fontSize.sm, color: danger ? Colors.statusError : Colors.textPrimary }}>{label}</Text>
-      {value && <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted, marginRight: Spacing.sm }}>{value}</Text>}
+      <Text
+        variant="caption"
+        style={{ flex: 1, color: danger ? Colors.statusError : Colors.textPrimary }}
+      >
+        {label}
+      </Text>
+      {value && <Text variant="caption" style={{ marginRight: Spacing.sm }}>{value}</Text>}
       <Feather name="chevron-right" size={16} color={Colors.textMuted} />
     </Pressable>
   );
@@ -19,12 +43,39 @@ function SettingRow({ label, value, danger, icon, onPress }: { label: string; va
 
 function ToggleRow({ label, icon, enabled, onToggle, saving }: { label: string; icon: string; enabled: boolean; onToggle: (next: boolean) => void; saving?: boolean }) {
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: Spacing.md, paddingHorizontal: Spacing.lg, paddingVertical: Spacing.md, borderBottomWidth: 1, borderBottomColor: Colors.bgSecondary }}>
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: Spacing.md,
+        paddingHorizontal: Spacing.lg,
+        paddingVertical: Spacing.md,
+        borderBottomWidth: 1,
+        borderBottomColor: Colors.bgSecondary,
+      }}
+    >
       <Feather name={icon as any} size={18} color={Colors.textMuted} />
-      <Text style={{ flex: 1, fontSize: Typography.fontSize.sm, color: Colors.textPrimary }}>{label}</Text>
+      <Text variant="caption" style={{ flex: 1, color: Colors.textPrimary }}>{label}</Text>
       {saving && <ActivityIndicator size="small" color={Colors.textMuted} style={{ marginRight: Spacing.sm }} />}
-      <Switch value={enabled} onValueChange={onToggle} trackColor={{ false: '#D1D5DB', true: '#0284C7' }} thumbColor="#fff" />
+      <Switch
+        value={enabled}
+        onValueChange={onToggle}
+        trackColor={{ false: Colors.borderLight, true: Colors.brandPrimary }}
+        thumbColor={Colors.white}
+      />
     </View>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      variant="caption"
+      weight="semibold"
+      style={{ color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}
+    >
+      {children}
+    </Text>
   );
 }
 
@@ -73,71 +124,122 @@ export default function SettingsScreen() {
 
   if (loading) {
     return (
-      <View style={{ padding: Spacing.lg, alignItems: 'center' }}>
-        <ActivityIndicator color={Colors.brandPrimary} />
-      </View>
+      <Screen>
+        <View style={{ padding: Spacing.lg, alignItems: 'center' }}>
+          <ActivityIndicator color={Colors.brandPrimary} />
+        </View>
+      </Screen>
     );
   }
 
   return (
-    <View style={{ padding: Spacing.lg, gap: Spacing.lg }}>
-      <Text style={{ fontSize: Typography.fontSize.xl, fontWeight: Typography.fontWeight.bold, color: Colors.textPrimary }}>Настройки</Text>
-      <View style={{ gap: Spacing.sm }}>
-        <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Уведомления</Text>
-        <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <ToggleRow label="Email-уведомления" icon="mail" enabled={emailNotif} onToggle={handleEmailToggle} saving={saving} />
-        </View>
-      </View>
-      <View style={{ gap: Spacing.sm }}>
-        <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Аккаунт</Text>
-        <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <SettingRow label="Email" value={user?.email ?? '—'} icon="mail" />
-        </View>
-      </View>
-      <View style={{ gap: Spacing.sm }}>
-        <Text style={{ fontSize: Typography.fontSize.xs, fontWeight: Typography.fontWeight.semibold, color: Colors.textMuted, textTransform: 'uppercase', letterSpacing: 0.5 }}>Информация</Text>
-        <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, borderWidth: 1, borderColor: Colors.border, overflow: 'hidden', ...Shadows.sm }}>
-          <SettingRow label="Политика конфиденциальности" icon="shield" onPress={() => router.push('/terms' as any)} />
-          <SettingRow label="Условия использования" icon="file-text" onPress={() => router.push('/terms' as any)} />
-          <SettingRow label="Версия" value="1.0.0" icon="info" />
-        </View>
-      </View>
-      <View style={{ gap: Spacing.sm }}>
-        <Pressable onPress={() => setShowLogout(!showLogout)} style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm, height: 48, backgroundColor: Colors.statusBg.error, borderRadius: BorderRadius.btn }}>
-          <Feather name="log-out" size={18} color={Colors.statusError} />
-          <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.statusError }}>Выйти из аккаунта</Text>
-        </Pressable>
-        {showLogout && (
-          <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.statusBg.error, gap: Spacing.md, ...Shadows.sm }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, textAlign: 'center' }}>Вы уверены, что хотите выйти?</Text>
-            <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-              <Pressable onPress={() => setShowLogout(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text>
+    <Screen>
+      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingVertical: Spacing.lg }}>
+        <Container>
+          <View style={{ gap: Spacing.lg }}>
+            <Heading level={3}>Настройки</Heading>
+
+            <View style={{ gap: Spacing.sm }}>
+              <SectionLabel>Уведомления</SectionLabel>
+              <Card padding="sm" variant="outlined" style={{ padding: 0, overflow: 'hidden' }}>
+                <ToggleRow
+                  label="Email-уведомления"
+                  icon="mail"
+                  enabled={emailNotif}
+                  onToggle={handleEmailToggle}
+                  saving={saving}
+                />
+              </Card>
+            </View>
+
+            <View style={{ gap: Spacing.sm }}>
+              <SectionLabel>Аккаунт</SectionLabel>
+              <Card padding="sm" variant="outlined" style={{ padding: 0, overflow: 'hidden' }}>
+                <SettingRow label="Email" value={user?.email ?? '—'} icon="mail" />
+              </Card>
+            </View>
+
+            <View style={{ gap: Spacing.sm }}>
+              <SectionLabel>Информация</SectionLabel>
+              <Card padding="sm" variant="outlined" style={{ padding: 0, overflow: 'hidden' }}>
+                <SettingRow label="Политика конфиденциальности" icon="shield" onPress={() => router.push('/terms' as any)} />
+                <SettingRow label="Условия использования" icon="file-text" onPress={() => router.push('/terms' as any)} />
+                <SettingRow label="Версия" value="1.0.0" icon="info" />
+              </Card>
+            </View>
+
+            <View style={{ gap: Spacing.sm }}>
+              <Pressable
+                onPress={() => setShowLogout(!showLogout)}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: Spacing.sm,
+                  height: 48,
+                  backgroundColor: Colors.statusBg.error,
+                  borderRadius: BorderRadius.btn,
+                }}
+              >
+                <Feather name="log-out" size={18} color={Colors.statusError} />
+                <Text variant="caption" weight="semibold" style={{ color: Colors.statusError }}>Выйти из аккаунта</Text>
               </Pressable>
-              <Pressable onPress={handleLogout} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}>
-                <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Выйти</Text>
+              {showLogout && (
+                <Card variant="outlined" style={{ borderColor: Colors.statusBg.error }}>
+                  <View style={{ gap: Spacing.md }}>
+                    <Text variant="caption" align="center" style={{ color: Colors.textSecondary }}>
+                      Вы уверены, что хотите выйти?
+                    </Text>
+                    <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+                      <View style={{ flex: 1 }}>
+                        <Button variant="secondary" onPress={() => setShowLogout(false)} fullWidth>Отмена</Button>
+                      </View>
+                      <View style={{ flex: 1 }}>
+                        <Button variant="danger" onPress={handleLogout} fullWidth>Выйти</Button>
+                      </View>
+                    </View>
+                  </View>
+                </Card>
+              )}
+
+              <Pressable
+                onPress={() => setShowDelete(!showDelete)}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: Spacing.sm,
+                  height: 48,
+                  backgroundColor: 'transparent',
+                  borderWidth: 1,
+                  borderColor: Colors.statusBg.error,
+                  borderRadius: BorderRadius.btn,
+                }}
+              >
+                <Feather name="trash-2" size={18} color={Colors.statusError} />
+                <Text variant="caption" weight="semibold" style={{ color: Colors.statusError }}>Удалить аккаунт</Text>
               </Pressable>
+              {showDelete && (
+                <Card variant="outlined" style={{ borderColor: Colors.statusBg.error }}>
+                  <View style={{ gap: Spacing.md }}>
+                    <Text variant="caption" align="center" style={{ color: Colors.textSecondary }}>
+                      Это действие необратимо. Все данные будут удалены.
+                    </Text>
+                    <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
+                      <View style={{ flex: 1 }}>
+                        <Button variant="secondary" onPress={() => setShowDelete(false)} fullWidth>Отмена</Button>
+                      </View>
+                      <View style={{ flex: 1 }}>
+                        <Button variant="danger" onPress={() => { /* TODO: implement delete */ }} fullWidth>Удалить</Button>
+                      </View>
+                    </View>
+                  </View>
+                </Card>
+              )}
             </View>
           </View>
-        )}
-        <Pressable onPress={() => setShowDelete(!showDelete)} style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: Spacing.sm, height: 48, backgroundColor: 'transparent', borderWidth: 1, borderColor: Colors.statusBg.error, borderRadius: BorderRadius.btn }}>
-          <Feather name="trash-2" size={18} color={Colors.statusError} />
-          <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.statusError }}>Удалить аккаунт</Text>
-        </Pressable>
-        {showDelete && (
-          <View style={{ backgroundColor: Colors.bgCard, borderRadius: BorderRadius.card, padding: Spacing.lg, borderWidth: 1, borderColor: Colors.statusBg.error, gap: Spacing.md, ...Shadows.sm }}>
-            <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textSecondary, textAlign: 'center' }}>Это действие необратимо. Все данные будут удалены.</Text>
-            <View style={{ flexDirection: 'row', gap: Spacing.sm }}>
-              <Pressable onPress={() => setShowDelete(false)} style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: Colors.border }}>
-                <Text style={{ fontSize: Typography.fontSize.sm, color: Colors.textMuted }}>Отмена</Text>
-              </Pressable>
-              <Pressable style={{ flex: 1, height: 40, borderRadius: BorderRadius.btn, alignItems: 'center', justifyContent: 'center', backgroundColor: Colors.statusError }}>
-                <Text style={{ fontSize: Typography.fontSize.sm, fontWeight: Typography.fontWeight.semibold, color: Colors.white }}>Удалить</Text>
-              </Pressable>
-            </View>
-          </View>
-        )}
-      </View>
-    </View>
+        </Container>
+      </ScrollView>
+    </Screen>
   );
 }


### PR DESCRIPTION
Phase 3C of UI overhaul.

## Scope
- app/(tabs)/*.tsx (all 7 list screens)
- app/(dashboard)/my-requests/{index,new}.tsx

## Changes
- dashboard.tsx: hand-rolled Pressables/cards → <Button>/<Card>/<Badge>/<EmptyState>
- requests.tsx: list cards → <Card>, status pills → <Badge>, confirm dialog → <Modal>
- feed.tsx: feed cards → <Card>, CTA → <Button>, empty/error → <EmptyState>
- messages.tsx: thread rows → <Card>, search → <Input>, states → <EmptyState>, retry CTA → <Button>
- profile.tsx: inline TextInputs → <Input>, stat blocks & save/cancel CTAs → <Card>/<Button>
- settings.tsx: section cards → <Card>, confirm blocks → <Button>
- my-requests/new.tsx: TextInput → <Input>, submit CTA → <Button>
- my-requests/index.tsx: verified redirect stub, no changes needed
- Layout wrapped in <Screen><Container> for consistent responsive max-width

## P3 placeholder bug fix
Request cards showed '—' placeholders because frontend read wrong property names.
Prisma Request model returns \`serviceType\` / \`ifnsName\`, but the UI was reading
\`serviceCategory\` / \`ifnsCode\` / \`fnsName\`. Fixed in requests.tsx, dashboard.tsx,
and feed.tsx (the feed also now falls back to \`category\` when \`serviceType\` is null).

## Metrics
- Files touched: 7
- LOC: 2023 → 2468 (+445, primitives are more verbose but clearer)
- StyleSheet.create: 0 → 0 (none in scope)
- Pressable usage in scope: 76 → 42
- Raw <TextInput>: 7 → 0
- tsc --noEmit: passes (errors present in pre-existing files outside scope)

Parallel with Phase 3A/B/D.