### PR TITLE
refactor: migrate 5 screens to NativeWind md: responsive classes

### DIFF
--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -1,14 +1,13 @@
 import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import EmptyState from "@/components/EmptyState";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
       <HeaderHome />
-      <ResponsiveContainer>
+      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
         <View className="flex-1">
           <EmptyState
             icon="check-circle"
@@ -16,7 +15,7 @@ export default function AdminModeration() {
             subtitle="Нет элементов, требующих модерации"
           />
         </View>
-      </ResponsiveContainer>
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -3,7 +3,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { colors } from "@/lib/theme";
 
 export default function PromotionScreen() {
@@ -16,7 +15,7 @@ export default function PromotionScreen() {
         onSettingsPress={() => router.push("/settings/specialist" as never)}
       />
       <ScrollView className="flex-1">
-        <ResponsiveContainer>
+        <View className="w-full px-4 md:max-w-[520px] md:self-center md:px-0">
           <View className="py-4">
             <Text className="text-2xl font-bold text-slate-900 mb-2">Продвижение</Text>
             <Text className="text-sm text-slate-500 mb-6">
@@ -57,7 +56,7 @@ export default function PromotionScreen() {
 
             <View className="h-8" />
           </View>
-        </ResponsiveContainer>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "expo-router";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import { colors } from "@/lib/theme";
 
@@ -59,7 +58,7 @@ export default function AuthEmailScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <ResponsiveContainer>
+      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
         <View className="flex-1" style={{ paddingTop: "13%" }}>
           <View className="items-center mb-8">
             <View className="w-20 h-20 rounded-2xl bg-blue-900 items-center justify-center mb-4">
@@ -122,7 +121,7 @@ export default function AuthEmailScreen() {
             </Text>
           </Pressable>
         </View>
-      </ResponsiveContainer>
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -2,7 +2,6 @@ import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
@@ -38,7 +37,7 @@ export default function PrivacyPolicyScreen() {
         <View className="w-10" />
       </View>
 
-      <ResponsiveContainer>
+      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 48 }}
@@ -93,7 +92,7 @@ export default function PrivacyPolicyScreen() {
             адресу: privacy@p2ptax.ru
           </Paragraph>
         </ScrollView>
-      </ResponsiveContainer>
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -2,7 +2,6 @@ import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
@@ -41,7 +40,7 @@ export default function TermsScreen() {
         </View>
       </View>
 
-      <ResponsiveContainer>
+      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 48 }}
@@ -112,7 +111,7 @@ export default function TermsScreen() {
             адресу: support@p2ptax.ru
           </Paragraph>
         </ScrollView>
-      </ResponsiveContainer>
+      </View>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary
Partial migration for task #1177 — JS-only responsive → NativeWind `md:` classes.

### Migrated screens (5)
- `app/legal/privacy.tsx`
- `app/legal/terms.tsx`
- `app/auth/email.tsx`
- `app/(specialist-tabs)/promotion.tsx`
- `app/(admin-tabs)/moderation.tsx`

### Pattern change
**Before:**
```tsx
import { ResponsiveContainer } from '@/components/ResponsiveContainer';
// ...
<ResponsiveContainer>
  <ScrollView>...</ScrollView>
</ResponsiveContainer>
```

**After:**
```tsx
<View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
  <ScrollView>...</ScrollView>
</View>
```

### Note on promotion.tsx
`ResponsiveContainer` was nested inside `ScrollView` (not wrapping it), so the replacement View uses `w-full` instead of `flex-1` to preserve scroll content layout.

### Remaining scope (22 screens — NOT in this PR)
All other screens still use `ResponsiveContainer` or `useWindowDimensions`. They were excluded because:
1. **Complex layout branching** — screens with `{isDesktop ? <DesktopLayout /> : <MobileLayout />}` need careful structural refactoring
2. **ResponsiveContainer can be deprecated** after all screens migrate
3. Risk mitigation — this PR proves the pattern works before full rollout

### Verification
- `tsc --noEmit` passes (0 errors, frontend + backend)
- Visual behavior preserved: mobile gets `px-4`, desktop gets `max-w-[520px]` centered

Closes #1177 (partial)