### PR TITLE
feat(api): BullMQ notification system — closes #220

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.6.0",
+        "bullmq": "^5.74.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -43,6 +44,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -70,6 +77,84 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@nodable/entities": {
       "version": "1.1.0",
@@ -545,6 +630,21 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bullmq": {
+      "version": "5.74.1",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.74.1.tgz",
+      "integrity": "sha512-GfJEos2zoOGM9xqkB7VZouwwFuejKFqm667cBcmbBekJXKqqXWk4QYP3Uy2pzgUwCbg1cR7GgGmGczM7fnhWSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "4.9.0",
+        "ioredis": "5.10.1",
+        "msgpackr": "1.11.5",
+        "node-abort-controller": "3.1.1",
+        "semver": "7.7.4",
+        "tslib": "2.8.1",
+        "uuid": "11.1.0"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -649,6 +749,15 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -748,6 +857,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -783,6 +904,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -807,6 +937,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -1328,6 +1468,53 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1464,10 +1651,22 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -1505,6 +1704,15 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1657,6 +1865,37 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
+      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/multer": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
@@ -1685,12 +1924,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/nodemailer": {
       "version": "6.10.1",
@@ -2024,6 +2284,27 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -2259,6 +2540,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -2536,6 +2823,12 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -2598,6 +2891,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.6.0",
+    "bullmq": "^5.74.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -31,14 +31,16 @@ model User {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 
-  specialistProfile  SpecialistProfile?
-  specialistFns      SpecialistFns[]
-  specialistServices SpecialistService[]
-  requests           Request[]
-  clientThreads      Thread[]  @relation("ClientThreads")
-  specialistThreads  Thread[]  @relation("SpecialistThreads")
-  messages           Message[]
-  refreshTokens      RefreshToken[]
+  specialistProfile       SpecialistProfile?
+  specialistFns           SpecialistFns[]
+  specialistServices      SpecialistService[]
+  requests                Request[]
+  clientThreads           Thread[]  @relation("ClientThreads")
+  specialistThreads       Thread[]  @relation("SpecialistThreads")
+  messages                Message[]
+  refreshTokens           RefreshToken[]
+  notifications           Notification[]
+  notificationPreferences NotificationPreference[]
 
   @@map("users")
 }
@@ -219,4 +221,47 @@ model RefreshToken {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("refresh_tokens")
+}
+
+model Notification {
+  id        String   @id @default(uuid())
+  userId    String   @map("user_id")
+  type      String   // new_response | new_message | new_request_in_city | promo_expiring
+  title     String
+  body      String
+  entityId  String?  @map("entity_id") // requestId or threadId
+  isRead    Boolean  @default(false) @map("is_read")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  deliveryLogs NotificationDeliveryLog[]
+
+  @@map("notifications")
+}
+
+model NotificationPreference {
+  id        String  @id @default(uuid())
+  userId    String  @map("user_id")
+  eventType String  @map("event_type") // new_response | new_message | new_request_in_city | promo_expiring
+  email     Boolean @default(true)
+  inApp     Boolean @default(true) @map("in_app")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, eventType])
+  @@map("notification_preferences")
+}
+
+model NotificationDeliveryLog {
+  id             String   @id @default(uuid())
+  notificationId String?  @map("notification_id")
+  channel        String   // email | inapp
+  status         String   // sent | skipped | failed
+  reason         String?
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  notification Notification? @relation(fields: [notificationId], references: [id], onDelete: SetNull)
+
+  @@map("notification_delivery_logs")
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -15,6 +15,8 @@ import userRoutes from "./routes/user";
 import specialistRoutes from "./routes/specialist";
 import threadsRoutes from "./routes/threads";
 import adminRoutes from "./routes/admin";
+import notificationsRoutes from "./routes/notifications";
+import { startNotificationWorker } from "./notifications/notification.processor";
 
 const app = express();
 const PORT = process.env.PORT || 3812;
@@ -40,7 +42,10 @@ app.use("/api/user", userRoutes);
 app.use("/api/specialist", specialistRoutes);
 app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
+app.use("/api/notifications", notificationsRoutes);
 
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);
+  // Start BullMQ worker (graceful degradation if Valkey unavailable)
+  startNotificationWorker();
 });

