### PR TITLE
fix(audit): brand colors + a11y + skeleton + responsive

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
+import { colors } from "@/lib/theme";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3812";
 
@@ -78,7 +79,7 @@ function StatusBadge({ status }: { status: "NEW" | "REVIEWED" }) {
   return (
     <View className="bg-emerald-50 px-2 py-0.5 rounded-lg flex-row items-center">
       <View
-        style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: "#047857", marginRight: 5 }}
+        style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: colors.success, marginRight: 5 }}
       />
       <Text className="text-xs font-medium text-emerald-700">Рассмотрена</Text>
     </View>
@@ -310,7 +311,7 @@ export default function AdminComplaints() {
             className="items-center justify-center rounded-full bg-red-50"
             style={{ width: 72, height: 72 }}
           >
-            <FontAwesome name="exclamation-circle" size={32} color="#f87171" />
+            <FontAwesome name="exclamation-circle" size={32} color={colors.error} />
           </View>
           <Text className="text-base font-medium text-slate-900 mt-4 text-center">
             Не удалось загрузить жалобы

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -1,19 +1,22 @@
 import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import HeaderHome from "@/components/HeaderHome";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 import EmptyState from "@/components/EmptyState";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
       <HeaderHome />
-      <View className="flex-1">
-        <EmptyState
-          icon="check-circle"
-          title="Всё чисто"
-          subtitle="Нет элементов, требующих модерации"
-        />
-      </View>
+      <ResponsiveContainer>
+        <View className="flex-1">
+          <EmptyState
+            icon="check-circle"
+            title="Всё чисто"
+            subtitle="Нет элементов, требующих модерации"
+          />
+        </View>
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -13,6 +13,7 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
 import EmptyState from "@/components/EmptyState";
+import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -94,9 +95,7 @@ export default function ClientDashboard() {
           </View>
 
           {loading ? (
-            <View className="items-center justify-center py-16">
-              <ActivityIndicator size="large" color="#1e3a8a" />
-            </View>
+            <LoadingState variant="skeleton" lines={5} />
           ) : error ? (
             <View className="items-center justify-center py-16 px-8">
               <Text className="text-lg font-semibold text-slate-900 text-center mb-2">

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import Header from "@/components/Header";
+import { colors } from "@/lib/theme";
 
 function TabIcon({ name, color }: { name: React.ComponentProps<typeof FontAwesome>["name"]; color: string }) {
   return <FontAwesome size={22} name={name} color={color} />;
@@ -17,7 +18,7 @@ export default function TabLayout() {
       <Tabs
         screenOptions={{
           tabBarActiveTintColor: "#2563eb",
-          tabBarInactiveTintColor: "#9ca3af",
+          tabBarInactiveTintColor: colors.textSecondary,
           tabBarStyle: {
             display: isMobile ? "flex" : "none",
             borderTopWidth: 1,

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 export default function CreateScreen() {
   return (
@@ -41,7 +42,7 @@ export default function CreateScreen() {
                 key={i}
                 className="w-[31%] aspect-square m-[1%] rounded-xl bg-gray-100 items-center justify-center"
               >
-                <FontAwesome name="image" size={20} color="#d1d5db" />
+                <FontAwesome name="image" size={20} color={colors.textSecondary} />
               </View>
             ))}
           </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { View, Text, TextInput, ScrollView, Pressable, FlatList } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 const CATEGORIES = [
   { id: "1", name: "Electronics", icon: "laptop" as const },
@@ -38,7 +39,7 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
     <Pressable accessibilityLabel={title} className="flex-1 m-1.5">
       <View className="rounded-2xl overflow-hidden bg-white" style={{ shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 4, elevation: 2 }}>
         <View className="h-36 items-center justify-center" style={{ backgroundColor: color }}>
-          <FontAwesome name="image" size={32} color="#9ca3af" />
+          <FontAwesome name="image" size={32} color={colors.textSecondary} />
         </View>
         <View className="p-3">
           <Text className="text-sm font-semibold text-gray-900" numberOfLines={2}>
@@ -46,7 +47,7 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
           </Text>
           <Text className="text-base font-bold text-blue-600 mt-1">{price}</Text>
           <View className="flex-row items-center mt-1">
-            <FontAwesome name="map-marker" size={12} color="#9ca3af" />
+            <FontAwesome name="map-marker" size={12} color={colors.textSecondary} />
             <Text className="text-xs text-gray-400 ml-1">{location}</Text>
           </View>
         </View>
@@ -73,12 +74,12 @@ export default function HomeScreen() {
             {/* Search Bar */}
             <View className="px-4 mb-4">
               <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
-                <FontAwesome name="search" size={16} color="#9ca3af" />
+                <FontAwesome name="search" size={16} color={colors.textSecondary} />
                 <TextInput
                   accessibilityLabel="Поиск объявлений"
                   className="flex-1 ml-3 text-base text-gray-900"
                   placeholder="Search listings..."
-                  placeholderTextColor="#9ca3af"
+                  placeholderTextColor={colors.textSecondary}
                 />
               </View>
             </View>

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, FlatList } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 const CONVERSATIONS = [
   {
@@ -52,7 +53,7 @@ const CONVERSATIONS = [
     id: "6",
     name: "Elena T.",
     avatar: "E",
-    avatarColor: "#ef4444",
+    avatarColor: colors.error,
     lastMessage: "Sent you the location pin",
     time: "2 days ago",
     unread: false,
@@ -114,7 +115,7 @@ export default function MessagesScreen() {
         renderItem={({ item }) => <ConversationItem {...item} />}
         ListEmptyComponent={
           <View className="flex-1 items-center justify-center py-20">
-            <FontAwesome name="comments-o" size={48} color="#d1d5db" />
+            <FontAwesome name="comments-o" size={48} color={colors.textSecondary} />
             <Text className="text-base text-gray-400 mt-4">No messages yet</Text>
           </View>
         }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useAuth } from "@/contexts/AuthContext";
+import { colors } from "@/lib/theme";
 
 const MENU_ITEMS = [
   { id: "listings", icon: "list-ul" as const, label: "My Listings", badge: "12" },
@@ -74,7 +75,7 @@ export default function ProfileScreen() {
                   <Text className="text-xs font-medium text-blue-600">{item.badge}</Text>
                 </View>
               )}
-              <FontAwesome name="chevron-right" size={12} color="#d1d5db" />
+              <FontAwesome name="chevron-right" size={12} color={colors.textSecondary} />
             </Pressable>
           ))}
         </View>
@@ -86,7 +87,7 @@ export default function ProfileScreen() {
             onPress={signOut}
             className="flex-row items-center justify-center h-12 rounded-xl border border-red-200 active:bg-red-50"
           >
-            <FontAwesome name="sign-out" size={16} color="#ef4444" />
+            <FontAwesome name="sign-out" size={16} color={colors.error} />
             <Text className="text-base font-medium text-red-500 ml-2">Log out</Text>
           </Pressable>
         </View>

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,6 +1,7 @@
 import { View, Text, TextInput, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 const RECENT_SEARCHES = [
   "iPhone 15",
@@ -30,12 +31,12 @@ export default function SearchScreen() {
         {/* Search Input */}
         <View className="px-4 mb-6">
           <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
-            <FontAwesome name="search" size={16} color="#9ca3af" />
+            <FontAwesome name="search" size={16} color={colors.textSecondary} />
             <TextInput
               accessibilityLabel="Поиск"
               className="flex-1 ml-3 text-base text-gray-900"
               placeholder="What are you looking for?"
-              placeholderTextColor="#9ca3af"
+              placeholderTextColor={colors.textSecondary}
             />
             <Pressable accessibilityLabel="Фильтры" className="ml-2 w-10 h-10 rounded-lg bg-blue-600 items-center justify-center">
               <FontAwesome name="sliders" size={16} color="#ffffff" />
@@ -57,9 +58,9 @@ export default function SearchScreen() {
               accessibilityLabel={search}
               className="flex-row items-center py-3 border-b border-gray-100"
             >
-              <FontAwesome name="clock-o" size={16} color="#9ca3af" />
+              <FontAwesome name="clock-o" size={16} color={colors.textSecondary} />
               <Text className="flex-1 ml-3 text-base text-gray-700">{search}</Text>
-              <FontAwesome name="arrow-right" size={12} color="#d1d5db" />
+              <FontAwesome name="arrow-right" size={12} color={colors.textSecondary} />
             </Pressable>
           ))}
         </View>
@@ -81,7 +82,7 @@ export default function SearchScreen() {
                 <Text className="text-base font-medium text-gray-900">{cat.name}</Text>
                 <Text className="text-xs text-gray-500">{cat.count}</Text>
               </View>
-              <FontAwesome name="chevron-right" size={12} color="#9ca3af" />
+              <FontAwesome name="chevron-right" size={12} color={colors.textSecondary} />
             </Pressable>
           ))}
         </View>

--- a/app/listing/[id].tsx
+++ b/app/listing/[id].tsx
@@ -2,6 +2,7 @@ import { View, Text, ScrollView, Pressable } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 export default function ListingDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -11,7 +12,7 @@ export default function ListingDetailScreen() {
       <ScrollView className="flex-1">
         {/* Image Placeholder */}
         <View className="h-72 bg-gray-100 items-center justify-center">
-          <FontAwesome name="image" size={48} color="#d1d5db" />
+          <FontAwesome name="image" size={48} color={colors.textSecondary} />
           <Text className="text-sm text-gray-400 mt-2">Listing #{id}</Text>
         </View>
 
@@ -24,10 +25,10 @@ export default function ListingDetailScreen() {
 
           {/* Location & Time */}
           <View className="flex-row items-center mt-3">
-            <FontAwesome name="map-marker" size={14} color="#9ca3af" />
+            <FontAwesome name="map-marker" size={14} color={colors.textSecondary} />
             <Text className="text-sm text-gray-500 ml-1.5">Tbilisi, Georgia</Text>
             <Text className="text-sm text-gray-300 mx-2">|</Text>
-            <FontAwesome name="clock-o" size={14} color="#9ca3af" />
+            <FontAwesome name="clock-o" size={14} color={colors.textSecondary} />
             <Text className="text-sm text-gray-500 ml-1.5">2 hours ago</Text>
           </View>
 

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -16,6 +16,7 @@ import HeaderBack from "@/components/HeaderBack";
 import StatusBadge from "@/components/StatusBadge";
 import Avatar from "@/components/ui/Avatar";
 import { api, apiPost, apiDelete } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface FileItem {
   id: string;
@@ -216,7 +217,7 @@ export default function MyRequestDetail() {
         title={request.title}
         rightAction={
           <Pressable accessibilityLabel="Удалить заявку" onPress={handleDelete}>
-            <FontAwesome name="trash-o" size={18} color="#ef4444" />
+            <FontAwesome name="trash-o" size={18} color={colors.error} />
           </Pressable>
         }
       />

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -19,6 +19,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { apiPatch } from "@/lib/api";
+import LoadingState from "@/components/ui/LoadingState";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3812";
@@ -168,8 +169,9 @@ export default function ClientSettings() {
 
   if (!ready) {
     return (
-      <SafeAreaView className="flex-1 bg-white items-center justify-center">
-        <ActivityIndicator size="large" color="#1e3a8a" />
+      <SafeAreaView className="flex-1 bg-white">
+        <HeaderBack title="Настройки" />
+        <LoadingState variant="skeleton" lines={5} />
       </SafeAreaView>
     );
   }

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -19,6 +19,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
+import LoadingState from "@/components/ui/LoadingState";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 interface ContactMethodItem {
@@ -309,9 +310,7 @@ export default function SpecialistSettings() {
     return (
       <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
         <HeaderBack title="Настройки специалиста" />
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
-        </View>
+        <LoadingState variant="skeleton" lines={5} />
       </SafeAreaView>
     );
   }

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -13,6 +13,7 @@ import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
 import EmptyState from "@/components/EmptyState";
 import { api } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -161,7 +162,7 @@ export default function SpecialistsCatalog() {
     if (loading) {
       return (
         <View className="flex-1 items-center justify-center py-16">
-          <ActivityIndicator size="large" color="#1e3a5f" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       );
     }
@@ -216,7 +217,7 @@ export default function SpecialistsCatalog() {
         onEndReachedThreshold={0.5}
         ListFooterComponent={
           loadingMore ? (
-            <ActivityIndicator size="small" color="#1e3a5f" style={{ paddingVertical: 16 }} />
+            <ActivityIndicator size="small" color={colors.primary} style={{ paddingVertical: 16 }} />
           ) : null
         }
       />

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -279,7 +279,7 @@ export default function ChatThread() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
-          <Pressable onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
             <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
@@ -295,7 +295,7 @@ export default function ChatThread() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
-          <Pressable onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
             <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
@@ -318,7 +318,7 @@ export default function ChatThread() {
     <SafeAreaView className="flex-1 bg-white" edges={["top", "bottom"]}>
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-slate-100 bg-white">
-        <Pressable onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+        <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
           <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
         </Pressable>
         {otherUser ? (

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import Feather from "@expo/vector-icons/Feather";
 import Button from "./Button";
+import { colors } from "../../lib/theme";
 
 export interface ErrorStateProps {
   message?: string;
@@ -17,7 +18,7 @@ export default function ErrorState({
         className="items-center justify-center rounded-full bg-red-50"
         style={{ width: 72, height: 72 }}
       >
-        <Feather name="alert-circle" size={32} color="#f87171" />
+        <Feather name="alert-circle" size={32} color={colors.error} />
       </View>
       <Text className="text-base font-medium text-slate-900 mt-4 text-center">
         {message}


### PR DESCRIPTION
## Summary
- Replace off-palette hex colors with theme tokens across 12 files
- Add `accessibilityLabel="Назад"` to 3 back buttons in `threads/[id].tsx`
- Replace bare `ActivityIndicator` with `LoadingState` skeleton in dashboard, client/specialist settings
- Wrap `admin/moderation.tsx` content in `ResponsiveContainer`

## Test plan
- [ ] TSC passes (pre-existing expo-document-picker error only)
- [ ] Verify color changes render correctly on web
- [ ] Check loading states show skeleton shimmer

Generated with Claude Code