### PR TITLE
feat(public): PublicRequestDetail screen — closes #1052

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { Prisma } from "@prisma/client";
 import { authMiddleware } from "../middleware/auth";
+import { verifyAccessToken } from "../lib/jwt";
 
 const router = Router();
 
@@ -61,16 +62,29 @@ router.get("/public", async (req: Request, res: Response) => {
   }
 });
 
-// GET /api/requests/:id/public — single request detail (public)
+// GET /api/requests/:id/public — single request detail (public, optional auth)
 router.get("/:id/public", async (req: Request, res: Response) => {
   try {
     const id = req.params.id as string;
+
+    // Resolve optional caller identity (specialist check for existing thread)
+    let callerId: string | null = null;
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith("Bearer ")) {
+      try {
+        const payload = verifyAccessToken(authHeader.slice(7));
+        callerId = payload.userId;
+      } catch {
+        // ignore invalid tokens — public route, auth is optional
+      }
+    }
+
     const result = await prisma.request.findUnique({
       where: { id },
       include: {
         city: true,
         fns: true,
-        user: true,
+        user: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
         _count: { select: { threads: true } },
       },
     });
@@ -78,6 +92,20 @@ router.get("/:id/public", async (req: Request, res: Response) => {
     if (!result) {
       res.status(404).json({ error: "Request not found" });
       return;
+    }
+
+    // Check if caller already has an existing thread on this request (specialist flow)
+    let hasExistingThread = false;
+    let existingThreadId: string | null = null;
+    if (callerId && callerId !== result.userId) {
+      const thread = await prisma.thread.findFirst({
+        where: { requestId: id, specialistId: callerId },
+        select: { id: true },
+      });
+      if (thread) {
+        hasExistingThread = true;
+        existingThreadId = thread.id;
+      }
     }
 
     res.json({
@@ -96,6 +124,8 @@ router.get("/:id/public", async (req: Request, res: Response) => {
         avatarUrl: result.user.avatarUrl,
       },
       threadsCount: result._count.threads,
+      hasExistingThread,
+      existingThreadId,
     });
   } catch (error) {
     console.error("requests/:id/public error:", error);

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -1,18 +1,13 @@
-import { useState, useEffect } from "react";
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  ActivityIndicator,
-} from "react-native";
+import { useState, useEffect, useCallback } from "react";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 
 interface RequestDetail {
   id: string;
@@ -30,40 +25,126 @@ interface RequestDetail {
     avatarUrl: string | null;
   };
   threadsCount: number;
+  hasExistingThread: boolean;
+  existingThreadId: string | null;
+}
+
+function DetailSkeleton() {
+  return (
+    <View className="py-4 px-4">
+      <View className="h-7 bg-slate-200 rounded-lg mb-2" style={{ width: "80%" }} />
+      <View className="h-7 bg-slate-200 rounded-lg mb-4" style={{ width: "55%" }} />
+      <View className="h-6 bg-slate-200 rounded-full mb-4" style={{ width: 80 }} />
+      <View className="flex-row gap-2 mb-4">
+        <View className="h-7 bg-slate-200 rounded-lg" style={{ width: 90 }} />
+        <View className="h-7 bg-slate-200 rounded-lg" style={{ width: 130 }} />
+      </View>
+      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "100%" }} />
+      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "92%" }} />
+      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "75%" }} />
+      <View className="h-4 bg-slate-200 rounded mb-6" style={{ width: "60%" }} />
+      <View className="border-t border-slate-100 pt-4 gap-3">
+        <View className="flex-row justify-between">
+          <View className="h-4 bg-slate-200 rounded" style={{ width: 60 }} />
+          <View className="h-4 bg-slate-200 rounded" style={{ width: 110 }} />
+        </View>
+        <View className="flex-row justify-between">
+          <View className="h-4 bg-slate-200 rounded" style={{ width: 80 }} />
+          <View className="h-4 bg-slate-200 rounded" style={{ width: 70 }} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function MetaRow({
+  label,
+  value,
+  last = false,
+}: {
+  label: string;
+  value: string;
+  last?: boolean;
+}) {
+  return (
+    <View
+      className={`flex-row justify-between items-center py-3 ${
+        !last ? "border-b border-slate-100" : ""
+      }`}
+    >
+      <Text className="text-sm text-slate-400">{label}</Text>
+      <Text className="text-sm text-slate-900 font-medium flex-1 text-right ml-4">
+        {value}
+      </Text>
+    </View>
+  );
 }
 
 export default function PublicRequestDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, isLoading: authLoading } = useAuth();
 
   const [request, setRequest] = useState<RequestDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await api<RequestDetail>(`/api/requests/${id}/public`, {
-          noAuth: true,
-        });
-        setRequest(res);
-      } catch (e) {
+  const load = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    setNotFound(false);
+    try {
+      // Optional auth: api() attaches token when available; API handles missing token gracefully
+      const res = await api<RequestDetail>(`/api/requests/${id}/public`);
+      setRequest(res);
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) {
+        setNotFound(true);
+      } else {
         setError("Не удалось загрузить заявку");
-        console.error("Request detail error:", e);
-      } finally {
-        setLoading(false);
+        console.error("PublicRequestDetail error:", e);
       }
+    } finally {
+      setLoading(false);
     }
