### PR TITLE
refactor: adopt <Button /> component across 14 screens

### DIFF
--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   ScrollView,
   Pressable,
-  ActivityIndicator,
   RefreshControl,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -14,6 +13,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
 import EmptyState from "@/components/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
+import Button from "@/components/ui/Button";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -104,16 +104,14 @@ export default function ClientDashboard() {
               <Text className="text-sm text-slate-500 text-center mb-6">
                 Проверьте соединение с интернетом и попробуйте снова
               </Text>
-              <Pressable
-                accessibilityLabel="Повторить"
+              <Button
+                label="Повторить"
                 onPress={() => {
                   setLoading(true);
                   fetchData().finally(() => setLoading(false));
                 }}
-                className="bg-blue-900 rounded-xl px-6 py-3"
-              >
-                <Text className="text-white font-semibold text-sm">Повторить</Text>
-              </Pressable>
+                fullWidth={false}
+              />
             </View>
           ) : (
             <View className="pb-6">

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -15,6 +15,7 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/EmptyState";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiGet, apiPatch } from "@/lib/api";
 
@@ -150,16 +151,16 @@ export default function SpecialistDashboard() {
           <Text className="text-sm text-slate-500 mt-2 text-center">
             Проверьте соединение с интернетом и попробуйте снова
           </Text>
-          <Pressable
-            accessibilityLabel="Повторить"
-            onPress={() => {
-              setLoading(true);
-              fetchData().finally(() => setLoading(false));
-            }}
-            className="mt-6 bg-blue-900 rounded-xl px-8 py-3"
-          >
-            <Text className="text-white font-semibold text-base">Повторить</Text>
-          </Pressable>
+          <View className="mt-6">
+            <Button
+              label="Повторить"
+              onPress={() => {
+                setLoading(true);
+                fetchData().finally(() => setLoading(false));
+              }}
+              fullWidth={false}
+            />
+          </View>
         </View>
       </SafeAreaView>
     );

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -2,7 +2,6 @@ import {
   View,
   Text,
   ScrollView,
-  Pressable,
   ActivityIndicator,
   TextInput,
   Platform,
@@ -12,6 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback } from "react";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 
@@ -134,22 +134,14 @@ export default function AdminSettings() {
                 </View>
               ))}
 
-              <Pressable
-                accessibilityLabel="Сохранить"
-                onPress={handleSave}
-                disabled={saving}
-                className={`h-12 rounded-xl items-center justify-center mt-2 ${
-                  saving ? "bg-blue-900/50" : "bg-blue-900"
-                }`}
-              >
-                {saving ? (
-                  <ActivityIndicator size="small" color="#ffffff" />
-                ) : (
-                  <Text className="text-white font-semibold text-base">
-                    Сохранить
-                  </Text>
-                )}
-              </Pressable>
+              <View className="mt-2">
+                <Button
+                  label="Сохранить"
+                  onPress={handleSave}
+                  disabled={saving}
+                  loading={saving}
+                />
+              </View>
             </View>
           </ResponsiveContainer>
         </ScrollView>

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -1,10 +1,11 @@
-import { View, Text, TextInput, Pressable, ActivityIndicator } from "react-native";
+import { View, Text, TextInput, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -101,24 +102,14 @@ export default function AuthEmailScreen() {
             <Text className="text-xs text-red-600 mt-1">{error}</Text>
           ) : null}
 
-          <Pressable
-            accessibilityLabel="Продолжить"
-            onPress={handleContinue}
-            disabled={isLoading || !email.trim()}
-            className={`h-12 rounded-xl items-center justify-center mt-6 ${
-              isLoading || !email.trim()
-                ? "bg-blue-900 opacity-50"
-                : "bg-blue-900 active:bg-slate-900"
-            }`}
-          >
-            {isLoading ? (
-              <ActivityIndicator color="#ffffff" />
-            ) : (
-              <Text className="text-white text-base font-semibold">
-                Продолжить
-              </Text>
-            )}
-          </Pressable>
+          <View className="mt-6">
+            <Button
+              label="Продолжить"
+              onPress={handleContinue}
+              disabled={isLoading || !email.trim()}
+              loading={isLoading}
+            />
+          </View>
 
           <Pressable
             accessibilityLabel="Условия использования"

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -15,6 +15,7 @@ import HeaderBack from "@/components/HeaderBack";
 import { useAuth, UserData } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import { colors } from "@/lib/theme";
 
 const CODE_LENGTH = 6;
@@ -331,35 +332,12 @@ export default function AuthOtpScreen() {
               )}
 
               {/* Verify button */}
