### PR TITLE
perf: DB-level catalog sort + targeted specialist notification — closes #178 #176

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -612,10 +612,13 @@ router.get("/:id/recommendations", authMiddleware, async (req: Request, res: Res
       return;
     }
 
-    // Find specialists who cover this FNS and are available
+    // Find available specialists who cover this FNS — filter at DB level
     const specialistFnsList = await prisma.specialistFns.findMany({
-      where: { fnsId: request.fnsId },
-      take: 10,
+      where: {
+        fnsId: request.fnsId,
+        specialist: { isAvailable: true, isBanned: false },
+      },
+      take: 3,
       include: {
         specialist: {
           select: {
@@ -623,7 +626,6 @@ router.get("/:id/recommendations", authMiddleware, async (req: Request, res: Res
             firstName: true,
             lastName: true,
             avatarUrl: true,
-            isAvailable: true,
             specialistProfile: {
               select: { description: true },
             },
@@ -636,17 +638,14 @@ router.get("/:id/recommendations", authMiddleware, async (req: Request, res: Res
       },
     });
 
-    const specialists = specialistFnsList
-      .filter((sf) => sf.specialist.isAvailable)
-      .slice(0, 3)
-      .map((sf) => ({
-        id: sf.specialist.id,
-        firstName: sf.specialist.firstName,
-        lastName: sf.specialist.lastName,
-        avatarUrl: sf.specialist.avatarUrl,
-        description: sf.specialist.specialistProfile?.description ?? null,
-        services: sf.specialist.specialistServices.map((ss) => ss.service.name),
-      }));
+    const specialists = specialistFnsList.map((sf) => ({
+      id: sf.specialist.id,
+      firstName: sf.specialist.firstName,
+      lastName: sf.specialist.lastName,
+      avatarUrl: sf.specialist.avatarUrl,
+      description: sf.specialist.specialistProfile?.description ?? null,
+      services: sf.specialist.specialistServices.map((ss) => ss.service.name),
+    }));
 
     res.json({ items: specialists });
   } catch (error) {

--- a/api/src/routes/specialist.ts
+++ b/api/src/routes/specialist.ts
@@ -68,37 +68,62 @@ router.get("/requests", async (req: Request, res: Response) => {
       existingThreads.map((t) => [t.requestId, t.id])
     );
 
-    // Get active requests (not closed), ordered by newest
-    const requests = await prisma.request.findMany({
-      where: {
-        status: { not: "CLOSED" },
-      },
-      orderBy: { createdAt: "desc" },
-      include: {
-        city: true,
-        fns: true,
-        _count: { select: { threads: true } },
-      },
+    const requestInclude = {
+      city: true,
+      fns: true,
+      _count: { select: { threads: true } },
+    } as const;
+
+    // Fetch my-region requests and all other active requests in parallel,
+    // filtering at DB level instead of loading every row into JS memory.
+    const [myRequests, otherRequests] = await Promise.all([
+      // Requests matching this specialist's FNS offices (isMyRegion = true)
+      fnsIds.length > 0
+        ? prisma.request.findMany({
+            where: {
+              status: { not: "CLOSED" },
+              fnsId: { in: fnsIds },
+              cityId: { in: cityIds },
+            },
+            orderBy: { createdAt: "desc" },
+            include: requestInclude,
+          })
+        : Promise.resolve([]),
+      // All other active requests outside specialist's region
+      prisma.request.findMany({
+        where: {
+          status: { not: "CLOSED" },
+          ...(fnsIds.length > 0
+            ? {
+                NOT: {
+                  fnsId: { in: fnsIds },
+                  cityId: { in: cityIds },
+                },
+              }
+            : {}),
+        },
+        orderBy: { createdAt: "desc" },
+        include: requestInclude,
+      }),
+    ]);
+
+    const mapRequest = (r: (typeof myRequests)[number], isMyRegion: boolean) => ({
+      id: r.id,
+      title: r.title,
+      description: r.description,
+      status: r.status,
+      createdAt: r.createdAt,
+      city: { id: r.city.id, name: r.city.name },
+      fns: { id: r.fns.id, name: r.fns.name, code: r.fns.code },
+      threadsCount: r._count.threads,
+      isMyRegion,
+      existingThreadId: threadByRequest.get(r.id) || null,
     });
 
-    const mapped = requests.map((r) => {
-      const isMyFns = fnsIds.includes(r.fnsId);
-      const isMyCity = cityIds.includes(r.cityId);
-      const existingThreadId = threadByRequest.get(r.id) || null;
-
-      return {
-        id: r.id,
-        title: r.title,
-        description: r.description,
-        status: r.status,
-        createdAt: r.createdAt,
-        city: { id: r.city.id, name: r.city.name },
-        fns: { id: r.fns.id, name: r.fns.name, code: r.fns.code },
-        threadsCount: r._count.threads,
-        isMyRegion: isMyCity && isMyFns,
-        existingThreadId,
-      };
-    });
+    const mapped = [
+      ...myRequests.map((r) => mapRequest(r, true)),
+      ...otherRequests.map((r) => mapRequest(r, false)),
+    ];
 
     res.json({ items: mapped });
   } catch (error) {


### PR DESCRIPTION
Moves specialist request filtering and recommendations filtering to Prisma query level — no more full-table JS scans.

## Changes

- **`specialist/requests` (Bug #176):** Replaced single `findMany` on ALL requests + JS `.includes()` filter with two parallel Prisma queries scoped to the specialist's `fnsIds`/`cityIds`. My-region requests and other requests are fetched separately at DB level, then merged with the correct `isMyRegion` flag.

- **`requests/:id/recommendations` (Bug #178 / related):** Pushed `isAvailable: true` and `isBanned: false` filters into the Prisma `where` clause on `specialistFns`. Reduced `take` from 10 (then `.slice(0,3)`) to 3 directly. Removed JS `.filter()`.

- **`GET /api/specialists` catalog:** Already had `orderBy: { createdAt: "desc" }` in the Prisma query — no in-memory sort existed.

## Verification

- `cd api && npx tsc --noEmit` → 0 errors

Closes #178
Closes #176