### PR TITLE
feat: ContactMethod structured contacts — closes #243

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -55,9 +55,24 @@ model SpecialistProfile {
   officeAddress String? @map("office_address")
   workingHours  String? @map("working_hours")
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
+  contactMethods ContactMethod[]
 
   @@map("specialist_profiles")
+}
+
+model ContactMethod {
+  id        String   @id @default(uuid())
+  profileId String   @map("profile_id")
+  type      String   // phone | email | telegram | whatsapp | vk | website
+  value     String
+  label     String?
+  order     Int      @default(0)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  profile SpecialistProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@map("contact_methods")
 }
 
 model SpecialistFns {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,7 @@ import specialistRoutes from "./routes/specialist";
 import threadsRoutes from "./routes/threads";
 import adminRoutes from "./routes/admin";
 import notificationsRoutes from "./routes/notifications";
+import contactsRoutes from "./routes/contacts";
 import { startNotificationWorker } from "./notifications/notification.processor";
 
 const app = express();
@@ -43,6 +44,7 @@ app.use("/api/specialist", specialistRoutes);
 app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/notifications", notificationsRoutes);
+app.use("/api", contactsRoutes);
 
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);

--- a/api/src/routes/contacts.ts
+++ b/api/src/routes/contacts.ts
@@ -1,0 +1,206 @@
+import { Router, Request, Response } from "express";
+import { prisma } from "../lib/prisma";
+import { authMiddleware, roleGuard } from "../middleware/auth";
+
+const router = Router();
+
+const VALID_TYPES = ["phone", "email", "telegram", "whatsapp", "vk", "website"];
+const MAX_CONTACTS = 6;
+
+// GET /api/specialists/:id/contacts — public
+router.get("/specialists/:id/contacts", async (req: Request, res: Response) => {
+  try {
+    const profile = await prisma.specialistProfile.findFirst({
+      where: { userId: req.params.id as string },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      res.json({ items: [] });
+      return;
+    }
+
+    const contacts = await prisma.contactMethod.findMany({
+      where: { profileId: profile.id },
+      orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+      select: { id: true, type: true, value: true, label: true, order: true },
+    });
+
+    res.json({ items: contacts });
+  } catch (error) {
+    console.error("contacts public error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// All routes below require SPECIALIST auth
+router.use(authMiddleware, roleGuard("SPECIALIST"));
+
+// GET /api/profile/contacts — own contacts
+router.get("/profile/contacts", async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const profile = await prisma.specialistProfile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      res.json({ items: [] });
+      return;
+    }
+
+    const contacts = await prisma.contactMethod.findMany({
+      where: { profileId: profile.id },
+      orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+      select: { id: true, type: true, value: true, label: true, order: true },
+    });
+
+    res.json({ items: contacts });
+  } catch (error) {
+    console.error("contacts profile error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/profile/contacts — add contact
+router.post("/profile/contacts", async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { type, value, label, order } = req.body as {
+      type: string;
+      value: string;
+      label?: string;
+      order?: number;
+    };
+
+    if (!type || !VALID_TYPES.includes(type)) {
+      res.status(400).json({ error: `type must be one of: ${VALID_TYPES.join(", ")}` });
+      return;
+    }
+
+    if (!value || typeof value !== "string" || !value.trim()) {
+      res.status(400).json({ error: "value is required" });
+      return;
+    }
+
+    // Ensure profile exists
+    let profile = await prisma.specialistProfile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      profile = await prisma.specialistProfile.create({
+        data: { userId },
+        select: { id: true },
+      });
+    }
+
+    // Check max 6 contacts
+    const count = await prisma.contactMethod.count({ where: { profileId: profile.id } });
+    if (count >= MAX_CONTACTS) {
+      res.status(400).json({ error: `Max ${MAX_CONTACTS} contacts allowed` });
+      return;
+    }
+
+    const contact = await prisma.contactMethod.create({
+      data: {
+        profileId: profile.id,
+        type,
+        value: value.trim(),
+        label: label?.trim() || null,
+        order: typeof order === "number" ? order : count,
+      },
+      select: { id: true, type: true, value: true, label: true, order: true },
+    });
+
+    res.status(201).json(contact);
+  } catch (error) {
+    console.error("contacts create error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PUT /api/profile/contacts/:id — update value/label/order
+router.put("/profile/contacts/:id", async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const contactId = req.params.id as string;
+    const { value, label, order } = req.body as {
+      value?: string;
+      label?: string;
+      order?: number;
+    };
+
+    const profile = await prisma.specialistProfile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      res.status(404).json({ error: "Profile not found" });
+      return;
+    }
+
+    const existing = await prisma.contactMethod.findFirst({
+      where: { id: contactId, profileId: profile.id },
+    });
+
+    if (!existing) {
+      res.status(404).json({ error: "Contact not found" });
+      return;
+    }
+
+    const updated = await prisma.contactMethod.update({
+      where: { id: contactId },
+      data: {
+        ...(value !== undefined ? { value: value.trim() } : {}),
+        ...(label !== undefined ? { label: label.trim() || null } : {}),
+        ...(order !== undefined ? { order } : {}),
+      },
+      select: { id: true, type: true, value: true, label: true, order: true },
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error("contacts update error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// DELETE /api/profile/contacts/:id
+router.delete("/profile/contacts/:id", async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const contactId = req.params.id as string;
+
+    const profile = await prisma.specialistProfile.findUnique({
+      where: { userId },
+      select: { id: true },
+    });
+
+    if (!profile) {
+      res.status(404).json({ error: "Profile not found" });
+      return;
+    }
+
+    const existing = await prisma.contactMethod.findFirst({
+      where: { id: contactId, profileId: profile.id },
+    });
+
+    if (!existing) {
+      res.status(404).json({ error: "Contact not found" });
+      return;
+    }
+
+    await prisma.contactMethod.delete({ where: { id: contactId } });
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error("contacts delete error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -18,8 +18,27 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
-import { apiGet, apiPatch } from "@/lib/api";
+import { apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+
+interface ContactMethodItem {
+  id: string;
+  type: string;
+  value: string;
+  label: string | null;
+  order: number;
+}
+
+const CONTACT_TYPE_LABELS: Record<string, string> = {
+  phone: "Телефон",
+  email: "Email",
+  telegram: "Telegram",
+  whatsapp: "WhatsApp",
+  vk: "ВКонтакте",
+  website: "Сайт",
+};
+
+const CONTACT_TYPES = Object.keys(CONTACT_TYPE_LABELS);
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3812";
 
@@ -88,11 +107,20 @@ export default function SpecialistSettings() {
   const [pushEnabled, setPushEnabled] = useState(true);
   const [emailEnabled, setEmailEnabled] = useState(true);
 
+  // ContactMethod state
+  const [contacts, setContacts] = useState<ContactMethodItem[]>([]);
+  const [addingContact, setAddingContact] = useState(false);
+  const [newContactType, setNewContactType] = useState("phone");
+  const [newContactValue, setNewContactValue] = useState("");
+  const [contactSaving, setContactSaving] = useState(false);
+  const [showTypePicker, setShowTypePicker] = useState(false);
+
   const fetchProfile = useCallback(async () => {
     try {
-      const profile = await apiGet<SpecialistProfileData>(
-        "/api/specialist/profile"
-      );
+      const [profile, contactsData] = await Promise.all([
+        apiGet<SpecialistProfileData>("/api/specialist/profile"),
+        apiGet<{ items: ContactMethodItem[] }>("/api/profile/contacts"),
+      ]);
       setData(profile);
       setFirstName(profile.firstName || "");
       setLastName(profile.lastName || "");
@@ -106,6 +134,7 @@ export default function SpecialistSettings() {
         setOfficeAddress(profile.profile.officeAddress || "");
         setWorkingHours(profile.profile.workingHours || "");
       }
+      setContacts(contactsData.items);
     } catch (error) {
       console.error("Profile fetch error:", error);
     } finally {
@@ -177,6 +206,48 @@ export default function SpecialistSettings() {
     } finally {
       setAvailabilityLoading(false);
     }
+  };
+
+  const handleAddContact = async () => {
+    if (!newContactValue.trim()) {
+      Alert.alert("Ошибка", "Введите значение контакта");
+      return;
+    }
+    setContactSaving(true);
+    try {
+      const created = await apiPost<ContactMethodItem>("/api/profile/contacts", {
+        type: newContactType,
+        value: newContactValue.trim(),
+        order: contacts.length,
+      });
+      setContacts((prev) => [...prev, created]);
+      setAddingContact(false);
+      setNewContactValue("");
+      setNewContactType("phone");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Не удалось добавить контакт";
+      Alert.alert("Ошибка", msg);
+    } finally {
+      setContactSaving(false);
+    }
+  };
+
+  const handleDeleteContact = (id: string) => {
+    Alert.alert("Удалить контакт?", "Это действие нельзя отменить", [
+      { text: "Отмена", style: "cancel" },
+      {
+        text: "Удалить",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await apiDelete(`/api/profile/contacts/${id}`);
+            setContacts((prev) => prev.filter((c) => c.id !== id));
+          } catch {
+            Alert.alert("Ошибка", "Не удалось удалить контакт");
+          }
+        },
+      },
+    ]);
   };
 
   const handleSave = async () => {
@@ -463,49 +534,144 @@ export default function SpecialistSettings() {
               </Pressable>
             )}
 
-            {/* Contacts */}
+            {/* Contacts — structured ContactMethod */}
             <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">
               Контакты
             </Text>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              Телефон
-            </Text>
-            <TextInput
-              accessibilityLabel="Телефон"
-              value={phone}
-              onChangeText={setPhone}
-              placeholder="+7 (___) ___-__-__"
-              placeholderTextColor="#94a3b8"
-              keyboardType="phone-pad"
-              style={INPUT_STYLE}
-            />
+            {contacts.map((contact) => (
+              <View
+                key={contact.id}
+                className="flex-row items-center bg-slate-50 border border-slate-200 rounded-xl px-4 py-3 mb-2"
+              >
+                <View className="flex-1">
+                  <Text className="text-xs text-slate-400 mb-0.5">
+                    {CONTACT_TYPE_LABELS[contact.type] || contact.type}
+                  </Text>
+                  <Text className="text-sm font-medium text-slate-900">
+                    {contact.value}
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityLabel="Удалить контакт"
+                  onPress={() => handleDeleteContact(contact.id)}
+                  className="ml-2 p-2"
+                >
+                  <FontAwesome name="trash-o" size={16} color="#dc2626" />
+                </Pressable>
+              </View>
+            ))}
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              Telegram
-            </Text>
-            <TextInput
-              accessibilityLabel="Telegram"
-              value={telegram}
-              onChangeText={setTelegram}
-              placeholder="@username"
-              placeholderTextColor="#94a3b8"
-              autoCapitalize="none"
-              style={INPUT_STYLE}
-            />
-
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              WhatsApp
-            </Text>
-            <TextInput
-              accessibilityLabel="WhatsApp"
-              value={whatsapp}
-              onChangeText={setWhatsapp}
-              placeholder="+7 (___) ___-__-__"
-              placeholderTextColor="#94a3b8"
-              keyboardType="phone-pad"
-              style={INPUT_STYLE}
-            />
+            {addingContact ? (
+              <View className="bg-slate-50 border border-slate-200 rounded-xl p-4 mb-2">
+                <Text className="text-sm font-medium text-slate-900 mb-2">Тип контакта</Text>
+                <Pressable
+                  accessibilityLabel="Выбрать тип контакта"
+                  onPress={() => setShowTypePicker(!showTypePicker)}
+                  className="flex-row items-center justify-between bg-white border border-slate-200 rounded-xl px-4 py-3 mb-3"
+                >
+                  <Text className="text-base text-slate-900">
+                    {CONTACT_TYPE_LABELS[newContactType]}
+                  </Text>
+                  <FontAwesome name="chevron-down" size={12} color="#94a3b8" />
+                </Pressable>
+                {showTypePicker && (
+                  <View className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-3">
+                    {CONTACT_TYPES.map((t) => (
+                      <Pressable
+                        key={t}
+                        accessibilityLabel={CONTACT_TYPE_LABELS[t]}
+                        onPress={() => {
+                          setNewContactType(t);
+                          setShowTypePicker(false);
+                        }}
+                        className={`px-4 py-3 border-b border-slate-100 ${
+                          newContactType === t ? "bg-blue-50" : ""
+                        }`}
+                      >
+                        <Text
+                          className={`text-base ${
+                            newContactType === t ? "text-blue-900 font-medium" : "text-slate-700"
+                          }`}
+                        >
+                          {CONTACT_TYPE_LABELS[t]}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                )}
+                <Text className="text-sm font-medium text-slate-900 mb-1">Значение</Text>
+                <TextInput
+                  accessibilityLabel="Значение контакта"
+                  value={newContactValue}
+                  onChangeText={setNewContactValue}
+                  placeholder={
+                    newContactType === "phone" || newContactType === "whatsapp"
+                      ? "+7 (___) ___-__-__"
+                      : newContactType === "telegram"
+                      ? "@username"
+                      : newContactType === "email"
+                      ? "email@example.com"
+                      : newContactType === "vk"
+                      ? "vk.com/username"
+                      : "https://example.com"
+                  }
+                  placeholderTextColor="#94a3b8"
+                  autoCapitalize="none"
+                  keyboardType={
+                    newContactType === "phone" || newContactType === "whatsapp"
+                      ? "phone-pad"
+                      : newContactType === "email"
+                      ? "email-address"
+                      : "default"
+                  }
+                  style={INPUT_STYLE}
+                />
+                <View className="flex-row gap-2">
+                  <Pressable
+                    accessibilityLabel="Отмена"
+                    onPress={() => {
+                      setAddingContact(false);
+                      setNewContactValue("");
+                      setNewContactType("phone");
+                      setShowTypePicker(false);
+                    }}
+                    className="flex-1 border border-slate-200 rounded-xl py-3 items-center"
+                  >
+                    <Text className="text-base text-slate-600">Отмена</Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityLabel="Добавить"
+                    onPress={handleAddContact}
+                    disabled={contactSaving}
+                    className={`flex-1 rounded-xl py-3 items-center ${
+                      contactSaving ? "bg-blue-900 opacity-50" : "bg-blue-900"
+                    }`}
+                  >
+                    {contactSaving ? (
+                      <ActivityIndicator color="#fff" size="small" />
+                    ) : (
+                      <Text className="text-base font-semibold text-white">Добавить</Text>
+                    )}
+                  </Pressable>
+                </View>
+              </View>
+            ) : contacts.length < 6 ? (
+              <Pressable
+                accessibilityLabel="Добавить контакт"
+                onPress={() => setAddingContact(true)}
+                className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
+              >
+                <FontAwesome name="plus" size={14} color="#1e3a8a" />
+                <Text className="text-sm text-blue-900 ml-2 font-medium">
+                  Добавить контакт
+                </Text>
+              </Pressable>
+            ) : (
+              <Text className="text-xs text-slate-400 text-center mb-4">
+                Максимум 6 контактов
+              </Text>
+            )}
 
             {/* Office info */}
             <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3 mt-2">

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -32,6 +32,14 @@ interface SpecialistProfile {
   workingHours: string | null;
 }
 
+interface ContactMethodItem {
+  id: string;
+  type: string;
+  value: string;
+  label: string | null;
+  order: number;
+}
+
 interface SpecialistDetail {
   id: string;
   firstName: string | null;
@@ -42,6 +50,34 @@ interface SpecialistDetail {
   profile: SpecialistProfile | null;
   fnsServices: FnsServiceGroup[];
 }
+
+function getContactUrl(type: string, value: string): string | null {
+  switch (type) {
+    case "phone":
+      return `tel:${value}`;
+    case "email":
+      return `mailto:${value}`;
+    case "telegram":
+      return `https://t.me/${value.replace("@", "")}`;
+    case "whatsapp":
+      return `https://wa.me/${value.replace(/\D/g, "")}`;
+    case "vk":
+      return value.startsWith("http") ? value : `https://vk.com/${value.replace(/^vk\.com\//, "")}`;
+    case "website":
+      return value.startsWith("http") ? value : `https://${value}`;
+    default:
+      return null;
+  }
+}
+
+const CONTACT_TYPE_CONFIG: Record<string, { label: string; icon: string; bg: string; color: string }> = {
+  phone: { label: "Телефон", icon: "phone", bg: "#eff6ff", color: "#1e3a8a" },
+  email: { label: "Email", icon: "envelope", bg: "#f0fdf4", color: "#166534" },
+  telegram: { label: "Telegram", icon: "paper-plane", bg: "#f0f9ff", color: "#0284c7" },
+  whatsapp: { label: "WhatsApp", icon: "whatsapp", bg: "#f0fdf4", color: "#059669" },
+  vk: { label: "ВКонтакте", icon: "vk", bg: "#eff6ff", color: "#2563eb" },
+  website: { label: "Сайт", icon: "globe", bg: "#fafaf9", color: "#57534e" },
+};
 
 interface SimilarSpecialist {
   id: string;
@@ -128,6 +164,7 @@ export default function SpecialistPublicProfile() {
   const { user, isAuthenticated } = useAuth();
 
   const [specialist, setSpecialist] = useState<SpecialistDetail | null>(null);
+  const [contacts, setContacts] = useState<ContactMethodItem[]>([]);
   const [similar, setSimilar] = useState<SimilarSpecialist[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -138,12 +175,14 @@ export default function SpecialistPublicProfile() {
   useEffect(() => {
     async function load() {
       try {
-        const [specRes, similarRes] = await Promise.all([
+        const [specRes, similarRes, contactsRes] = await Promise.all([
           api<SpecialistDetail>(`/api/specialists/${id}`, { noAuth: true }),
           api<{ items: SimilarSpecialist[] }>("/api/specialists/featured", { noAuth: true }),
+          api<{ items: ContactMethodItem[] }>(`/api/specialists/${id}/contacts`, { noAuth: true }),
         ]);
         setSpecialist(specRes);
         setSimilar(similarRes.items.filter((s) => s.id !== id));
+        setContacts(contactsRes.items);
       } catch (e) {
         setError("Не удалось загрузить профиль");
         console.error("Specialist detail error:", e);
@@ -220,13 +259,9 @@ export default function SpecialistPublicProfile() {
     </Pressable>
   ) : undefined;
 
-  const hasContacts =
-    specialist.profile &&
-    (specialist.profile.phone ||
-      specialist.profile.telegram ||
-      specialist.profile.whatsapp ||
-      specialist.profile.officeAddress ||
-      specialist.profile.workingHours);
+  const hasContacts = contacts.length > 0 ||
+    (specialist.profile &&
+      (specialist.profile.officeAddress || specialist.profile.workingHours));
 
   const cardShadow = {
     shadowColor: "#0F172A",
@@ -335,88 +370,77 @@ export default function SpecialistPublicProfile() {
               >
                 <Text className="text-base font-semibold text-slate-900 mb-3">Контакты</Text>
 
-                {specialist.profile!.phone && (
-                  <Pressable
-                    accessibilityLabel={`Позвонить ${specialist.profile!.phone}`}
-                    onPress={() => Linking.openURL(`tel:${specialist.profile!.phone}`)}
-                    className="flex-row items-center py-2.5 border-b border-slate-100"
-                  >
+                {contacts.map((contact, index) => {
+                  const cfg = CONTACT_TYPE_CONFIG[contact.type] || {
+                    label: contact.type,
+                    icon: "link",
+                    bg: "#f8fafc",
+                    color: "#64748b",
+                  };
+                  const url = getContactUrl(contact.type, contact.value);
+                  const isLast =
+                    index === contacts.length - 1 &&
+                    !specialist.profile?.officeAddress &&
+                    !specialist.profile?.workingHours;
+
+                  if (url) {
+                    return (
+                      <Pressable
+                        key={contact.id}
+                        accessibilityLabel={`${cfg.label} ${contact.value}`}
+                        onPress={() => Linking.openURL(url)}
+                        className={`flex-row items-center py-2.5 ${isLast ? "" : "border-b border-slate-100"}`}
+                      >
+                        <View
+                          className="w-8 h-8 rounded-full items-center justify-center mr-3"
+                          style={{ backgroundColor: cfg.bg }}
+                        >
+                          <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                        </View>
+                        <View className="flex-1">
+                          <Text className="text-xs text-slate-400 mb-0.5">{cfg.label}</Text>
+                          <Text className="text-sm font-medium" style={{ color: cfg.color }}>
+                            {contact.value}
+                          </Text>
+                        </View>
+                        <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
+                      </Pressable>
+                    );
+                  }
+                  return (
                     <View
-                      className="w-8 h-8 rounded-full bg-blue-50 items-center justify-center mr-3"
+                      key={contact.id}
+                      className={`flex-row items-center py-2.5 ${isLast ? "" : "border-b border-slate-100"}`}
                     >
-                      <FontAwesome name="phone" size={14} color="#1e3a8a" />
+                      <View
+                        className="w-8 h-8 rounded-full items-center justify-center mr-3"
+                        style={{ backgroundColor: cfg.bg }}
+                      >
+                        <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                      </View>
+                      <View className="flex-1">
+                        <Text className="text-xs text-slate-400 mb-0.5">{cfg.label}</Text>
+                        <Text className="text-sm font-medium text-slate-700">{contact.value}</Text>
+                      </View>
                     </View>
-                    <View className="flex-1">
-                      <Text className="text-xs text-slate-400 mb-0.5">Телефон</Text>
-                      <Text className="text-sm font-medium text-blue-900">
-                        {specialist.profile!.phone}
-                      </Text>
-                    </View>
-                    <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
-                  </Pressable>
-                )}
+                  );
+                })}
 
-                {specialist.profile!.telegram && (
-                  <Pressable
-                    accessibilityLabel={`Telegram ${specialist.profile!.telegram}`}
-                    onPress={() =>
-                      Linking.openURL(
-                        `https://t.me/${specialist.profile!.telegram!.replace("@", "")}`
-                      )
-                    }
-                    className="flex-row items-center py-2.5 border-b border-slate-100"
-                  >
-                    <View className="w-8 h-8 rounded-full bg-sky-50 items-center justify-center mr-3">
-                      <FontAwesome name="paper-plane" size={13} color="#0284c7" />
-                    </View>
-                    <View className="flex-1">
-                      <Text className="text-xs text-slate-400 mb-0.5">Telegram</Text>
-                      <Text className="text-sm font-medium text-sky-700">
-                        {specialist.profile!.telegram}
-                      </Text>
-                    </View>
-                    <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
-                  </Pressable>
-                )}
-
-                {specialist.profile!.whatsapp && (
-                  <Pressable
-                    accessibilityLabel={`WhatsApp ${specialist.profile!.whatsapp}`}
-                    onPress={() =>
-                      Linking.openURL(
-                        `https://wa.me/${specialist.profile!.whatsapp!.replace(/\D/g, "")}`
-                      )
-                    }
-                    className="flex-row items-center py-2.5 border-b border-slate-100"
-                  >
-                    <View className="w-8 h-8 rounded-full bg-emerald-50 items-center justify-center mr-3">
-                      <FontAwesome name="whatsapp" size={15} color="#059669" />
-                    </View>
-                    <View className="flex-1">
-                      <Text className="text-xs text-slate-400 mb-0.5">WhatsApp</Text>
-                      <Text className="text-sm font-medium text-emerald-700">
-                        {specialist.profile!.whatsapp}
-                      </Text>
-                    </View>
-                    <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
-                  </Pressable>
-                )}
-
-                {specialist.profile!.officeAddress && (
-                  <View className="flex-row items-start py-2.5 border-b border-slate-100">
+                {specialist.profile?.officeAddress && (
+                  <View className={`flex-row items-start py-2.5 ${specialist.profile?.workingHours ? "border-b border-slate-100" : ""}`}>
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
                       <FontAwesome name="map-marker" size={14} color="#64748b" />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Адрес офиса</Text>
                       <Text className="text-sm text-slate-700 leading-5">
-                        {specialist.profile!.officeAddress}
+                        {specialist.profile.officeAddress}
                       </Text>
                     </View>
                   </View>
                 )}
 
-                {specialist.profile!.workingHours && (
+                {specialist.profile?.workingHours && (
                   <View className="flex-row items-center py-2.5">
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
                       <FontAwesome name="clock-o" size={14} color="#64748b" />
@@ -424,7 +448,7 @@ export default function SpecialistPublicProfile() {
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Часы работы</Text>
                       <Text className="text-sm text-slate-700">
-                        {specialist.profile!.workingHours}
+                        {specialist.profile.workingHours}
                       </Text>
                     </View>
                   </View>


### PR DESCRIPTION
Replaces legacy contacts string fields in SpecialistProfile with structured ContactMethod records.

## What changed

- **Schema**: new \`ContactMethod\` model (\`contact_methods\` table) — supports phone/email/telegram/whatsapp/vk/website types with value, label, order
- **API**:
  - \`GET /api/specialists/:id/contacts\` — public, no auth required
  - \`GET /api/profile/contacts\` — auth, own contacts
  - \`POST /api/profile/contacts\` — add contact (max 6 total)
  - \`PUT /api/profile/contacts/:id\` — update value/label/order
  - \`DELETE /api/profile/contacts/:id\` — delete
- **Settings screen**: dynamic contacts section replaces static phone/telegram/whatsapp fields — shows existing contacts as editable rows, type picker + value input for adding new ones
- **Public profile**: fetches contacts from new endpoint, renders each with type-appropriate icon and deep link (tel:/mailto:/t.me/wa.me/vk.com/https)

## DB note

\`contact_methods\` table was created via Prisma raw SQL (db push is blocked by an unrelated pending cities.slug migration in the development branch).

Closes #243