### PR TITLE
fix(a11y): bump tap targets to min 44px on 19 Pressable controls

### DIFF
--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -38,7 +38,7 @@ export default function SearchScreen() {
               placeholder="What are you looking for?"
               placeholderTextColor={colors.textSecondary}
             />
-            <Pressable accessibilityLabel="Фильтры" className="ml-2 w-10 h-10 rounded-lg bg-blue-600 items-center justify-center">
+            <Pressable accessibilityLabel="Фильтры" className="ml-2 w-11 h-11 rounded-lg bg-blue-600 items-center justify-center">
               <FontAwesome name="sliders" size={16} color="#ffffff" />
             </Pressable>
           </View>

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -27,7 +27,7 @@ export default function PrivacyPolicyScreen() {
         <Pressable
           accessibilityLabel="Назад"
           onPress={() => router.back()}
-          className="w-10 h-10 items-center justify-center -ml-2"
+          className="w-11 h-11 items-center justify-center -ml-2"
         >
           <FontAwesome name="arrow-left" size={18} color="#0f172a" />
         </Pressable>

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -33,7 +33,7 @@ export default function TermsScreen() {
           <Pressable
             accessibilityLabel="Закрыть"
             onPress={() => router.back()}
-            className="w-10 h-10 items-center justify-center"
+            className="w-11 h-11 items-center justify-center"
           >
             <FontAwesome name="times" size={20} color="#0f172a" />
           </Pressable>

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -579,7 +579,7 @@ export default function NewRequest() {
                     <Pressable
                       accessibilityLabel="Удалить файл"
                       onPress={() => handleRemoveFile(index)}
-                      className="w-8 h-8 items-center justify-center"
+                      className="w-11 h-11 items-center justify-center"
                     >
                       <FontAwesome name="times" size={14} color="#94a3b8" />
                     </Pressable>

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -284,7 +284,7 @@ export default function ChatThread() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
-          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
             <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
@@ -300,7 +300,7 @@ export default function ChatThread() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
-          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
             <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
@@ -324,7 +324,7 @@ export default function ChatThread() {
       <View className="flex-1" style={desktopStyle}>
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-slate-100 bg-white">
-        <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-8 h-8 items-center justify-center">
+        <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
           <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
         </Pressable>
         {otherUser ? (
@@ -416,7 +416,7 @@ export default function ChatThread() {
               accessibilityLabel="Прикрепить файл (PDF, JPG, PNG — до 10 МБ, не более 3)"
               onPress={handleAttachFile}
               disabled={pendingFiles.length >= 3 || sending}
-              className="w-10 h-10 items-center justify-center mr-1"
+              className="w-11 h-11 items-center justify-center mr-1"
             >
               <FontAwesome
                 name="paperclip"
@@ -453,7 +453,7 @@ export default function ChatThread() {
               accessibilityLabel="Отправить сообщение"
               onPress={handleSend}
               disabled={(!text.trim() && pendingFiles.length === 0) || sending}
-              className="w-10 h-10 items-center justify-center ml-2"
+              className="w-11 h-11 items-center justify-center ml-2"
             >
               {sending || uploading ? (
                 <ActivityIndicator size="small" color="#1e3a8a" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
     return (
       <>
         <View className="flex-row items-center justify-between px-4 h-14 bg-white border-b border-slate-100">
-          <Pressable accessibilityLabel="Открыть меню" onPress={() => setMenuOpen(true)} className="w-10 h-10 items-center justify-center">
+          <Pressable accessibilityLabel="Открыть меню" onPress={() => setMenuOpen(true)} className="w-11 h-11 items-center justify-center">
             <FontAwesome name="bars" size={20} color="#0f172a" />
           </Pressable>
 
@@ -29,7 +29,7 @@ export default function Header() {
               <Pressable
                 accessibilityLabel="Уведомления"
                 onPress={() => router.push("/notifications" as never)}
-                className="w-10 h-10 items-center justify-center"
+                className="w-11 h-11 items-center justify-center"
               >
                 <FontAwesome name="bell-o" size={18} color="#0f172a" />
               </Pressable>
@@ -41,7 +41,7 @@ export default function Header() {
                     : "/settings/client";
                   router.push(settingsPath as never);
                 }}
-                className="w-8 h-8 rounded-full bg-blue-100 items-center justify-center"
+                className="w-11 h-11 rounded-full bg-blue-100 items-center justify-center"
               >
                 <Text className="text-sm font-bold text-blue-900">{initials}</Text>
               </Pressable>
@@ -50,7 +50,7 @@ export default function Header() {
             <Pressable
               accessibilityLabel="Войти"
               onPress={() => router.push("/auth/email" as never)}
-              className="px-4 h-9 rounded-lg bg-blue-900 items-center justify-center"
+              className="px-4 h-11 rounded-lg bg-blue-900 items-center justify-center"
             >
               <Text className="text-sm font-semibold text-white">Sign In</Text>
             </Pressable>
@@ -74,7 +74,7 @@ export default function Header() {
           <Pressable
             accessibilityLabel="Уведомления"
             onPress={() => router.push("/notifications" as never)}
-            className="w-10 h-10 rounded-lg items-center justify-center active:bg-slate-100"
+            className="w-11 h-11 rounded-lg items-center justify-center active:bg-slate-100"
           >
             <FontAwesome name="bell-o" size={18} color="#0f172a" />
           </Pressable>
@@ -86,7 +86,7 @@ export default function Header() {
                 : "/settings/client";
               router.push(settingsPath as never);
             }}
-            className="w-9 h-9 rounded-full bg-blue-100 items-center justify-center"
+            className="w-11 h-11 rounded-full bg-blue-100 items-center justify-center"
           >
             <Text className="text-sm font-bold text-blue-900">{initials}</Text>
           </Pressable>
@@ -95,7 +95,7 @@ export default function Header() {
         <Pressable
           accessibilityLabel="Войти"
           onPress={() => router.push("/auth/email" as never)}
-          className="px-5 h-10 rounded-lg bg-blue-900 items-center justify-center active:bg-slate-900"
+          className="px-5 h-11 rounded-lg bg-blue-900 items-center justify-center active:bg-slate-900"
         >
           <Text className="text-sm font-semibold text-white">Sign In</Text>
         </Pressable>

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -17,7 +17,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
         <Pressable
           accessibilityLabel="Уведомления"
           onPress={() => router.push("/notifications" as never)}
-          className="w-10 h-10 items-center justify-center"
+          className="w-11 h-11 items-center justify-center"
         >
           <FontAwesome name="bell-o" size={18} color="#ffffff" />
           {notificationCount > 0 && (
@@ -32,7 +32,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
           <Pressable
             accessibilityLabel="Настройки"
             onPress={onSettingsPress}
-            className="w-10 h-10 items-center justify-center"
+            className="w-11 h-11 items-center justify-center"
           >
             <FontAwesome name="cog" size={18} color="#ffffff" />
           </Pressable>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -61,7 +61,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
           </View>
 
           {/* Close button */}
-          <Pressable accessibilityLabel="Закрыть меню" onPress={onClose} className="absolute top-12 right-3 w-8 h-8 items-center justify-center">
+          <Pressable accessibilityLabel="Закрыть меню" onPress={onClose} className="absolute top-12 right-3 w-11 h-11 items-center justify-center">
             <FontAwesome name="times" size={20} color="#ffffff" />
           </Pressable>
 


### PR DESCRIPTION
## Summary
- All Pressable elements with `h-8`/`h-9`/`h-10`/`w-8`/`w-9`/`w-10` (32–40px) bumped to `h-11`/`w-11` (44px)
- Covers 8 files: Header, HeaderHome, MobileMenu, search, threads/[id], legal/terms, legal/privacy, requests/new
- tsc --noEmit passes with 0 errors

## Files changed
- `components/Header.tsx` — 6 controls (burger, notifications ×2, avatar ×2, sign-in ×2)
- `components/HeaderHome.tsx` — 2 controls (notifications, settings)
- `components/MobileMenu.tsx` — 1 control (close button)
- `app/(tabs)/search.tsx` — 1 control (filter button)
- `app/threads/[id].tsx` — 5 controls (back ×3, attach, send)
- `app/legal/terms.tsx` — 1 control (close)
- `app/legal/privacy.tsx` — 1 control (back)
- `app/requests/new.tsx` — 1 control (remove file)

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)