-              <Pressable
-                accessibilityLabel="Подтвердить"
+              <Button
+                label="Подтвердить"
                 onPress={() => handleVerify(digits.join(""))}
                 disabled={isLoading || !isCodeFull}
-                className={`h-12 rounded-xl items-center justify-center ${
-                  isLoading || !isCodeFull
-                    ? "bg-blue-900 opacity-50"
-                    : "bg-blue-900 active:bg-blue-800"
-                }`}
-                style={
-                  isCodeFull && !isLoading
-                    ? {
-                        shadowColor: "#1e3a8a",
-                        shadowOffset: { width: 0, height: 2 },
-                        shadowOpacity: 0.25,
-                        shadowRadius: 4,
-                        elevation: 3,
-                      }
-                    : undefined
-                }
-              >
-                {isLoading ? (
-                  <ActivityIndicator color="#ffffff" />
-                ) : (
-                  <Text className="text-white text-base font-semibold">
-                    Подтвердить
-                  </Text>
-                )}
-              </Pressable>
+                loading={isLoading}
+              />
 
               {/* Resend link with countdown */}
               <Pressable

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput, Pressable, ActivityIndicator } from "react-native";
+import { View, Text, TextInput, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState } from "react";
@@ -6,6 +6,7 @@ import HeaderBack from "@/components/HeaderBack";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 
 export default function OnboardingNameScreen() {
   const router = useRouter();
@@ -160,22 +161,12 @@ export default function OnboardingNameScreen() {
             </Text>
           ) : null}
 
-          <Pressable
-            accessibilityLabel="Далее"
+          <Button
+            label="Далее"
             onPress={handleNext}
             disabled={!canProceed || isLoading}
-            className={`h-12 rounded-xl items-center justify-center ${
-              !canProceed || isLoading
-                ? "bg-blue-900 opacity-50"
-                : "bg-blue-900 active:bg-slate-900"
-            }`}
-          >
-            {isLoading ? (
-              <ActivityIndicator color="#ffffff" />
-            ) : (
-              <Text className="text-white text-base font-semibold">Далее</Text>
-            )}
-          </Pressable>
+            loading={isLoading}
+          />
         </View>
       </ResponsiveContainer>
     </SafeAreaView>

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -16,6 +16,7 @@ import HeaderBack from "@/components/HeaderBack";
 import { API_URL, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 
@@ -373,24 +374,12 @@ export default function OnboardingProfileScreen() {
               </Text>
             ) : null}
 
-            <Pressable
-              accessibilityLabel="Завершить регистрацию"
+            <Button
+              label="Завершить регистрацию"
               onPress={handleSubmit}
               disabled={isLoading || avatarUploading}
-              className={`h-12 rounded-xl items-center justify-center ${
-                isLoading || avatarUploading
-                  ? "bg-blue-900 opacity-50"
-                  : "bg-blue-900 active:bg-slate-900"
-              }`}
-            >
-              {isLoading ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <Text className="text-white text-base font-semibold">
-                  Завершить регистрацию
-                </Text>
-              )}
-            </Pressable>
+              loading={isLoading}
+            />
 
             {/* Skip link */}
             <Pressable

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -2,7 +2,6 @@ import {
   View,
   Text,
   Pressable,
-  ActivityIndicator,
   ScrollView,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -12,6 +11,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 
 interface City {
   id: string;
@@ -329,24 +329,12 @@ export default function OnboardingWorkAreaScreen() {
               </Text>
             ) : null}
 
-            <Pressable
-              accessibilityLabel="Далее"
+            <Button
+              label="Далее"
               onPress={handleNext}
               disabled={!canProceed || isLoading}
-              className={`h-12 rounded-xl items-center justify-center ${
-                !canProceed || isLoading
-                  ? "bg-blue-900 opacity-50"
-                  : "bg-blue-900 active:bg-slate-900"
-              }`}
-            >
-              {isLoading ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <Text className="text-white text-base font-semibold">
-                  Далее
-                </Text>
-              )}
-            </Pressable>
+              loading={isLoading}
+            />
           </View>
         </ScrollView>
       </ResponsiveContainer>

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -15,6 +15,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import StatusBadge from "@/components/StatusBadge";
 import Avatar from "@/components/ui/Avatar";
+import Button from "@/components/ui/Button";
 import { api, apiPost, apiDelete } from "@/lib/api";
 import { colors } from "@/lib/theme";
 
