### PR TITLE
fix: add press feedback to Pressable elements (#1171)

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -38,7 +38,7 @@ function StatCard({
   );
 
   if (onPress) {
-    return <Pressable accessibilityLabel={label} onPress={onPress}>{content}</Pressable>;
+    return <Pressable accessibilityLabel={label} onPress={onPress} style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}>{content}</Pressable>;
   }
   return content;
 }

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -243,6 +243,7 @@ export default function AdminUsers() {
                   ? "bg-blue-900 border-blue-900"
                   : "bg-white border-slate-200"
               }`}
+              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
             >
               <Text
                 className={`text-sm ${
@@ -288,6 +289,7 @@ export default function AdminUsers() {
                         setExpandedId(expandedId === user.id ? null : user.id)
                       }
                       className="bg-white border-b border-slate-100 px-4 py-3"
+                      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                     >
                       <View className="flex-row items-center">
                         {/* Avatar */}
@@ -363,6 +365,7 @@ export default function AdminUsers() {
                             className={`px-3 py-2 rounded-lg ${
                               user.isBanned ? "bg-emerald-600" : "bg-red-600"
                             }`}
+                            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                           >
                             <Text className="text-xs text-white font-medium">
                               {user.isBanned ? "Разблокировать" : "Заблокировать"}
@@ -374,6 +377,7 @@ export default function AdminUsers() {
                               accessibilityLabel="Закрыть все заявки"
                               onPress={() => closeAllRequests(user)}
                               className="px-3 py-2 rounded-lg bg-amber-500"
+                              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                             >
                               <Text className="text-xs text-white font-medium">
                                 Закрыть все заявки

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -117,6 +117,7 @@ export default function ClientMessages() {
           accessibilityLabel={`Чат с ${name}`}
           onPress={() => router.push(`/threads/${item.id}` as never)}
           className="flex-row items-center py-3 border-b border-slate-100 active:bg-slate-50"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
         >
           {/* Avatar with unread badge */}
           <View className="relative mr-3">

--- a/app/(specialist-tabs)/threads.tsx
+++ b/app/(specialist-tabs)/threads.tsx
@@ -178,6 +178,7 @@ function FilterChip({
       className={`px-4 py-2 rounded-full border ${
         active ? "bg-blue-900 border-blue-900" : "bg-white border-slate-200"
       }`}
+      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
     >
       <Text
         className={`text-sm font-medium ${
@@ -228,6 +229,7 @@ function ThreadCard({
       accessibilityLabel={`Чат с ${name}`}
       onPress={onPress}
       className="flex-row items-center py-3 border-b border-slate-100 active:bg-slate-50"
+      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
     >
       {/* Avatar with unread badge */}
       <View className="relative mr-3">

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -35,6 +35,7 @@ export default function TermsScreen() {
             accessibilityLabel="Закрыть"
             onPress={() => router.back()}
             className="w-11 h-11 items-center justify-center"
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
           >
             <FontAwesome name="times" size={20} color={colors.text} />
           </Pressable>

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -217,7 +217,11 @@ export default function MyRequestDetail() {
       <HeaderBack
         title={request.title}
         rightAction={
-          <Pressable accessibilityLabel="Удалить заявку" onPress={handleDelete}>
+          <Pressable
+            accessibilityLabel="Удалить заявку"
+            onPress={handleDelete}
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+          >
             <FontAwesome name="trash-o" size={18} color={colors.error} />
           </Pressable>
         }
@@ -284,6 +288,7 @@ export default function MyRequestDetail() {
                     accessibilityLabel={`Открыть файл ${file.filename}`}
                     onPress={() => handleFilePress(file)}
                     className="flex-row items-center bg-slate-50 rounded-xl p-3 mb-2"
+                    style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                   >
                     <FontAwesome
                       name={
@@ -315,6 +320,7 @@ export default function MyRequestDetail() {
                 onPress={handleExtend}
                 disabled={extending}
                 className="bg-amber-500 rounded-xl py-3 items-center mb-4"
+                style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
               >
                 {extending ? (
                   <ActivityIndicator color={colors.surface} />
@@ -414,6 +420,7 @@ export default function MyRequestDetail() {
                               router.push(`/threads/${thread.id}` as never)
                             }
                             className="bg-blue-900 rounded-lg px-3 py-1.5"
+                            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                           >
                             <Text className="text-white text-xs font-semibold">
                               Открыть чат
@@ -431,6 +438,7 @@ export default function MyRequestDetail() {
                       router.push(`/requests/${id}/messages` as never)
                     }
                     className="mt-3 border border-blue-900 rounded-xl py-2.5 items-center"
+                    style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
                   >
                     <Text className="text-blue-900 font-semibold text-sm">
                       Все сообщения ({request.threadsCount})
@@ -456,13 +464,16 @@ export default function MyRequestDetail() {
                         router.push(`/specialists/${spec.id}` as never)
                       }
                       className="bg-white rounded-2xl p-4 mb-3"
-                      style={{
-                        shadowColor: colors.text,
-                        shadowOffset: { width: 0, height: 1 },
-                        shadowOpacity: 0.05,
-                        shadowRadius: 8,
-                        elevation: 2,
-                      }}
+                      style={({ pressed }) => [
+                        {
+                          shadowColor: colors.text,
+                          shadowOffset: { width: 0, height: 1 },
+                          shadowOpacity: 0.05,
+                          shadowRadius: 8,
+                          elevation: 2,
+                        },
+                        pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
+                      ]}
                     >
                       <View className="flex-row items-center">
                         <Avatar

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -104,6 +104,7 @@ export default function RequestMessages() {
           accessibilityLabel={`Чат с ${name}`}
           onPress={() => router.push(`/threads/${item.id}` as never)}
           className="flex-row items-center py-3 border-b border-slate-100"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
         >
           {/* Avatar */}
           <View className="w-10 h-10 rounded-full bg-blue-900 items-center justify-center">

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -190,6 +190,7 @@ export default function ClientSettings() {
                 accessibilityLabel="Фото профиля"
                 onPress={handleAvatarPress}
                 className="items-center"
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
                 {avatarUploading ? (
                   <View
@@ -355,6 +356,7 @@ export default function ClientSettings() {
                 accessibilityLabel="Условия использования"
                 onPress={() => router.push("/legal/terms" as never)}
                 className="flex-row items-center px-4 py-3"
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
                 <FontAwesome name="file-text-o" size={16} color={colors.placeholder} />
                 <Text className="text-base text-slate-900 ml-3 flex-1">
@@ -374,6 +376,7 @@ export default function ClientSettings() {
                 accessibilityLabel="Выйти из аккаунта"
                 onPress={handleLogout}
                 className="flex-row items-center px-4 py-3 border-b border-slate-100"
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
                 <FontAwesome name="sign-out" size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
@@ -384,6 +387,7 @@ export default function ClientSettings() {
                 accessibilityLabel="Удалить аккаунт"
                 onPress={handleDeleteAccount}
                 className="flex-row items-center px-4 py-3"
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
                 <FontAwesome name="trash-o" size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -312,6 +312,7 @@ export default function ChatThread() {
           <Pressable
             onPress={loadData}
             className="mt-4 px-6 py-3 bg-blue-900 rounded-xl"
+            style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
           >
             <Text className="text-white text-sm font-semibold">Повторить</Text>
           </Pressable>
@@ -325,7 +326,7 @@ export default function ChatThread() {
       <View className="flex-1" style={desktopStyle}>
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-slate-100 bg-white">
-        <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
+        <Pressable accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center" style={({ pressed }) => [pressed && { opacity: 0.7 }]}>
           <FontAwesome name="chevron-left" size={18} color={colors.primary} />
         </Pressable>
         {otherUser ? (
@@ -401,6 +402,7 @@ export default function ChatThread() {
                 <Pressable
                   onPress={() => handleRemovePendingFile(i)}
                   accessibilityLabel={`Удалить файл ${f.name}`}
+                  style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                 >
                   <FontAwesome name="times" size={11} color={colors.placeholder} />
                 </Pressable>
@@ -418,6 +420,7 @@ export default function ChatThread() {
               onPress={handleAttachFile}
               disabled={pendingFiles.length >= 3 || sending}
               className="w-11 h-11 items-center justify-center mr-1"
+              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
             >
               <FontAwesome
                 name="paperclip"
@@ -455,6 +458,7 @@ export default function ChatThread() {
               onPress={handleSend}
               disabled={(!text.trim() && pendingFiles.length === 0) || sending}
               className="w-11 h-11 items-center justify-center ml-2"
+              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
             >
               {sending || uploading ? (
                 <ActivityIndicator size="small" color={colors.primary} />

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -27,6 +27,7 @@ export default function RequestCard({
       accessibilityLabel={title}
       onPress={() => onPress(id)}
       className="bg-white border border-slate-200 rounded-xl p-4 mb-3"
+      style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
     >
       <View className="flex-row items-center justify-between mb-2">
         <Text className="text-lg font-semibold text-slate-900 flex-1 mr-2" numberOfLines={1}>

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -37,7 +37,7 @@ export default function SpecialistCard({
         accessibilityLabel={name}
         onPress={() => onPress(id)}
         className="bg-white border border-slate-200 rounded-xl p-4 mr-3"
-        style={{ width: 200 }}
+        style={({ pressed }) => [{ width: 200 }, pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
       >
         <View className="w-12 h-12 rounded-full bg-blue-900 items-center justify-center mb-2">
           <Text className="text-white font-bold text-base">{initials}</Text>
@@ -69,6 +69,7 @@ export default function SpecialistCard({
       accessibilityLabel={name}
       onPress={() => onPress(id)}
       className="bg-white border border-slate-200 rounded-xl p-4 mb-3"
+      style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
     >
       <View className="flex-row items-center">
         <View className="w-12 h-12 rounded-full bg-blue-900 items-center justify-center mr-3">


### PR DESCRIPTION
Closes #1171

## Changes
- Added `style={({pressed}) => [pressed && {opacity: 0.7, transform: [{scale: 0.98}]}]}` to all interactive Pressable elements
- Cards (RequestCard, SpecialistCard, recommendations): opacity + scale
- Rows/buttons (threads, settings, admin actions): opacity only
- Send button in ChatThread: opacity only (no scale to avoid UX issues)
- Affected screens: PublicRequestsFeed, SpecialistsCatalog, MyRequestDetail, ClientMessages, RequestMessages, ClientSettings, ChatThread, AdminDashboard, AdminUsers, TermsScreen, SpecialistThreads
- Native press feedback now works on iOS/Android
- Web `active:bg-slate-50` class preserved

## Verification
- [x] tsc --noEmit passes (0 errors frontend + backend)
- [ ] Press feedback visible on native simulator
- [x] No StyleSheet.create introduced
- [x] No hardcoded hex colors
- [x] No console.log added