### PR TITLE
fix: Promotion nav + OG meta tags — closes #215 #216

### DIFF
--- a/app/(specialist-tabs)/_layout.tsx
+++ b/app/(specialist-tabs)/_layout.tsx
@@ -45,6 +45,15 @@ export default function SpecialistTabsLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="promotion"
+        options={{
+          title: "Продвижение",
+          tabBarIcon: ({ color, size }) => (
+            <FontAwesome name="rocket" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -1,0 +1,63 @@
+import { View, Text, ScrollView, Pressable } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import HeaderHome from "@/components/HeaderHome";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
+
+export default function PromotionScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
+      <HeaderHome
+        notificationCount={0}
+        onSettingsPress={() => router.push("/settings/specialist" as never)}
+      />
+      <ScrollView className="flex-1">
+        <ResponsiveContainer>
+          <View className="py-4">
+            <Text className="text-2xl font-bold text-slate-900 mb-2">Продвижение</Text>
+            <Text className="text-sm text-slate-500 mb-6">
+              Инструменты для привлечения новых клиентов
+            </Text>
+
+            {/* Placeholder card */}
+            <View className="bg-white border border-slate-200 rounded-xl p-6 items-center">
+              <View className="w-16 h-16 rounded-full bg-amber-50 items-center justify-center mb-4">
+                <FontAwesome name="rocket" size={28} color="#b45309" />
+              </View>
+              <Text className="text-lg font-semibold text-slate-900 text-center mb-2">
+                Скоро будет доступно
+              </Text>
+              <Text className="text-sm text-slate-500 text-center leading-5">
+                Здесь появятся инструменты продвижения вашего профиля: платное размещение в топе,
+                баннеры и специальные предложения для клиентов.
+              </Text>
+            </View>
+
+            {/* Profile tip */}
+            <Pressable
+              accessibilityLabel="Улучшить профиль"
+              onPress={() => router.push("/settings/specialist" as never)}
+              className="bg-blue-900 rounded-xl p-4 mt-4 flex-row items-center"
+            >
+              <View className="w-10 h-10 rounded-full bg-blue-800 items-center justify-center mr-3">
+                <FontAwesome name="user" size={16} color="#ffffff" />
+              </View>
+              <View className="flex-1">
+                <Text className="text-white font-semibold text-sm">Заполните профиль</Text>
+                <Text className="text-blue-200 text-xs mt-0.5">
+                  Полный профиль повышает доверие клиентов
+                </Text>
+              </View>
+              <FontAwesome name="chevron-right" size={12} color="#93c5fd" />
+            </Pressable>
+
+            <View className="h-8" />
+          </View>
+        </ResponsiveContainer>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import Head from "expo-router/head";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
@@ -235,8 +236,17 @@ export default function PublicRequestDetail() {
     );
   };
 
+  const ogDescription = `Заявка на налоговую помощь в ${request.city.name}. ${request.description}`.slice(0, 160);
+
   return (
     <SafeAreaView className="flex-1 bg-slate-50">
+      <Head>
+        <title>{request.title} | P2PTax</title>
+        <meta property="og:title" content={`${request.title} | P2PTax`} />
+        <meta property="og:description" content={ogDescription} />
+        <meta property="og:url" content={`https://p2ptax.ru/requests/${id}`} />
+        <meta property="og:type" content="article" />
+      </Head>
       <HeaderBack title="Заявка" />
 
       <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 16 }}>

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import Head from "expo-router/head";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
@@ -236,8 +237,19 @@ export default function SpecialistPublicProfile() {
     elevation: 3,
   };
 
+  const ogDescription = specialist.profile?.description
+    ? specialist.profile.description.slice(0, 160)
+    : `Специалист по налогам P2P ${cities.length > 0 ? `в ${cities[0]}` : ""}`.trim();
+
   return (
     <SafeAreaView className="flex-1 bg-slate-50">
+      <Head>
+        <title>{name} — специалист по налогам P2P | P2PTax</title>
+        <meta property="og:title" content={`${name} — специалист по налогам P2P | P2PTax`} />
+        <meta property="og:description" content={ogDescription} />
+        <meta property="og:url" content={`https://p2ptax.ru/specialists/${id}`} />
+        <meta property="og:type" content="profile" />
+      </Head>
       <HeaderBack title="Профиль специалиста" rightAction={rightAction} />
       <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
         <ResponsiveContainer>


### PR DESCRIPTION
Adds navigation entry to Promotion screen in specialist dashboard and OG meta tags to specialist/request detail pages.

## Changes
- New screen `app/(specialist-tabs)/promotion.tsx` — placeholder page with rocket icon and "Скоро будет доступно" content
- Promotion tab added to specialist-tabs layout (`_layout.tsx`) with `FontAwesome rocket` icon
- `app/specialists/[id].tsx` — `expo-router/head` Head with og:title, og:description (≤160 chars), og:url, og:type=profile
- `app/requests/[id]/index.tsx` — Head with og:title, og:description (city + truncated description), og:url, og:type=article

## tsc result
Frontend: 1 pre-existing error in `threads/[id].tsx` (expo-document-picker missing types) — not related to these changes. Zero errors in changed files.

Closes #215
Closes #216