### PR TITLE
fix: email format validation + specialists query error message

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -19,6 +19,12 @@ router.post("/request-otp", async (req: Request, res: Response) => {
       return;
     }
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email.trim())) {
+      res.status(400).json({ error: "Invalid email format" });
+      return;
+    }
+
     // Find or create user (no role yet — assigned during onboarding)
     let user = await prisma.user.findUnique({
       where: { email: email.toLowerCase() },

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -86,6 +86,29 @@ router.get("/", async (req: Request, res: Response) => {
       ? servicesParam.split(",").filter(Boolean)
       : [];
 
+    // Reject unknown city-related params to catch misuse (e.g. ?city=москва)
+    if (req.query.city && !req.query.city_id) {
+      res.status(400).json({
+        error: "Invalid query parameter: use 'city_id' (UUID) instead of 'city'",
+      });
+      return;
+    }
+
+    // Validate city_id and fns_id are UUID format to prevent DB crashes
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (cityId && !uuidRegex.test(cityId)) {
+      res.status(400).json({
+        error: "Invalid city_id format: must be a valid UUID",
+      });
+      return;
+    }
+    if (fnsId && !uuidRegex.test(fnsId)) {
+      res.status(400).json({
+        error: "Invalid fns_id format: must be a valid UUID",
+      });
+      return;
+    }
+
     const where: Prisma.UserWhereInput = {
       role: "SPECIALIST",
       isAvailable: true,


### PR DESCRIPTION
- POST /api/auth/request-otp: validates email format with regex, returns 400 for invalid emails (e.g. \`notanemail\`)
- GET /api/specialists: returns descriptive 400 for invalid \`city_id\`/\`fns_id\` (non-UUID format) and wrong param name (\`?city=\` instead of \`?city_id=\`)

Found in Test Cycle 3.