### PR TITLE
fix(landing): serve at p2ptax.smartlaunchhub.com root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,5 @@ jobs:
             npm ci
             npm run build
             cd ..
-            cp nginx-landing.conf /etc/nginx/sites-available/landing-p2ptax
-            ln -sf /etc/nginx/sites-available/landing-p2ptax /etc/nginx/sites-enabled/landing-p2ptax
+            cp nginx-p2ptax.conf /etc/nginx/sites-available/p2ptax
             nginx -t && systemctl reload nginx

--- a/nginx-p2ptax.conf
+++ b/nginx-p2ptax.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name p2ptax.smartlaunchhub.com dev.p2ptax.smartlaunchhub.com;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # API backend
+    location /api/ {
+        proxy_pass http://localhost:3812/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # Landing Next.js static assets (/_next/)
+    location /_next/ {
+        root /var/www/p2ptax/landing/out;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Landing homepage
+    location = / {
+        root /var/www/p2ptax/landing/out;
+        try_files /index.html =404;
+    }
+
+    # Expo app — all other routes (requests/new, specialists, messages, etc.)
+    location / {
+        root /var/www/p2ptax/dist;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Landing now served at root `p2ptax.smartlaunchhub.com/`
- nginx split routing: `/` and `/_next/` → landing/out, `/api/` → backend, everything else → Expo app (dist/)
- CTAs `/requests/new`, `/specialists` still route to Expo app correctly
- Replaces `landing.p2ptax.smartlaunchhub.com` with main domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)