### PR TITLE
feat(onboarding): OnboardingWorkArea screen — closes #1047

### DIFF
--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -57,11 +57,11 @@ export default function OnboardingWorkAreaScreen() {
     const loadData = async () => {
       try {
         const [citiesRes, servicesRes] = await Promise.all([
-          api<{ cities: City[] }>("/api/cities", { noAuth: true }),
-          api<{ services: ServiceItem[] }>("/api/services", { noAuth: true }),
+          api<{ items: City[] }>("/api/cities", { noAuth: true }),
+          api<{ items: ServiceItem[] }>("/api/services", { noAuth: true }),
         ]);
-        setCities(citiesRes.cities);
-        setServices(servicesRes.services);
+        setCities(citiesRes.items);
+        setServices(servicesRes.items);
       } catch {
         setError("Не удалось загрузить данные");
       }


### PR DESCRIPTION
Implements /onboarding/work-area — step 2/3 with city→FNS cascade select and services checkboxes.

**What's in this PR:**
- Screen was pre-built; fixed API response key mismatch: `/api/cities` and `/api/services` return `{items:[]}` not `{cities:[]}` / `{services:[]}`
- All other logic was already correct: city picker → FNS cascade load → service checkboxes per FNS → chip display with remove → "Next" disabled until ≥1 FNS + ≥1 service

**tsc result:** 0 errors (frontend + backend)

Closes #1047