-    if (id) load();
   }, [id]);
 
-  if (loading) {
+  useEffect(() => {
+    // Wait for auth to settle so the token is available before fetching
+    if (!authLoading) {
+      load();
+    }
+  }, [authLoading, load]);
+
+  if (loading || authLoading) {
+    return (
+      <SafeAreaView className="flex-1 bg-slate-50">
+        <HeaderBack title="Заявка" />
+        <ResponsiveContainer>
+          <DetailSkeleton />
+        </ResponsiveContainer>
+      </SafeAreaView>
+    );
+  }
+
+  if (notFound) {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Заявка" />
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a5f" />
+        <View className="flex-1 items-center justify-center px-6">
+          <Text className="text-2xl font-bold text-slate-900 text-center mb-2">
+            Заявка не найдена
+          </Text>
+          <Text className="text-base text-slate-500 text-center mb-6">
+            Возможно, она была удалена или вы перешли по неверной ссылке
+          </Text>
+          <Button
+            label="Назад к заявкам"
+            onPress={() => router.push("/requests" as never)}
+            fullWidth={false}
+          />
         </View>
       </SafeAreaView>
     );
@@ -73,26 +154,18 @@ export default function PublicRequestDetail() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Заявка" />
-        <View className="flex-1 items-center justify-center px-4">
-          <Text className="text-base text-red-600 text-center">
-            {error || "Заявка не найдена"}
+        <View className="flex-1 items-center justify-center px-6">
+          <Text className="text-base text-red-600 text-center mb-4">
+            {error || "Не удалось загрузить заявку"}
           </Text>
-          <Pressable
-            accessibilityLabel="Назад"
-            onPress={() => router.back()}
-            className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
-          >
-            <Text className="text-white font-semibold">Назад</Text>
-          </Pressable>
+          <Button variant="secondary" label="Повторить" onPress={load} fullWidth={false} />
         </View>
       </SafeAreaView>
     );
   }
 
+  const isOwner = !!user && user.id === request.user.id;
   const isSpecialist = user?.role === "SPECIALIST";
