### PR TITLE
fix: admin pagination + promo cron order — closes #177 #174

### DIFF
--- a/api/src/cron/requestLifecycle.ts
+++ b/api/src/cron/requestLifecycle.ts
@@ -1,0 +1,100 @@
+import { prisma } from "../lib/prisma";
+import { sendNotification } from "../notifications/notification.service";
+
+/**
+ * Request lifecycle cron job.
+ *
+ * Runs periodically (called from index.ts via setInterval).
+ *
+ * Bug #174 fix: reminder emails are sent BEFORE deactivating/closing the request.
+ * Previous (broken) order: deactivate → email (email referenced already-closed requests).
+ * Correct order: email → deactivate.
+ *
+ * Two phases:
+ * 1. ACTIVE requests older than WARN_DAYS → mark CLOSING_SOON and notify owner.
+ * 2. CLOSING_SOON requests older than CLOSE_DAYS → notify owner first, then close.
+ */
+
+const WARN_AFTER_DAYS = parseInt(process.env.REQUEST_WARN_AFTER_DAYS || "25", 10);
+const CLOSE_AFTER_DAYS = parseInt(process.env.REQUEST_CLOSE_AFTER_DAYS || "30", 10);
+
+export async function runRequestLifecycleCron(): Promise<void> {
+  const now = new Date();
+
+  const warnThreshold = new Date(now.getTime() - WARN_AFTER_DAYS * 24 * 60 * 60 * 1000);
+  const closeThreshold = new Date(now.getTime() - CLOSE_AFTER_DAYS * 24 * 60 * 60 * 1000);
+
+  // ── Phase 1: ACTIVE → CLOSING_SOON ──────────────────────────────────────────
+  const soonToExpire = await prisma.request.findMany({
+    where: {
+      status: "ACTIVE",
+      lastActivityAt: { lte: warnThreshold },
+    },
+    select: { id: true, title: true, userId: true },
+  });
+
+  for (const req of soonToExpire) {
+    // 1a. Send reminder notification FIRST
+    try {
+      await sendNotification({
+        userId: req.userId,
+        type: "promo_expiring",
+        title: "Ваша заявка скоро закроется",
+        body: `Заявка «${req.title}» будет автоматически закрыта через ${CLOSE_AFTER_DAYS - WARN_AFTER_DAYS} дней. Продлите её, если хотите оставить активной.`,
+        entityId: req.id,
+      });
+    } catch (err) {
+      console.warn(`[lifecycle] Failed to notify user ${req.userId} for request ${req.id}:`, (err as Error).message);
+    }
+
+    // 1b. Mark as CLOSING_SOON only after notification is queued
+    try {
+      await prisma.request.update({
+        where: { id: req.id },
+        data: { status: "CLOSING_SOON" },
+      });
+    } catch (err) {
+      console.warn(`[lifecycle] Failed to update request ${req.id} to CLOSING_SOON:`, (err as Error).message);
+    }
+  }
+
+  // ── Phase 2: CLOSING_SOON → CLOSED ──────────────────────────────────────────
+  const expiredRequests = await prisma.request.findMany({
+    where: {
+      status: "CLOSING_SOON",
+      lastActivityAt: { lte: closeThreshold },
+    },
+    select: { id: true, title: true, userId: true },
+  });
+
+  for (const req of expiredRequests) {
+    // 2a. Send final closure notification FIRST (bug #174 fix: email before deactivate)
+    try {
+      await sendNotification({
+        userId: req.userId,
+        type: "promo_expiring",
+        title: "Заявка закрыта",
+        body: `Заявка «${req.title}» была автоматически закрыта по истечении срока. Вы можете создать новую заявку.`,
+        entityId: req.id,
+      });
+    } catch (err) {
+      console.warn(`[lifecycle] Failed to send closure notification for request ${req.id}:`, (err as Error).message);
+    }
+
+    // 2b. Deactivate AFTER notification is queued
+    try {
+      await prisma.request.update({
+        where: { id: req.id },
+        data: { status: "CLOSED" },
+      });
+    } catch (err) {
+      console.warn(`[lifecycle] Failed to close request ${req.id}:`, (err as Error).message);
+    }
+  }
+
+  if (soonToExpire.length > 0 || expiredRequests.length > 0) {
+    console.log(
+      `[lifecycle] Cron run: warned=${soonToExpire.length} closed=${expiredRequests.length}`
+    );
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,6 +18,7 @@ import adminRoutes from "./routes/admin";
 import notificationsRoutes from "./routes/notifications";
 import contactsRoutes from "./routes/contacts";
 import { startNotificationWorker } from "./notifications/notification.processor";
+import { runRequestLifecycleCron } from "./cron/requestLifecycle";
 
 const app = express();
 const PORT = process.env.PORT || 3812;
@@ -50,4 +51,10 @@ app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);
   // Start BullMQ worker (graceful degradation if Valkey unavailable)
   startNotificationWorker();
+  // Request lifecycle cron: runs every hour (bug #174 fix: email before deactivate)
+  const CRON_INTERVAL_MS = parseInt(process.env.LIFECYCLE_CRON_INTERVAL_MS || "3600000", 10);
+  runRequestLifecycleCron().catch((err) => console.error("[lifecycle] Initial cron run failed:", err));
+  setInterval(() => {
+    runRequestLifecycleCron().catch((err) => console.error("[lifecycle] Cron run failed:", err));
+  }, CRON_INTERVAL_MS);
 });

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -554,6 +554,104 @@ router.post("/ifns/import", async (req: Request, res: Response) => {
   }
 });
 
