### PR TITLE
fix(admin): prevent self-block — closes #219

### DIFF
--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -172,6 +172,12 @@ router.patch("/users/:id", async (req: Request, res: Response) => {
     const id = req.params.id as string;
     const { isBanned, firstName, lastName, role } = req.body;
 
+    // Self-block protection: admin cannot block their own account
+    if (isBanned === true && req.user?.userId === id) {
+      res.status(400).json({ error: "Нельзя заблокировать собственный аккаунт" });
+      return;
+    }
+
     const data: Record<string, unknown> = {};
     if (typeof isBanned === "boolean") data.isBanned = isBanned;
     if (typeof firstName === "string") data.firstName = firstName;


### PR DESCRIPTION
Adds guard in admin blockUser() — throws 400 if admin tries to block themselves.

Closes #219