### PR TITLE
feat(client): MyRequestDetail screen — closes #1058

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -517,4 +517,68 @@ router.post("/:id/extend", authMiddleware, async (req: Request, res: Response) =
   }
 });
 
+// GET /api/requests/:id/recommendations — matching specialists (auth required, client owner)
+router.get("/:id/recommendations", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const id = req.params.id as string;
+
+    const request = await prisma.request.findUnique({
+      where: { id },
+      select: { userId: true, fnsId: true, cityId: true },
+    });
+
+    if (!request) {
+      res.status(404).json({ error: "Request not found" });
+      return;
+    }
+
+    if (request.userId !== userId) {
+      res.status(403).json({ error: "Access denied" });
+      return;
+    }
+
+    // Find specialists who cover this FNS and are available
+    const specialistFnsList = await prisma.specialistFns.findMany({
+      where: { fnsId: request.fnsId },
+      take: 10,
+      include: {
+        specialist: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            avatarUrl: true,
+            isAvailable: true,
+            specialistProfile: {
+              select: { description: true },
+            },
+            specialistServices: {
+              where: { fnsId: request.fnsId },
+              include: { service: { select: { id: true, name: true } } },
+            },
+          },
+        },
+      },
+    });
+
+    const specialists = specialistFnsList
+      .filter((sf) => sf.specialist.isAvailable)
+      .slice(0, 3)
+      .map((sf) => ({
+        id: sf.specialist.id,
+        firstName: sf.specialist.firstName,
+        lastName: sf.specialist.lastName,
+        avatarUrl: sf.specialist.avatarUrl,
+        description: sf.specialist.specialistProfile?.description ?? null,
+        services: sf.specialist.specialistServices.map((ss) => ss.service.name),
+      }));
+
+    res.json({ items: specialists });
+  } catch (error) {
+    console.error("requests/:id/recommendations error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 export default router;

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -7,13 +7,14 @@ import {
   ActivityIndicator,
   Alert,
   Linking,
+  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
+import Avatar from "@/components/ui/Avatar";
 import { api, apiPost, apiDelete } from "@/lib/api";
 
 interface FileItem {
@@ -22,6 +23,27 @@ interface FileItem {
   filename: string;
   size: number;
   mimeType: string;
+}
+
+interface ThreadSummary {
+  id: string;
+  otherUser: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  lastMessage: { text: string; createdAt: string } | null;
+  unreadCount: number;
+}
+
+interface SpecialistCard {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  description: string | null;
+  services: string[];
 }
 
 interface RequestDetailData {
@@ -40,19 +62,38 @@ interface RequestDetailData {
   unreadMessages: number;
 }
 
+function getSpecialistName(
+  user: { firstName: string | null; lastName: string | null }
+): string {
+  return [user.firstName, user.lastName].filter(Boolean).join(" ") || "Специалист";
+}
+
 export default function MyRequestDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
 
   const [request, setRequest] = useState<RequestDetailData | null>(null);
+  const [threads, setThreads] = useState<ThreadSummary[]>([]);
+  const [recommendations, setRecommendations] = useState<SpecialistCard[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [extending, setExtending] = useState(false);
 
-  const fetchDetail = useCallback(async () => {
+  const fetchAll = useCallback(async () => {
     try {
-      const res = await api<RequestDetailData>(`/api/requests/${id}/detail`);
-      setRequest(res);
+      const [detail, threadsRes] = await Promise.all([
+        api<RequestDetailData>(`/api/requests/${id}/detail`),
+        api<{ items: ThreadSummary[] }>(`/api/threads?request_id=${id}`),
+      ]);
+      setRequest(detail);
+      setThreads(threadsRes.items);
+
+      // Load recommendations in background — non-blocking
+      api<{ items: SpecialistCard[] }>(`/api/requests/${id}/recommendations`)
+        .then((r) => setRecommendations(r.items))
+        .catch(() => {/* silent — not critical */});
     } catch (e) {
       setError("Не удалось загрузить заявку");
       console.error("Request detail error:", e);
@@ -62,17 +103,17 @@ export default function MyRequestDetail() {
   }, [id]);
 
   useEffect(() => {
-    if (id) fetchDetail();
-  }, [id, fetchDetail]);
+    if (id) fetchAll();
+  }, [id, fetchAll]);
 
   const handleDelete = useCallback(() => {
     Alert.alert(
       "Удалить заявку",
-      "Вы уверены? Это действие нельзя отменить.",
+      "Удалить заявку? Все сообщения и файлы будут потеряны. Это действие нельзя отменить.",
       [
         { text: "Отмена", style: "cancel" },
         {
-          text: "Удалить",
+          text: "Да, удалить",
           style: "destructive",
           onPress: async () => {
             try {
@@ -165,8 +206,12 @@ export default function MyRequestDetail() {
     request.status === "CLOSING_SOON" &&
     request.extensionsCount < request.maxExtensions;
 
+  const containerStyle = isDesktop
+    ? { maxWidth: 520, width: "100%" as const, alignSelf: "center" as const }
+    : undefined;
+
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-slate-50">
       <HeaderBack
         title={request.title}
         rightAction={
@@ -176,9 +221,10 @@ export default function MyRequestDetail() {
         }
       />
       <ScrollView className="flex-1">
-        <ResponsiveContainer>
+        <View style={containerStyle} className={isDesktop ? "" : "px-4"}>
           <View className="py-4">
-            {/* Status badge */}
+
+            {/* Status + date */}
             <View className="flex-row items-center mb-3">
               <StatusBadge status={request.status} />
               <Text className="text-sm text-slate-400 ml-3">{createdDate}</Text>
@@ -186,36 +232,63 @@ export default function MyRequestDetail() {
 
             {/* City + FNS chips */}
             <View className="flex-row flex-wrap gap-2 mb-4">
-              <View className="bg-slate-50 border border-slate-200 px-3 py-1 rounded-lg">
-                <Text className="text-sm text-slate-900">{request.city.name}</Text>
+              <View className="bg-white border border-slate-200 px-3 py-1 rounded-lg">
+                <Text className="text-sm text-slate-700">{request.city.name}</Text>
               </View>
-              <View className="bg-slate-50 border border-slate-200 px-3 py-1 rounded-lg">
-                <Text className="text-sm text-slate-900">
+              <View className="bg-white border border-slate-200 px-3 py-1 rounded-lg">
+                <Text className="text-sm text-slate-700">
                   {request.fns.name} ({request.fns.code})
                 </Text>
               </View>
             </View>
 
             {/* Description */}
-            <Text className="text-base text-slate-900 leading-6 mb-4">
-              {request.description}
-            </Text>
+            <View
+              className="bg-white rounded-2xl p-4 mb-4"
+              style={{
+                shadowColor: "#0F172A",
+                shadowOffset: { width: 0, height: 1 },
+                shadowOpacity: 0.05,
+                shadowRadius: 8,
+                elevation: 2,
+              }}
+            >
+              <Text className="text-xs font-semibold text-slate-400 mb-2 uppercase tracking-wide">
+                Описание
+              </Text>
+              <Text className="text-base text-slate-900 leading-6">
+                {request.description}
+              </Text>
+            </View>
 
             {/* Files */}
             {request.files.length > 0 && (
-              <View className="mb-4">
-                <Text className="text-sm font-semibold text-slate-900 mb-2">
-                  Прикрепленные файлы
+              <View
+                className="bg-white rounded-2xl p-4 mb-4"
+                style={{
+                  shadowColor: "#0F172A",
+                  shadowOffset: { width: 0, height: 1 },
+                  shadowOpacity: 0.05,
+                  shadowRadius: 8,
+                  elevation: 2,
+                }}
+              >
+                <Text className="text-xs font-semibold text-slate-400 mb-3 uppercase tracking-wide">
+                  Прикреплённые документы
                 </Text>
                 {request.files.map((file) => (
                   <Pressable
                     key={file.id}
                     accessibilityLabel={`Открыть файл ${file.filename}`}
                     onPress={() => handleFilePress(file)}
-                    className="flex-row items-center bg-slate-50 rounded-lg p-3 mb-2"
+                    className="flex-row items-center bg-slate-50 rounded-xl p-3 mb-2"
                   >
                     <FontAwesome
-                      name={file.mimeType === "application/pdf" ? "file-pdf-o" : "file-image-o"}
+                      name={
+                        file.mimeType === "application/pdf"
+                          ? "file-pdf-o"
+                          : "file-image-o"
+                      }
                       size={20}
                       color="#1e3a8a"
                     />
@@ -224,7 +297,7 @@ export default function MyRequestDetail() {
                         {file.filename}
                       </Text>
                       <Text className="text-xs text-slate-400">
-                        {(file.size / 1024).toFixed(0)} KB
+                        {(file.size / 1024).toFixed(0)} КБ
                       </Text>
                     </View>
                     <FontAwesome name="download" size={14} color="#94a3b8" />
@@ -233,19 +306,7 @@ export default function MyRequestDetail() {
               </View>
             )}
 
-            {/* Messages button */}
-            <Pressable
-              accessibilityLabel="Сообщения"
-              onPress={() => router.push(`/requests/${id}/messages` as never)}
-              className="flex-row items-center justify-center bg-slate-50 border border-slate-200 rounded-xl py-3 mb-4"
-            >
-              <FontAwesome name="comments-o" size={18} color="#1e3a8a" />
-              <Text className="text-blue-900 font-semibold text-base ml-2">
-                Сообщения ({request.unreadMessages})
-              </Text>
-            </Pressable>
-
-            {/* Extend button (for closing_soon) */}
+            {/* Extend button (closing_soon + extensions remaining) */}
             {canExtend && (
               <Pressable
                 accessibilityLabel="Продлить заявку"
@@ -257,27 +318,216 @@ export default function MyRequestDetail() {
                   <ActivityIndicator color="#ffffff" />
                 ) : (
                   <Text className="text-white font-semibold text-base">
-                    Продлить ({request.extensionsCount}/{request.maxExtensions})
+                    Продлить заявку — Продлений: {request.extensionsCount}/
+                    {request.maxExtensions}
                   </Text>
                 )}
               </Pressable>
             )}
 
-            {/* Stats */}
-            <View className="border-t border-slate-200 pt-4">
+            {/* Extend limit banner */}
+            {request.status === "CLOSING_SOON" &&
+              request.extensionsCount >= request.maxExtensions && (
+                <View className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-4">
+                  <Text className="text-sm text-amber-700 text-center font-medium">
+                    Продление использовано ({request.extensionsCount}/
+                    {request.maxExtensions})
+                  </Text>
+                </View>
+              )}
+
+            {/* Messages / response threads */}
+            <View
+              className="bg-white rounded-2xl p-4 mb-4"
+              style={{
+                shadowColor: "#0F172A",
+                shadowOffset: { width: 0, height: 1 },
+                shadowOpacity: 0.05,
+                shadowRadius: 8,
+                elevation: 2,
+              }}
+            >
+              <View className="flex-row items-center justify-between mb-3">
+                <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide">
+                  Сообщения
+                </Text>
+                {request.unreadMessages > 0 && (
+                  <View className="bg-blue-900 rounded-full px-2 py-0.5">
+                    <Text className="text-white text-xs font-bold">
+                      {request.unreadMessages}
+                    </Text>
+                  </View>
+                )}
+              </View>
+
+              {threads.length === 0 ? (
+                <Text className="text-sm text-slate-400 py-2 text-center">
+                  Специалисты ещё не написали
+                </Text>
+              ) : (
+                <>
+                  <Text className="text-sm text-slate-500 mb-3">
+                    {request.threadsCount}{" "}
+                    {request.threadsCount === 1
+                      ? "специалист написал"
+                      : "специалистов написали"}{" "}
+                    вам
+                  </Text>
+                  {threads.map((thread) => {
+                    const name = getSpecialistName(thread.otherUser);
+                    return (
+                      <View
+                        key={thread.id}
+                        className="flex-row items-center py-3 border-b border-slate-100"
+                      >
+                        <Avatar
+                          name={name}
+                          imageUrl={thread.otherUser.avatarUrl ?? undefined}
+                          size="sm"
+                        />
+                        <View className="flex-1 ml-3">
+                          <Text className="text-sm font-semibold text-slate-900">
+                            {name}
+                          </Text>
+                          {thread.lastMessage && (
+                            <Text
+                              className="text-xs text-slate-400 mt-0.5"
+                              numberOfLines={1}
+                            >
+                              {thread.lastMessage.text}
+                            </Text>
+                          )}
+                        </View>
+                        <View className="flex-row items-center">
+                          {thread.unreadCount > 0 && (
+                            <View className="bg-blue-900 rounded-full w-5 h-5 items-center justify-center mr-2">
+                              <Text className="text-white text-xs font-bold">
+                                {thread.unreadCount > 9 ? "9+" : thread.unreadCount}
+                              </Text>
+                            </View>
+                          )}
+                          <Pressable
+                            accessibilityLabel={`Открыть чат с ${name}`}
+                            onPress={() =>
+                              router.push(`/threads/${thread.id}` as never)
+                            }
+                            className="bg-blue-900 rounded-lg px-3 py-1.5"
+                          >
+                            <Text className="text-white text-xs font-semibold">
+                              Открыть чат
+                            </Text>
+                          </Pressable>
+                        </View>
+                      </View>
+                    );
+                  })}
+
+                  {/* View all button */}
+                  <Pressable
+                    accessibilityLabel="Все сообщения"
+                    onPress={() =>
+                      router.push(`/requests/${id}/messages` as never)
+                    }
+                    className="mt-3 border border-blue-900 rounded-xl py-2.5 items-center"
+                  >
+                    <Text className="text-blue-900 font-semibold text-sm">
+                      Все сообщения ({request.threadsCount})
+                    </Text>
+                  </Pressable>
+                </>
+              )}
+            </View>
+
+            {/* Recommended specialists */}
+            {recommendations.length > 0 && (
+              <View className="mb-4">
+                <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">
+                  Рекомендованные специалисты
+                </Text>
+                {recommendations.map((spec) => {
+                  const name = getSpecialistName(spec);
+                  return (
+                    <Pressable
+                      key={spec.id}
+                      accessibilityLabel={`Профиль специалиста ${name}`}
+                      onPress={() =>
+                        router.push(`/specialists/${spec.id}` as never)
+                      }
+                      className="bg-white rounded-2xl p-4 mb-3"
+                      style={{
+                        shadowColor: "#0F172A",
+                        shadowOffset: { width: 0, height: 1 },
+                        shadowOpacity: 0.05,
+                        shadowRadius: 8,
+                        elevation: 2,
+                      }}
+                    >
+                      <View className="flex-row items-center">
+                        <Avatar
+                          name={name}
+                          imageUrl={spec.avatarUrl ?? undefined}
+                          size="md"
+                        />
+                        <View className="ml-3 flex-1">
+                          <Text className="text-base font-semibold text-slate-900">
+                            {name}
+                          </Text>
+                          {spec.services.length > 0 && (
+                            <Text
+                              className="text-xs text-slate-400 mt-0.5"
+                              numberOfLines={1}
+                            >
+                              {spec.services.join(", ")}
+                            </Text>
+                          )}
+                          {spec.description && (
+                            <Text
+                              className="text-sm text-slate-600 mt-1 leading-5"
+                              numberOfLines={2}
+                            >
+                              {spec.description}
+                            </Text>
+                          )}
+                        </View>
+                        <FontAwesome name="chevron-right" size={12} color="#94a3b8" />
+                      </View>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            )}
+
+            {/* Meta stats */}
+            <View
+              className="bg-white rounded-2xl p-4 mb-6"
+              style={{
+                shadowColor: "#0F172A",
+                shadowOffset: { width: 0, height: 1 },
+                shadowOpacity: 0.05,
+                shadowRadius: 8,
+                elevation: 2,
+              }}
+            >
               <View className="flex-row justify-between mb-2">
                 <Text className="text-sm text-slate-400">Откликов</Text>
-                <Text className="text-sm text-slate-900">{request.threadsCount}</Text>
+                <Text className="text-sm text-slate-900">
+                  {request.threadsCount}
+                </Text>
               </View>
-              <View className="flex-row justify-between">
+              <View className="flex-row justify-between mb-2">
                 <Text className="text-sm text-slate-400">Продлений</Text>
                 <Text className="text-sm text-slate-900">
                   {request.extensionsCount}/{request.maxExtensions}
                 </Text>
               </View>
+              <View className="flex-row justify-between">
+                <Text className="text-sm text-slate-400">Город</Text>
+                <Text className="text-sm text-slate-900">{request.city.name}</Text>
+              </View>
             </View>
+
           </View>
-        </ResponsiveContainer>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );


### PR DESCRIPTION
Implements `/requests/[id]/detail` — client's own request detail screen.

## What's included

- Full request details: status badge, city+FNS chips, description, attached files
- Response threads list: each specialist's thread with last message preview, unread count badge, and "Открыть чат" button → `/threads/[id]`
- "Все сообщения" button → `/requests/[id]/messages`
- Extend action: visible only for `CLOSING_SOON` status, max 3 extensions with counter display
- Extend limit banner when all extensions used
- Delete action: trash icon in header → confirm dialog → DELETE `/api/requests/:id` → navigate back
- Recommended specialists section: new `GET /api/requests/:id/recommendations` endpoint returns up to 3 available specialists covering the same FNS; each card taps → `/specialists/[id]`
- Responsive layout: mobile px-4, desktop maxWidth 520 centered

## API changes

Added `GET /api/requests/:id/recommendations` to `api/src/routes/requests.ts` — queries `SpecialistFns` for the request's FNS, filters `isAvailable=true`, returns up to 3 specialists with name, avatar, description, and services list.

Closes #1058