--- a/api/src/notifications/notification.processor.ts
+++ b/api/src/notifications/notification.processor.ts
@@ -1,0 +1,147 @@
+import { Worker, Job } from "bullmq";
+import { prisma } from "../lib/prisma";
+import { QUEUE_NAME, getRedisConnection } from "./notification.queue";
+import nodemailer from "nodemailer";
+
+export interface NotificationJobData {
+  notificationId: string;
+  userId: string;
+  eventType: string;
+  title: string;
+  body: string;
+  entityId?: string;
+}
+
+// Email channel
+async function sendEmail(data: NotificationJobData): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: data.userId },
+    select: { email: true },
+  });
+
+  if (!user?.email) {
+    await prisma.notificationDeliveryLog.create({
+      data: {
+        notificationId: data.notificationId,
+        channel: "email",
+        status: "skipped",
+        reason: "no email on user",
+      },
+    });
+    return;
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || "587"),
+      secure: process.env.SMTP_SECURE === "true",
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || "noreply@p2ptax.ru",
+      to: user.email,
+      subject: data.title,
+      text: data.body,
+    });
+
+    await prisma.notificationDeliveryLog.create({
+      data: {
+        notificationId: data.notificationId,
+        channel: "email",
+        status: "sent",
+      },
+    });
+  } catch (err) {
+    const message = (err as Error).message;
+    console.warn("[notifications] Email send failed:", message);
+    await prisma.notificationDeliveryLog.create({
+      data: {
+        notificationId: data.notificationId,
+        channel: "email",
+        status: "failed",
+        reason: message,
+      },
+    });
+  }
+}
+
+// In-app channel: notification is already written; just log delivery
+async function sendInApp(data: NotificationJobData): Promise<void> {
+  try {
+    await prisma.notificationDeliveryLog.create({
+      data: {
+        notificationId: data.notificationId,
+        channel: "inapp",
+        status: "sent",
+      },
+    });
+  } catch (err) {
+    console.warn("[notifications] InApp log failed:", (err as Error).message);
+  }
+}
+
+// Fan-out processor
+async function processNotificationJob(job: Job<NotificationJobData>): Promise<void> {
+  const { notificationId, userId, eventType, title, body, entityId } = job.data;
+
+  // Load preferences (default: everything enabled)
+  const prefs = await prisma.notificationPreference.findUnique({
+    where: { userId_eventType: { userId, eventType } },
+  });
+
+  const emailEnabled = prefs?.email !== false;
+  const inAppEnabled = prefs?.inApp !== false;
+
+  await Promise.allSettled([
+    emailEnabled
+      ? sendEmail({ notificationId, userId, eventType, title, body, entityId })
+      : prisma.notificationDeliveryLog.create({
+          data: { notificationId, channel: "email", status: "skipped", reason: "user preference" },
+        }),
+    inAppEnabled
+      ? sendInApp({ notificationId, userId, eventType, title, body, entityId })
+      : prisma.notificationDeliveryLog.create({
+          data: { notificationId, channel: "inapp", status: "skipped", reason: "user preference" },
+        }),
+  ]);
+}
+
+let _worker: Worker | null = null;
+
+export function startNotificationWorker(): void {
+  try {
+    _worker = new Worker<NotificationJobData>(
+      QUEUE_NAME,
+      processNotificationJob,
+      { connection: getRedisConnection() }
+    );
+
+    _worker.on("completed", (job) => {
+      console.log(`[notifications] Job ${job.id} completed`);
+    });
+
+    _worker.on("failed", (job, err) => {
+      console.error(`[notifications] Job ${job?.id} failed:`, err.message);
+    });
+
+    _worker.on("error", (err) => {
+      console.warn("[notifications] Worker error:", err.message);
+    });
+
+    console.log("[notifications] Worker started");
+  } catch (err) {
+    console.warn("[notifications] Failed to start worker (Valkey unavailable):", (err as Error).message);
+  }
+}
+
+export async function stopNotificationWorker(): Promise<void> {
+  if (_worker) {
+    await _worker.close();
+    _worker = null;
+  }
+}

--- a/api/src/notifications/notification.queue.ts
+++ b/api/src/notifications/notification.queue.ts
@@ -1,0 +1,45 @@
+import { Queue } from "bullmq";
+
+const QUEUE_NAME = "notifications";
+
+function getRedisConnection() {
+  const redisUrl = process.env.REDIS_URL;
+  if (redisUrl) {
+    // Parse redis://host:port or redis://:password@host:port
+    const url = new URL(redisUrl);
+    return {
+      host: url.hostname || "127.0.0.1",
+      port: parseInt(url.port || "6379"),
+      password: url.password || undefined,
+      keyPrefix: "p2ptax:bull:",
+    };
+  }
+  return {
+    host: process.env.REDIS_HOST || "127.0.0.1",
+    port: parseInt(process.env.REDIS_PORT || "6379"),
+    keyPrefix: "p2ptax:bull:",
+  };
+}
+
+let _queue: Queue | null = null;
+
+export function getNotificationQueue(): Queue | null {
+  if (_queue) return _queue;
+  try {
+    _queue = new Queue(QUEUE_NAME, {
+      connection: getRedisConnection(),
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 2000 },
+        removeOnComplete: 100,
+        removeOnFail: 50,
+      },
+    });
+    return _queue;
+  } catch (err) {
+    console.warn("[notifications] Failed to create BullMQ queue:", (err as Error).message);
+    return null;
+  }
+}
+
+export { QUEUE_NAME, getRedisConnection };

