### PR TITLE
fix: add migration file for schema drift fields #1140

### DIFF
--- a/api/prisma/migrations/20250419000000_add_schema_fields/migration.sql
+++ b/api/prisma/migrations/20250419000000_add_schema_fields/migration.sql
@@ -1,0 +1,9 @@
+-- Add slug to cities (applied manually, backfilled 2026-04-19)
+ALTER TABLE cities ADD COLUMN IF NOT EXISTS slug TEXT DEFAULT '' NOT NULL;
+UPDATE cities SET slug = lower(regexp_replace(trim(name), '\s+', '-', 'g')) WHERE slug = '';
+ALTER TABLE cities ADD CONSTRAINT IF NOT EXISTS cities_slug_key UNIQUE (slug);
+
+-- Add address and search_aliases to fns_offices
+ALTER TABLE fns_offices ADD COLUMN IF NOT EXISTS address TEXT;
+ALTER TABLE fns_offices ADD COLUMN IF NOT EXISTS search_aliases TEXT;
+ALTER TABLE fns_offices ADD CONSTRAINT IF NOT EXISTS fns_offices_code_key UNIQUE (code);


### PR DESCRIPTION
Adds migration file for City.slug, FnsOffice.address, FnsOffice.searchAliases fields that were applied to DB via raw SQL but were missing from the migrations history.

**What this migration does:**
- `ALTER TABLE cities ADD COLUMN IF NOT EXISTS slug` + backfill + UNIQUE constraint
- `ALTER TABLE fns_offices ADD COLUMN IF NOT EXISTS address`
- `ALTER TABLE fns_offices ADD COLUMN IF NOT EXISTS search_aliases`
- `ALTER TABLE fns_offices ADD CONSTRAINT fns_offices_code_key UNIQUE (code)`

Migration was marked as applied in DB via `prisma migrate resolve --applied`.

Closes #1140