@@ -185,13 +186,13 @@ export default function MyRequestDetail() {
           <Text className="text-base text-red-600 text-center">
             {error || "Заявка не найдена"}
           </Text>
-          <Pressable
-            accessibilityLabel="Назад"
-            onPress={() => router.back()}
-            className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
-          >
-            <Text className="text-white font-semibold">Назад</Text>
-          </Pressable>
+          <View className="mt-4">
+            <Button
+              label="Назад"
+              onPress={() => router.back()}
+              fullWidth={false}
+            />
+          </View>
         </View>
       </SafeAreaView>
     );

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -14,6 +14,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import { API_URL, api, apiPost } from "@/lib/api";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { colors } from "@/lib/theme";
@@ -628,31 +629,12 @@ export default function NewRequest() {
       {/* Sticky submit button */}
       <View className="border-t border-slate-200 px-4 py-3 bg-white">
         <View style={{ maxWidth: 520, width: "100%", alignSelf: "center" }}>
-          <Pressable
-            accessibilityLabel="Опубликовать заявку"
+          <Button
+            label="Опубликовать заявку"
             onPress={handleSubmit}
             disabled={submitting || atLimit}
-            className={`rounded-xl h-12 items-center justify-center ${
-              !atLimit && !submitting ? "bg-blue-900 active:bg-slate-900" : "bg-blue-900 opacity-40"
-            }`}
-            style={
-              !atLimit && !submitting
-                ? {
-                    shadowColor: colors.primary,
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.25,
-                    shadowRadius: 4,
-                    elevation: 3,
-                  }
-                : undefined
-            }
-          >
-            {submitting ? (
-              <ActivityIndicator color="#ffffff" />
-            ) : (
-              <Text className="text-white text-base font-semibold">Опубликовать заявку</Text>
-            )}
-          </Pressable>
+            loading={submitting}
+          />
         </View>
       </View>
     </SafeAreaView>

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiPatch } from "@/lib/api";
@@ -294,20 +295,14 @@ export default function ClientSettings() {
             </View>
 
             {/* Save button */}
-            <Pressable
-              accessibilityLabel="Сохранить"
-              onPress={handleSave}
-              disabled={!hasChanges || saving}
-              className={`rounded-xl py-3 items-center mb-8 ${
-                hasChanges && !saving ? "bg-blue-900" : "bg-slate-300"
-              }`}
-            >
-              {saving ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <Text className="text-white font-semibold text-base">Сохранить</Text>
-              )}
-            </Pressable>
+            <View className="mb-8">
+              <Button
+                label="Сохранить"
+                onPress={handleSave}
+                disabled={!hasChanges || saving}
+                loading={saving}
+              />
+            </View>
 
             {/* Notifications section */}
             <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
