### PR TITLE
fix: pin expo-document-picker to SDK 54 compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^7.1.8",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
-        "expo-document-picker": "^55.0.13",
+        "expo-document-picker": "~14.0.8",
         "expo-font": "~14.0.11",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/expo-document-picker": {
-      "version": "55.0.13",
-      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-55.0.13.tgz",
-      "integrity": "sha512-IhswJElhdzs3fKDEKW8KXYRoFkWGEsXRMYAZT46Yo56zqqy8yQXrczo33RSwD2hFzNQBdLT97SJL9N311UyS3g==",
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-14.0.8.tgz",
+      "integrity": "sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
-    "expo-document-picker": "^55.0.13",
+    "expo-document-picker": "~14.0.8",
     "expo-font": "~14.0.11",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",


### PR DESCRIPTION
## Summary
- Fixes TSC error: `Cannot find module 'expo-document-picker'`
- Package had wrong version `^55.0.13`, correct for Expo SDK 54 is `~14.0.8`
- Prisma types for backend were regenerated locally (fixes stale types for `slug`/`address`/`searchAliases` fields) — node_modules not committed, no schema changes needed

## Test plan
- [ ] `npx tsc --noEmit` passes (frontend)
- [ ] `npx tsc --noEmit` passes (api/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)