### PR TITLE
fix: replace hardcoded hex colors with theme tokens (#1169)

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 export default function AdminTabsLayout() {
   const { width } = useWindowDimensions();
@@ -11,10 +12,10 @@ export default function AdminTabsLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: isMobile
-          ? { height: 60, paddingBottom: 8, borderTopColor: "#e2e8f0" }
+          ? { height: 60, paddingBottom: 8, borderTopColor: colors.border }
           : { display: "none" },
-        tabBarActiveTintColor: "#1e3a8a",
-        tabBarInactiveTintColor: "#94a3b8",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.placeholder,
         tabBarLabelStyle: { fontSize: 12 },
       }}
     >

--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -70,7 +70,7 @@ function StatusBadge({ status }: { status: "NEW" | "REVIEWED" }) {
     return (
       <View className="bg-amber-50 px-2 py-0.5 rounded-lg flex-row items-center">
         <View
-          style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: "#b45309", marginRight: 5 }}
+          style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: colors.accent, marginRight: 5 }}
         />
         <Text className="text-xs font-medium text-amber-700">Новая</Text>
       </View>
@@ -222,7 +222,7 @@ export default function AdminComplaints() {
             <FontAwesome
               name={isExpanded ? "chevron-up" : "chevron-down"}
               size={11}
-              color="#94a3b8"
+              color={colors.placeholder}
             />
           </View>
         </Pressable>
@@ -256,7 +256,7 @@ export default function AdminComplaints() {
                 }`}
               >
                 {isReviewing ? (
-                  <ActivityIndicator size="small" color="#ffffff" />
+                  <ActivityIndicator size="small" color={colors.surface} />
                 ) : (
                   <Text className="text-xs text-white font-medium">Рассмотрено</Text>
                 )}
@@ -338,7 +338,7 @@ export default function AdminComplaints() {
                 className="items-center justify-center rounded-full bg-slate-100"
                 style={{ width: 72, height: 72 }}
               >
-                <FontAwesome name="flag-o" size={32} color="#94a3b8" />
+                <FontAwesome name="flag-o" size={32} color={colors.placeholder} />
               </View>
               <Text className="text-base font-semibold text-slate-900 mt-4 text-center">
                 Жалоб нет
@@ -355,7 +355,7 @@ export default function AdminComplaints() {
           ListFooterComponent={
             loadingMore ? (
               <View className="py-4 items-center">
-                <ActivityIndicator size="small" color="#1e3a8a" />
+                <ActivityIndicator size="small" color={colors.primary} />
               </View>
             ) : null
           }

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -7,6 +7,7 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 
 interface Stats {
@@ -108,7 +109,7 @@ export default function AdminDashboard() {
       />
       {loading ? (
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
         <ScrollView className="flex-1">

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -14,6 +14,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 
 type RoleFilter = "ALL" | "CLIENT" | "SPECIALIST" | "BANNED";
@@ -214,7 +215,7 @@ export default function AdminUsers() {
             borderRadius: 10,
             height: 40,
             paddingHorizontal: 14,
-            color: "#ffffff",
+            color: colors.surface,
             fontSize: 15,
           }}
           placeholder="Поиск по email или имени..."
@@ -259,7 +260,7 @@ export default function AdminUsers() {
 
       {loading ? (
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
         <ScrollView
@@ -273,7 +274,7 @@ export default function AdminUsers() {
             <View className="py-2">
               {users.length === 0 ? (
                 <View className="items-center py-16">
-                  <FontAwesome name="users" size={48} color="#94a3b8" />
+                  <FontAwesome name="users" size={48} color={colors.placeholder} />
                   <Text className="text-base text-slate-400 mt-3">
                     Пользователи не найдены
                   </Text>
@@ -388,7 +389,7 @@ export default function AdminUsers() {
 
               {loadingMore && (
                 <View className="py-4 items-center">
-                  <ActivityIndicator size="small" color="#1e3a8a" />
+                  <ActivityIndicator size="small" color={colors.primary} />
                 </View>
               )}
             </View>

--- a/app/(client-tabs)/_layout.tsx
+++ b/app/(client-tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 export default function ClientTabsLayout() {
   const { width } = useWindowDimensions();
@@ -11,10 +12,10 @@ export default function ClientTabsLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: isMobile
-          ? { height: 60, paddingBottom: 8, borderTopColor: "#e2e8f0" }
+          ? { height: 60, paddingBottom: 8, borderTopColor: colors.border }
           : { display: "none" },
-        tabBarActiveTintColor: "#1e3a8a",
-        tabBarInactiveTintColor: "#94a3b8",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.placeholder,
         tabBarLabelStyle: { fontSize: 12 },
       }}
     >

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -15,6 +15,7 @@ import EmptyState from "@/components/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
 import { apiGet } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface ThreadItem {
   id: string;
@@ -183,7 +184,7 @@ export default function ClientMessages() {
       <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
         <HeaderHome />
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -212,7 +213,7 @@ export default function ClientMessages() {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={handleRefresh}
-              tintColor="#1e3a8a"
+              tintColor={colors.primary}
             />
           }
           ListEmptyComponent={

--- a/app/(specialist-tabs)/_layout.tsx
+++ b/app/(specialist-tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 export default function SpecialistTabsLayout() {
   const { width } = useWindowDimensions();
@@ -11,10 +12,10 @@ export default function SpecialistTabsLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: isMobile
-          ? { height: 60, paddingBottom: 8, borderTopColor: "#e2e8f0" }
+          ? { height: 60, paddingBottom: 8, borderTopColor: colors.border }
           : { display: "none" },
-        tabBarActiveTintColor: "#1e3a8a",
-        tabBarInactiveTintColor: "#94a3b8",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.placeholder,
         tabBarLabelStyle: { fontSize: 12 },
       }}
     >

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -18,6 +18,7 @@ import EmptyState from "@/components/EmptyState";
 import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiGet, apiPatch } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface Stats {
   threadsTotal: number;
@@ -131,7 +132,7 @@ export default function SpecialistDashboard() {
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -144,7 +145,7 @@ export default function SpecialistDashboard() {
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
         <View className="flex-1 items-center justify-center px-8">
-          <FontAwesome name="exclamation-circle" size={48} color="#94a3b8" />
+          <FontAwesome name="exclamation-circle" size={48} color={colors.placeholder} />
           <Text className="text-lg font-semibold text-slate-900 mt-4 text-center">
             Не удалось загрузить заявки
           </Text>
@@ -201,8 +202,8 @@ export default function SpecialistDashboard() {
                 value={isAvailable}
                 onValueChange={handleToggleAvailability}
                 disabled={availabilityToggling}
-                trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                thumbColor="#ffffff"
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor={colors.surface}
               />
             </View>
 
@@ -217,7 +218,7 @@ export default function SpecialistDashboard() {
                   <FontAwesome
                     name="exclamation-triangle"
                     size={16}
-                    color="#b45309"
+                    color={colors.accent}
                     style={{ marginTop: 2 }}
                   />
                   <View className="flex-1 ml-2">

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { colors } from "@/lib/theme";
 
 export default function PromotionScreen() {
   const router = useRouter();
@@ -25,7 +26,7 @@ export default function PromotionScreen() {
             {/* Placeholder card */}
             <View className="bg-white border border-slate-200 rounded-xl p-6 items-center">
               <View className="w-16 h-16 rounded-full bg-amber-50 items-center justify-center mb-4">
-                <FontAwesome name="rocket" size={28} color="#b45309" />
+                <FontAwesome name="rocket" size={28} color={colors.accent} />
               </View>
               <Text className="text-lg font-semibold text-slate-900 text-center mb-2">
                 Скоро будет доступно
@@ -43,7 +44,7 @@ export default function PromotionScreen() {
               className="bg-blue-900 rounded-xl p-4 mt-4 flex-row items-center"
             >
               <View className="w-10 h-10 rounded-full bg-blue-800 items-center justify-center mr-3">
-                <FontAwesome name="user" size={16} color="#ffffff" />
+                <FontAwesome name="user" size={16} color={colors.surface} />
               </View>
               <View className="flex-1">
                 <Text className="text-white font-semibold text-sm">Заполните профиль</Text>

--- a/app/(specialist-tabs)/requests.tsx
+++ b/app/(specialist-tabs)/requests.tsx
@@ -14,6 +14,7 @@ import RequestCard from "@/components/RequestCard";
 import FilterBar from "@/components/FilterBar";
 import EmptyState from "@/components/EmptyState";
 import { api } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -153,7 +154,7 @@ export default function SpecialistPublicRequests() {
 
         {loading ? (
           <View className="flex-1 items-center justify-center py-16">
-            <ActivityIndicator size="large" color="#1e3a8a" />
+            <ActivityIndicator size="large" color={colors.primary} />
           </View>
         ) : error ? (
           <EmptyState
@@ -201,7 +202,7 @@ export default function SpecialistPublicRequests() {
             onEndReachedThreshold={0.5}
             ListFooterComponent={
               loadingMore ? (
-                <ActivityIndicator size="small" color="#1e3a8a" className="py-4" />
+                <ActivityIndicator size="small" color={colors.primary} className="py-4" />
               ) : null
             }
           />

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -14,6 +14,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 
 interface SettingField {
@@ -104,7 +105,7 @@ export default function AdminSettings() {
       <HeaderBack title="Настройки системы" />
       {loading ? (
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       ) : (
         <ScrollView className="flex-1">
@@ -118,14 +119,14 @@ export default function AdminSettings() {
                   <TextInput
                     accessibilityLabel={field.label}
                     style={{
-                      backgroundColor: "#ffffff",
+                      backgroundColor: colors.surface,
                       borderWidth: 1,
-                      borderColor: "#e2e8f0",
+                      borderColor: colors.border,
                       borderRadius: 10,
                       height: 48,
                       paddingHorizontal: 14,
                       fontSize: 16,
-                      color: "#0f172a",
+                      color: colors.text,
                     }}
                     value={getValue(field.key, field.defaultValue)}
                     onChangeText={(val) => setValue(field.key, val)}

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import { colors } from "@/lib/theme";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -78,15 +79,15 @@ export default function AuthEmailScreen() {
             style={{
               height: 48,
               borderRadius: 12,
-              backgroundColor: error ? "#fef2f2" : "#f8fafc",
+              backgroundColor: error ? colors.errorBg : colors.background,
               borderWidth: 1,
-              borderColor: error ? "#dc2626" : "#e2e8f0",
+              borderColor: error ? colors.error : colors.border,
               paddingHorizontal: 16,
               fontSize: 16,
-              color: "#0f172a",
+              color: colors.text,
             }}
             placeholder="your@email.com"
-            placeholderTextColor="#94a3b8"
+            placeholderTextColor={colors.placeholder}
             value={email}
             onChangeText={(t) => {
               setEmail(t);

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -240,7 +240,7 @@ export default function AuthOtpScreen() {
               onPress={() => handleRoleChoice("SPECIALIST")}
               className="bg-blue-900 rounded-2xl p-5 active:bg-blue-800"
               style={{
-                shadowColor: "#1e3a8a",
+                shadowColor: colors.primary,
                 shadowOffset: { width: 0, height: 2 },
                 shadowOpacity: 0.25,
                 shadowRadius: 4,
@@ -299,12 +299,12 @@ export default function AuthOtpScreen() {
                         ? colors.error
                         : digit
                           ? colors.primary
-                          : "#e2e8f0",
+                          : colors.border,
                       backgroundColor: error
-                        ? "#fef2f2"
+                        ? colors.errorBg
                         : digit
                           ? "#eff6ff"
-                          : "#f8fafc",
+                          : colors.background,
                       textAlign: "center",
                       fontSize: 22,
                       fontWeight: "700",

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -14,6 +14,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import SpecialistCard from "@/components/SpecialistCard";
 import ErrorState from "@/components/ui/ErrorState";
+import { colors } from "@/lib/theme";
 
 interface FeaturedSpecialist {
   id: string;
@@ -163,7 +164,7 @@ export default function LandingScreen() {
   if (loading) {
     return (
       <SafeAreaView className="flex-1 bg-white items-center justify-center">
-        <ActivityIndicator size="large" color="#1e3a8a" />
+        <ActivityIndicator size="large" color={colors.primary} />
       </SafeAreaView>
     );
   }
@@ -258,7 +259,7 @@ export default function LandingScreen() {
                 </Text>
               </View>
               <View
-                style={{ width: 1, backgroundColor: "#334155", marginHorizontal: 8 }}
+                style={{ width: 1, backgroundColor: colors.textMuted, marginHorizontal: 8 }}
               />
               <View className="items-center">
                 <Text className="text-2xl font-bold text-white">
@@ -269,7 +270,7 @@ export default function LandingScreen() {
                 </Text>
               </View>
               <View
-                style={{ width: 1, backgroundColor: "#334155", marginHorizontal: 8 }}
+                style={{ width: 1, backgroundColor: colors.textMuted, marginHorizontal: 8 }}
               />
               <View className="items-center">
                 <Text className="text-2xl font-bold text-white">
@@ -294,7 +295,7 @@ export default function LandingScreen() {
             <View className="mb-8">
               <View className="flex-row items-center mb-4">
                 <View className="w-7 h-7 rounded-full bg-blue-900/10 items-center justify-center mr-2">
-                  <FontAwesome name="user" size={13} color="#1e3a8a" />
+                  <FontAwesome name="user" size={13} color={colors.primary} />
                 </View>
                 <Text className="text-base font-semibold text-slate-900">
                   Для клиентов
@@ -327,7 +328,7 @@ export default function LandingScreen() {
             <View>
               <View className="flex-row items-center mb-4">
                 <View className="w-7 h-7 rounded-full bg-amber-700/10 items-center justify-center mr-2">
-                  <FontAwesome name="briefcase" size={13} color="#b45309" />
+                  <FontAwesome name="briefcase" size={13} color={colors.accent} />
                 </View>
                 <Text className="text-base font-semibold text-slate-900">
                   Для специалистов
@@ -435,12 +436,12 @@ export default function LandingScreen() {
                   </Text>
                   <View className="flex-row items-center gap-3">
                     <View className="flex-row items-center gap-1">
-                      <FontAwesome name="map-marker" size={11} color="#94a3b8" />
+                      <FontAwesome name="map-marker" size={11} color={colors.placeholder} />
                       <Text className="text-xs text-slate-400">{r.city.name}</Text>
                     </View>
                     {r.threadsCount > 0 && (
                       <View className="flex-row items-center gap-1">
-                        <FontAwesome name="comments" size={11} color="#94a3b8" />
+                        <FontAwesome name="comments" size={11} color={colors.placeholder} />
                         <Text className="text-xs text-slate-400">
                           {r.threadsCount}
                         </Text>

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -3,6 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
   return (
@@ -29,7 +30,7 @@ export default function PrivacyPolicyScreen() {
           onPress={() => router.back()}
           className="w-11 h-11 items-center justify-center -ml-2"
         >
-          <FontAwesome name="arrow-left" size={18} color="#0f172a" />
+          <FontAwesome name="arrow-left" size={18} color={colors.text} />
         </Pressable>
         <Text className="flex-1 text-center text-base font-semibold text-slate-900">
           Политика конфиденциальности

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -3,6 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
   return (
@@ -35,7 +36,7 @@ export default function TermsScreen() {
             onPress={() => router.back()}
             className="w-11 h-11 items-center justify-center"
           >
-            <FontAwesome name="times" size={20} color="#0f172a" />
+            <FontAwesome name="times" size={20} color={colors.text} />
           </Pressable>
         </View>
       </View>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -31,15 +31,15 @@ interface NotificationsResponse {
 function iconForType(type: string): { name: React.ComponentProps<typeof FontAwesome>["name"]; color: string } {
   switch (type) {
     case "new_response":
-      return { name: "comments", color: "#1e3a8a" };
+      return { name: "comments", color: colors.primary };
     case "new_message":
-      return { name: "envelope", color: "#1e3a8a" };
+      return { name: "envelope", color: colors.primary };
     case "new_request_in_city":
-      return { name: "map-marker", color: "#059669" };
+      return { name: "map-marker", color: colors.success };
     case "promo_expiring":
-      return { name: "clock-o", color: "#b45309" };
+      return { name: "clock-o", color: colors.accent };
     default:
-      return { name: "bell", color: "#0f172a" };
+      return { name: "bell", color: colors.text };
   }
 }
 
@@ -75,7 +75,7 @@ function NotificationRow({
     >
       <View
         className="w-10 h-10 rounded-full items-center justify-center mt-0.5"
-        style={{ backgroundColor: "#f8fafc" }}
+        style={{ backgroundColor: colors.background }}
       >
         <FontAwesome name={icon.name} size={16} color={icon.color} />
       </View>
@@ -176,7 +176,7 @@ export default function NotificationsScreen() {
       <View className="flex-row items-center justify-between px-4 pt-2 pb-3 border-b border-slate-50">
         <View className="flex-row items-center">
           <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
-            <FontAwesome name="arrow-left" size={18} color="#0f172a" />
+            <FontAwesome name="arrow-left" size={18} color={colors.text} />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Уведомления</Text>
         </View>
@@ -221,7 +221,7 @@ export default function NotificationsScreen() {
             }
             ListEmptyComponent={
               <View className="flex-1 items-center justify-center py-20">
-                <FontAwesome name="bell-slash-o" size={48} color="#94a3b8" />
+                <FontAwesome name="bell-slash-o" size={48} color={colors.placeholder} />
                 <Text className="text-base text-slate-400 mt-4">Нет уведомлений</Text>
                 <Text className="text-sm text-slate-300 mt-1">Здесь будут ваши уведомления</Text>
               </View>

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import { colors } from "@/lib/theme";
 
 export default function OnboardingNameScreen() {
   const router = useRouter();
@@ -79,16 +80,16 @@ export default function OnboardingNameScreen() {
             style={{
               height: 48,
               borderRadius: 12,
-              backgroundColor: "#f8fafc",
+              backgroundColor: colors.background,
               borderWidth: 1,
-              borderColor: firstNameError ? "#dc2626" : "#e2e8f0",
+              borderColor: firstNameError ? colors.error : colors.border,
               paddingHorizontal: 16,
               fontSize: 16,
-              color: "#0f172a",
+              color: colors.text,
               marginBottom: 4,
             }}
             placeholder="Иван"
-            placeholderTextColor="#94a3b8"
+            placeholderTextColor={colors.placeholder}
             value={firstName}
             onChangeText={setFirstName}
             editable={!isLoading}
@@ -106,16 +107,16 @@ export default function OnboardingNameScreen() {
             style={{
               height: 48,
               borderRadius: 12,
-              backgroundColor: "#f8fafc",
+              backgroundColor: colors.background,
               borderWidth: 1,
-              borderColor: lastNameError ? "#dc2626" : "#e2e8f0",
+              borderColor: lastNameError ? colors.error : colors.border,
               paddingHorizontal: 16,
               fontSize: 16,
-              color: "#0f172a",
+              color: colors.text,
               marginBottom: 4,
             }}
             placeholder="Петров"
-            placeholderTextColor="#94a3b8"
+            placeholderTextColor={colors.placeholder}
             value={lastName}
             onChangeText={setLastName}
             editable={!isLoading}

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { colors } from "@/lib/theme";
 
 
 export default function OnboardingProfileScreen() {
@@ -167,7 +168,7 @@ export default function OnboardingProfileScreen() {
                   className="items-center justify-center rounded-full bg-slate-100"
                   style={{ width: 80, height: 80 }}
                 >
-                  <ActivityIndicator color="#1e3a8a" />
+                  <ActivityIndicator color={colors.primary} />
                 </View>
               ) : avatarUrl ? (
                 <View>
@@ -178,14 +179,14 @@ export default function OnboardingProfileScreen() {
                       height: 80,
                       borderRadius: 40,
                       borderWidth: 2,
-                      borderColor: "#e2e8f0",
+                      borderColor: colors.border,
                     }}
                   />
                   <View
                     className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
                     style={{ width: 24, height: 24 }}
                   >
-                    <FontAwesome name="pencil" size={12} color="#fff" />
+                    <FontAwesome name="pencil" size={12} color={colors.surface} />
                   </View>
                 </View>
               ) : (
@@ -195,11 +196,11 @@ export default function OnboardingProfileScreen() {
                     width: 80,
                     height: 80,
                     borderWidth: 2,
-                    borderColor: "#cbd5e1",
+                    borderColor: colors.borderLight,
                     borderStyle: "dashed",
                   }}
                 >
-                  <FontAwesome name="camera" size={24} color="#94a3b8" />
+                  <FontAwesome name="camera" size={24} color={colors.placeholder} />
                 </View>
               )}
               <Text className="text-sm text-slate-400 mt-2">
@@ -232,18 +233,18 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 100,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 paddingVertical: 12,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 textAlignVertical: "top",
                 marginBottom: 4,
               }}
               placeholder="Расскажите о своём опыте: сколько лет в профессии, какие вопросы решаете, с какими инспекциями работаете"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={description}
               onChangeText={(t) => {
                 if (t.length <= 1000) setDescription(t);
@@ -262,16 +263,16 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 48,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 marginBottom: 16,
               }}
               placeholder="+7 (___) ___-__-__"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={phone}
               onChangeText={(t) => setPhone(formatPhone(t))}
               keyboardType="phone-pad"
@@ -285,16 +286,16 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 48,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 marginBottom: 16,
               }}
               placeholder="@username"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={telegram}
               onChangeText={setTelegram}
               autoCapitalize="none"
@@ -308,16 +309,16 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 48,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 marginBottom: 16,
               }}
               placeholder="+7 (___) ___-__-__"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={whatsapp}
               onChangeText={(t) => setWhatsapp(formatPhone(t))}
               keyboardType="phone-pad"
@@ -331,16 +332,16 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 48,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 marginBottom: 16,
               }}
               placeholder="г. Москва, ул. Примерная, д. 1, оф. 100"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={officeAddress}
               onChangeText={setOfficeAddress}
               editable={!isLoading}
@@ -353,16 +354,16 @@ export default function OnboardingProfileScreen() {
               style={{
                 height: 48,
                 borderRadius: 12,
-                backgroundColor: "#f8fafc",
+                backgroundColor: colors.background,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                color: "#0f172a",
+                color: colors.text,
                 marginBottom: 24,
               }}
               placeholder="Пн-Пт 9:00-18:00"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               value={workingHours}
               onChangeText={setWorkingHours}
               editable={!isLoading}

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -12,6 +12,7 @@ import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import { colors } from "@/lib/theme";
 
 interface City {
   id: string;
@@ -177,7 +178,7 @@ export default function OnboardingWorkAreaScreen() {
                     <Text className="text-xs text-slate-400">{item.cityName}</Text>
                   </View>
                   <Pressable accessibilityLabel="Удалить отделение" onPress={() => removeFns(item.fnsId)}>
-                    <FontAwesome name="times" size={16} color="#94a3b8" />
+                    <FontAwesome name="times" size={16} color={colors.placeholder} />
                   </Pressable>
                 </View>
 
@@ -289,7 +290,7 @@ export default function OnboardingWorkAreaScreen() {
                 }}
                 className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-6"
               >
-                <FontAwesome name="plus" size={14} color="#b45309" />
+                <FontAwesome name="plus" size={14} color={colors.accent} />
                 <Text className="text-sm text-amber-700 ml-2 font-medium">
                   Добавить город
                 </Text>

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -172,7 +172,7 @@ export default function MyRequestDetail() {
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Заявка" />
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -248,7 +248,7 @@ export default function MyRequestDetail() {
             <View
               className="bg-white rounded-2xl p-4 mb-4"
               style={{
-                shadowColor: "#0F172A",
+                shadowColor: colors.text,
                 shadowOffset: { width: 0, height: 1 },
                 shadowOpacity: 0.05,
                 shadowRadius: 8,
@@ -268,7 +268,7 @@ export default function MyRequestDetail() {
               <View
                 className="bg-white rounded-2xl p-4 mb-4"
                 style={{
-                  shadowColor: "#0F172A",
+                  shadowColor: colors.text,
                   shadowOffset: { width: 0, height: 1 },
                   shadowOpacity: 0.05,
                   shadowRadius: 8,
@@ -292,7 +292,7 @@ export default function MyRequestDetail() {
                           : "file-image-o"
                       }
                       size={20}
-                      color="#1e3a8a"
+                      color={colors.primary}
                     />
                     <View className="ml-3 flex-1">
                       <Text className="text-sm text-slate-900" numberOfLines={1}>
@@ -302,7 +302,7 @@ export default function MyRequestDetail() {
                         {(file.size / 1024).toFixed(0)} КБ
                       </Text>
                     </View>
-                    <FontAwesome name="download" size={14} color="#94a3b8" />
+                    <FontAwesome name="download" size={14} color={colors.placeholder} />
                   </Pressable>
                 ))}
               </View>
@@ -317,7 +317,7 @@ export default function MyRequestDetail() {
                 className="bg-amber-500 rounded-xl py-3 items-center mb-4"
               >
                 {extending ? (
-                  <ActivityIndicator color="#ffffff" />
+                  <ActivityIndicator color={colors.surface} />
                 ) : (
                   <Text className="text-white font-semibold text-base">
                     Продлить заявку — Продлений: {request.extensionsCount}/
@@ -342,7 +342,7 @@ export default function MyRequestDetail() {
             <View
               className="bg-white rounded-2xl p-4 mb-4"
               style={{
-                shadowColor: "#0F172A",
+                shadowColor: colors.text,
                 shadowOffset: { width: 0, height: 1 },
                 shadowOpacity: 0.05,
                 shadowRadius: 8,
@@ -457,7 +457,7 @@ export default function MyRequestDetail() {
                       }
                       className="bg-white rounded-2xl p-4 mb-3"
                       style={{
-                        shadowColor: "#0F172A",
+                        shadowColor: colors.text,
                         shadowOffset: { width: 0, height: 1 },
                         shadowOpacity: 0.05,
                         shadowRadius: 8,
@@ -491,7 +491,7 @@ export default function MyRequestDetail() {
                             </Text>
                           )}
                         </View>
-                        <FontAwesome name="chevron-right" size={12} color="#94a3b8" />
+                        <FontAwesome name="chevron-right" size={12} color={colors.placeholder} />
                       </View>
                     </Pressable>
                   );
@@ -503,7 +503,7 @@ export default function MyRequestDetail() {
             <View
               className="bg-white rounded-2xl p-4 mb-6"
               style={{
-                shadowColor: "#0F172A",
+                shadowColor: colors.text,
                 shadowOffset: { width: 0, height: 1 },
                 shadowOpacity: 0.05,
                 shadowRadius: 8,

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -13,6 +13,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import EmptyState from "@/components/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import { api, ApiError } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface ThreadItem {
   id: string;
@@ -201,7 +202,7 @@ export default function RequestMessages() {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={handleRefresh}
-              tintColor="#1e3a8a"
+              tintColor={colors.primary}
             />
           }
           ListEmptyComponent={

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -13,6 +13,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { colors } from "@/lib/theme";
 
 interface RequestSummary {
   id: string;
@@ -116,7 +117,7 @@ export default function SpecialistConfirmWrite() {
       <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
         <HeaderBack title="Написать клиенту" />
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -163,7 +164,7 @@ export default function SpecialistConfirmWrite() {
             <View
               className="bg-white rounded-2xl border border-slate-100 p-4 mb-4"
               style={{
-                shadowColor: "#0F172A",
+                shadowColor: colors.text,
                 shadowOffset: { width: 0, height: 2 },
                 shadowOpacity: 0.06,
                 shadowRadius: 12,
@@ -202,19 +203,19 @@ export default function SpecialistConfirmWrite() {
               if (t.length <= MAX_CHARS) setMessage(t);
             }}
             placeholder="Здравствуйте! Я специалист по... Могу помочь с вашей ситуацией. Расскажите подробнее..."
-            placeholderTextColor="#94a3b8"
+            placeholderTextColor={colors.placeholder}
             multiline
             editable={!isLimitReached}
             style={{
               minHeight: 140,
               borderWidth: 1,
-              borderColor: isLimitReached ? "#e2e8f0" : "#cbd5e1",
+              borderColor: isLimitReached ? colors.border : colors.borderLight,
               borderRadius: 12,
               paddingHorizontal: 14,
               paddingVertical: 12,
               fontSize: 16,
-              color: "#0f172a",
-              backgroundColor: isLimitReached ? "#f8fafc" : "#ffffff",
+              color: colors.text,
+              backgroundColor: isLimitReached ? colors.background : colors.surface,
               textAlignVertical: "top",
               opacity: isLimitReached ? 0.5 : 1,
             }}

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -308,11 +308,11 @@ export default function NewRequest() {
                   borderColor:
                     (submitted || title.length > 0) && !titleValid
                       ? colors.error
-                      : "#e2e8f0",
+                      : colors.border,
                   borderRadius: 12,
                   paddingHorizontal: 16,
                   fontSize: 16,
-                  backgroundColor: atLimit ? "#f8fafc" : "#ffffff",
+                  backgroundColor: atLimit ? colors.background : colors.surface,
                   color: colors.text,
                   outlineWidth: 0,
                 } as any}
@@ -351,7 +351,7 @@ export default function NewRequest() {
                 <Text className={selectedCity ? "text-slate-900 text-base" : "text-slate-400 text-base"}>
                   {selectedCity?.name || "Выберите город"}
                 </Text>
-                <FontAwesome name={cityOpen ? "chevron-up" : "chevron-down"} size={12} color="#94a3b8" />
+                <FontAwesome name={cityOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
               </Pressable>
               {submitted && !selectedCityId && (
                 <Text className="text-xs text-red-600 mt-1">Выберите город</Text>
@@ -411,9 +411,9 @@ export default function NewRequest() {
                       (selectedCityId ? "Выберите инспекцию" : "Сначала выберите город")}
                 </Text>
                 {loadingFns ? (
-                  <ActivityIndicator size="small" color="#94a3b8" />
+                  <ActivityIndicator size="small" color={colors.placeholder} />
                 ) : (
-                  <FontAwesome name={fnsOpen ? "chevron-up" : "chevron-down"} size={12} color="#94a3b8" />
+                  <FontAwesome name={fnsOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
                 )}
               </Pressable>
               {submitted && selectedCityId && !selectedFnsId && (
@@ -463,7 +463,7 @@ export default function NewRequest() {
                 <Text className={selectedService ? "text-slate-900 text-base" : "text-slate-400 text-base"}>
                   {selectedService?.name || "Не знаю / не указывать"}
                 </Text>
-                <FontAwesome name={serviceOpen ? "chevron-up" : "chevron-down"} size={12} color="#94a3b8" />
+                <FontAwesome name={serviceOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
               </Pressable>
               {serviceOpen && (
                 <View
@@ -516,13 +516,13 @@ export default function NewRequest() {
                   borderColor:
                     (submitted || description.length > 0) && !descriptionValid
                       ? colors.error
-                      : "#e2e8f0",
+                      : colors.border,
                   borderRadius: 12,
                   paddingHorizontal: 16,
                   paddingTop: 12,
                   paddingBottom: 12,
                   fontSize: 16,
-                  backgroundColor: atLimit ? "#f8fafc" : "#ffffff",
+                  backgroundColor: atLimit ? colors.background : colors.surface,
                   color: colors.text,
                   textAlignVertical: "top",
                   outlineWidth: 0,
@@ -575,14 +575,14 @@ export default function NewRequest() {
                     )}
                   </View>
                   {file.uploading ? (
-                    <ActivityIndicator size="small" color="#94a3b8" />
+                    <ActivityIndicator size="small" color={colors.placeholder} />
                   ) : (
                     <Pressable
                       accessibilityLabel="Удалить файл"
                       onPress={() => handleRemoveFile(index)}
                       className="w-11 h-11 items-center justify-center"
                     >
-                      <FontAwesome name="times" size={14} color="#94a3b8" />
+                      <FontAwesome name="times" size={14} color={colors.placeholder} />
                     </Pressable>
                   )}
                 </View>

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -22,6 +22,7 @@ import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiPatch } from "@/lib/api";
 import LoadingState from "@/components/ui/LoadingState";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { colors } from "@/lib/theme";
 
 
 export default function ClientSettings() {
@@ -195,7 +196,7 @@ export default function ClientSettings() {
                     className="rounded-full bg-slate-100 items-center justify-center"
                     style={{ width: 80, height: 80 }}
                   >
-                    <ActivityIndicator color="#1e3a8a" />
+                    <ActivityIndicator color={colors.primary} />
                   </View>
                 ) : avatarUrl ? (
                   <View>
@@ -206,14 +207,14 @@ export default function ClientSettings() {
                         height: 80,
                         borderRadius: 40,
                         borderWidth: 2,
-                        borderColor: "#e2e8f0",
+                        borderColor: colors.border,
                       }}
                     />
                     <View
                       className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
                       style={{ width: 24, height: 24 }}
                     >
-                      <FontAwesome name="pencil" size={12} color="#fff" />
+                      <FontAwesome name="pencil" size={12} color={colors.surface} />
                     </View>
                   </View>
                 ) : (
@@ -256,12 +257,12 @@ export default function ClientSettings() {
               style={{
                 height: 48,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 borderRadius: 12,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                backgroundColor: "#f8fafc",
-                color: "#0f172a",
+                backgroundColor: colors.background,
+                color: colors.text,
                 marginBottom: 12,
               }}
             />
@@ -275,12 +276,12 @@ export default function ClientSettings() {
               style={{
                 height: 48,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 borderRadius: 12,
                 paddingHorizontal: 16,
                 fontSize: 16,
-                backgroundColor: "#f8fafc",
-                color: "#0f172a",
+                backgroundColor: colors.background,
+                color: colors.text,
                 marginBottom: 12,
               }}
             />
@@ -321,8 +322,8 @@ export default function ClientSettings() {
                   accessibilityLabel="Новые сообщения"
                   value={newMessages}
                   onValueChange={setNewMessages}
-                  trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                  thumbColor="#ffffff"
+                  trackColor={{ false: colors.border, true: colors.primary }}
+                  thumbColor={colors.surface}
                 />
               </View>
               <View className="flex-row items-center px-4 py-3">
@@ -338,8 +339,8 @@ export default function ClientSettings() {
                   accessibilityLabel="Предупреждения о закрытии"
                   value={closingWarnings}
                   onValueChange={setClosingWarnings}
-                  trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                  thumbColor="#ffffff"
+                  trackColor={{ false: colors.border, true: colors.primary }}
+                  thumbColor={colors.surface}
                 />
               </View>
             </View>
@@ -355,11 +356,11 @@ export default function ClientSettings() {
                 onPress={() => router.push("/legal/terms" as never)}
                 className="flex-row items-center px-4 py-3"
               >
-                <FontAwesome name="file-text-o" size={16} color="#94a3b8" />
+                <FontAwesome name="file-text-o" size={16} color={colors.placeholder} />
                 <Text className="text-base text-slate-900 ml-3 flex-1">
                   Условия использования
                 </Text>
-                <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
+                <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />
               </Pressable>
             </View>
 
@@ -374,7 +375,7 @@ export default function ClientSettings() {
                 onPress={handleLogout}
                 className="flex-row items-center px-4 py-3 border-b border-slate-100"
               >
-                <FontAwesome name="sign-out" size={16} color="#dc2626" />
+                <FontAwesome name="sign-out" size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Выйти из аккаунта
                 </Text>
@@ -384,7 +385,7 @@ export default function ClientSettings() {
                 onPress={handleDeleteAccount}
                 className="flex-row items-center px-4 py-3"
               >
-                <FontAwesome name="trash-o" size={16} color="#dc2626" />
+                <FontAwesome name="trash-o" size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Удалить аккаунт
                 </Text>

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useState } from "react";
 import { useRequireAuth } from "@/lib/useRequireAuth";
+import { colors } from "@/lib/theme";
 
 function SettingRow({
   icon,
@@ -23,10 +24,10 @@ function SettingRow({
       className="flex-row items-center px-4 py-4 border-b border-slate-50 active:bg-slate-50"
     >
       <View className="w-9 h-9 rounded-lg bg-slate-50 items-center justify-center">
-        <FontAwesome name={icon} size={16} color="#0f172a" />
+        <FontAwesome name={icon} size={16} color={colors.text} />
       </View>
       <Text className="flex-1 ml-3 text-base text-slate-900">{label}</Text>
-      {rightElement || <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />}
+      {rightElement || <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />}
     </Pressable>
   );
 }
@@ -49,7 +50,7 @@ export default function SettingsScreen() {
   if (!ready) {
     return (
       <SafeAreaView className="flex-1 bg-white items-center justify-center">
-        <ActivityIndicator size="large" color="#1e3a8a" />
+        <ActivityIndicator size="large" color={colors.primary} />
       </SafeAreaView>
     );
   }
@@ -60,7 +61,7 @@ export default function SettingsScreen() {
         {/* Header */}
         <View className="flex-row items-center px-4 pt-2 pb-3 border-b border-slate-50">
           <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
-            <FontAwesome name="arrow-left" size={18} color="#0f172a" />
+            <FontAwesome name="arrow-left" size={18} color={colors.text} />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Настройки</Text>
         </View>
@@ -70,21 +71,21 @@ export default function SettingsScreen() {
           icon="bell"
           label="Push-уведомления"
           rightElement={
-            <Switch accessibilityLabel="Push-уведомления" value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Push-уведомления" value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
         <SettingRow
           icon="envelope"
           label="Email-уведомления"
           rightElement={
-            <Switch accessibilityLabel="Email-уведомления" value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Email-уведомления" value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
         <SettingRow
           icon="comments"
           label="Уведомления о сообщениях"
           rightElement={
-            <Switch accessibilityLabel="Уведомления о сообщениях" value={messageEnabled} onValueChange={setMessageEnabled} trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }} thumbColor="#ffffff" />
+            <Switch accessibilityLabel="Уведомления о сообщениях" value={messageEnabled} onValueChange={setMessageEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
 

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -22,6 +22,7 @@ import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
 import LoadingState from "@/components/ui/LoadingState";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { colors } from "@/lib/theme";
 
 interface ContactMethodItem {
   id: string;
@@ -70,12 +71,12 @@ interface SpecialistProfileData {
 const INPUT_STYLE = {
   height: 48,
   borderWidth: 1,
-  borderColor: "#e2e8f0",
+  borderColor: colors.border,
   borderRadius: 12,
   paddingHorizontal: 16,
   fontSize: 16,
-  color: "#0f172a",
-  backgroundColor: "#f8fafc",
+  color: colors.text,
+  backgroundColor: colors.background,
   marginBottom: 12,
 } as const;
 
@@ -334,7 +335,7 @@ export default function SpecialistSettings() {
                     className="rounded-full bg-slate-100 items-center justify-center"
                     style={{ width: 80, height: 80 }}
                   >
-                    <ActivityIndicator color="#1e3a8a" />
+                    <ActivityIndicator color={colors.primary} />
                   </View>
                 ) : avatarUrl ? (
                   <View>
@@ -345,14 +346,14 @@ export default function SpecialistSettings() {
                         height: 80,
                         borderRadius: 40,
                         borderWidth: 2,
-                        borderColor: "#e2e8f0",
+                        borderColor: colors.border,
                       }}
                     />
                     <View
                       className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
                       style={{ width: 24, height: 24 }}
                     >
-                      <FontAwesome name="pencil" size={12} color="#fff" />
+                      <FontAwesome name="pencil" size={12} color={colors.surface} />
                     </View>
                   </View>
                 ) : (
@@ -398,14 +399,14 @@ export default function SpecialistSettings() {
                 </Text>
               </View>
               {availabilityLoading ? (
-                <ActivityIndicator size="small" color="#1e3a8a" />
+                <ActivityIndicator size="small" color={colors.primary} />
               ) : (
                 <Switch
                   accessibilityLabel="Принимаю заявки"
                   value={isAvailable}
                   onValueChange={handleToggleAvailable}
-                  trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                  thumbColor="#ffffff"
+                  trackColor={{ false: colors.border, true: colors.primary }}
+                  thumbColor={colors.surface}
                 />
               )}
             </View>
@@ -421,7 +422,7 @@ export default function SpecialistSettings() {
               value={firstName}
               onChangeText={setFirstName}
               placeholder="Введите имя"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               maxLength={50}
               style={INPUT_STYLE}
             />
@@ -432,7 +433,7 @@ export default function SpecialistSettings() {
               value={lastName}
               onChangeText={setLastName}
               placeholder="Введите фамилию"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               maxLength={50}
               style={INPUT_STYLE}
             />
@@ -457,19 +458,19 @@ export default function SpecialistSettings() {
               value={description}
               onChangeText={setDescription}
               placeholder="Расскажите о своём опыте и специализации..."
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               multiline
               numberOfLines={4}
               maxLength={500}
               style={{
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
                 borderRadius: 12,
                 paddingHorizontal: 16,
                 paddingVertical: 12,
                 fontSize: 16,
-                color: "#0f172a",
-                backgroundColor: "#f8fafc",
+                color: colors.text,
+                backgroundColor: colors.background,
                 marginBottom: 4,
                 minHeight: 96,
                 textAlignVertical: "top",
@@ -514,7 +515,7 @@ export default function SpecialistSettings() {
                   onPress={() => router.push("/onboarding/work-area" as never)}
                   className="flex-row items-center justify-center py-2 mb-4"
                 >
-                  <FontAwesome name="pencil" size={12} color="#b45309" />
+                  <FontAwesome name="pencil" size={12} color={colors.accent} />
                   <Text className="text-sm text-amber-700 ml-1 font-medium">
                     Изменить рабочую зону
                   </Text>
@@ -526,7 +527,7 @@ export default function SpecialistSettings() {
                 onPress={() => router.push("/onboarding/work-area" as never)}
                 className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
               >
-                <FontAwesome name="plus" size={14} color="#b45309" />
+                <FontAwesome name="plus" size={14} color={colors.accent} />
                 <Text className="text-sm text-amber-700 ml-2 font-medium">
                   Добавить ИФНС и услуги
                 </Text>
@@ -556,7 +557,7 @@ export default function SpecialistSettings() {
                   onPress={() => handleDeleteContact(contact.id)}
                   className="ml-2 p-2"
                 >
-                  <FontAwesome name="trash-o" size={16} color="#dc2626" />
+                  <FontAwesome name="trash-o" size={16} color={colors.error} />
                 </Pressable>
               </View>
             ))}
@@ -572,7 +573,7 @@ export default function SpecialistSettings() {
                   <Text className="text-base text-slate-900">
                     {CONTACT_TYPE_LABELS[newContactType]}
                   </Text>
-                  <FontAwesome name="chevron-down" size={12} color="#94a3b8" />
+                  <FontAwesome name="chevron-down" size={12} color={colors.placeholder} />
                 </Pressable>
                 {showTypePicker && (
                   <View className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-3">
@@ -615,7 +616,7 @@ export default function SpecialistSettings() {
                       ? "vk.com/username"
                       : "https://example.com"
                   }
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor={colors.placeholder}
                   autoCapitalize="none"
                   keyboardType={
                     newContactType === "phone" || newContactType === "whatsapp"
@@ -655,7 +656,7 @@ export default function SpecialistSettings() {
                 onPress={() => setAddingContact(true)}
                 className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
               >
-                <FontAwesome name="plus" size={14} color="#1e3a8a" />
+                <FontAwesome name="plus" size={14} color={colors.primary} />
                 <Text className="text-sm text-blue-900 ml-2 font-medium">
                   Добавить контакт
                 </Text>
@@ -679,7 +680,7 @@ export default function SpecialistSettings() {
               value={officeAddress}
               onChangeText={setOfficeAddress}
               placeholder="Город, улица, дом"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               style={INPUT_STYLE}
             />
 
@@ -691,7 +692,7 @@ export default function SpecialistSettings() {
               value={workingHours}
               onChangeText={setWorkingHours}
               placeholder="Пн-Пт 9:00-18:00"
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               style={INPUT_STYLE}
             />
 
@@ -724,8 +725,8 @@ export default function SpecialistSettings() {
                   accessibilityLabel="Push-уведомления"
                   value={pushEnabled}
                   onValueChange={setPushEnabled}
-                  trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                  thumbColor="#ffffff"
+                  trackColor={{ false: colors.border, true: colors.primary }}
+                  thumbColor={colors.surface}
                 />
               </View>
               <View className="flex-row items-center px-4 py-3">
@@ -741,8 +742,8 @@ export default function SpecialistSettings() {
                   accessibilityLabel="Email-уведомления"
                   value={emailEnabled}
                   onValueChange={setEmailEnabled}
-                  trackColor={{ false: "#e2e8f0", true: "#1e3a8a" }}
-                  thumbColor="#ffffff"
+                  trackColor={{ false: colors.border, true: colors.primary }}
+                  thumbColor={colors.surface}
                 />
               </View>
             </View>
@@ -758,7 +759,7 @@ export default function SpecialistSettings() {
                 onPress={handleLogout}
                 className="flex-row items-center px-4 py-3"
               >
-                <FontAwesome name="sign-out" size={16} color="#dc2626" />
+                <FontAwesome name="sign-out" size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Выйти из аккаунта
                 </Text>

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -18,6 +18,7 @@ import SpecialistCard from "@/components/SpecialistCard";
 import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface FnsServiceGroup {
   fns: { id: string; name: string; code: string };
@@ -73,7 +74,7 @@ function getContactUrl(type: string, value: string): string | null {
 }
 
 const CONTACT_TYPE_CONFIG: Record<string, { label: string; icon: string; bg: string; color: string }> = {
-  phone: { label: "Телефон", icon: "phone", bg: "#eff6ff", color: "#1e3a8a" },
+  phone: { label: "Телефон", icon: "phone", bg: "#eff6ff", color: colors.primary },
   email: { label: "Email", icon: "envelope", bg: "#f0fdf4", color: "#166534" },
   telegram: { label: "Telegram", icon: "paper-plane", bg: "#f0f9ff", color: "#0284c7" },
   whatsapp: { label: "WhatsApp", icon: "whatsapp", bg: "#f0fdf4", color: "#059669" },
@@ -128,7 +129,7 @@ function SkeletonBlock({
   return (
     <Animated.View
       style={[
-        { height, borderRadius, backgroundColor: "#e2e8f0", marginBottom, width: width ?? "100%" },
+        { height, borderRadius, backgroundColor: colors.border, marginBottom, width: width ?? "100%" },
         { opacity },
       ]}
     />
@@ -219,7 +220,7 @@ export default function SpecialistPublicProfile() {
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Профиль специалиста" />
         <View className="flex-1 items-center justify-center px-6">
-          <FontAwesome name="exclamation-circle" size={48} color="#94a3b8" />
+          <FontAwesome name="exclamation-circle" size={48} color={colors.placeholder} />
           <Text className="text-xl font-semibold text-slate-900 mt-4 text-center">
             Специалист не найден
           </Text>
@@ -257,7 +258,7 @@ export default function SpecialistPublicProfile() {
       accessibilityLabel="Редактировать профиль"
       onPress={() => router.push("/settings" as never)}
     >
-      <FontAwesome name="pencil" size={16} color="#0f172a" />
+      <FontAwesome name="pencil" size={16} color={colors.text} />
     </Pressable>
   ) : undefined;
 
@@ -266,7 +267,7 @@ export default function SpecialistPublicProfile() {
       (specialist.profile.officeAddress || specialist.profile.workingHours));
 
   const cardShadow = {
-    shadowColor: "#0F172A",
+    shadowColor: colors.text,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.06,
     shadowRadius: 12,
@@ -304,7 +305,7 @@ export default function SpecialistPublicProfile() {
 
               {cities.length > 0 && (
                 <View className="flex-row items-center mt-1.5">
-                  <FontAwesome name="map-marker" size={12} color="#94a3b8" />
+                  <FontAwesome name="map-marker" size={12} color={colors.placeholder} />
                   <Text className="text-sm text-slate-500 ml-1.5">{cities.join(", ")}</Text>
                 </View>
               )}
@@ -387,8 +388,8 @@ export default function SpecialistPublicProfile() {
                   const cfg = CONTACT_TYPE_CONFIG[contact.type] || {
                     label: contact.type,
                     icon: "link",
-                    bg: "#f8fafc",
-                    color: "#64748b",
+                    bg: colors.background,
+                    color: colors.textSecondary,
                   };
                   const url = getContactUrl(contact.type, contact.value);
                   const isLast =
@@ -416,7 +417,7 @@ export default function SpecialistPublicProfile() {
                             {contact.value}
                           </Text>
                         </View>
-                        <FontAwesome name="chevron-right" size={12} color="#cbd5e1" />
+                        <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />
                       </Pressable>
                     );
                   }
@@ -442,7 +443,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.officeAddress && (
                   <View className={`flex-row items-start py-2.5 ${specialist.profile?.workingHours ? "border-b border-slate-100" : ""}`}>
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
-                      <FontAwesome name="map-marker" size={14} color="#64748b" />
+                      <FontAwesome name="map-marker" size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Адрес офиса</Text>
@@ -456,7 +457,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.workingHours && (
                   <View className="flex-row items-center py-2.5">
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
-                      <FontAwesome name="clock-o" size={14} color="#64748b" />
+                      <FontAwesome name="clock-o" size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Часы работы</Text>

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -21,6 +21,7 @@ import { Avatar } from "@/components/ui";
 import { API_URL, api, apiPost, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { colors } from "@/lib/theme";
 
 
 interface FileAttachment {
@@ -285,12 +286,12 @@ export default function ChatThread() {
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
           <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
+            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
         </View>
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#1e3a8a" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -301,12 +302,12 @@ export default function ChatThread() {
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
           <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
+            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
         </View>
         <View className="flex-1 items-center justify-center px-4">
-          <FontAwesome name="exclamation-circle" size={40} color="#dc2626" />
+          <FontAwesome name="exclamation-circle" size={40} color={colors.error} />
           <Text className="text-base text-red-600 text-center mt-3">{error}</Text>
           <Pressable
             onPress={loadData}
@@ -325,7 +326,7 @@ export default function ChatThread() {
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-slate-100 bg-white">
         <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-          <FontAwesome name="chevron-left" size={18} color="#1e3a8a" />
+          <FontAwesome name="chevron-left" size={18} color={colors.primary} />
         </Pressable>
         {otherUser ? (
           <Avatar
@@ -335,7 +336,7 @@ export default function ChatThread() {
           />
         ) : (
           <View className="w-9 h-9 rounded-full bg-slate-200 items-center justify-center">
-            <FontAwesome name="user" size={16} color="#94a3b8" />
+            <FontAwesome name="user" size={16} color={colors.placeholder} />
           </View>
         )}
         <View className="ml-3 flex-1">
@@ -366,7 +367,7 @@ export default function ChatThread() {
           }}
           ListEmptyComponent={
             <View className="flex-1 items-center justify-center py-16">
-              <FontAwesome name="comments-o" size={48} color="#94a3b8" />
+              <FontAwesome name="comments-o" size={48} color={colors.placeholder} />
               <Text className="text-base text-slate-500 font-medium mt-4">Начните общение</Text>
               <Text className="text-sm text-slate-400 mt-1 text-center px-4">
                 Напишите сообщение, чтобы начать диалог
@@ -392,7 +393,7 @@ export default function ChatThread() {
                 key={i}
                 className="flex-row items-center bg-white border border-slate-200 rounded-lg px-2 py-1 mr-2 mb-1"
               >
-                <FontAwesome name="file-o" size={13} color="#1e3a8a" />
+                <FontAwesome name="file-o" size={13} color={colors.primary} />
                 <Text className="text-xs text-slate-700 mx-1 max-w-[90px]" numberOfLines={1}>
                   {f.name}
                 </Text>
@@ -401,7 +402,7 @@ export default function ChatThread() {
                   onPress={() => handleRemovePendingFile(i)}
                   accessibilityLabel={`Удалить файл ${f.name}`}
                 >
-                  <FontAwesome name="times" size={11} color="#94a3b8" />
+                  <FontAwesome name="times" size={11} color={colors.placeholder} />
                 </Pressable>
               </View>
             ))}
@@ -421,7 +422,7 @@ export default function ChatThread() {
               <FontAwesome
                 name="paperclip"
                 size={20}
-                color={pendingFiles.length >= 3 ? "#cbd5e1" : "#64748b"}
+                color={pendingFiles.length >= 3 ? colors.borderLight : colors.textSecondary}
               />
             </Pressable>
 
@@ -431,7 +432,7 @@ export default function ChatThread() {
               value={text}
               onChangeText={setText}
               placeholder="Введите сообщение..."
-              placeholderTextColor="#94a3b8"
+              placeholderTextColor={colors.placeholder}
               multiline
               style={{
                 flex: 1,
@@ -440,11 +441,11 @@ export default function ChatThread() {
                 paddingHorizontal: 12,
                 paddingVertical: 8,
                 fontSize: 16,
-                color: "#0f172a",
-                backgroundColor: "#f8fafc",
+                color: colors.text,
+                backgroundColor: colors.background,
                 borderRadius: 20,
                 borderWidth: 1,
-                borderColor: "#e2e8f0",
+                borderColor: colors.border,
               }}
             />
 
@@ -456,12 +457,12 @@ export default function ChatThread() {
               className="w-11 h-11 items-center justify-center ml-2"
             >
               {sending || uploading ? (
-                <ActivityIndicator size="small" color="#1e3a8a" />
+                <ActivityIndicator size="small" color={colors.primary} />
               ) : (
                 <FontAwesome
                   name="send"
                   size={20}
-                  color={(text.trim() || pendingFiles.length > 0) ? "#1e3a8a" : "#94a3b8"}
+                  color={(text.trim() || pendingFiles.length > 0) ? colors.primary : colors.placeholder}
                 />
               )}
             </Pressable>

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import Button from "@/components/ui/Button";
+import { colors } from "@/lib/theme";
 
 interface EmptyStateProps {
   icon?: React.ComponentProps<typeof FontAwesome>["name"];
@@ -19,7 +20,7 @@ export default function EmptyState({
 }: EmptyStateProps) {
   return (
     <View className="flex-1 items-center justify-center py-16 px-8">
-      <FontAwesome name={icon} size={64} color="#94a3b8" />
+      <FontAwesome name={icon} size={64} color={colors.placeholder} />
       <Text className="text-lg font-semibold text-slate-900 mt-4 text-center">
         {title}
       </Text>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useAuth } from "@/contexts/AuthContext";
 import { useState } from "react";
 import MobileMenu from "./MobileMenu";
+import { colors } from "@/lib/theme";
 
 export default function Header() {
   const { width } = useWindowDimensions();
@@ -19,7 +20,7 @@ export default function Header() {
       <>
         <View className="flex-row items-center justify-between px-4 h-14 bg-white border-b border-slate-100">
           <Pressable accessibilityLabel="Открыть меню" onPress={() => setMenuOpen(true)} className="w-11 h-11 items-center justify-center">
-            <FontAwesome name="bars" size={20} color="#0f172a" />
+            <FontAwesome name="bars" size={20} color={colors.text} />
           </Pressable>
 
           <Text className="text-lg font-bold text-blue-900">P2PTax</Text>
@@ -31,7 +32,7 @@ export default function Header() {
                 onPress={() => router.push("/notifications" as never)}
                 className="w-11 h-11 items-center justify-center"
               >
-                <FontAwesome name="bell-o" size={18} color="#0f172a" />
+                <FontAwesome name="bell-o" size={18} color={colors.text} />
               </Pressable>
               <Pressable
                 accessibilityLabel="Профиль"
@@ -76,7 +77,7 @@ export default function Header() {
             onPress={() => router.push("/notifications" as never)}
             className="w-11 h-11 rounded-lg items-center justify-center active:bg-slate-100"
           >
-            <FontAwesome name="bell-o" size={18} color="#0f172a" />
+            <FontAwesome name="bell-o" size={18} color={colors.text} />
           </Pressable>
           <Pressable
             accessibilityLabel="Профиль"

--- a/components/HeaderBack.tsx
+++ b/components/HeaderBack.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 interface HeaderBackProps {
   title: string;
@@ -17,7 +18,7 @@ export default function HeaderBack({ title, rightAction }: HeaderBackProps) {
         onPress={() => router.back()}
         className="w-11 h-11 items-center justify-center -ml-2"
       >
-        <FontAwesome name="arrow-left" size={18} color="#0f172a" />
+        <FontAwesome name="arrow-left" size={18} color={colors.text} />
       </Pressable>
       <Text className="flex-1 text-center text-base font-semibold text-slate-900" numberOfLines={1}>
         {title}

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 interface HeaderHomeProps {
   notificationCount?: number;
@@ -19,7 +20,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
           onPress={() => router.push("/notifications" as never)}
           className="w-11 h-11 items-center justify-center"
         >
-          <FontAwesome name="bell-o" size={18} color="#ffffff" />
+          <FontAwesome name="bell-o" size={18} color={colors.surface} />
           {notificationCount > 0 && (
             <View className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-amber-500 items-center justify-center px-1">
               <Text className="text-[9px] font-bold text-white">
@@ -34,7 +35,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
             onPress={onSettingsPress}
             className="w-11 h-11 items-center justify-center"
           >
-            <FontAwesome name="cog" size={18} color="#ffffff" />
+            <FontAwesome name="cog" size={18} color={colors.surface} />
           </Pressable>
         )}
       </View>

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 interface FileAttachment {
   id: string;
@@ -66,7 +67,7 @@ export default function MessageBubble({
               <FontAwesome
                 name="image"
                 size={32}
-                color={isOwn ? "#ffffff" : "#64748b"}
+                color={isOwn ? colors.surface : colors.textSecondary}
               />
               <Text
                 className={`text-xs mt-1 ${isOwn ? "text-blue-200" : "text-slate-400"}`}
@@ -91,7 +92,7 @@ export default function MessageBubble({
             <FontAwesome
               name={file.mimeType === "application/pdf" ? "file-pdf-o" : "file-o"}
               size={18}
-              color={isOwn ? "#93c5fd" : "#1e3a8a"}
+              color={isOwn ? "#93c5fd" : colors.primary}
             />
             <View className="ml-2 flex-1">
               <Text
@@ -109,7 +110,7 @@ export default function MessageBubble({
             <FontAwesome
               name="download"
               size={12}
-              color={isOwn ? "#93c5fd" : "#94a3b8"}
+              color={isOwn ? "#93c5fd" : colors.placeholder}
             />
           </Pressable>
         ))}

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -2,6 +2,7 @@ import { View, Text, Pressable, Modal } from "react-native";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useAuth } from "@/contexts/AuthContext";
+import { colors } from "@/lib/theme";
 
 const MENU_ITEMS: { label: string; route: string; icon: React.ComponentProps<typeof FontAwesome>["name"] }[] = [
   { label: "Главная", route: "/", icon: "home" },
@@ -52,7 +53,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
             ) : (
               <>
                 <View className="w-14 h-14 rounded-full bg-slate-50 items-center justify-center mb-3">
-                  <FontAwesome name="user" size={24} color="#1e3a8a" />
+                  <FontAwesome name="user" size={24} color={colors.primary} />
                 </View>
                 <Text className="text-lg font-bold text-white">Гость</Text>
                 <Text className="text-sm text-slate-50 mt-0.5">Войдите для продолжения</Text>
@@ -62,7 +63,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
 
           {/* Close button */}
           <Pressable accessibilityLabel="Закрыть меню" onPress={onClose} className="absolute top-12 right-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="times" size={20} color="#ffffff" />
+            <FontAwesome name="times" size={20} color={colors.surface} />
           </Pressable>
 
           {/* Menu items */}
@@ -75,7 +76,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
                 className="flex-row items-center px-5 py-3.5 active:bg-slate-50"
               >
                 <View className="w-8 items-center">
-                  <FontAwesome name={item.icon} size={18} color="#64748b" />
+                  <FontAwesome name={item.icon} size={18} color={colors.textSecondary} />
                 </View>
                 <Text className="text-base text-slate-800 ml-3">{item.label}</Text>
               </Pressable>
@@ -86,7 +87,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
           <View className="border-t border-slate-100 px-5 py-4 pb-8">
             {isAuthenticated ? (
               <Pressable accessibilityLabel="Выйти" onPress={handleLogout} className="flex-row items-center py-3">
-                <FontAwesome name="sign-out" size={18} color="#dc2626" />
+                <FontAwesome name="sign-out" size={18} color={colors.error} />
                 <Text className="text-base font-medium text-red-600 ml-3">Выйти</Text>
               </Pressable>
             ) : (

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 interface SpecialistCardProps {
   id: string;
@@ -79,7 +80,7 @@ export default function SpecialistCard({
           </Text>
           {cities.length > 0 && (
             <View className="flex-row items-center mt-0.5">
-              <FontAwesome name="map-marker" size={10} color="#94a3b8" />
+              <FontAwesome name="map-marker" size={10} color={colors.placeholder} />
               <Text className="text-xs text-slate-400 ml-1" numberOfLines={1}>
                 {cities.map((c) => c.name).join(", ")}
               </Text>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -16,7 +16,7 @@ const variantStyles = {
   primary: {
     container: "bg-blue-900 rounded-xl h-12 flex-row items-center justify-center",
     text: "text-white text-base font-semibold",
-    iconColor: "#FFFFFF",
+    iconColor: colors.surface,
   },
   secondary: {
     container: "bg-white border border-slate-200 rounded-xl h-12 flex-row items-center justify-center",
@@ -26,7 +26,7 @@ const variantStyles = {
   destructive: {
     container: "bg-red-600 rounded-xl h-12 flex-row items-center justify-center",
     text: "text-white text-base font-semibold",
-    iconColor: "#FFFFFF",
+    iconColor: colors.surface,
   },
 } as const;
 
@@ -51,7 +51,7 @@ export default function Button({
       className={`${styles.container} ${widthClass} ${opacityClass}`}
       style={({ pressed }) => [
         variant === "primary" && !pressed
-          ? { shadowColor: '#1e3a8a', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.25, shadowRadius: 4, elevation: 3 }
+          ? { shadowColor: colors.primary, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.25, shadowRadius: 4, elevation: 3 }
           : undefined,
         pressed ? { opacity: 0.9, transform: [{ scale: 0.98 }] } : undefined,
       ]}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,4 +1,5 @@
 import { View, Pressable } from "react-native";
+import { colors } from "../../lib/theme";
 
 export interface CardProps {
   children: React.ReactNode;
@@ -27,7 +28,7 @@ export default function Card({
   const shadowStyle =
     variant === "default"
       ? {
-          shadowColor: '#0F172A',
+          shadowColor: colors.text,
           shadowOffset: { width: 0, height: 2 },
           shadowOpacity: 0.06,
           shadowRadius: 12,

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import Feather from "@expo/vector-icons/Feather";
 import Button from "./Button";
+import { colors } from "../../lib/theme";
 
 export interface EmptyStateProps {
   icon: React.ComponentProps<typeof Feather>["name"];
@@ -23,7 +24,7 @@ export default function EmptyState({
         className="items-center justify-center rounded-full bg-slate-100"
         style={{ width: 72, height: 72 }}
       >
-        <Feather name={icon} size={32} color="#94a3b8" />
+        <Feather name={icon} size={32} color={colors.placeholder} />
       </View>
       <Text className="text-base font-semibold text-slate-900 mt-4 text-center">
         {title}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -32,8 +32,8 @@ export default function Input({
     ? colors.error
     : focused
       ? colors.accent
-      : '#e2e8f0';
-  const bgColor = error ? '#fef2f2' : '#FFFFFF';
+      : colors.border;
+  const bgColor = error ? colors.errorBg : colors.surface;
 
   return (
     <View>
@@ -57,7 +57,7 @@ export default function Input({
           <Feather
             name={icon}
             size={18}
-            color="#94a3b8"
+            color={colors.placeholder}
             style={{ marginRight: 8 }}
           />
         )}

--- a/components/ui/LoadingState.tsx
+++ b/components/ui/LoadingState.tsx
@@ -41,7 +41,7 @@ function SkeletonLines({ lines }: { lines: number }) {
             height: heights[i % heights.length],
             width: widths[i % widths.length],
             borderRadius: 8,
-            backgroundColor: '#e2e8f0',
+            backgroundColor: colors.border,
             opacity,
           }}
         />

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -2,14 +2,21 @@ export const colors = {
   // Brand — navy authority + amber accent
   primary: '#1e3a8a',      // blue-900 — deep navy
   accent: '#b45309',       // amber-700 — warm accent CTA
-  background: '#F8FAFC',   // slate-50 — soft warm white
-  surface: '#FFFFFF',       // pure white cards
-  text: '#0f172a',          // slate-900 — dark text
-  textSecondary: '#64748B', // slate-500 — muted secondary
+  background: '#f8fafc',   // slate-50 — soft warm white
+  surface: '#ffffff',      // pure white cards
+  text: '#0f172a',         // slate-900 — dark text
+  textSecondary: '#64748b', // slate-500 — muted secondary
+  textMuted: '#334155',    // slate-700 — dividers, subtle text
+  // Borders
+  border: '#e2e8f0',       // slate-200 — default border
+  borderLight: '#cbd5e1',  // slate-300 — lighter border
+  // Inputs
+  placeholder: '#94a3b8',  // slate-400 — placeholder text
   // Semantic
-  error: '#DC2626',         // red-600
-  success: '#059669',       // emerald-600
-  warning: '#D97706',       // amber-600
+  error: '#dc2626',        // red-600
+  errorBg: '#fef2f2',      // red-50 — error background
+  success: '#059669',      // emerald-600
+  warning: '#d97706',      // amber-600
 } as const
 
 export const tw = {


### PR DESCRIPTION
## Summary

- Expanded `lib/theme.ts` with 6 new tokens: `textMuted`, `border`, `borderLight`, `placeholder`, `errorBg`; normalized all existing hex values to lowercase
- Replaced ~190 hardcoded hex color values across 42 files (screens + components) with named `colors.*` references
- TextInput inline styles preserved as-is (NativeWind web bug workaround)
- One-off semantic colors left as hardcoded (e.g. `#93c5fd` in MessageBubble for own-message accent, contact type bg colors in specialist profile, sample data arrays in stub screens)

## Test plan

- [ ] `npx tsc --noEmit` passes with 0 errors (frontend)
- [ ] `cd api && npx tsc --noEmit` passes with 0 errors (backend)
- [ ] All screens render correctly — no color regressions
- [ ] Input focus/error states still show correct border/bg colors
- [ ] Switch components (availability toggle, settings) still show correct track/thumb colors
- [ ] Message bubbles (own vs other) still show correct icon colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)