### PR TITLE
hardening: rate limiting on OTP endpoint (#1150)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.3.2",
         "jsonwebtoken": "^9.0.2",
         "minio": "^8.0.7",
         "multer": "^2.1.1",
@@ -1137,6 +1138,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -1514,6 +1533,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.3.2",
     "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.7",
     "multer": "^2.1.1",

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import rateLimit from "express-rate-limit";
 import { prisma } from "../lib/prisma";
 import {
   signAccessToken,
@@ -9,8 +10,16 @@ import { authMiddleware } from "../middleware/auth";
 
 const router = Router();
 
+const otpRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Слишком много запросов. Попробуйте через 15 минут." },
+});
+
 // POST /api/auth/request-otp
-router.post("/request-otp", async (req: Request, res: Response) => {
+router.post("/request-otp", otpRateLimiter, async (req: Request, res: Response) => {
   try {
     const { email } = req.body;
 


### PR DESCRIPTION
Task #1150

Adds rate limiting (5 req/15min per IP) to POST /api/auth/request-otp to prevent OTP spam.

- Package: `express-rate-limit`
- Applied only to `/request-otp` route via `otpRateLimiter` middleware
- 429 response: `{ "error": "Слишком много запросов. Попробуйте через 15 минут." }`
- tsc --noEmit: 0 errors (frontend + backend)