### PR TITLE
fix: maxLength 2000 on specialist response — closes #218

### DIFF
--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -192,8 +192,8 @@ router.post("/", async (req: Request, res: Response) => {
       return;
     }
 
-    if (firstMessage.length < 10 || firstMessage.length > 1000) {
-      res.status(400).json({ error: "Message must be 10-1000 characters" });
+    if (firstMessage.length < 10 || firstMessage.length > 2000) {
+      res.status(400).json({ error: "Message must be 10-2000 characters" });
       return;
     }
 

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -29,7 +29,7 @@ interface RateLimitInfo {
   limit: number;
 }
 
-const MAX_CHARS = 1000;
+const MAX_CHARS = 2000;
 const MIN_CHARS = 10;
 const DAILY_LIMIT = 20;
 
@@ -197,6 +197,7 @@ export default function SpecialistConfirmWrite() {
           <TextInput
             accessibilityLabel="Ваше сообщение"
             value={message}
+            maxLength={MAX_CHARS}
             onChangeText={(t) => {
               if (t.length <= MAX_CHARS) setMessage(t);
             }}


### PR DESCRIPTION
Adds maxLength 2000 validation to the specialist first-response message field.

**Backend** (`api/src/routes/threads.ts`): inline length guard updated from `> 1000` to `> 2000`, error message updated accordingly.

**Frontend** (`app/requests/[id]/write.tsx`): `MAX_CHARS` constant bumped from 1000 to 2000, `maxLength={2000}` prop added to the `TextInput`.

Closes #218