### PR TITLE
fix: use slug-based endpoint for FNS offices in create request #1141

### DIFF
--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -23,6 +23,7 @@ const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3812";
 interface CityOption {
   id: string;
   name: string;
+  slug: string;
 }
 
 interface FnsOption {
@@ -106,12 +107,15 @@ export default function NewRequest() {
   }, []);
 
   // Load FNS offices when city changes
-  const loadFnsForCity = useCallback(async (cityId: string) => {
+  const loadFnsForCity = useCallback(async (citySlug: string) => {
     setLoadingFns(true);
     setFnsOffices([]);
     try {
-      const data = await api<{ offices: FnsOption[] }>(`/api/fns?city_id=${cityId}`, { noAuth: true });
-      setFnsOffices(data.offices);
+      const data = await api<{ city: { id: string; name: string; slug: string }; items: FnsOption[] }>(
+        `/api/cities/${citySlug}/ifns`,
+        { noAuth: true }
+      );
+      setFnsOffices(data.items);
     } catch {
       // silent — user can retry by reselecting city
     } finally {
@@ -123,7 +127,7 @@ export default function NewRequest() {
     setSelectedCityId(city.id);
     setSelectedFnsId(null);
     setCityOpen(false);
-    loadFnsForCity(city.id);
+    loadFnsForCity(city.slug);
   }, [loadFnsForCity]);
 
   const handleFnsSelect = useCallback((fns: FnsOption) => {


### PR DESCRIPTION
Fixes the FNS offices loading logic in the create request screen (`app/requests/new.tsx`).

**Problem:** `loadFnsForCity` was calling the legacy `/api/fns?city_id=` endpoint. The newer canonical endpoint is `GET /api/cities/:slug/ifns` which returns `{ city: {...}, items: FnsOption[] }`.

**Changes:**
- Added `slug: string` to `CityOption` interface (API already returns `slug` in `/api/cities` response)
- Changed `loadFnsForCity(cityId)` → `loadFnsForCity(citySlug)`, calls `/api/cities/:slug/ifns`
- Updated response parsing: `data.offices` → `data.items` (matches new endpoint shape)
- `handleCitySelect` now passes `city.slug` instead of `city.id`

TSC passes clean on both frontend and api.

Closes #1141