### PR TITLE
fix(low): console.logs, cities take limit — closes #182 #189

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -47,7 +47,6 @@ app.use("/api/notifications", notificationsRoutes);
 app.use("/api", contactsRoutes);
 
 app.listen(PORT, () => {
-  console.log(`API server running on http://localhost:${PORT}`);
   // Start BullMQ worker (graceful degradation if Valkey unavailable)
   startNotificationWorker();
 });

--- a/api/src/notifications/notification.processor.ts
+++ b/api/src/notifications/notification.processor.ts
@@ -121,8 +121,8 @@ export function startNotificationWorker(): void {
       { connection: getRedisConnection() }
     );
 
-    _worker.on("completed", (job) => {
-      console.log(`[notifications] Job ${job.id} completed`);
+    _worker.on("completed", (_job) => {
+      // job completed silently
     });
 
     _worker.on("failed", (job, err) => {
@@ -133,7 +133,7 @@ export function startNotificationWorker(): void {
       console.warn("[notifications] Worker error:", err.message);
     });
 
-    console.log("[notifications] Worker started");
+    // worker started
   } catch (err) {
     console.warn("[notifications] Failed to start worker (Valkey unavailable):", (err as Error).message);
   }

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -48,13 +48,13 @@ router.get("/stats", async (_req: Request, res: Response) => {
         ? Math.round((requestsWithThreads / totalRequests) * 100)
         : 0;
 
-    // Top 5 cities by active requests
+    // Top cities by active requests
     const topCities = await prisma.request.groupBy({
       by: ["cityId"],
       where: { status: { in: ["ACTIVE", "CLOSING_SOON"] } },
       _count: { id: true },
       orderBy: { _count: { id: "desc" } },
-      take: 5,
+      take: 50,
     });
 
     const cityIds = topCities.map((c) => c.cityId);

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -43,7 +43,7 @@ router.post("/request-otp", async (req: Request, res: Response) => {
     });
 
     // In production: send email via nodemailer
-    console.log(`[DEV] OTP for ${email}: ${code}`);
+    // Dev OTP: always 000000 (see auth.md)
 
     res.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary
- **#182**: Remove all `console.log` from production code — notification processor (job completed + worker started), auth OTP log, index.ts server startup. `console.error` and `console.warn` kept.
- **#189**: Increase admin stats top-cities `take` from 5 to 50 (covers all real cities).
- **#185**: Already fixed — `upload.ts` already uses `memoryStorage`, no disk I/O.
- **#190**: `promotionPrice` / `as any` cast not present in codebase — no action needed.

## Test plan
- [ ] `tsc --noEmit` passes (verified: 0 errors)
- [ ] API starts without console.log noise
- [ ] Admin stats returns up to 50 cities instead of 5

Closes #182
Closes #189