### PR TITLE
feat: add accessibility labels to all interactive elements

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -37,7 +37,7 @@ function StatCard({
   );
 
   if (onPress) {
-    return <Pressable onPress={onPress}>{content}</Pressable>;
+    return <Pressable accessibilityLabel={label} onPress={onPress}>{content}</Pressable>;
   }
   return content;
 }

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -208,6 +208,7 @@ export default function AdminUsers() {
       {/* Search header */}
       <View className="bg-blue-900 px-4 pb-3 pt-2">
         <TextInput
+          accessibilityLabel="Поиск по email или имени"
           style={{
             backgroundColor: "rgba(255,255,255,0.15)",
             borderRadius: 10,
@@ -234,6 +235,7 @@ export default function AdminUsers() {
           {FILTER_OPTIONS.map((opt) => (
             <Pressable
               key={opt.key}
+              accessibilityLabel={opt.label}
               onPress={() => setFilter(opt.key)}
               className={`px-3 py-1.5 rounded-full border ${
                 filter === opt.key
@@ -280,6 +282,7 @@ export default function AdminUsers() {
                 users.map((user) => (
                   <View key={user.id}>
                     <Pressable
+                      accessibilityLabel={`${[user.firstName, user.lastName].filter(Boolean).join(" ") || user.email}`}
                       onPress={() =>
                         setExpandedId(expandedId === user.id ? null : user.id)
                       }
@@ -354,6 +357,7 @@ export default function AdminUsers() {
 
                         <View className="flex-row gap-2 flex-wrap">
                           <Pressable
+                            accessibilityLabel={user.isBanned ? "Разблокировать" : "Заблокировать"}
                             onPress={() => toggleBan(user)}
                             className={`px-3 py-2 rounded-lg ${
                               user.isBanned ? "bg-emerald-600" : "bg-red-600"
@@ -366,6 +370,7 @@ export default function AdminUsers() {
 
                           {user.role === "CLIENT" && (
                             <Pressable
+                              accessibilityLabel="Закрыть все заявки"
                               onPress={() => closeAllRequests(user)}
                               className="px-3 py-2 rounded-lg bg-amber-500"
                             >

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -107,6 +107,7 @@ export default function ClientDashboard() {
 
               {/* Create request button */}
               <Pressable
+                accessibilityLabel="Создать заявку"
                 onPress={() => router.push("/requests/new" as never)}
                 disabled={atLimit}
                 className={`rounded-xl py-3 items-center mb-6 ${
@@ -124,7 +125,7 @@ export default function ClientDashboard() {
                   Мои заявки
                 </Text>
                 {requests.length > 0 && (
-                  <Pressable onPress={() => router.push("/(client-tabs)/requests" as never)}>
+                  <Pressable accessibilityLabel="Все заявки" onPress={() => router.push("/(client-tabs)/requests" as never)}>
                     <Text className="text-sm text-blue-900 font-medium">
                       Все заявки
                     </Text>

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -96,6 +96,7 @@ export default function ClientMessages() {
 
       return (
         <Pressable
+          accessibilityLabel={`Чат с ${displayName(item.otherUser)}`}
           onPress={() => router.push(`/threads/${item.id}` as never)}
           className="flex-row items-center py-3 border-b border-slate-100"
         >

--- a/app/(client-tabs)/requests.tsx
+++ b/app/(client-tabs)/requests.tsx
@@ -131,6 +131,7 @@ export default function MyRequests() {
                 />
                 {item.status !== "CLOSED" && (
                   <Pressable
+                    accessibilityLabel="Закрыть заявку"
                     onPress={() => handleClose(item.id, item.title)}
                     className="self-end -mt-1 mb-3 px-3 py-1.5 bg-red-600 rounded-lg"
                   >
@@ -146,6 +147,7 @@ export default function MyRequests() {
             }
             ListFooterComponent={
               <Pressable
+                accessibilityLabel="Создать заявку"
                 onPress={() => router.push("/requests/new" as never)}
                 className="bg-blue-900 rounded-xl py-3 items-center mt-2"
               >

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -92,6 +92,7 @@ export default function SpecialistDashboard() {
           {/* Unavailable warning */}
           {user && !user.isAvailable && (
             <Pressable
+              accessibilityLabel="Включить приём заявок"
               onPress={() => router.push("/settings/specialist" as never)}
               className="bg-amber-50 border border-amber-300 rounded-xl p-4 mt-4"
             >
@@ -199,6 +200,7 @@ function SpecialistRequestCard({
             <Text className="text-xs text-emerald-600 font-medium">Вы уже писали</Text>
           </View>
           <Pressable
+            accessibilityLabel="Открыть чат"
             onPress={onOpenThread}
             className="bg-blue-900 rounded-xl px-4 py-2"
           >
@@ -207,6 +209,7 @@ function SpecialistRequestCard({
         </View>
       ) : (
         <Pressable
+          accessibilityLabel="Написать клиенту"
           onPress={onWrite}
           className="bg-amber-700 rounded-xl py-3 items-center"
         >

--- a/app/(specialist-tabs)/threads.tsx
+++ b/app/(specialist-tabs)/threads.tsx
@@ -148,6 +148,7 @@ function FilterChip({
 }) {
   return (
     <Pressable
+      accessibilityLabel={label}
       onPress={onPress}
       className={`px-4 py-2 rounded-full border ${
         active ? "bg-blue-900 border-blue-900" : "bg-white border-slate-200"
@@ -194,6 +195,7 @@ function ThreadCard({
 
   return (
     <Pressable
+      accessibilityLabel={`Чат с ${name}`}
       onPress={onPress}
       className="flex-row items-center py-3 border-b border-slate-100"
     >

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -30,7 +30,7 @@ export default function CreateScreen() {
 
           <View className="flex-row flex-wrap">
             {/* Add Photo Button */}
-            <Pressable className="w-[31%] aspect-square m-[1%] rounded-xl border-2 border-dashed border-blue-300 bg-blue-50 items-center justify-center">
+            <Pressable accessibilityLabel="Добавить фото" className="w-[31%] aspect-square m-[1%] rounded-xl border-2 border-dashed border-blue-300 bg-blue-50 items-center justify-center">
               <FontAwesome name="camera" size={24} color="#3b82f6" />
               <Text className="text-xs text-blue-600 mt-1 font-medium">Add photo</Text>
             </Pressable>
@@ -60,7 +60,7 @@ export default function CreateScreen() {
 
         {/* Next Button */}
         <View className="px-4 mt-8">
-          <Pressable className="h-14 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
+          <Pressable accessibilityLabel="Далее: детали" className="h-14 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
             <Text className="text-white text-base font-semibold">Next: Details</Text>
           </Pressable>
         </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -24,7 +24,7 @@ const LISTINGS = [
 
 function CategoryChip({ name, icon }: { name: string; icon: React.ComponentProps<typeof FontAwesome>["name"] }) {
   return (
-    <Pressable className="mr-3 items-center">
+    <Pressable accessibilityLabel={name} className="mr-3 items-center">
       <View className="w-14 h-14 rounded-2xl bg-gray-100 items-center justify-center mb-1">
         <FontAwesome name={icon} size={20} color="#4b5563" />
       </View>
@@ -35,7 +35,7 @@ function CategoryChip({ name, icon }: { name: string; icon: React.ComponentProps
 
 function ListingCard({ title, price, location, color }: { title: string; price: string; location: string; color: string }) {
   return (
-    <Pressable className="flex-1 m-1.5">
+    <Pressable accessibilityLabel={title} className="flex-1 m-1.5">
       <View className="rounded-2xl overflow-hidden bg-white" style={{ shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 4, elevation: 2 }}>
         <View className="h-36 items-center justify-center" style={{ backgroundColor: color }}>
           <FontAwesome name="image" size={32} color="#9ca3af" />
@@ -75,6 +75,7 @@ export default function HomeScreen() {
               <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
                 <FontAwesome name="search" size={16} color="#9ca3af" />
                 <TextInput
+                  accessibilityLabel="Поиск объявлений"
                   className="flex-1 ml-3 text-base text-gray-900"
                   placeholder="Search listings..."
                   placeholderTextColor="#9ca3af"
@@ -96,7 +97,7 @@ export default function HomeScreen() {
             {/* Section Title */}
             <View className="flex-row justify-between items-center px-4 mb-2">
               <Text className="text-lg font-bold text-gray-900">Recent Listings</Text>
-              <Pressable>
+              <Pressable accessibilityLabel="Показать все">
                 <Text className="text-sm text-blue-600">See all</Text>
               </Pressable>
             </View>

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -68,7 +68,7 @@ function ConversationItem({
   unread,
 }: (typeof CONVERSATIONS)[0]) {
   return (
-    <Pressable className="flex-row items-center px-4 py-3 active:bg-gray-50">
+    <Pressable accessibilityLabel={`Чат с ${name}`} className="flex-row items-center px-4 py-3 active:bg-gray-50">
       <View
         className="w-12 h-12 rounded-full items-center justify-center"
         style={{ backgroundColor: avatarColor }}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -62,6 +62,7 @@ export default function ProfileScreen() {
           {MENU_ITEMS.map((item) => (
             <Pressable
               key={item.id}
+              accessibilityLabel={item.label}
               className="flex-row items-center px-4 py-4 active:bg-gray-50"
             >
               <View className="w-10 h-10 rounded-lg bg-gray-100 items-center justify-center">
@@ -81,6 +82,7 @@ export default function ProfileScreen() {
         {/* Logout */}
         <View className="mt-4 px-4">
           <Pressable
+            accessibilityLabel="Выйти"
             onPress={signOut}
             className="flex-row items-center justify-center h-12 rounded-xl border border-red-200 active:bg-red-50"
           >

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -32,11 +32,12 @@ export default function SearchScreen() {
           <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
             <FontAwesome name="search" size={16} color="#9ca3af" />
             <TextInput
+              accessibilityLabel="Поиск"
               className="flex-1 ml-3 text-base text-gray-900"
               placeholder="What are you looking for?"
               placeholderTextColor="#9ca3af"
             />
-            <Pressable className="ml-2 w-10 h-10 rounded-lg bg-blue-600 items-center justify-center">
+            <Pressable accessibilityLabel="Фильтры" className="ml-2 w-10 h-10 rounded-lg bg-blue-600 items-center justify-center">
               <FontAwesome name="sliders" size={16} color="#ffffff" />
             </Pressable>
           </View>
@@ -46,13 +47,14 @@ export default function SearchScreen() {
         <View className="px-4 mb-6">
           <View className="flex-row justify-between items-center mb-3">
             <Text className="text-base font-semibold text-gray-900">Recent Searches</Text>
-            <Pressable>
+            <Pressable accessibilityLabel="Очистить историю поиска">
               <Text className="text-sm text-blue-600">Clear</Text>
             </Pressable>
           </View>
           {RECENT_SEARCHES.map((search, index) => (
             <Pressable
               key={index}
+              accessibilityLabel={search}
               className="flex-row items-center py-3 border-b border-gray-100"
             >
               <FontAwesome name="clock-o" size={16} color="#9ca3af" />
@@ -68,6 +70,7 @@ export default function SearchScreen() {
           {POPULAR_CATEGORIES.map((cat) => (
             <Pressable
               key={cat.id}
+              accessibilityLabel={cat.name}
               className="flex-row items-center p-3 rounded-xl mb-2"
               style={{ backgroundColor: cat.color }}
             >

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -116,6 +116,7 @@ export default function AdminSettings() {
                     {field.label}
                   </Text>
                   <TextInput
+                    accessibilityLabel={field.label}
                     style={{
                       backgroundColor: "#ffffff",
                       borderWidth: 1,
@@ -134,6 +135,7 @@ export default function AdminSettings() {
               ))}
 
               <Pressable
+                accessibilityLabel="Сохранить"
                 onPress={handleSave}
                 disabled={saving}
                 className={`h-12 rounded-xl items-center justify-center mt-2 ${

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -73,6 +73,7 @@ export default function AuthEmailScreen() {
           </Text>
 
           <TextInput
+            accessibilityLabel="Email адрес"
             style={{
               height: 48,
               borderRadius: 12,
@@ -101,6 +102,7 @@ export default function AuthEmailScreen() {
           ) : null}
 
           <Pressable
+            accessibilityLabel="Продолжить"
             onPress={handleContinue}
             disabled={isLoading || !email.trim()}
             className={`h-12 rounded-xl items-center justify-center mt-6 ${
@@ -119,6 +121,7 @@ export default function AuthEmailScreen() {
           </Pressable>
 
           <Pressable
+            accessibilityLabel="Условия использования"
             onPress={() => router.push("/legal/terms" as never)}
             className="mt-4 py-3"
           >

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -138,6 +138,7 @@ export default function AuthOtpScreen() {
             {digits.map((digit, i) => (
               <TextInput
                 key={i}
+                accessibilityLabel={`Цифра ${i + 1} кода подтверждения`}
                 ref={(ref) => {
                   inputRefs.current[i] = ref;
                 }}
@@ -172,6 +173,7 @@ export default function AuthOtpScreen() {
           ) : null}
 
           <Pressable
+            accessibilityLabel="Подтвердить"
             onPress={() => handleVerify(digits.join(""))}
             disabled={isLoading || digits.join("").length !== CODE_LENGTH}
             className={`h-12 rounded-xl items-center justify-center mt-4 ${
@@ -190,6 +192,7 @@ export default function AuthOtpScreen() {
           </Pressable>
 
           <Pressable
+            accessibilityLabel="Отправить повторно"
             onPress={handleResend}
             disabled={resendTimer > 0}
             className="mt-4 py-3"

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -103,6 +103,7 @@ export default function LandingScreen() {
         <Text className="text-lg font-bold text-white">P2PTax</Text>
         {!isAuthenticated && (
           <Pressable
+            accessibilityLabel="Войти"
             onPress={() => router.push("/(auth)/email" as never)}
             className="bg-white/20 rounded-lg px-4 min-h-[44px] items-center justify-center"
           >
@@ -133,6 +134,7 @@ export default function LandingScreen() {
               {cities.map((city) => (
                 <Pressable
                   key={city.id}
+                  accessibilityLabel={city.name}
                   onPress={() => handleCitySelect(city.id)}
                   className={`px-3 py-2 rounded-lg mr-2 border ${
                     selectedCityId === city.id
@@ -162,6 +164,7 @@ export default function LandingScreen() {
                 {fnsOffices.map((fns) => (
                   <Pressable
                     key={fns.id}
+                    accessibilityLabel={fns.name}
                     onPress={() =>
                       setSelectedFnsId(selectedFnsId === fns.id ? null : fns.id)
                     }
@@ -193,6 +196,7 @@ export default function LandingScreen() {
               {services.map((s) => (
                 <Pressable
                   key={s.id}
+                  accessibilityLabel={s.name}
                   onPress={() =>
                     setSelectedServiceId(selectedServiceId === s.id ? null : s.id)
                   }
@@ -218,6 +222,7 @@ export default function LandingScreen() {
 
           {/* CTA button */}
           <Pressable
+            accessibilityLabel="Отправить заявку"
             onPress={() => {
               if (!isAuthenticated) {
                 router.push("/(auth)/email" as never);
@@ -234,6 +239,7 @@ export default function LandingScreen() {
           {/* Navigation links */}
           <View className="flex-row gap-3 mb-6">
             <Pressable
+              accessibilityLabel="Все заявки"
               onPress={() => router.push("/requests" as never)}
               className="flex-1 bg-slate-50 border border-slate-200 rounded-xl py-3 items-center"
             >
@@ -243,6 +249,7 @@ export default function LandingScreen() {
               </Text>
             </Pressable>
             <Pressable
+              accessibilityLabel="Все специалисты"
               onPress={() => router.push("/specialists" as never)}
               className="flex-1 bg-slate-50 border border-slate-200 rounded-xl py-3 items-center"
             >

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -25,6 +25,7 @@ export default function PrivacyPolicyScreen() {
     <SafeAreaView className="flex-1 bg-white">
       <View className="flex-row items-center h-14 bg-white border-b border-slate-200 px-4">
         <Pressable
+          accessibilityLabel="Назад"
           onPress={() => router.back()}
           className="w-10 h-10 items-center justify-center -ml-2"
         >

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -31,6 +31,7 @@ export default function TermsScreen() {
         </Text>
         <View className="flex-1 items-end">
           <Pressable
+            accessibilityLabel="Закрыть"
             onPress={() => router.back()}
             className="w-10 h-10 items-center justify-center"
           >

--- a/app/listing/[id].tsx
+++ b/app/listing/[id].tsx
@@ -65,10 +65,10 @@ export default function ListingDetailScreen() {
 
       {/* Bottom Action Bar */}
       <View className="flex-row px-4 py-3 border-t border-gray-100 gap-3">
-        <Pressable className="flex-1 h-12 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
+        <Pressable accessibilityLabel="Написать продавцу" className="flex-1 h-12 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
           <Text className="text-white text-base font-semibold">Message Seller</Text>
         </Pressable>
-        <Pressable className="w-12 h-12 rounded-xl border border-gray-200 items-center justify-center active:bg-gray-50">
+        <Pressable accessibilityLabel="Добавить в избранное" className="w-12 h-12 rounded-xl border border-gray-200 items-center justify-center active:bg-gray-50">
           <FontAwesome name="heart-o" size={20} color="#6b7280" />
         </Pressable>
       </View>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -88,6 +88,7 @@ function NotificationItem({
 }) {
   return (
     <Pressable
+      accessibilityLabel={item.title}
       onPress={() => onToggleRead(item.id)}
       className={`flex-row items-start px-4 py-3.5 border-b border-slate-50 active:bg-slate-50 ${
         !item.read ? "bg-slate-50/50" : ""
@@ -134,12 +135,12 @@ export default function NotificationsScreen() {
       {/* Header */}
       <View className="flex-row items-center justify-between px-4 pt-2 pb-3 border-b border-slate-50">
         <View className="flex-row items-center">
-          <Pressable onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
             <FontAwesome name="arrow-left" size={18} color="#0f172a" />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Уведомления</Text>
         </View>
-        <Pressable onPress={markAllRead} className="py-3 pl-3">
+        <Pressable accessibilityLabel="Прочитать все" onPress={markAllRead} className="py-3 pl-3">
           <Text className="text-sm text-blue-900 font-medium">Прочитать все</Text>
         </Pressable>
       </View>

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -62,6 +62,7 @@ export default function OnboardingNameScreen() {
 
           <Text className="text-sm text-slate-500 mb-1">Имя</Text>
           <TextInput
+            accessibilityLabel="Имя"
             style={{
               height: 48,
               borderRadius: 12,
@@ -88,6 +89,7 @@ export default function OnboardingNameScreen() {
 
           <Text className="text-sm text-slate-500 mb-1">Фамилия</Text>
           <TextInput
+            accessibilityLabel="Фамилия"
             style={{
               height: 48,
               borderRadius: 12,
@@ -114,6 +116,7 @@ export default function OnboardingNameScreen() {
 
           {/* Terms checkbox */}
           <Pressable
+            accessibilityLabel="Принять условия использования"
             onPress={() => setAgreed(!agreed)}
             className="flex-row items-start mb-6"
           >
@@ -146,6 +149,7 @@ export default function OnboardingNameScreen() {
           ) : null}
 
           <Pressable
+            accessibilityLabel="Далее"
             onPress={handleNext}
             disabled={!canProceed || isLoading}
             className={`h-12 rounded-xl items-center justify-center ${

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -81,7 +81,7 @@ export default function OnboardingProfileScreen() {
             </Text>
 
             {/* Avatar area */}
-            <Pressable className="items-center mb-6">
+            <Pressable accessibilityLabel="Добавить фото" className="items-center mb-6">
               <View className="w-20 h-20 rounded-full bg-slate-100 items-center justify-center border-2 border-dashed border-slate-300">
                 <FontAwesome name="camera" size={24} color="#94a3b8" />
               </View>
@@ -93,6 +93,7 @@ export default function OnboardingProfileScreen() {
             {/* About */}
             <Text className="text-sm text-slate-500 mb-1">О себе</Text>
             <TextInput
+              accessibilityLabel="О себе"
               style={{
                 height: 100,
                 borderRadius: 12,
@@ -122,6 +123,7 @@ export default function OnboardingProfileScreen() {
             {/* Phone */}
             <Text className="text-sm text-slate-500 mb-1">Телефон</Text>
             <TextInput
+              accessibilityLabel="Телефон"
               style={{
                 height: 48,
                 borderRadius: 12,
@@ -144,6 +146,7 @@ export default function OnboardingProfileScreen() {
             {/* Telegram */}
             <Text className="text-sm text-slate-500 mb-1">Telegram</Text>
             <TextInput
+              accessibilityLabel="Telegram"
               style={{
                 height: 48,
                 borderRadius: 12,
@@ -166,6 +169,7 @@ export default function OnboardingProfileScreen() {
             {/* WhatsApp */}
             <Text className="text-sm text-slate-500 mb-1">WhatsApp</Text>
             <TextInput
+              accessibilityLabel="WhatsApp"
               style={{
                 height: 48,
                 borderRadius: 12,
@@ -199,6 +203,7 @@ export default function OnboardingProfileScreen() {
                 color: "#0f172a",
                 marginBottom: 16,
               }}
+              accessibilityLabel="Адрес офиса"
               placeholder="г. Москва, ул. Примерная, 1"
               placeholderTextColor="#94a3b8"
               value={officeAddress}
@@ -220,6 +225,7 @@ export default function OnboardingProfileScreen() {
                 color: "#0f172a",
                 marginBottom: 24,
               }}
+              accessibilityLabel="Часы работы"
               placeholder="Пн-Пт 9:00-18:00"
               placeholderTextColor="#94a3b8"
               value={workingHours}
@@ -234,6 +240,7 @@ export default function OnboardingProfileScreen() {
             ) : null}
 
             <Pressable
+              accessibilityLabel="Завершить"
               onPress={handleSubmit}
               disabled={isLoading}
               className={`h-12 rounded-xl items-center justify-center ${

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -176,7 +176,7 @@ export default function OnboardingWorkAreaScreen() {
                     </Text>
                     <Text className="text-xs text-slate-400">{item.cityName}</Text>
                   </View>
-                  <Pressable onPress={() => removeFns(item.fnsId)}>
+                  <Pressable accessibilityLabel="Удалить отделение" onPress={() => removeFns(item.fnsId)}>
                     <FontAwesome name="times" size={16} color="#94a3b8" />
                   </Pressable>
                 </View>
@@ -187,6 +187,7 @@ export default function OnboardingWorkAreaScreen() {
                   return (
                     <Pressable
                       key={svc.id}
+                      accessibilityLabel={svc.name}
                       onPress={() => toggleService(item.fnsId, svc.id)}
                       className="flex-row items-center py-1.5"
                     >
@@ -225,6 +226,7 @@ export default function OnboardingWorkAreaScreen() {
                   {cities.map((city) => (
                     <Pressable
                       key={city.id}
+                      accessibilityLabel={city.name}
                       onPress={() => handleCitySelect(city)}
                       className="px-4 py-3 border-b border-slate-100 active:bg-slate-50"
                     >
@@ -254,6 +256,7 @@ export default function OnboardingWorkAreaScreen() {
                     .map((fns) => (
                       <Pressable
                         key={fns.id}
+                        accessibilityLabel={fns.name}
                         onPress={() => handleFnsSelect(fns)}
                         className="px-4 py-3 border-b border-slate-100 active:bg-slate-50"
                       >
@@ -279,6 +282,7 @@ export default function OnboardingWorkAreaScreen() {
             {/* Add city button */}
             {!showCityPicker && !showFnsPicker && (
               <Pressable
+                accessibilityLabel="Добавить город"
                 onPress={() => {
                   setShowCityPicker(true);
                   setShowFnsPicker(false);
@@ -294,6 +298,7 @@ export default function OnboardingWorkAreaScreen() {
 
             {showCityPicker && (
               <Pressable
+                accessibilityLabel="Отмена"
                 onPress={() => setShowCityPicker(false)}
                 className="mb-4"
               >
@@ -305,6 +310,7 @@ export default function OnboardingWorkAreaScreen() {
 
             {showFnsPicker && (
               <Pressable
+                accessibilityLabel="Отмена"
                 onPress={() => {
                   setShowFnsPicker(false);
                   setSelectedCityId(null);
@@ -324,6 +330,7 @@ export default function OnboardingWorkAreaScreen() {
             ) : null}
 
             <Pressable
+              accessibilityLabel="Далее"
               onPress={handleNext}
               disabled={!canProceed || isLoading}
               className={`h-12 rounded-xl items-center justify-center ${

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -144,6 +144,7 @@ export default function MyRequestDetail() {
             {error || "Заявка не найдена"}
           </Text>
           <Pressable
+            accessibilityLabel="Назад"
             onPress={() => router.back()}
             className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
           >
@@ -169,7 +170,7 @@ export default function MyRequestDetail() {
       <HeaderBack
         title={request.title}
         rightAction={
-          <Pressable onPress={handleDelete}>
+          <Pressable accessibilityLabel="Удалить заявку" onPress={handleDelete}>
             <FontAwesome name="trash-o" size={18} color="#ef4444" />
           </Pressable>
         }
@@ -209,6 +210,7 @@ export default function MyRequestDetail() {
                 {request.files.map((file) => (
                   <Pressable
                     key={file.id}
+                    accessibilityLabel={`Открыть файл ${file.filename}`}
                     onPress={() => handleFilePress(file)}
                     className="flex-row items-center bg-slate-50 rounded-lg p-3 mb-2"
                   >
@@ -233,6 +235,7 @@ export default function MyRequestDetail() {
 
             {/* Messages button */}
             <Pressable
+              accessibilityLabel="Сообщения"
               onPress={() => router.push(`/requests/${id}/messages` as never)}
               className="flex-row items-center justify-center bg-slate-50 border border-slate-200 rounded-xl py-3 mb-4"
             >
@@ -245,6 +248,7 @@ export default function MyRequestDetail() {
             {/* Extend button (for closing_soon) */}
             {canExtend && (
               <Pressable
+                accessibilityLabel="Продлить заявку"
                 onPress={handleExtend}
                 disabled={extending}
                 className="bg-amber-500 rounded-xl py-3 items-center mb-4"

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -78,6 +78,7 @@ export default function PublicRequestDetail() {
             {error || "Заявка не найдена"}
           </Text>
           <Pressable
+            accessibilityLabel="Назад"
             onPress={() => router.back()}
             className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
           >
@@ -152,6 +153,7 @@ export default function PublicRequestDetail() {
         <ResponsiveContainer>
           {isAuthenticated && isSpecialist ? (
             <Pressable
+              accessibilityLabel="Написать клиенту"
               onPress={() => router.push(`/requests/${id}/write` as never)}
               className="bg-blue-900 rounded-xl py-3 items-center"
             >
@@ -161,6 +163,7 @@ export default function PublicRequestDetail() {
             </Pressable>
           ) : (
             <Pressable
+              accessibilityLabel={isAuthenticated ? "Написать клиенту" : "Войти для ответа"}
               onPress={() => router.push("/(auth)/email" as never)}
               className="bg-blue-900 rounded-xl py-3 items-center"
             >

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -132,6 +132,7 @@ export default function SpecialistConfirmWrite() {
             Ваше сообщение
           </Text>
           <TextInput
+            accessibilityLabel="Ваше сообщение"
             value={message}
             onChangeText={setMessage}
             placeholder="Здравствуйте! Могу помочь с..."
@@ -162,6 +163,7 @@ export default function SpecialistConfirmWrite() {
 
           {/* Actions */}
           <Pressable
+            accessibilityLabel="Отправить"
             onPress={handleSend}
             disabled={message.length < 10 || sending}
             className={`rounded-xl py-3 items-center mt-4 ${
@@ -176,6 +178,7 @@ export default function SpecialistConfirmWrite() {
           </Pressable>
 
           <Pressable
+            accessibilityLabel="Отмена"
             onPress={() => router.back()}
             className="rounded-xl py-3 items-center mt-2 bg-slate-100"
           >

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -125,6 +125,7 @@ export default function NewRequest() {
               Заголовок
             </Text>
             <TextInput
+              accessibilityLabel="Заголовок заявки"
               value={title}
               onChangeText={setTitle}
               placeholder="Опишите кратко вашу ситуацию"
@@ -149,6 +150,7 @@ export default function NewRequest() {
               Город
             </Text>
             <Pressable
+              accessibilityLabel="Выбрать город"
               onPress={() => { setCityOpen(!cityOpen); setFnsOpen(false); }}
               className="h-12 border border-slate-200 rounded-[10px] bg-slate-50 px-4 flex-row items-center justify-between"
             >
@@ -162,6 +164,7 @@ export default function NewRequest() {
                 {cities.map((city) => (
                   <Pressable
                     key={city.id}
+                    accessibilityLabel={city.name}
                     onPress={() => handleCitySelect(city.id)}
                     className="px-4 py-3 border-b border-slate-50 active:bg-slate-50"
                   >
@@ -176,6 +179,7 @@ export default function NewRequest() {
               Отделение ФНС
             </Text>
             <Pressable
+              accessibilityLabel="Выбрать отделение ФНС"
               onPress={() => {
                 if (!selectedCityId) return;
                 setFnsOpen(!fnsOpen);
@@ -200,6 +204,7 @@ export default function NewRequest() {
                 {fnsOptions.map((fns) => (
                   <Pressable
                     key={fns.id}
+                    accessibilityLabel={`${fns.name} (${fns.code})`}
                     onPress={() => handleFnsSelect(fns.id)}
                     className="px-4 py-3 border-b border-slate-50 active:bg-slate-50"
                   >
@@ -216,6 +221,7 @@ export default function NewRequest() {
               Описание
             </Text>
             <TextInput
+              accessibilityLabel="Описание заявки"
               value={description}
               onChangeText={setDescription}
               placeholder="Опишите подробно вашу ситуацию (минимум 10 символов)"
@@ -246,6 +252,7 @@ export default function NewRequest() {
       <View className="border-t border-slate-200 px-4 py-3 bg-white">
         <View className="w-full" style={{ maxWidth: 520, alignSelf: "center" }}>
           <Pressable
+            accessibilityLabel="Опубликовать"
             onPress={handleSubmit}
             disabled={!formValid || submitting}
             className={`rounded-xl py-3 items-center ${

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -100,6 +100,7 @@ export default function ClientSettings() {
             {/* Name inputs */}
             <Text className="text-sm font-medium text-slate-900 mb-1">Имя</Text>
             <TextInput
+              accessibilityLabel="Имя"
               value={firstName}
               onChangeText={setFirstName}
               placeholder="Введите имя"
@@ -118,6 +119,7 @@ export default function ClientSettings() {
 
             <Text className="text-sm font-medium text-slate-900 mb-1">Фамилия</Text>
             <TextInput
+              accessibilityLabel="Фамилия"
               value={lastName}
               onChangeText={setLastName}
               placeholder="Введите фамилию"
@@ -141,6 +143,7 @@ export default function ClientSettings() {
 
             {/* Save button */}
             <Pressable
+              accessibilityLabel="Сохранить"
               onPress={handleSave}
               disabled={!hasChanges || saving}
               className={`rounded-xl py-3 items-center mb-6 ${
@@ -160,15 +163,16 @@ export default function ClientSettings() {
             </Text>
             <View className="flex-row items-center justify-between py-3 border-b border-slate-100">
               <Text className="text-base text-slate-900">Push-уведомления</Text>
-              <Switch value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+              <Switch accessibilityLabel="Push-уведомления" value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
             </View>
             <View className="flex-row items-center justify-between py-3 border-b border-slate-100 mb-6">
               <Text className="text-base text-slate-900">Email-уведомления</Text>
-              <Switch value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+              <Switch accessibilityLabel="Email-уведомления" value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
             </View>
 
             {/* Links */}
             <Pressable
+              accessibilityLabel="Условия использования"
               onPress={() => router.push("/legal/terms" as never)}
               className="flex-row items-center py-3 border-b border-slate-100"
             >
@@ -181,6 +185,7 @@ export default function ClientSettings() {
 
             {/* Logout */}
             <Pressable
+              accessibilityLabel="Выйти"
               onPress={handleLogout}
               className="mt-6 bg-red-600 rounded-xl py-3 items-center"
             >

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -17,6 +17,7 @@ function SettingRow({
 }) {
   return (
     <Pressable
+      accessibilityLabel={label}
       onPress={onPress}
       className="flex-row items-center px-4 py-4 border-b border-slate-50 active:bg-slate-50"
     >
@@ -48,7 +49,7 @@ export default function SettingsScreen() {
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
         {/* Header */}
         <View className="flex-row items-center px-4 pt-2 pb-3 border-b border-slate-50">
-          <Pressable onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
             <FontAwesome name="arrow-left" size={18} color="#0f172a" />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Настройки</Text>
@@ -59,21 +60,21 @@ export default function SettingsScreen() {
           icon="bell"
           label="Push-уведомления"
           rightElement={
-            <Switch value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Push-уведомления" value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
           }
         />
         <SettingRow
           icon="envelope"
           label="Email-уведомления"
           rightElement={
-            <Switch value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Email-уведомления" value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
           }
         />
         <SettingRow
           icon="comments"
           label="Уведомления о сообщениях"
           rightElement={
-            <Switch value={messageEnabled} onValueChange={setMessageEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Уведомления о сообщениях" value={messageEnabled} onValueChange={setMessageEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
           }
         />
 

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -170,7 +170,7 @@ export default function SpecialistSettings() {
                 {(lastName[0] || "").toUpperCase()}
               </Text>
             </View>
-            <Pressable className="mt-2 py-2 px-3">
+            <Pressable accessibilityLabel="Изменить фото" className="mt-2 py-2 px-3">
               <Text className="text-sm text-blue-900 font-medium">
                 Изменить фото
               </Text>
@@ -182,6 +182,7 @@ export default function SpecialistSettings() {
             Имя *
           </Text>
           <TextInput
+            accessibilityLabel="Имя"
             value={firstName}
             onChangeText={setFirstName}
             placeholder="Имя"
@@ -203,6 +204,7 @@ export default function SpecialistSettings() {
             Фамилия *
           </Text>
           <TextInput
+            accessibilityLabel="Фамилия"
             value={lastName}
             onChangeText={setLastName}
             placeholder="Фамилия"
@@ -256,6 +258,7 @@ export default function SpecialistSettings() {
 
           <Text className="text-xs text-slate-400 mb-1">Телефон</Text>
           <TextInput
+            accessibilityLabel="Телефон"
             value={phone}
             onChangeText={setPhone}
             placeholder="+7 (___) ___-__-__"
@@ -275,6 +278,7 @@ export default function SpecialistSettings() {
 
           <Text className="text-xs text-slate-400 mt-3 mb-1">Telegram</Text>
           <TextInput
+            accessibilityLabel="Telegram"
             value={telegram}
             onChangeText={setTelegram}
             placeholder="@username"
@@ -294,6 +298,7 @@ export default function SpecialistSettings() {
 
           <Text className="text-xs text-slate-400 mt-3 mb-1">WhatsApp</Text>
           <TextInput
+            accessibilityLabel="WhatsApp"
             value={whatsapp}
             onChangeText={setWhatsapp}
             placeholder="+7 (___) ___-__-__"
@@ -313,6 +318,7 @@ export default function SpecialistSettings() {
 
           <Text className="text-xs text-slate-400 mt-3 mb-1">Адрес офиса</Text>
           <TextInput
+            accessibilityLabel="Адрес офиса"
             value={officeAddress}
             onChangeText={setOfficeAddress}
             placeholder="Адрес"
@@ -331,6 +337,7 @@ export default function SpecialistSettings() {
 
           <Text className="text-xs text-slate-400 mt-3 mb-1">Часы работы</Text>
           <TextInput
+            accessibilityLabel="Часы работы"
             value={workingHours}
             onChangeText={setWorkingHours}
             placeholder="Пн-Пт 9:00-18:00"
@@ -358,6 +365,7 @@ export default function SpecialistSettings() {
               </Text>
             </View>
             <Switch
+              accessibilityLabel="Принимаю заявки"
               value={isAvailable}
               onValueChange={handleToggleAvailable}
               trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
@@ -373,6 +381,7 @@ export default function SpecialistSettings() {
           <View className="flex-row items-center justify-between py-3 border-b border-slate-100">
             <Text className="text-sm text-slate-900">Push-уведомления</Text>
             <Switch
+              accessibilityLabel="Push-уведомления"
               value={pushEnabled}
               onValueChange={setPushEnabled}
               trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
@@ -383,6 +392,7 @@ export default function SpecialistSettings() {
           <View className="flex-row items-center justify-between py-3 border-b border-slate-100">
             <Text className="text-sm text-slate-900">Email-уведомления</Text>
             <Switch
+              accessibilityLabel="Email-уведомления"
               value={emailEnabled}
               onValueChange={setEmailEnabled}
               trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
@@ -392,6 +402,7 @@ export default function SpecialistSettings() {
 
           {/* Save button */}
           <Pressable
+            accessibilityLabel="Сохранить"
             onPress={handleSave}
             disabled={saving}
             className={`rounded-xl py-3 items-center mt-6 ${
@@ -409,6 +420,7 @@ export default function SpecialistSettings() {
 
           {/* Logout */}
           <Pressable
+            accessibilityLabel="Выйти"
             onPress={handleLogout}
             className="rounded-xl py-3 items-center mt-3 border border-red-600"
           >

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -118,6 +118,7 @@ export default function SpecialistPublicProfile() {
             {error || "Специалист не найден"}
           </Text>
           <Pressable
+            accessibilityLabel="Назад"
             onPress={() => router.back()}
             className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
           >
@@ -134,7 +135,7 @@ export default function SpecialistPublicProfile() {
   const initials = getInitials(specialist.firstName, specialist.lastName);
 
   const rightAction = isOwnProfile ? (
-    <Pressable onPress={() => router.push("/settings" as never)}>
+    <Pressable accessibilityLabel="Редактировать профиль" onPress={() => router.push("/settings" as never)}>
       <FontAwesome name="pencil" size={16} color="#0f172a" />
     </Pressable>
   ) : undefined;
@@ -209,6 +210,7 @@ export default function SpecialistPublicProfile() {
                 <View className="bg-slate-50 border border-slate-200 rounded-xl p-4">
                   {specialist.profile.phone && (
                     <Pressable
+                      accessibilityLabel={`Позвонить ${specialist.profile!.phone}`}
                       onPress={() => Linking.openURL(`tel:${specialist.profile!.phone}`)}
                       className="flex-row items-center mb-3"
                     >
@@ -220,6 +222,7 @@ export default function SpecialistPublicProfile() {
                   )}
                   {specialist.profile.telegram && (
                     <Pressable
+                      accessibilityLabel={`Telegram ${specialist.profile!.telegram}`}
                       onPress={() =>
                         Linking.openURL(
                           `https://t.me/${specialist.profile!.telegram!.replace("@", "")}`
@@ -235,6 +238,7 @@ export default function SpecialistPublicProfile() {
                   )}
                   {specialist.profile.whatsapp && (
                     <Pressable
+                      accessibilityLabel={`WhatsApp ${specialist.profile!.whatsapp}`}
                       onPress={() =>
                         Linking.openURL(
                           `https://wa.me/${specialist.profile!.whatsapp!.replace(/\D/g, "")}`

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -221,6 +221,7 @@ export default function ChatThread() {
         {!isClosed && (
           <View className="flex-row items-end border-t border-slate-200 px-3 py-2 bg-white">
             <TextInput
+              accessibilityLabel="Написать сообщение"
               value={text}
               onChangeText={setText}
               placeholder="Написать сообщение..."
@@ -241,6 +242,7 @@ export default function ChatThread() {
               }}
             />
             <Pressable
+              accessibilityLabel="Отправить сообщение"
               onPress={handleSend}
               disabled={!text.trim() || sending}
               className="w-10 h-10 items-center justify-center ml-2"

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -27,6 +27,7 @@ export default function EmptyState({
       )}
       {actionLabel && onAction && (
         <Pressable
+          accessibilityLabel={actionLabel}
           onPress={onAction}
           className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
         >

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -29,6 +29,7 @@ function FilterChip({
 }) {
   return (
     <Pressable
+      accessibilityLabel={label}
       onPress={onPress}
       className={`px-3 py-1.5 rounded-full mr-2 mb-2 border ${
         active ? "bg-blue-900 border-blue-900" : "bg-white border-slate-200"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
     return (
       <>
         <View className="flex-row items-center justify-between px-4 h-14 bg-white border-b border-slate-100">
-          <Pressable onPress={() => setMenuOpen(true)} className="w-10 h-10 items-center justify-center">
+          <Pressable accessibilityLabel="Открыть меню" onPress={() => setMenuOpen(true)} className="w-10 h-10 items-center justify-center">
             <FontAwesome name="bars" size={20} color="#0f172a" />
           </Pressable>
 
@@ -27,12 +27,14 @@ export default function Header() {
           {isAuthenticated ? (
             <View className="flex-row items-center gap-3">
               <Pressable
+                accessibilityLabel="Уведомления"
                 onPress={() => router.push("/notifications" as never)}
                 className="w-10 h-10 items-center justify-center"
               >
                 <FontAwesome name="bell-o" size={18} color="#0f172a" />
               </Pressable>
               <Pressable
+                accessibilityLabel="Профиль"
                 onPress={() => {
                   const settingsPath = user?.role === "SPECIALIST"
                     ? "/settings/specialist"
@@ -46,6 +48,7 @@ export default function Header() {
             </View>
           ) : (
             <Pressable
+              accessibilityLabel="Войти"
               onPress={() => router.push("/auth/email" as never)}
               className="px-4 h-9 rounded-lg bg-blue-900 items-center justify-center"
             >
@@ -62,19 +65,21 @@ export default function Header() {
   // Desktop header
   return (
     <View className="flex-row items-center justify-between px-6 h-16 bg-white border-b border-slate-100">
-      <Pressable onPress={() => router.push("/" as never)}>
+      <Pressable accessibilityLabel="Главная" onPress={() => router.push("/" as never)}>
         <Text className="text-xl font-bold text-blue-900">P2PTax</Text>
       </Pressable>
 
       {isAuthenticated ? (
         <View className="flex-row items-center gap-3">
           <Pressable
+            accessibilityLabel="Уведомления"
             onPress={() => router.push("/notifications" as never)}
             className="w-10 h-10 rounded-lg items-center justify-center active:bg-slate-100"
           >
             <FontAwesome name="bell-o" size={18} color="#0f172a" />
           </Pressable>
           <Pressable
+            accessibilityLabel="Профиль"
             onPress={() => {
               const settingsPath = user?.role === "SPECIALIST"
                 ? "/settings/specialist"
@@ -88,6 +93,7 @@ export default function Header() {
         </View>
       ) : (
         <Pressable
+          accessibilityLabel="Войти"
           onPress={() => router.push("/auth/email" as never)}
           className="px-5 h-10 rounded-lg bg-blue-900 items-center justify-center active:bg-slate-900"
         >

--- a/components/HeaderBack.tsx
+++ b/components/HeaderBack.tsx
@@ -13,6 +13,7 @@ export default function HeaderBack({ title, rightAction }: HeaderBackProps) {
   return (
     <View className="flex-row items-center h-14 bg-white border-b border-slate-200 px-4">
       <Pressable
+        accessibilityLabel="Назад"
         onPress={() => router.back()}
         className="w-11 h-11 items-center justify-center -ml-2"
       >

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -15,6 +15,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
       <Text className="text-lg font-bold text-white">P2PTax</Text>
       <View className="flex-row items-center gap-4">
         <Pressable
+          accessibilityLabel="Уведомления"
           onPress={() => router.push("/notifications" as never)}
           className="w-10 h-10 items-center justify-center"
         >
@@ -29,6 +30,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
         </Pressable>
         {onSettingsPress && (
           <Pressable
+            accessibilityLabel="Настройки"
             onPress={onSettingsPress}
             className="w-10 h-10 items-center justify-center"
           >

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -58,6 +58,7 @@ export default function MessageBubble({
         {imageFiles.map((img) => (
           <Pressable
             key={img.id}
+            accessibilityLabel={`Изображение ${img.filename}`}
             onPress={() => onImagePress?.(img.url)}
             className="mb-1"
           >
@@ -81,6 +82,7 @@ export default function MessageBubble({
         {docFiles.map((file) => (
           <Pressable
             key={file.id}
+            accessibilityLabel={`Файл ${file.filename}`}
             onPress={() => onFilePress?.(file)}
             className={`flex-row items-center rounded-lg p-2 mb-1 ${
               isOwn ? "bg-blue-800" : "bg-slate-100"

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -37,7 +37,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
 
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <Pressable onPress={onClose} className="flex-1 flex-row bg-black/50">
+      <Pressable accessibilityLabel="Закрыть меню" onPress={onClose} className="flex-1 flex-row bg-black/50">
         <Pressable className="w-72 bg-white h-full" onPress={() => {}}>
           {/* User info */}
           <View className="pt-14 pb-6 px-5 bg-blue-900">
@@ -61,7 +61,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
           </View>
 
           {/* Close button */}
-          <Pressable onPress={onClose} className="absolute top-12 right-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Закрыть меню" onPress={onClose} className="absolute top-12 right-3 w-8 h-8 items-center justify-center">
             <FontAwesome name="times" size={20} color="#ffffff" />
           </Pressable>
 
@@ -70,6 +70,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
             {MENU_ITEMS.map((item) => (
               <Pressable
                 key={item.label}
+                accessibilityLabel={item.label}
                 onPress={() => handleNavigate(item.route)}
                 className="flex-row items-center px-5 py-3.5 active:bg-slate-50"
               >
@@ -84,12 +85,13 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
           {/* Bottom actions */}
           <View className="border-t border-slate-100 px-5 py-4 pb-8">
             {isAuthenticated ? (
-              <Pressable onPress={handleLogout} className="flex-row items-center py-3">
+              <Pressable accessibilityLabel="Выйти" onPress={handleLogout} className="flex-row items-center py-3">
                 <FontAwesome name="sign-out" size={18} color="#dc2626" />
                 <Text className="text-base font-medium text-red-600 ml-3">Выйти</Text>
               </Pressable>
             ) : (
               <Pressable
+                accessibilityLabel="Войти"
                 onPress={() => handleNavigate("/auth/email")}
                 className="h-12 rounded-xl bg-blue-900 items-center justify-center"
               >

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -24,6 +24,7 @@ export default function RequestCard({
 }: RequestCardProps) {
   return (
     <Pressable
+      accessibilityLabel={title}
       onPress={() => onPress(id)}
       className="bg-white border border-slate-200 rounded-xl p-4 mb-3"
     >

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -33,6 +33,7 @@ export default function SpecialistCard({
   if (horizontal) {
     return (
       <Pressable
+        accessibilityLabel={name}
         onPress={() => onPress(id)}
         className="bg-white border border-slate-200 rounded-xl p-4 mr-3"
         style={{ width: 200 }}
@@ -64,6 +65,7 @@ export default function SpecialistCard({
 
   return (
     <Pressable
+      accessibilityLabel={name}
       onPress={() => onPress(id)}
       className="bg-white border border-slate-200 rounded-xl p-4 mb-3"
     >

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -45,6 +45,7 @@ export default function Button({
 
   return (
     <Pressable
+      accessibilityLabel={label}
       onPress={onPress}
       disabled={disabled || loading}
       className={`${styles.container} ${widthClass} ${opacityClass}`}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -62,6 +62,7 @@ export default function Input({
           />
         )}
         <TextInput
+          accessibilityLabel={label || placeholder}
           value={value}
           onChangeText={onChangeText}
           placeholder={placeholder}


### PR DESCRIPTION
## Summary
- Adds `accessibilityLabel` to every `Pressable`, `TextInput`, and `Switch` across 43 files
- Labels are in Russian (project language), matching visible text or describing the action for icon-only buttons
- No functional changes — purely accessibility metadata

## Scope
- 20 screen files (auth, onboarding, settings, requests, threads, specialists, admin, legal, listing, notifications)
- 10 tab screens (client-tabs, specialist-tabs, admin-tabs, generic tabs)
- 13 shared components (Header, HeaderBack, HeaderHome, MobileMenu, RequestCard, SpecialistCard, EmptyState, FilterBar, MessageBubble, ui/Button, ui/Input)
- ~150 labels total

## Test plan
- [x] `npx tsc --noEmit` passes with 0 errors
- [ ] Screen reader (VoiceOver / TalkBack) reads labels correctly on key flows