### PR TITLE
fix: nginx deploy landing to main domain with SSL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,5 @@ jobs:
             npm ci
             npm run build
             cd ..
-            cp nginx-p2ptax.conf /etc/nginx/sites-available/p2ptax
+            cp nginx-p2ptax.conf /etc/nginx/sites-enabled/p2ptax.smartlaunchhub.com
             nginx -t && systemctl reload nginx

--- a/nginx-p2ptax.conf
+++ b/nginx-p2ptax.conf
@@ -1,6 +1,5 @@
 server {
-    listen 80;
-    server_name p2ptax.smartlaunchhub.com dev.p2ptax.smartlaunchhub.com;
+    server_name p2ptax.smartlaunchhub.com;
 
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
@@ -12,6 +11,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Landing Next.js static assets (/_next/)
@@ -21,15 +21,38 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # Landing homepage
+    # Landing homepage at root
     location = / {
         root /var/www/p2ptax/landing/out;
         try_files /index.html =404;
+    }
+
+    # Expo static assets with caching
+    location /_expo/ {
+        root /var/www/p2ptax/dist;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
     }
 
     # Expo app — all other routes (requests/new, specialists, messages, etc.)
     location / {
         root /var/www/p2ptax/dist;
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
+
+    listen 443 ssl;
+    ssl_certificate /etc/letsencrypt/live/p2ptax.smartlaunchhub.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/p2ptax.smartlaunchhub.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+}
+
+server {
+    if ($host = p2ptax.smartlaunchhub.com) {
+        return 301 https://$host$request_uri;
+    }
+    listen 80;
+    server_name p2ptax.smartlaunchhub.com;
+    return 404;
 }


### PR DESCRIPTION
## Summary
- Fixed deploy.yml to copy nginx config to the correct active file (`/etc/nginx/sites-enabled/p2ptax.smartlaunchhub.com`) instead of `sites-available/p2ptax` which was never loaded
- Updated nginx config to include SSL block (certbot certs already exist for this domain)
- Added HTTP→HTTPS redirect
- Split routing: `/` → landing page, `/_next/` → Next.js assets, `/api/` → backend :3812, everything else → Expo app

## Root Cause
`deploy.yml` was writing nginx config to `sites-available/p2ptax` which had no symlink in `sites-enabled`. The actual active config at `sites-enabled/p2ptax.smartlaunchhub.com` was never updated, so the landing was never served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)