### PR TITLE
chore(lint): ESLint guardrails vs raw hex + fontSize [Phase 4]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: ESLint (Phase 4 UI guardrails)
+        run: npm run lint
+        continue-on-error: true
+
       - name: Build frontend (web)
         run: npx expo export --platform web
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,42 @@
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 
+// Shared no-restricted-syntax rules for Phase 4 UI guardrails.
+// Blocks raw hex literals and raw numeric fontSize props from sneaking back
+// into app/** and components/** — enforcing use of Colors.<token> and
+// Typography.<key> tokens from constants/.
+const uiGuardrailSelectors = [
+  {
+    selector: "Literal[value=/^#[0-9a-fA-F]{3,8}$/]",
+    message:
+      'Raw hex literals are forbidden outside Colors.ts/palette.js/tailwind.config.js. Use Colors.<token> from constants/Colors.ts.',
+  },
+  {
+    selector: "TemplateElement[value.raw=/#[0-9a-fA-F]{3,8}/]",
+    message: 'Raw hex in template literal. Use Colors.<token>.',
+  },
+  {
+    selector:
+      "Property[key.name='fontSize'][value.type='Literal'][value.raw=/^[0-9]+(\\.[0-9]+)?$/]",
+    message: 'Raw numeric fontSize forbidden. Use Typography.<key>.',
+  },
+  {
+    selector:
+      "Property[key.name='color'][value.type='Literal'][value.value=/^#[0-9a-fA-F]{3,8}$/]",
+    message: 'Raw hex color prop. Use Colors.<token>.',
+  },
+  {
+    selector:
+      "Property[key.name='backgroundColor'][value.type='Literal'][value.value=/^#[0-9a-fA-F]{3,8}$/]",
+    message: 'Raw hex backgroundColor. Use Colors.<token>.',
+  },
+  {
+    selector:
+      "Property[key.name='borderColor'][value.type='Literal'][value.value=/^#[0-9a-fA-F]{3,8}$/]",
+    message: 'Raw hex borderColor. Use Colors.<token>.',
+  },
+];
+
 export default [
   {
     ignores: ['node_modules/**', 'dist/**', '.expo/**', 'api/**'],
@@ -29,6 +65,25 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/ban-ts-comment': 'warn',
+    },
+  },
+  // Phase 4 UI guardrails — block raw hex + raw fontSize in app/components
+  {
+    files: [
+      'app/**/*.ts',
+      'app/**/*.tsx',
+      'components/**/*.ts',
+      'components/**/*.tsx',
+    ],
+    ignores: [
+      'constants/Colors.ts',
+      'constants/palette.js',
+      'tailwind.config.js',
+      'components/ui/**',
+      'app/_dev/**',
+    ],
+    rules: {
+      'no-restricted-syntax': ['warn', ...uiGuardrailSelectors],
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "build:web": "npx expo export --platform web",
-    "lint": "eslint . --ext .ts,.tsx --max-warnings 200",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 500",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "format": "prettier --write '**/*.{ts,tsx,json,md}'",
     "format:check": "prettier --check '**/*.{ts,tsx,json,md}'",


### PR DESCRIPTION
Phase 4 (final) of UI overhaul.

Adds ESLint `no-restricted-syntax` rules to prevent regression of Phases 1-3:
- Raw hex literals (`#abc`, `#abc123`) outside `constants/Colors.ts`, `constants/palette.js`, `tailwind.config.js`
- Raw numeric `fontSize` props (require `Typography.<key>`)
- Raw `color` / `backgroundColor` / `borderColor` hex
- Hex inside template literals

Exclusions: `constants/Colors.ts`, `constants/palette.js`, `tailwind.config.js`, `components/ui/**`, `app/_dev/**`.

## Baseline
- Pre-existing warnings (type/unused): 250
- New guardrail warnings: 176 across 11 files (mostly `components/proto/states/*` mock states + a few `app/*` pages)
- Total: 426 — bumped `--max-warnings` 200 to 500 to absorb (`warn` level, non-blocking)

## CI
Added `npm run lint` step to `build` job in `.github/workflows/deploy.yml` with `continue-on-error: true` while rules are `warn`. Remove `continue-on-error` when upgraded to `error`.

## Verified
- Intentional bad `#ff0000` + `fontSize: 14` + `color/backgroundColor/borderColor` hex → all 6 rules fire as warnings
- `npm run lint` exits 0
- Frontend `npx tsc --noEmit` exits 0 (unchanged)