### PR TITLE
Batch 5: Messaging (3 screens)

### DIFF
--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -23,10 +23,15 @@ router.get("/", async (req: Request, res: Response) => {
 
     const isSpecialist = user.role === "SPECIALIST";
 
+    const requestIdFilter = req.query.request_id as string | undefined;
+
     const threads = await prisma.thread.findMany({
-      where: isSpecialist
-        ? { specialistId: userId }
-        : { clientId: userId },
+      where: {
+        ...(isSpecialist
+          ? { specialistId: userId }
+          : { clientId: userId }),
+        ...(requestIdFilter ? { requestId: requestIdFilter } : {}),
+      },
       orderBy: { lastMessageAt: { sort: "desc", nulls: "last" } },
       include: {
         request: {

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -1,15 +1,186 @@
-import { View, Text } from "react-native";
+import { useState, useEffect, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
+import EmptyState from "@/components/EmptyState";
+import { api } from "@/lib/api";
+
+interface ThreadItem {
+  id: string;
+  otherUser: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  request: {
+    id: string;
+    title: string;
+    status: string;
+  };
+  lastMessage: {
+    text: string;
+    createdAt: string;
+  } | null;
+  unreadCount: number;
+  createdAt: string;
+}
+
+function displayName(user: { firstName: string | null; lastName: string | null }): string {
+  const parts = [user.firstName, user.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Специалист";
+}
+
+function getInitials(user: { firstName: string | null; lastName: string | null }): string {
+  const f = user.firstName?.[0] || "";
+  const l = user.lastName?.[0] || "";
+  return (f + l).toUpperCase() || "?";
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+
+  if (isToday) {
+    return d.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString("ru-RU", { day: "numeric", month: "short" });
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen) + "...";
+}
 
 export default function ClientMessages() {
+  const router = useRouter();
+
+  const [threads, setThreads] = useState<ThreadItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchThreads = useCallback(async () => {
+    try {
+      const res = await api<{ items: ThreadItem[] }>("/api/threads");
+      setThreads(res.items);
+    } catch (e) {
+      console.error("fetch client threads error:", e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchThreads();
+  }, [fetchThreads]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchThreads();
+  }, [fetchThreads]);
+
+  const renderThread = useCallback(
+    ({ item }: { item: ThreadItem }) => {
+      const hasUnread = item.unreadCount > 0;
+
+      return (
+        <Pressable
+          onPress={() => router.push(`/threads/${item.id}` as never)}
+          className="flex-row items-center py-3 border-b border-slate-100"
+        >
+          {/* Avatar */}
+          <View className="w-10 h-10 rounded-full bg-blue-900 items-center justify-center">
+            <Text className="text-white text-sm font-bold">
+              {getInitials(item.otherUser)}
+            </Text>
+            {hasUnread && (
+              <View className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-red-600 items-center justify-center px-1">
+                <Text className="text-[10px] font-bold text-white">
+                  {item.unreadCount > 99 ? "99+" : item.unreadCount}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* Content */}
+          <View className="flex-1 ml-3">
+            <Text
+              className={`text-base ${hasUnread ? "font-bold" : "font-semibold"} text-slate-900`}
+              numberOfLines={1}
+            >
+              {displayName(item.otherUser)}
+            </Text>
+            {item.lastMessage && (
+              <Text
+                className={`text-sm mt-0.5 ${hasUnread ? "font-semibold text-slate-700" : "text-slate-400"}`}
+                numberOfLines={1}
+              >
+                {truncate(item.lastMessage.text, 60)}
+              </Text>
+            )}
+          </View>
+
+          {/* Time */}
+          {item.lastMessage && (
+            <Text className="text-xs text-slate-400 ml-2">
+              {formatTime(item.lastMessage.createdAt)}
+            </Text>
+          )}
+        </Pressable>
+      );
+    },
+    [router]
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+        <HeaderHome />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color="#1e3a8a" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       <HeaderHome />
-      <View className="flex-1 items-center justify-center px-4">
-        <Text className="text-2xl font-bold text-slate-900">Messages</Text>
-        <Text className="text-sm text-slate-400 mt-2">Coming in Batch 1</Text>
-      </View>
+      <ResponsiveContainer>
+        <FlatList
+          data={threads}
+          keyExtractor={(item) => item.id}
+          renderItem={renderThread}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              tintColor="#1e3a8a"
+            />
+          }
+          ListEmptyComponent={
+            <EmptyState
+              icon="comments-o"
+              title="Сообщений пока нет"
+              subtitle="Здесь появятся сообщения от специалистов"
+              actionLabel="Найти специалиста"
+              onAction={() => router.push("/specialists" as never)}
+            />
+          }
+          contentContainerStyle={{ flexGrow: 1 }}
+        />
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -36,6 +36,9 @@ export default function RootLayout() {
         <Stack.Screen name="specialists/index" />
         <Stack.Screen name="specialists/[id]" />
 
+        {/* Chat */}
+        <Stack.Screen name="threads/[id]" />
+
         {/* Specialist flow */}
         <Stack.Screen name="requests/[id]/write" />
         <Stack.Screen name="settings" />

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -1,15 +1,181 @@
-import { View, Text } from "react-native";
+import { useState, useEffect, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  RefreshControl,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
+import EmptyState from "@/components/EmptyState";
+import { api } from "@/lib/api";
+
+interface ThreadItem {
+  id: string;
+  otherUser: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  lastMessage: {
+    text: string;
+    createdAt: string;
+  } | null;
+  unreadCount: number;
+  createdAt: string;
+}
+
+function displayName(user: { firstName: string | null; lastName: string | null }): string {
+  const parts = [user.firstName, user.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Специалист";
+}
+
+function getInitials(user: { firstName: string | null; lastName: string | null }): string {
+  const f = user.firstName?.[0] || "";
+  const l = user.lastName?.[0] || "";
+  return (f + l).toUpperCase() || "?";
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+
+  if (isToday) {
+    return d.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString("ru-RU", { day: "numeric", month: "short" });
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen) + "...";
+}
 
 export default function RequestMessages() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+
+  const [threads, setThreads] = useState<ThreadItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchThreads = useCallback(async () => {
+    if (!id) return;
+    try {
+      const res = await api<{ items: ThreadItem[] }>(`/api/threads?request_id=${id}`);
+      setThreads(res.items);
+    } catch (e) {
+      console.error("fetch request threads error:", e);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchThreads();
+  }, [fetchThreads]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchThreads();
+  }, [fetchThreads]);
+
+  const renderThread = useCallback(
+    ({ item }: { item: ThreadItem }) => {
+      const hasUnread = item.unreadCount > 0;
+      return (
+        <Pressable
+          onPress={() => router.push(`/threads/${item.id}` as never)}
+          className="flex-row items-center py-3 border-b border-slate-100"
+        >
+          {/* Avatar */}
+          <View className="w-10 h-10 rounded-full bg-blue-900 items-center justify-center">
+            <Text className="text-white text-sm font-bold">
+              {getInitials(item.otherUser)}
+            </Text>
+            {hasUnread && (
+              <View className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-red-600 items-center justify-center px-1">
+                <Text className="text-[10px] font-bold text-white">
+                  {item.unreadCount > 99 ? "99+" : item.unreadCount}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* Content */}
+          <View className="flex-1 ml-3">
+            <Text
+              className={`text-base ${hasUnread ? "font-bold" : "font-semibold"} text-slate-900`}
+              numberOfLines={1}
+            >
+              {displayName(item.otherUser)}
+            </Text>
+            {item.lastMessage && (
+              <Text
+                className={`text-sm mt-0.5 ${hasUnread ? "font-semibold text-slate-700" : "text-slate-400"}`}
+                numberOfLines={1}
+              >
+                {truncate(item.lastMessage.text, 60)}
+              </Text>
+            )}
+          </View>
+
+          {/* Time */}
+          {item.lastMessage && (
+            <Text className="text-xs text-slate-400 ml-2">
+              {formatTime(item.lastMessage.createdAt)}
+            </Text>
+          )}
+        </Pressable>
+      );
+    },
+    [router]
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView className="flex-1 bg-white">
+        <HeaderBack title="Сообщения" />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color="#1e3a8a" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="Сообщения" />
-      <View className="flex-1 items-center justify-center px-4">
-        <Text className="text-2xl font-bold text-slate-900">Сообщения</Text>
-        <Text className="text-sm text-slate-400 mt-2">Coming in Batch 4</Text>
-      </View>
+      <ResponsiveContainer>
+        <FlatList
+          data={threads}
+          keyExtractor={(item) => item.id}
+          renderItem={renderThread}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+              tintColor="#1e3a8a"
+            />
+          }
+          ListEmptyComponent={
+            <EmptyState
+              icon="comments-o"
+              title="Специалисты ещё не написали"
+              subtitle="Отклики от специалистов появятся здесь"
+            />
+          }
+          contentContainerStyle={{ flexGrow: 1 }}
+        />
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -1,0 +1,263 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  ActivityIndicator,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useLocalSearchParams } from "expo-router";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import HeaderBack from "@/components/HeaderBack";
+import MessageBubble from "@/components/MessageBubble";
+import { api, apiPost, apiPatch } from "@/lib/api";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface MessageSender {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+}
+
+interface MessageItem {
+  id: string;
+  threadId: string;
+  senderId: string;
+  text: string;
+  createdAt: string;
+  sender: MessageSender;
+}
+
+interface ThreadInfo {
+  id: string;
+  requestId: string;
+  clientId: string;
+  specialistId: string;
+  request: { id: string; title: string; status: string };
+  client: { id: string; firstName: string | null; lastName: string | null };
+  specialist: { id: string; firstName: string | null; lastName: string | null };
+}
+
+function displayName(user: { firstName: string | null; lastName: string | null }): string {
+  const parts = [user.firstName, user.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Пользователь";
+}
+
+export default function ChatThread() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { user } = useAuth();
+
+  const [messages, setMessages] = useState<MessageItem[]>([]);
+  const [thread, setThread] = useState<ThreadInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const flatListRef = useRef<FlatList>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const isClosed = thread?.request?.status === "CLOSED";
+  const myId = user?.id;
+
+  const otherUserName = useCallback(() => {
+    if (!thread || !myId) return "Чат";
+    const other = thread.clientId === myId ? thread.specialist : thread.client;
+    return displayName(other);
+  }, [thread, myId]);
+
+  const fetchMessages = useCallback(async () => {
+    if (!id) return;
+    try {
+      const res = await api<{ messages: MessageItem[] }>(`/api/messages/${id}`);
+      setMessages(res.messages);
+    } catch (e) {
+      console.error("fetch messages error:", e);
+    }
+  }, [id]);
+
+  const fetchThread = useCallback(async () => {
+    if (!id) return;
+    try {
+      // Fetch thread info from threads list filtered by this thread
+      const res = await api<{ items: ThreadInfo[] }>(`/api/threads`);
+      const found = res.items.find((t: ThreadInfo) => t.id === id);
+      if (found) setThread(found);
+    } catch (e) {
+      console.error("fetch thread error:", e);
+    }
+  }, [id]);
+
+  const markAsRead = useCallback(async () => {
+    if (!id) return;
+    try {
+      await apiPatch(`/api/messages/${id}/read`, {});
+    } catch (e) {
+      console.error("mark read error:", e);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        await Promise.all([fetchMessages(), fetchThread()]);
+        await markAsRead();
+      } catch {
+        setError("Не удалось загрузить сообщения");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [fetchMessages, fetchThread, markAsRead]);
+
+  // Poll for new messages every 5 seconds
+  useEffect(() => {
+    pollRef.current = setInterval(() => {
+      fetchMessages();
+    }, 5000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [fetchMessages]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = text.trim();
+    if (!trimmed || sending || !id) return;
+    setSending(true);
+    try {
+      const res = await apiPost<{ message: MessageItem }>(`/api/messages/${id}`, {
+        text: trimmed,
+      });
+      setMessages((prev) => [...prev, res.message]);
+      setText("");
+      setTimeout(() => {
+        flatListRef.current?.scrollToEnd({ animated: true });
+      }, 100);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Ошибка отправки";
+      setError(msg);
+    } finally {
+      setSending(false);
+    }
+  }, [text, sending, id]);
+
+  const renderMessage = useCallback(
+    ({ item }: { item: MessageItem }) => (
+      <MessageBubble
+        text={item.text}
+        createdAt={item.createdAt}
+        isOwn={item.senderId === myId}
+      />
+    ),
+    [myId]
+  );
+
+  if (loading) {
+    return (
+      <SafeAreaView className="flex-1 bg-white">
+        <HeaderBack title="Чат" />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" color="#1e3a8a" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error && messages.length === 0) {
+    return (
+      <SafeAreaView className="flex-1 bg-white">
+        <HeaderBack title="Чат" />
+        <View className="flex-1 items-center justify-center px-4">
+          <Text className="text-base text-red-600 text-center">{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-white" edges={["top", "bottom"]}>
+      <HeaderBack title={otherUserName()} />
+
+      <KeyboardAvoidingView
+        className="flex-1"
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={0}
+      >
+        <FlatList
+          ref={flatListRef}
+          data={messages}
+          keyExtractor={(item) => item.id}
+          renderItem={renderMessage}
+          contentContainerStyle={{ padding: 16, flexGrow: 1, justifyContent: "flex-end" }}
+          onContentSizeChange={() => {
+            flatListRef.current?.scrollToEnd({ animated: false });
+          }}
+          ListEmptyComponent={
+            <View className="flex-1 items-center justify-center py-16">
+              <FontAwesome name="comments-o" size={48} color="#94a3b8" />
+              <Text className="text-sm text-slate-400 mt-3">Нет сообщений</Text>
+            </View>
+          }
+        />
+
+        {/* Closed banner */}
+        {isClosed && (
+          <View className="bg-amber-50 border-t border-amber-200 px-4 py-3">
+            <Text className="text-sm text-amber-700 text-center">
+              Заявка закрыта. Чат доступен только для чтения.
+            </Text>
+          </View>
+        )}
+
+        {/* Input bar */}
+        {!isClosed && (
+          <View className="flex-row items-end border-t border-slate-200 px-3 py-2 bg-white">
+            <TextInput
+              value={text}
+              onChangeText={setText}
+              placeholder="Написать сообщение..."
+              placeholderTextColor="#94a3b8"
+              multiline
+              style={{
+                flex: 1,
+                minHeight: 40,
+                maxHeight: 120,
+                paddingHorizontal: 12,
+                paddingVertical: 8,
+                fontSize: 16,
+                color: "#0f172a",
+                backgroundColor: "#f8fafc",
+                borderRadius: 20,
+                borderWidth: 1,
+                borderColor: "#e2e8f0",
+              }}
+            />
+            <Pressable
+              onPress={handleSend}
+              disabled={!text.trim() || sending}
+              className="w-10 h-10 items-center justify-center ml-2"
+            >
+              {sending ? (
+                <ActivityIndicator size="small" color="#1e3a8a" />
+              ) : (
+                <FontAwesome
+                  name="send"
+                  size={20}
+                  color={text.trim() ? "#1e3a8a" : "#94a3b8"}
+                />
+              )}
+            </Pressable>
+          </View>
+        )}
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -1,0 +1,129 @@
+import { View, Text, Pressable } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+
+interface FileAttachment {
+  id: string;
+  url: string;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+interface MessageBubbleProps {
+  text: string;
+  createdAt: string;
+  isOwn: boolean;
+  files?: FileAttachment[];
+  onFilePress?: (file: FileAttachment) => void;
+  onImagePress?: (url: string) => void;
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function isImage(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+export default function MessageBubble({
+  text,
+  createdAt,
+  isOwn,
+  files = [],
+  onFilePress,
+  onImagePress,
+}: MessageBubbleProps) {
+  const imageFiles = files.filter((f) => isImage(f.mimeType));
+  const docFiles = files.filter((f) => !isImage(f.mimeType));
+
+  return (
+    <View
+      className={`mb-2 ${isOwn ? "items-end" : "items-start"}`}
+    >
+      <View
+        className={`rounded-2xl px-3 py-2 ${
+          isOwn ? "bg-blue-900" : "bg-slate-50"
+        }`}
+        style={{ maxWidth: "80%" }}
+      >
+        {/* Image thumbnails */}
+        {imageFiles.map((img) => (
+          <Pressable
+            key={img.id}
+            onPress={() => onImagePress?.(img.url)}
+            className="mb-1"
+          >
+            <View className="w-[200px] h-[200px] bg-slate-200 rounded-xl items-center justify-center">
+              <FontAwesome
+                name="image"
+                size={32}
+                color={isOwn ? "#ffffff" : "#64748b"}
+              />
+              <Text
+                className={`text-xs mt-1 ${isOwn ? "text-blue-200" : "text-slate-400"}`}
+                numberOfLines={1}
+              >
+                {img.filename}
+              </Text>
+            </View>
+          </Pressable>
+        ))}
+
+        {/* Document files */}
+        {docFiles.map((file) => (
+          <Pressable
+            key={file.id}
+            onPress={() => onFilePress?.(file)}
+            className={`flex-row items-center rounded-lg p-2 mb-1 ${
+              isOwn ? "bg-blue-800" : "bg-slate-100"
+            }`}
+          >
+            <FontAwesome
+              name={file.mimeType === "application/pdf" ? "file-pdf-o" : "file-o"}
+              size={18}
+              color={isOwn ? "#93c5fd" : "#1e3a8a"}
+            />
+            <View className="ml-2 flex-1">
+              <Text
+                className={`text-sm ${isOwn ? "text-white" : "text-slate-900"}`}
+                numberOfLines={1}
+              >
+                {file.filename}
+              </Text>
+              <Text
+                className={`text-xs ${isOwn ? "text-blue-200" : "text-slate-400"}`}
+              >
+                {formatFileSize(file.size)}
+              </Text>
+            </View>
+            <FontAwesome
+              name="download"
+              size={12}
+              color={isOwn ? "#93c5fd" : "#94a3b8"}
+            />
+          </Pressable>
+        ))}
+
+        {/* Text */}
+        {text ? (
+          <Text className={`text-base ${isOwn ? "text-white" : "text-slate-900"}`}>
+            {text}
+          </Text>
+        ) : null}
+      </View>
+
+      {/* Time */}
+      <Text className="text-xs text-slate-400 mt-1 px-1">
+        {formatTime(createdAt)}
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- **ChatThread** (`app/threads/[id].tsx`) — real-time chat with message bubbles, polling, send input, closed-request banner
- **MessagesGrouped** (`app/requests/[id]/messages.tsx`) — threads list per request with unread badges
- **ClientMessages** (`app/(client-tabs)/messages.tsx`) — all client threads across requests with empty state CTA
- **MessageBubble** component — own/other styling, file/image attachment support
- Backend: added `request_id` query filter to `GET /api/threads`

Issues: #1064 #1065 #1066

## Test plan
- [ ] Open ChatThread — messages load, send works, auto-scroll to bottom
- [ ] Closed request shows read-only banner, input disabled
- [ ] MessagesGrouped shows threads for specific request
- [ ] ClientMessages tab shows all threads, pull-to-refresh works
- [ ] Empty states render correctly
- [ ] tsc --noEmit passes on both frontend and backend