### PR TITLE
feat(onboarding): OnboardingProfile screen — closes #1048

### DIFF
--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -5,18 +5,27 @@ import {
   Pressable,
   ActivityIndicator,
   ScrollView,
+  Image,
+  Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
+import { useAuth } from "@/contexts/AuthContext";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3812";
 
 export default function OnboardingProfileScreen() {
   const router = useRouter();
+  const { updateUser } = useAuth();
 
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
   const [description, setDescription] = useState("");
   const [phone, setPhone] = useState("");
   const [telegram, setTelegram] = useState("");
@@ -26,18 +35,72 @@ export default function OnboardingProfileScreen() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
+  // Web-only hidden file input ref
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
   const formatPhone = (text: string) => {
-    // Keep only digits
     const digits = text.replace(/\D/g, "");
-    // Auto-prepend 7 if user starts typing
     if (digits.length === 0) return "";
     let formatted = "+7";
-    const rest = digits.startsWith("7") ? digits.slice(1) : digits.startsWith("8") ? digits.slice(1) : digits;
+    const rest = digits.startsWith("7")
+      ? digits.slice(1)
+      : digits.startsWith("8")
+        ? digits.slice(1)
+        : digits;
     if (rest.length > 0) formatted += " (" + rest.slice(0, 3);
     if (rest.length >= 3) formatted += ") " + rest.slice(3, 6);
     if (rest.length >= 6) formatted += "-" + rest.slice(6, 8);
     if (rest.length >= 8) formatted += "-" + rest.slice(8, 10);
     return formatted;
+  };
+
+  const uploadAvatar = async (file: File) => {
+    setAvatarUploading(true);
+    setError("");
+    try {
+      const token = await AsyncStorage.getItem("p2ptax_access_token");
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch(`${API_URL}/api/upload/avatar`, {
+        method: "POST",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || "Не удалось загрузить фото");
+      }
+
+      const data = (await res.json()) as { url: string; key: string };
+      // Build full URL from relative path returned by server
+      const fullUrl = data.url.startsWith("http")
+        ? data.url
+        : `${API_URL}${data.url}`;
+      setAvatarUrl(fullUrl);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Ошибка загрузки фото";
+      setError(msg);
+    } finally {
+      setAvatarUploading(false);
+    }
+  };
+
+  const handleAvatarPress = () => {
+    if (Platform.OS === "web" && fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+    // Native: expo-image-picker not installed — web-only upload for now
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      void uploadAvatar(file);
+      // Reset so the same file can be re-selected
+      e.target.value = "";
+    }
   };
 
   const handleSubmit = async () => {
@@ -55,8 +118,13 @@ export default function OnboardingProfileScreen() {
           whatsapp: whatsapp.trim() || null,
           officeAddress: officeAddress.trim() || null,
           workingHours: workingHours.trim() || null,
+          avatarUrl: avatarUrl || null,
         },
       });
+
+      if (avatarUrl) {
+        updateUser({ avatarUrl });
+      }
 
       router.replace("/(specialist-tabs)/dashboard" as never);
     } catch (e: unknown) {
@@ -71,24 +139,91 @@ export default function OnboardingProfileScreen() {
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
       <ResponsiveContainer>
-        <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 40 }}>
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
           <View style={{ paddingTop: "6%" }}>
+            {/* Step indicator */}
             <Text className="text-sm text-amber-700 text-center mb-2">
               Шаг 3 из 3
             </Text>
-            <Text className="text-2xl font-bold text-slate-900 text-center mb-6">
+            <Text className="text-2xl font-bold text-slate-900 text-center mb-1">
               Профиль
             </Text>
+            <Text className="text-sm text-slate-500 text-center mb-6">
+              Всё необязательно — можно заполнить позже
+            </Text>
 
-            {/* Avatar area */}
-            <Pressable accessibilityLabel="Добавить фото" className="items-center mb-6">
-              <View className="w-20 h-20 rounded-full bg-slate-100 items-center justify-center border-2 border-dashed border-slate-300">
-                <FontAwesome name="camera" size={24} color="#94a3b8" />
-              </View>
+            {/* Avatar upload */}
+            <Pressable
+              accessibilityLabel="Добавить фото"
+              onPress={handleAvatarPress}
+              className="items-center mb-6"
+            >
+              {avatarUploading ? (
+                <View
+                  className="items-center justify-center rounded-full bg-slate-100"
+                  style={{ width: 80, height: 80 }}
+                >
+                  <ActivityIndicator color="#1e3a8a" />
+                </View>
+              ) : avatarUrl ? (
+                <View>
+                  <Image
+                    source={{ uri: avatarUrl }}
+                    style={{
+                      width: 80,
+                      height: 80,
+                      borderRadius: 40,
+                      borderWidth: 2,
+                      borderColor: "#e2e8f0",
+                    }}
+                  />
+                  <View
+                    className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
+                    style={{ width: 24, height: 24 }}
+                  >
+                    <FontAwesome name="pencil" size={12} color="#fff" />
+                  </View>
+                </View>
+              ) : (
+                <View
+                  className="rounded-full bg-slate-100 items-center justify-center"
+                  style={{
+                    width: 80,
+                    height: 80,
+                    borderWidth: 2,
+                    borderColor: "#cbd5e1",
+                    borderStyle: "dashed",
+                  }}
+                >
+                  <FontAwesome name="camera" size={24} color="#94a3b8" />
+                </View>
+              )}
               <Text className="text-sm text-slate-400 mt-2">