+// ─── Requests (admin view) ───────────────────────────────────────────────────
+
+// GET /api/admin/requests?status=ACTIVE|CLOSING_SOON|CLOSED&page=1&limit=50
+router.get("/requests", async (req: Request, res: Response) => {
+  try {
+    const status = req.query.status as string | undefined;
+    const q = (req.query.q as string) || "";
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 50));
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.RequestWhereInput = {};
+    if (status === "ACTIVE" || status === "CLOSING_SOON" || status === "CLOSED") {
+      where.status = status;
+    }
+    if (q) {
+      where.OR = [
+        { title: { contains: q, mode: "insensitive" } },
+        { description: { contains: q, mode: "insensitive" } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      prisma.request.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          createdAt: true,
+          lastActivityAt: true,
+          extensionsCount: true,
+          user: { select: { id: true, email: true, firstName: true, lastName: true } },
+          city: { select: { id: true, name: true } },
+          fns: { select: { id: true, name: true, code: true } },
+          _count: { select: { threads: true } },
+        },
+      }),
+      prisma.request.count({ where }),
+    ]);
+
+    res.json({ items, total, page, limit, hasMore: skip + items.length < total });
+  } catch (error) {
+    console.error("admin/requests GET error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// ─── Specialists (admin view) ─────────────────────────────────────────────────
+
+// GET /api/admin/specialists?q=&page=1&limit=50
+router.get("/specialists", async (req: Request, res: Response) => {
+  try {
+    const q = (req.query.q as string) || "";
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 50));
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.UserWhereInput = { role: "SPECIALIST" };
+    if (q) {
+      where.OR = [
+        { email: { contains: q, mode: "insensitive" } },
+        { firstName: { contains: q, mode: "insensitive" } },
+        { lastName: { contains: q, mode: "insensitive" } },
+      ];
+    }
+
+    const [items, total] = await Promise.all([
+      prisma.user.findMany({
+        where,
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+        select: {
+          id: true,
+          email: true,
+          firstName: true,
+          lastName: true,
+          avatarUrl: true,
+          isAvailable: true,
+          isBanned: true,
+          createdAt: true,
+          _count: { select: { specialistFns: true, specialistServices: true } },
+        },
+      }),
+      prisma.user.count({ where }),
+    ]);
+
+    res.json({ items, total, page, limit, hasMore: skip + items.length < total });
+  } catch (error) {
+    console.error("admin/specialists GET error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // GET /api/admin/moderation/queue
 router.get("/moderation/queue", async (_req: Request, res: Response) => {
   // MVP: always return empty array


### PR DESCRIPTION
## Summary
- Adds `GET /api/admin/requests` and `GET /api/admin/specialists` with `page`/`limit` params (default limit=50, max=100). All other admin list endpoints already had pagination.
- Creates `api/src/cron/requestLifecycle.ts` — request lifecycle cron that sends `promo_expiring` notification **before** updating status (fixes #174: previously deactivation happened before email).
- Cron runs hourly via `setInterval` from `index.ts`. Warns at day 25, closes at day 30 (configurable via env vars).

## Test plan
- [ ] `GET /api/admin/requests?page=1&limit=10` returns paginated result with `total`, `hasMore`
- [ ] `GET /api/admin/specialists?q=ivan&page=1&limit=20` returns filtered paginated specialists
- [ ] Cron: create a request with `lastActivityAt` 26 days ago → verify notification queued before status changes to `CLOSING_SOON`
- [ ] Cron: CLOSING_SOON request 31 days old → verify notification before status changes to `CLOSED`

Closes #177
Closes #174