--- a/api/src/notifications/notification.service.ts
+++ b/api/src/notifications/notification.service.ts
@@ -1,0 +1,65 @@
+import { prisma } from "../lib/prisma";
+import { getNotificationQueue } from "./notification.queue";
+
+export interface SendNotificationData {
+  userId: string;
+  type: string; // new_response | new_message | new_request_in_city | promo_expiring
+  title: string;
+  body: string;
+  entityId?: string;
+}
+
+/**
+ * Create an in-app notification and enqueue fan-out (email + inApp delivery).
+ * Graceful degradation: if Valkey/BullMQ is unavailable, logs to DB directly.
+ */
+export async function sendNotification(data: SendNotificationData) {
+  // Persist in-app notification record
+  const notification = await prisma.notification.create({
+    data: {
+      userId: data.userId,
+      type: data.type,
+      title: data.title,
+      body: data.body,
+      entityId: data.entityId,
+    },
+  });
+
+  const queue = getNotificationQueue();
+
+  if (queue) {
+    try {
+      await queue.add("fan-out", {
+        notificationId: notification.id,
+        userId: data.userId,
+        eventType: data.type,
+        title: data.title,
+        body: data.body,
+        entityId: data.entityId,
+      });
+    } catch (err) {
+      console.warn("[notifications] Queue add failed, falling back to direct delivery:", (err as Error).message);
+      // Graceful degradation: log inapp delivery directly
+      await prisma.notificationDeliveryLog.create({
+        data: {
+          notificationId: notification.id,
+          channel: "inapp",
+          status: "sent",
+          reason: "queue_unavailable_fallback",
+        },
+      });
+    }
+  } else {
+    // Queue never initialised (Valkey not configured) — store inapp log directly
+    await prisma.notificationDeliveryLog.create({
+      data: {
+        notificationId: notification.id,
+        channel: "inapp",
+        status: "sent",
+        reason: "queue_unavailable_fallback",
+      },
+    });
+  }
+
+  return notification;
+}

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
+import { sendNotification } from "../notifications/notification.service";
 
 const router = Router();
 
@@ -192,6 +193,17 @@ router.post("/:threadId", authMiddleware, async (req: Request, res: Response) =>
       where: { id: threadId },
       data: { lastMessageAt: now },
     });