-  const authorName = [request.user.firstName, request.user.lastName]
-    .filter(Boolean)
-    .join(" ") || "Клиент";
 
   const createdDate = new Date(request.createdAt).toLocaleDateString("ru-RU", {
     day: "numeric",
@@ -100,80 +173,112 @@ export default function PublicRequestDetail() {
     year: "numeric",
   });
 
-  return (
-    <SafeAreaView className="flex-1 bg-white">
-      <HeaderBack title="Заявка" />
-      <ScrollView className="flex-1">
+  const responsesLabel =
+    request.threadsCount === 1
+      ? "1 специалист откликнулся"
+      : request.threadsCount > 0
+      ? `${request.threadsCount} специалистов откликнулись`
+      : "Нет откликов";
+
+  const renderFooter = () => {
+    if (isOwner) {
+      return (
+        <View className="border-t border-slate-100 bg-white px-4 py-3">
+          <ResponsiveContainer>
+            <View className="bg-slate-50 border border-slate-200 rounded-xl py-3 items-center">
+              <Text className="text-slate-500 text-sm font-medium">Ваша заявка</Text>
+            </View>
+          </ResponsiveContainer>
+        </View>
+      );
+    }
+
+    if (isAuthenticated && isSpecialist) {
+      if (request.hasExistingThread && request.existingThreadId) {
+        return (
+          <View className="border-t border-slate-100 bg-white px-4 py-3">
+            <ResponsiveContainer>
+              <Button
+                label="Открыть чат"
+                onPress={() =>
+                  router.push(`/threads/${request.existingThreadId}` as never)
+                }
+                icon="message-circle"
+              />
+            </ResponsiveContainer>
+          </View>
+        );
+      }
+      return (
+        <View className="border-t border-slate-100 bg-white px-4 py-3">
+          <ResponsiveContainer>
+            <Button
+              label="Написать клиенту"
+              onPress={() => router.push(`/requests/${id}/write` as never)}
+              icon="send"
+            />
+          </ResponsiveContainer>
+        </View>
+      );
+    }
+
+    // Guest or non-specialist authenticated user
+    return (
+      <View className="border-t border-slate-100 bg-white px-4 py-3">
         <ResponsiveContainer>
-          <View className="py-4">
-            {/* Title + status */}
-            <View className="flex-row items-start justify-between mb-3">
-              <Text className="text-2xl font-bold text-slate-900 flex-1 mr-3">
+          <Button
+            label="Войдите, чтобы откликнуться"
+            onPress={() => router.push("/auth/email" as never)}
+          />
+        </ResponsiveContainer>
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView className="flex-1 bg-slate-50">
+      <HeaderBack title="Заявка" />
+
+      <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 16 }}>
+        <ResponsiveContainer>
+          {/* Main card: title, status, chips, description */}
+          <View className="bg-white rounded-2xl mx-4 mt-4 px-4 py-5">
+            <View className="flex-row items-start justify-between mb-3 gap-2">
+              <Text className="text-2xl font-bold text-slate-900 flex-1 leading-tight">
                 {request.title}
               </Text>
               <StatusBadge status={request.status} />
             </View>
 
-            {/* Chips */}
-            <View className="flex-row flex-wrap gap-2 mb-4">
+            <View className="flex-row flex-wrap gap-2 mb-3">
               <View className="bg-slate-50 border border-slate-200 px-3 py-1 rounded-lg">
-                <Text className="text-sm text-slate-900">{request.city.name}</Text>
+                <Text className="text-sm text-slate-700">{request.city.name}</Text>
               </View>
               <View className="bg-slate-50 border border-slate-200 px-3 py-1 rounded-lg">
-                <Text className="text-sm text-slate-900">{request.fns.name}</Text>
+                <Text className="text-sm text-slate-700">{request.fns.name}</Text>
               </View>
             </View>
 
-            {/* Description */}
-            <Text className="text-base text-slate-900 leading-6 mb-4">
+            <Text className="text-xs text-slate-400 mb-4">{responsesLabel}</Text>
+
+            <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+              Описание
+            </Text>
+            <Text className="text-base text-slate-900 leading-6">
               {request.description}
             </Text>
+          </View>
 
-            {/* Meta */}
-            <View className="border-t border-slate-200 pt-4 mb-4">
-              <View className="flex-row justify-between mb-2">
-                <Text className="text-sm text-slate-400">Создано</Text>
-                <Text className="text-sm text-slate-900">{createdDate}</Text>
-              </View>
-              <View className="flex-row justify-between mb-2">
-                <Text className="text-sm text-slate-400">Автор</Text>
-                <Text className="text-sm text-slate-900">{authorName}</Text>
-              </View>
-              <View className="flex-row justify-between">
-                <Text className="text-sm text-slate-400">Откликов</Text>
-                <Text className="text-sm text-slate-900">{request.threadsCount}</Text>
-              </View>
-            </View>
+          {/* Meta card */}
+          <View className="bg-white rounded-2xl mx-4 mt-3 px-4 py-1">
+            <MetaRow label="Город" value={request.city.name} />
+            <MetaRow label="Инспекция" value={request.fns.name} />
+            <MetaRow label="Создана" value={createdDate} last />
           </View>
         </ResponsiveContainer>
       </ScrollView>
 
-      {/* Footer CTA */}
-      <View className="border-t border-slate-200 px-4 py-3">
-        <ResponsiveContainer>
-          {isAuthenticated && isSpecialist ? (
-            <Pressable
-              accessibilityLabel="Написать клиенту"
-              onPress={() => router.push(`/requests/${id}/write` as never)}
-              className="bg-blue-900 rounded-xl py-3 items-center"
-            >
-              <Text className="text-white font-semibold text-base">
-                Написать клиенту
-              </Text>
-            </Pressable>
-          ) : (
-            <Pressable
-              accessibilityLabel={isAuthenticated ? "Написать клиенту" : "Войти для ответа"}
-              onPress={() => router.push("/(auth)/email" as never)}
-              className="bg-blue-900 rounded-xl py-3 items-center"
-            >
-              <Text className="text-white font-semibold text-base">
-                {isAuthenticated ? "Написать клиенту" : "Войти для ответа"}
-              </Text>
-            </Pressable>
-          )}
-        </ResponsiveContainer>
-      </View>
+      {renderFooter()}
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
Implements `/requests/[id]` — public detail view with role-based footer.

## Changes

**Frontend (`app/requests/[id]/index.tsx`)**
- Skeleton loading state (animated placeholder blocks)
- 404 state with spec-exact copy ("Заявка не найдена" + back to feed)
- Error state with retry
- Status badge (active/closing_soon/closed with correct colors)
- City + FNS chips
- Responses counter label
- Meta card: Город, Инспекция, Создана
- Footer logic:
  - Guest → "Войдите, чтобы откликнуться" → `/auth/email`
  - Specialist (no existing thread) → "Написать клиенту" → `/requests/[id]/write`
  - Specialist (existing thread) → "Открыть чат" → `/threads/[threadId]`
  - Request owner (client) → "Ваша заявка" badge, no action button

**Backend (`api/src/routes/requests.ts`)**
- Updated `GET /api/requests/:id/public` to support optional JWT auth
- Returns `hasExistingThread` and `existingThreadId` when caller is an authenticated specialist
- Invalid/missing token is silently ignored (public route)

## tsc result
- Frontend: 0 errors
- Backend: 0 errors

Closes #1052