### PR TITLE
fix: OTP cleanup + JWT secret lazy load — closes #188 #240

### DIFF
--- a/api/src/lib/jwt.ts
+++ b/api/src/lib/jwt.ts
@@ -1,7 +1,9 @@
 import jwt from "jsonwebtoken";
 import crypto from "crypto";
 
-const JWT_SECRET = process.env.JWT_SECRET || "dev-secret-change-in-production";
+function getJwtSecret(): string {
+  return process.env.JWT_SECRET || "dev-secret-change-in-production";
+}
 
 export interface JwtPayload {
   userId: string;
@@ -9,11 +11,11 @@ export interface JwtPayload {
 }
 
 export function signAccessToken(payload: JwtPayload): string {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: "15m" });
+  return jwt.sign(payload, getJwtSecret(), { expiresIn: "15m" });
 }
 
 export function verifyAccessToken(token: string): JwtPayload {
-  return jwt.verify(token, JWT_SECRET) as JwtPayload;
+  return jwt.verify(token, getJwtSecret()) as JwtPayload;
 }
 
 export function generateRefreshToken(): string {

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -38,6 +38,11 @@ router.post("/request-otp", async (req: Request, res: Response) => {
     const code = generateOtpCode();
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
 
+    // Delete previous unused OTPs for this email
+    await prisma.otpCode.deleteMany({
+      where: { email: email.toLowerCase(), used: false },
+    });
+
     await prisma.otpCode.create({
       data: { email: email.toLowerCase(), code, expiresAt },
     });


### PR DESCRIPTION
## Summary

- **#188**: JWT_SECRET was read at module import time as a module-level `const`. Replaced with `getJwtSecret()` helper that reads `process.env.JWT_SECRET` at call time, so the secret is always picked up correctly regardless of env load order.
- **#240**: OTP storage was already on PostgreSQL (`OtpCode` model + `prisma.otpCode.*`). Completed the fix: `request-otp` now deletes previous unused OTPs for the same email before creating a new one, preventing stale code accumulation.

## Changes

- `api/src/lib/jwt.ts` — `getJwtSecret()` lazy getter replaces module-level const
- `api/src/routes/auth.ts` — `prisma.otpCode.deleteMany` before creating new OTP

## Verification

- `npx tsc --noEmit` → 0 errors

Closes #188
Closes #240