@@ -626,32 +627,26 @@ export default function SpecialistSettings() {
                   style={INPUT_STYLE}
                 />
                 <View className="flex-row gap-2">
-                  <Pressable
-                    accessibilityLabel="Отмена"
-                    onPress={() => {
-                      setAddingContact(false);
-                      setNewContactValue("");
-                      setNewContactType("phone");
-                      setShowTypePicker(false);
-                    }}
-                    className="flex-1 border border-slate-200 rounded-xl py-3 items-center"
-                  >
-                    <Text className="text-base text-slate-600">Отмена</Text>
-                  </Pressable>
-                  <Pressable
-                    accessibilityLabel="Добавить"
-                    onPress={handleAddContact}
-                    disabled={contactSaving}
-                    className={`flex-1 rounded-xl py-3 items-center ${
-                      contactSaving ? "bg-blue-900 opacity-50" : "bg-blue-900"
-                    }`}
-                  >
-                    {contactSaving ? (
-                      <ActivityIndicator color="#fff" size="small" />
-                    ) : (
-                      <Text className="text-base font-semibold text-white">Добавить</Text>
-                    )}
-                  </Pressable>
+                  <View className="flex-1">
+                    <Button
+                      variant="secondary"
+                      label="Отмена"
+                      onPress={() => {
+                        setAddingContact(false);
+                        setNewContactValue("");
+                        setNewContactType("phone");
+                        setShowTypePicker(false);
+                      }}
+                    />
+                  </View>
+                  <View className="flex-1">
+                    <Button
+                      label="Добавить"
+                      onPress={handleAddContact}
+                      disabled={contactSaving}
+                      loading={contactSaving}
+                    />
+                  </View>
                 </View>
               </View>
             ) : contacts.length < 6 ? (
@@ -701,22 +696,14 @@ export default function SpecialistSettings() {
             />
 
             {/* Save button */}
-            <Pressable
-              accessibilityLabel="Сохранить"
-              onPress={handleSave}
-              disabled={saving}
-              className={`rounded-xl py-3 items-center mt-2 mb-4 ${
-                saving ? "bg-blue-900 opacity-50" : "bg-blue-900"
-              }`}
-            >
-              {saving ? (
-                <ActivityIndicator color="#ffffff" />
-              ) : (
-                <Text className="text-white text-base font-semibold">
-                  Сохранить
-                </Text>
-              )}
-            </Pressable>
+            <View className="mt-2 mb-4">
+              <Button
+                label="Сохранить"
+                onPress={handleSave}
+                disabled={saving}
+                loading={saving}
+              />
+            </View>
 
             {/* Notifications */}
             <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -15,6 +15,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
+import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 
@@ -225,13 +226,13 @@ export default function SpecialistPublicProfile() {
           <Text className="text-sm text-slate-500 mt-2 text-center leading-5">
             Возможно, профиль был удалён или вы перешли по неверной ссылке
           </Text>
-          <Pressable
-            accessibilityLabel="Назад к каталогу"
-            onPress={() => router.push("/specialists" as never)}
-            className="mt-6 bg-blue-900 rounded-xl px-6 py-3"
-          >
-            <Text className="text-white font-semibold">Назад к каталогу</Text>
-          </Pressable>
+          <View className="mt-6">
+            <Button
+              label="Назад к каталогу"
+              onPress={() => router.push("/specialists" as never)}
+              fullWidth={false}
+            />
+          </View>
         </View>
       </SafeAreaView>
     );
@@ -510,25 +511,10 @@ export default function SpecialistPublicProfile() {
                   <Text className="text-sm font-semibold text-slate-500">Это вы</Text>
                 </View>
               ) : isSpecialist ? null : (
-                <Pressable
-                  accessibilityLabel={isAuthenticated ? "Написать специалисту" : "Войти и написать"}
+                <Button
+                  label={isAuthenticated ? "Написать" : "Войти и написать"}
                   onPress={handleWritePress}
-                  className="bg-blue-900 rounded-xl py-3.5 items-center"
-                  style={({ pressed }) => [
-                    {
-                      shadowColor: "#1e3a8a",
-                      shadowOffset: { width: 0, height: 2 },
-                      shadowOpacity: 0.25,
-                      shadowRadius: 4,
-                      elevation: 3,
-                    },
-                    pressed ? { opacity: 0.9, transform: [{ scale: 0.98 }] } : undefined,
-                  ]}
-                >
-                  <Text className="text-white text-base font-semibold">
-                    {isAuthenticated ? "Написать" : "Войти и написать"}
-                  </Text>
-                </Pressable>
+                />
               )}
             </View>
 

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,5 +1,6 @@
-import { View, Text, Pressable } from "react-native";
+import { View, Text } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import Button from "@/components/ui/Button";
 
 interface EmptyStateProps {
   icon?: React.ComponentProps<typeof FontAwesome>["name"];
@@ -26,13 +27,13 @@ export default function EmptyState({
         <Text className="text-sm text-slate-400 mt-2 text-center">{subtitle}</Text>
       )}
       {actionLabel && onAction && (
-        <Pressable
-          accessibilityLabel={actionLabel}
-          onPress={onAction}
-          className="mt-4 bg-blue-900 rounded-xl px-6 py-3"
-        >
-          <Text className="text-white font-semibold text-sm">{actionLabel}</Text>
-        </Pressable>
+        <View className="mt-4">
+          <Button
+            label={actionLabel}
+            onPress={onAction}
+            fullWidth={false}
+          />
+        </View>
       )}
     </View>
   );


### PR DESCRIPTION
Closes #1166

## Summary
- Replaces raw `Pressable+Text` button patterns with the shared `<Button variant=... />` component across 14 files
- Preserves all onPress handlers and behavioral logic (loading, disabled states)
- Removes unused `ActivityIndicator` imports where Button handles loading internally
- Net reduction: -120 lines of boilerplate

## Scope
Replaced buttons in: auth flow, onboarding, settings, request creation, specialist profile, dashboards, EmptyState component.

Skipped (intentionally): icon-only buttons, list items, filter pills, complex card-style CTAs, buttons with non-standard colors (amber-700, blue-600), tiny inline compact buttons.

## Test plan
- [x] `tsc --noEmit` passes (0 errors, frontend + API)
- [ ] Visual check: buttons render identically (same h-12, bg-blue-900, rounded-xl, shadow)
- [ ] Loading states still show spinner
- [ ] Disabled states still show opacity