### PR TITLE
fix(admin): seed email mismatch + IDOR blockUser — closes #275 #171

### DIFF
--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -789,8 +789,31 @@ async function main() {
     });
   }
 
+  // Admin users — must match ADMIN_EMAILS env var
+  await prisma.user.upsert({
+    where: { email: "admin@p2ptax.ru" },
+    update: { role: "ADMIN" },
+    create: {
+      email: "admin@p2ptax.ru",
+      role: "ADMIN",
+      firstName: "Admin",
+      lastName: "P2PTax",
+    },
+  });
+
+  await prisma.user.upsert({
+    where: { email: "ruslan@p2ptax.ru" },
+    update: { role: "ADMIN" },
+    create: {
+      email: "ruslan@p2ptax.ru",
+      role: "ADMIN",
+      firstName: "Ruslan",
+      lastName: "",
+    },
+  });
+
   console.log(
-    `Seed complete: 10 cities, ${fnsCount} FNS offices, 3 services, 7 settings`
+    `Seed complete: 10 cities, ${fnsCount} FNS offices, 3 services, 7 settings, 2 admins`
   );
 }
 

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -179,6 +179,22 @@ router.patch("/users/:id", async (req: Request, res: Response) => {
       return;
     }
 
+    // Validate isBanned type if provided
+    if ("isBanned" in req.body && typeof isBanned !== "boolean") {
+      res.status(400).json({ error: "isBanned must be a boolean" });
+      return;
+    }
+
+    // Check user exists before update to avoid leaking P2025
+    const existing = await prisma.user.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!existing) {
+      res.status(404).json({ error: "User not found" });
+      return;
+    }
+
     const data: Record<string, unknown> = {};
     if (typeof isBanned === "boolean") data.isBanned = isBanned;
     if (typeof firstName === "string") data.firstName = firstName;


### PR DESCRIPTION
Updates seed admin email to match ADMIN_EMAILS env. Adds existence check and boolean validation to blockUser.

## Changes

- `api/prisma/seed.ts`: create `admin@p2ptax.ru` and `ruslan@p2ptax.ru` with `role: ADMIN` (upsert). Previously no admin user was seeded, causing 403 on all `/api/admin/*` endpoints after seed.
- `api/src/routes/admin.ts` PATCH `/users/:id`: added `findUnique` check before `update` → returns 404 instead of leaking Prisma P2025 error as 500. Added explicit `isBanned` boolean type guard at request level (400 if not boolean).

Closes #275
Closes #171