### PR TITLE
fix: request DTO validation + one-time role set guard — closes #168 #169

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -226,4 +226,50 @@ router.get("/me", authMiddleware, async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/auth/set-role — set role for new users (auth required, one-time only)
+router.post("/set-role", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { role } = req.body;
+
+    if (role !== "CLIENT" && role !== "SPECIALIST") {
+      res.status(400).json({ error: "Role must be CLIENT or SPECIALIST" });
+      return;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { role: true },
+    });
+
+    if (!user) {
+      res.status(404).json({ error: "User not found" });
+      return;
+    }
+
+    // Guard: role can only be set once
+    if (user.role !== null) {
+      res.status(400).json({ error: "Role already set" });
+      return;
+    }
+
+    const updated = await prisma.user.update({
+      where: { id: userId },
+      data: { role },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        firstName: true,
+        lastName: true,
+      },
+    });
+
+    res.json({ user: updated });
+  } catch (error) {
+    console.error("set-role error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 export default router;

--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -29,6 +29,16 @@ router.put("/name", authMiddleware, async (req: Request, res: Response) => {
       return;
     }
 
+    // Guard: role can only be set once (during onboarding)
+    const existing = await prisma.user.findUnique({
+      where: { id: req.user!.userId },
+      select: { role: true },
+    });
+    if (existing?.role !== null && existing?.role !== undefined) {
+      res.status(400).json({ error: "Role already set" });
+      return;
+    }
+
     const user = await prisma.user.update({
       where: { id: req.user!.userId },
       data: {

--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -396,6 +396,80 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
   }
 });
 
+// PATCH /api/requests/:id — update own request (auth required)
+// Only whitelisted fields: title, description. Unknown fields are rejected.
+router.patch("/:id", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const id = req.params.id as string;
+
+    // Whitelist: only title and description are editable
+    const ALLOWED_KEYS = ["title", "description"];
+    const bodyKeys = Object.keys(req.body);
+    const unknownKeys = bodyKeys.filter((k) => !ALLOWED_KEYS.includes(k));
+    if (unknownKeys.length > 0) {
+      res.status(400).json({ error: `Unknown fields: ${unknownKeys.join(", ")}` });
+      return;
+    }
+
+    const { title, description } = req.body;
+
+    // At least one field must be provided
+    if (title === undefined && description === undefined) {
+      res.status(400).json({ error: "At least one field (title or description) is required" });
+      return;
+    }
+
+    // Validate title if provided
+    if (title !== undefined) {
+      if (typeof title !== "string" || title.length < 3 || title.length > 100) {
+        res.status(400).json({ error: "Title must be 3-100 characters" });
+        return;
+      }
+    }
+
+    // Validate description if provided
+    if (description !== undefined) {
+      if (typeof description !== "string" || description.length < 10 || description.length > 2000) {
+        res.status(400).json({ error: "Description must be 10-2000 characters" });
+        return;
+      }
+    }
+
+    const request = await prisma.request.findUnique({ where: { id } });
+
+    if (!request) {
+      res.status(404).json({ error: "Request not found" });
+      return;
+    }
+
+    if (request.userId !== userId) {
+      res.status(403).json({ error: "Access denied" });
+      return;
+    }
+
+    if (request.status === "CLOSED") {
+      res.status(400).json({ error: "Cannot edit a closed request" });
+      return;
+    }
+
+    const data: Record<string, unknown> = {};
+    if (title !== undefined) data.title = title.trim();
+    if (description !== undefined) data.description = description.trim();
+
+    const updated = await prisma.request.update({
+      where: { id },
+      data,
+      select: { id: true, title: true, description: true, status: true },
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error("requests/:id patch error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // DELETE /api/requests/:id — delete own request (auth required)
 router.delete("/:id", authMiddleware, async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
Adds body validation to PATCH /requests/:id and prevents role change when already set.

## Changes

**Bug #168 — PATCH /requests/:id DTO validation:**
- Added new `PATCH /api/requests/:id` endpoint (previously missing)
- Whitelisted fields: `title` and `description` only — unknown fields rejected with 400
- Validates title (3–100 chars) and description (10–2000 chars)
- Blocks edits on closed requests

**Bug #169 — One-time role set guard:**
- Added `POST /api/auth/set-role` endpoint with guard: returns 400 if `user.role !== null`
- Added same guard to `PUT /api/onboarding/name`: returns 400 if role already set

Closes #168
Closes #169