-                Добавить фото
+                {avatarUrl ? "Изменить фото" : "Нажмите, чтобы загрузить фото"}
               </Text>
             </Pressable>
+
+            {/* Hidden web file input */}
+            {Platform.OS === "web" && (
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                style={{ display: "none" }}
+                onChange={handleFileChange}
+              />
+            )}
+
+            {/* Contacts note */}
+            <View className="bg-blue-50 rounded-xl px-4 py-3 mb-4">
+              <Text className="text-xs text-blue-800 text-center">
+                Контакты будут видны всем посетителям платформы
+              </Text>
+            </View>
 
             {/* About */}
             <Text className="text-sm text-slate-500 mb-1">О себе</Text>
@@ -107,7 +242,7 @@ export default function OnboardingProfileScreen() {
                 textAlignVertical: "top",
                 marginBottom: 4,
               }}
-              placeholder="Расскажите о своем опыте..."
+              placeholder="Расскажите о своём опыте: сколько лет в профессии, какие вопросы решаете, с какими инспекциями работаете"
               placeholderTextColor="#94a3b8"
               value={description}
               onChangeText={(t) => {
@@ -192,6 +327,7 @@ export default function OnboardingProfileScreen() {
             {/* Office address */}
             <Text className="text-sm text-slate-500 mb-1">Адрес офиса</Text>
             <TextInput
+              accessibilityLabel="Адрес офиса"
               style={{
                 height: 48,
                 borderRadius: 12,
@@ -203,8 +339,7 @@ export default function OnboardingProfileScreen() {
                 color: "#0f172a",
                 marginBottom: 16,
               }}
-              accessibilityLabel="Адрес офиса"
-              placeholder="г. Москва, ул. Примерная, 1"
+              placeholder="г. Москва, ул. Примерная, д. 1, оф. 100"
               placeholderTextColor="#94a3b8"
               value={officeAddress}
               onChangeText={setOfficeAddress}
@@ -214,6 +349,7 @@ export default function OnboardingProfileScreen() {
             {/* Working hours */}
             <Text className="text-sm text-slate-500 mb-1">Часы работы</Text>
             <TextInput
+              accessibilityLabel="Часы работы"
               style={{
                 height: 48,
                 borderRadius: 12,
@@ -225,7 +361,6 @@ export default function OnboardingProfileScreen() {
                 color: "#0f172a",
                 marginBottom: 24,
               }}
-              accessibilityLabel="Часы работы"
               placeholder="Пн-Пт 9:00-18:00"
               placeholderTextColor="#94a3b8"
               value={workingHours}
@@ -240,11 +375,11 @@ export default function OnboardingProfileScreen() {
             ) : null}
 
             <Pressable
-              accessibilityLabel="Завершить"
+              accessibilityLabel="Завершить регистрацию"
               onPress={handleSubmit}
-              disabled={isLoading}
+              disabled={isLoading || avatarUploading}
               className={`h-12 rounded-xl items-center justify-center ${
-                isLoading
+                isLoading || avatarUploading
                   ? "bg-blue-900 opacity-50"
                   : "bg-blue-900 active:bg-slate-900"
               }`}
@@ -253,9 +388,19 @@ export default function OnboardingProfileScreen() {
                 <ActivityIndicator color="#ffffff" />
               ) : (
                 <Text className="text-white text-base font-semibold">
-                  Завершить
+                  Завершить регистрацию
                 </Text>
               )}
+            </Pressable>
+
+            {/* Skip link */}
+            <Pressable
+              accessibilityLabel="Пропустить"
+              onPress={handleSubmit}
+              disabled={isLoading || avatarUploading}
+              className="items-center mt-4 py-2"
+            >
+              <Text className="text-sm text-slate-400">Пропустить</Text>
             </Pressable>
           </View>
         </ScrollView>


### PR DESCRIPTION
Implements `/onboarding/profile` — step 3/3 with avatar upload, contact fields, and description.

## Changes

- Avatar upload: hidden `<input type="file">` on web, uploads to `POST /api/upload/avatar`, previews result with edit overlay
- All spec fields from SCREEN_MAP: description (1000 chars with counter), phone, telegram, whatsapp, office address, working hours
- Contacts info banner: "Контакты будут видны всем посетителям платформы"
- "Пропустить" skip link (all fields optional)
- Submit disabled while avatar is uploading
- `avatarUrl` passed to `PUT /api/onboarding/profile` and synced to AuthContext
- Frontend tsc: 0 errors

Closes #1048