+
+    // Notify the other participant
+    const recipientId = thread.clientId === userId ? thread.specialistId : thread.clientId;
+    const senderName = message.sender.firstName || "Пользователь";
+    sendNotification({
+      userId: recipientId,
+      type: "new_message",
+      title: `Новое сообщение от ${senderName}`,
+      body: trimmedText ? trimmedText.slice(0, 200) : "Вложение",
+      entityId: threadId,
+    }).catch((err: Error) => console.warn("[notifications] new_message trigger failed:", err.message));
 
     res.json({ message: { ...message, files: savedFiles } });
   } catch (error) {

--- a/api/src/routes/notifications.ts
+++ b/api/src/routes/notifications.ts
@@ -1,0 +1,186 @@
+import { Router, Request, Response } from "express";
+import { prisma } from "../lib/prisma";
+import { authMiddleware } from "../middleware/auth";
+
+const router = Router();
+
+const VALID_EVENT_TYPES = [
+  "new_response",
+  "new_message",
+  "new_request_in_city",
+  "promo_expiring",
+] as const;
+
+function param(val: string | string[] | undefined): string {
+  return Array.isArray(val) ? val[0] : val || "";
+}
+
+function isValidEventType(type: string): boolean {
+  return (VALID_EVENT_TYPES as readonly string[]).includes(type);
+}
+
+// GET /api/notifications — list user's in-app notifications
+router.get("/", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const page = Math.max(1, parseInt(String(req.query.page || "1")));
+    const limit = Math.min(50, Math.max(1, parseInt(String(req.query.limit || "20"))));
+
+    const [notifications, total, unreadCount] = await Promise.all([
+      prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.notification.count({ where: { userId } }),
+      prisma.notification.count({ where: { userId, isRead: false } }),
+    ]);
+
+    res.json({ notifications, total, unreadCount, page, limit });
+  } catch (error) {
+    console.error("list notifications error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PATCH /api/notifications/:id/read — mark notification as read
+router.patch("/:id/read", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const id = param(req.params.id);
+
+    const notification = await prisma.notification.findUnique({ where: { id } });
+
+    if (!notification) {
+      res.status(404).json({ error: "Notification not found" });
+      return;
+    }
+
+    if (notification.userId !== userId) {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+
+    const updated = await prisma.notification.update({
+      where: { id },
+      data: { isRead: true },
+    });
+
+    res.json({ notification: updated });
+  } catch (error) {
+    console.error("mark notification read error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PATCH /api/notifications/read-all — mark all notifications as read
+router.patch("/read-all", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+
+    await prisma.notification.updateMany({
+      where: { userId, isRead: false },
+      data: { isRead: true },
+    });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error("mark all read error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/notifications/preferences — all preferences for current user
+router.get("/preferences", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+
+    const saved = await prisma.notificationPreference.findMany({
+      where: { userId },
+    });
+
+    // Return full list with defaults for missing event types
+    const prefsMap: Record<string, { email: boolean; inApp: boolean }> = {};
+    for (const p of saved) {
+      prefsMap[p.eventType] = { email: p.email, inApp: p.inApp };
+    }
+
+    const preferences = VALID_EVENT_TYPES.map((eventType) => ({
+      eventType,
+      email: prefsMap[eventType]?.email ?? true,
+      inApp: prefsMap[eventType]?.inApp ?? true,
+    }));
+
+    res.json({ preferences });
+  } catch (error) {
+    console.error("get preferences error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/notifications/preferences/:eventType — single event type preference
+router.get("/preferences/:eventType", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const eventType = param(req.params.eventType);
+
+    if (!isValidEventType(eventType)) {
+      res.status(400).json({ error: `Invalid eventType. Valid: ${VALID_EVENT_TYPES.join(", ")}` });
+      return;
+    }
+
+    const pref = await prisma.notificationPreference.findUnique({
+      where: { userId_eventType: { userId, eventType } },
+    });
+
+    res.json({
+      eventType,
+      email: pref?.email ?? true,
+      inApp: pref?.inApp ?? true,
+    });
+  } catch (error) {
+    console.error("get preference error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PUT /api/notifications/preferences/:eventType — upsert preference
+router.put("/preferences/:eventType", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const eventType = param(req.params.eventType);
+    const { email, inApp } = req.body as { email?: boolean; inApp?: boolean };
+
+    if (!isValidEventType(eventType)) {
+      res.status(400).json({ error: `Invalid eventType. Valid: ${VALID_EVENT_TYPES.join(", ")}` });
+      return;
+    }
+
+    if (email !== undefined && typeof email !== "boolean") {
+      res.status(400).json({ error: "email must be a boolean" });
+      return;
+    }
+    if (inApp !== undefined && typeof inApp !== "boolean") {
+      res.status(400).json({ error: "inApp must be a boolean" });
+      return;
+    }
+
+    const updateData: { email?: boolean; inApp?: boolean } = {};
+    if (email !== undefined) updateData.email = email;
+    if (inApp !== undefined) updateData.inApp = inApp;
+
+    const pref = await prisma.notificationPreference.upsert({
+      where: { userId_eventType: { userId, eventType } },
+      create: { userId, eventType, ...updateData },
+      update: updateData,
+    });
+
+    res.json({ preference: pref });
+  } catch (error) {
+    console.error("update preference error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
+import { sendNotification } from "../notifications/notification.service";
 
 const router = Router();
 
@@ -284,6 +285,15 @@ router.post("/", async (req: Request, res: Response) => {
       where: { id: requestId },
       data: { lastActivityAt: now },
     });
+
+    // Notify client: new response on their request
+    sendNotification({
+      userId: request.userId,
+      type: "new_response",
+      title: "Новый отклик на вашу заявку",
+      body: firstMessage.slice(0, 200),
+      entityId: thread.id,
+    }).catch((err: Error) => console.warn("[notifications] new_response trigger failed:", err.message));
 
     res.status(201).json({
       id: thread.id,


### PR DESCRIPTION
## Summary

- BullMQ + Valkey queue (`keyPrefix: p2ptax:bull:`) with async fan-out worker
- `Notification`, `NotificationPreference`, `NotificationDeliveryLog` tables added to Prisma schema
- `notification.service.ts`: central `sendNotification()` with graceful degradation (falls back to direct DB log when Valkey unavailable)
- Routes: `GET /api/notifications`, `PATCH /api/notifications/:id/read`, `PATCH /api/notifications/read-all`, `GET /api/notifications/preferences`, `GET/PUT /api/notifications/preferences/:eventType`
- Integrated triggers: `new_response` (specialist creates thread), `new_message` (message sent)
- Worker starts automatically in Express app; SMTP email via existing nodemailer

## Test plan

- [ ] `npx tsc --noEmit` passes (0 errors) — verified locally
- [ ] `POST /api/threads` → client receives `new_response` notification
- [ ] `POST /api/messages/:threadId` → recipient receives `new_message` notification
- [ ] `GET /api/notifications/preferences` returns all 4 event types with defaults
- [ ] `PUT /api/notifications/preferences/new_message` with `{email: false}` persists correctly
- [ ] App starts cleanly even if `REDIS_URL` is not set (graceful degradation logged, no crash)

Closes #220