### PR TITLE
fix: deduplicate city records, normalize slug (#1143)

### DIFF
--- a/api/src/lib/slug.ts
+++ b/api/src/lib/slug.ts
@@ -1,0 +1,37 @@
+/**
+ * Transliteration map: Cyrillic -> Latin
+ */
+const CYRILLIC_TO_LATIN: Record<string, string> = {
+  а: "a", б: "b", в: "v", г: "g", д: "d", е: "e", ё: "yo", ж: "zh",
+  з: "z", и: "i", й: "y", к: "k", л: "l", м: "m", н: "n", о: "o",
+  п: "p", р: "r", с: "s", т: "t", у: "u", ф: "f", х: "kh", ц: "ts",
+  ч: "ch", ш: "sh", щ: "shch", ъ: "", ы: "y", ь: "", э: "e", ю: "yu",
+  я: "ya",
+  // uppercase handled by lowercasing input first
+};
+
+/**
+ * Normalize a city slug:
+ * - Transliterate Cyrillic characters to Latin
+ * - Lowercase
+ * - Replace spaces and non-alphanumeric chars (except hyphen) with hyphens
+ * - Collapse multiple hyphens
+ * - Trim leading/trailing hyphens
+ */
+export function normalizeSlug(input: string): string {
+  const lower = input.toLowerCase();
+  const transliterated = lower
+    .split("")
+    .map((ch) => {
+      if (ch in CYRILLIC_TO_LATIN) {
+        return CYRILLIC_TO_LATIN[ch];
+      }
+      return ch;
+    })
+    .join("");
+
+  return transliterated
+    .replace(/[^a-z0-9-]/g, "-") // replace non-alphanumeric (except hyphen) with hyphen
+    .replace(/-+/g, "-")          // collapse multiple hyphens
+    .replace(/^-|-$/g, "");       // trim leading/trailing hyphens
+}

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
 import { roleGuard } from "../middleware/auth";
+import { normalizeSlug } from "../lib/slug";
 
 const router = Router();
 
@@ -293,7 +294,12 @@ router.post("/cities", async (req: Request, res: Response) => {
       res.status(400).json({ error: "name and slug are required" });
       return;
     }
-    const city = await prisma.city.create({ data: { name, slug } });
+    const normalizedSlug = normalizeSlug(slug);
+    if (!normalizedSlug) {
+      res.status(400).json({ error: "slug is invalid after normalization" });
+      return;
+    }
+    const city = await prisma.city.create({ data: { name, slug: normalizedSlug } });
     res.status(201).json(city);
   } catch (error: unknown) {
     const e = error as { code?: string };
@@ -313,7 +319,14 @@ router.patch("/cities/:id", async (req: Request, res: Response) => {
     const { name, slug } = req.body as { name?: string; slug?: string };
     const data: Prisma.CityUpdateInput = {};
     if (name) data.name = name;
-    if (slug) data.slug = slug;
+    if (slug) {
+      const normalizedSlug = normalizeSlug(slug);
+      if (!normalizedSlug) {
+        res.status(400).json({ error: "slug is invalid after normalization" });
+        return;
+      }
+      data.slug = normalizedSlug;
+    }
 
     const city = await prisma.city.update({ where: { id }, data });
     res.json(city);

--- a/api/src/scripts/deduplicate-cities.ts
+++ b/api/src/scripts/deduplicate-cities.ts
@@ -1,0 +1,137 @@
+/**
+ * Deduplication script for city records.
+ *
+ * Problem: DB may have duplicate city entries for the same city —
+ * one with a Cyrillic slug (e.g. "москва") and one with a Latin slug
+ * (e.g. "moskva" or "moscow").
+ *
+ * Strategy:
+ * 1. Load all cities.
+ * 2. Group by normalized city name (case-insensitive).
+ * 3. For each group with >1 record, pick the canonical record:
+ *    - Prefer the one with a Latin-only slug.
+ *    - Among Latin slugs, prefer shorter/cleaner one.
+ * 4. Re-point all FnsOffice and Request FK references from duplicate IDs
+ *    to the canonical ID.
+ * 5. Delete duplicate city records.
+ *
+ * Run: npx ts-node src/scripts/deduplicate-cities.ts
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { normalizeSlug } from "../lib/slug";
+
+const prisma = new PrismaClient();
+
+function isLatinSlug(slug: string): boolean {
+  return /^[a-z0-9-]+$/.test(slug);
+}
+
+async function main() {
+  const cities = await prisma.city.findMany({ orderBy: { name: "asc" } });
+
+  // Group cities by normalized name
+  const groups = new Map<string, typeof cities>();
+  for (const city of cities) {
+    const key = city.name.trim().toLowerCase();
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(city);
+  }
+
+  let totalDuplicatesRemoved = 0;
+
+  for (const [cityName, group] of groups.entries()) {
+    if (group.length <= 1) continue;
+
+    console.log(`\nDuplicate group: "${cityName}" (${group.length} records)`);
+    for (const c of group) {
+      console.log(`  id=${c.id} slug="${c.slug}"`);
+    }
+
+    // Pick canonical: prefer Latin slug, then shortest slug
+    const sorted = [...group].sort((a, b) => {
+      const aLatin = isLatinSlug(a.slug) ? 0 : 1;
+      const bLatin = isLatinSlug(b.slug) ? 0 : 1;
+      if (aLatin !== bLatin) return aLatin - bLatin;
+      return a.slug.length - b.slug.length;
+    });
+
+    const canonical = sorted[0];
+    const duplicates = sorted.slice(1);
+
+    console.log(`  -> Canonical: id=${canonical.id} slug="${canonical.slug}"`);
+    console.log(`  -> Duplicates to remove: ${duplicates.map((d) => d.id).join(", ")}`);
+
+    await prisma.$transaction(async (tx) => {
+      for (const dup of duplicates) {
+        // Re-point FnsOffice records
+        const fnsCount = await tx.fnsOffice.count({ where: { cityId: dup.id } });
+        if (fnsCount > 0) {
+          await tx.fnsOffice.updateMany({
+            where: { cityId: dup.id },
+            data: { cityId: canonical.id },
+          });
+          console.log(`  Re-pointed ${fnsCount} FnsOffice(s) from ${dup.id} to ${canonical.id}`);
+        }
+
+        // Re-point Request records
+        const reqCount = await tx.request.count({ where: { cityId: dup.id } });
+        if (reqCount > 0) {
+          await tx.request.updateMany({
+            where: { cityId: dup.id },
+            data: { cityId: canonical.id },
+          });
+          console.log(`  Re-pointed ${reqCount} Request(s) from ${dup.id} to ${canonical.id}`);
+        }
+
+        // Delete duplicate city
+        await tx.city.delete({ where: { id: dup.id } });
+        console.log(`  Deleted city id=${dup.id} slug="${dup.slug}"`);
+        totalDuplicatesRemoved++;
+      }
+
+      // Normalize canonical slug if it's still Cyrillic
+      if (!isLatinSlug(canonical.slug)) {
+        const newSlug = normalizeSlug(canonical.slug);
+        await tx.city.update({
+          where: { id: canonical.id },
+          data: { slug: newSlug },
+        });
+        console.log(`  Normalized slug: "${canonical.slug}" -> "${newSlug}"`);
+      }
+    });
+  }
+
+  // Also normalize all remaining cities that have Cyrillic slugs
+  const remaining = await prisma.city.findMany();
+  for (const city of remaining) {
+    if (!isLatinSlug(city.slug)) {
+      const newSlug = normalizeSlug(city.slug);
+      console.log(`\nNormalizing slug for city "${city.name}": "${city.slug}" -> "${newSlug}"`);
+      try {
+        await prisma.city.update({
+          where: { id: city.id },
+          data: { slug: newSlug },
+        });
+      } catch (e: unknown) {
+        const err = e as { code?: string; message?: string };
+        if (err.code === "P2002") {
+          console.error(`  Conflict: slug "${newSlug}" already exists. Manual resolution needed.`);
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+
+  console.log(`\nDone. Removed ${totalDuplicatesRemoved} duplicate city record(s).`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Task #1143

## Summary
- Added `normalizeSlug()` utility (`api/src/lib/slug.ts`): transliterates Cyrillic → Latin, strips non-alphanumeric chars, collapses hyphens
- `POST /api/admin/cities` and `PATCH /api/admin/cities/:id` now normalize slug before writing to DB — Cyrillic slugs are no longer possible
- Added deduplication script `api/src/scripts/deduplicate-cities.ts`: finds duplicate city groups by name, picks Latin-slug canonical, re-points all FnsOffice/Request FK references, deletes duplicates, normalizes remaining Cyrillic slugs

## Root cause
Admin API accepted raw slug from request body without any normalization. An admin entering "москва" would create a second city record alongside the existing "moscow" or "moskva" entry.

## How to run deduplication
```bash
cd api && npx ts-node src/scripts/deduplicate-cities.ts
```