### PR TITLE
fix: replace inline TextInput with shared Input component in 8 screens (#1170)

### DIFF
--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -3,7 +3,6 @@ import {
   Text,
   ScrollView,
   ActivityIndicator,
-  TextInput,
   Platform,
   Alert,
 } from "react-native";
@@ -12,6 +11,7 @@ import { useEffect, useState, useCallback } from "react";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -112,27 +112,13 @@ export default function AdminSettings() {
           <ResponsiveContainer>
             <View className="py-4 gap-4">
               {SETTINGS_FIELDS.map((field) => (
-                <View key={field.key}>
-                  <Text className="text-sm font-medium text-slate-700 mb-1">
-                    {field.label}
-                  </Text>
-                  <TextInput
-                    accessibilityLabel={field.label}
-                    style={{
-                      backgroundColor: colors.surface,
-                      borderWidth: 1,
-                      borderColor: colors.border,
-                      borderRadius: 10,
-                      height: 48,
-                      paddingHorizontal: 14,
-                      fontSize: 16,
-                      color: colors.text,
-                    }}
-                    value={getValue(field.key, field.defaultValue)}
-                    onChangeText={(val) => setValue(field.key, val)}
-                    keyboardType="numeric"
-                  />
-                </View>
+                <Input
+                  key={field.key}
+                  label={field.label}
+                  value={getValue(field.key, field.defaultValue)}
+                  onChangeText={(val) => setValue(field.key, val)}
+                  keyboardType="numeric"
+                />
               ))}
 
               <View className="mt-2">

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -1,11 +1,11 @@
-import { View, Text, TextInput, Pressable } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import Button from "@/components/ui/Button";
-import { colors } from "@/lib/theme";
+import Input from "@/components/ui/Input";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -73,34 +73,21 @@ export default function AuthEmailScreen() {
             Введите email для продолжения
           </Text>
 
-          <TextInput
+          <Input
             accessibilityLabel="Email адрес"
-            style={{
-              height: 48,
-              borderRadius: 12,
-              backgroundColor: error ? colors.errorBg : colors.background,
-              borderWidth: 1,
-              borderColor: error ? colors.error : colors.border,
-              paddingHorizontal: 16,
-              fontSize: 16,
-              color: colors.text,
-            }}
             placeholder="your@email.com"
-            placeholderTextColor={colors.placeholder}
             value={email}
             onChangeText={(t) => {
               setEmail(t);
               if (error) setError("");
             }}
+            error={error}
             keyboardType="email-address"
             autoCapitalize="none"
             autoComplete="email"
             editable={!isLoading}
             onSubmitEditing={handleContinue}
           />
-          {error ? (
-            <Text className="text-xs text-red-600 mt-1">{error}</Text>
-          ) : null}
 
           <View className="mt-6">
             <Button

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TextInput, Pressable } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState } from "react";
@@ -7,7 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
-import { colors } from "@/lib/theme";
+import Input from "@/components/ui/Input";
 
 export default function OnboardingNameScreen() {
   const router = useRouter();
@@ -74,59 +74,29 @@ export default function OnboardingNameScreen() {
             Ваше имя
           </Text>
 
-          <Text className="text-sm text-slate-500 mb-1">Имя</Text>
-          <TextInput
-            accessibilityLabel="Имя"
-            style={{
-              height: 48,
-              borderRadius: 12,
-              backgroundColor: colors.background,
-              borderWidth: 1,
-              borderColor: firstNameError ? colors.error : colors.border,
-              paddingHorizontal: 16,
-              fontSize: 16,
-              color: colors.text,
-              marginBottom: 4,
-            }}
-            placeholder="Иван"
-            placeholderTextColor={colors.placeholder}
-            value={firstName}
-            onChangeText={setFirstName}
-            editable={!isLoading}
-            autoCapitalize="words"
-          />
-          {firstNameError ? (
-            <Text className="text-xs text-red-600 mb-3">{firstNameError}</Text>
-          ) : (
-            <View className="mb-3" />
-          )}
+          <View className="mb-3">
+            <Input
+              label="Имя"
+              placeholder="Иван"
+              value={firstName}
+              onChangeText={setFirstName}
+              error={firstNameError}
+              editable={!isLoading}
+              autoCapitalize="words"
+            />
+          </View>
 
-          <Text className="text-sm text-slate-500 mb-1">Фамилия</Text>
-          <TextInput
-            accessibilityLabel="Фамилия"
-            style={{
-              height: 48,
-              borderRadius: 12,
-              backgroundColor: colors.background,
-              borderWidth: 1,
-              borderColor: lastNameError ? colors.error : colors.border,
-              paddingHorizontal: 16,
-              fontSize: 16,
-              color: colors.text,
-              marginBottom: 4,
-            }}
-            placeholder="Петров"
-            placeholderTextColor={colors.placeholder}
-            value={lastName}
-            onChangeText={setLastName}
-            editable={!isLoading}
-            autoCapitalize="words"
-          />
-          {lastNameError ? (
-            <Text className="text-xs text-red-600 mb-4">{lastNameError}</Text>
-          ) : (
-            <View className="mb-4" />
-          )}
+          <View className="mb-4">
+            <Input
+              label="Фамилия"
+              placeholder="Петров"
+              value={lastName}
+              onChangeText={setLastName}
+              error={lastNameError}
+              editable={!isLoading}
+              autoCapitalize="words"
+            />
+          </View>
 
           {/* Terms checkbox */}
           <Pressable

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -1,7 +1,6 @@
 import {
   View,
   Text,
-  TextInput,
   Pressable,
   ActivityIndicator,
   ScrollView,
@@ -17,6 +16,7 @@ import { API_URL, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { colors } from "@/lib/theme";
 
@@ -228,147 +228,79 @@ export default function OnboardingProfileScreen() {
             </View>
 
             {/* About */}
-            <Text className="text-sm text-slate-500 mb-1">О себе</Text>
-            <TextInput
-              accessibilityLabel="О себе"
-              style={{
-                height: 100,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-                fontSize: 16,
-                color: colors.text,
-                textAlignVertical: "top",
-                marginBottom: 4,
-              }}
-              placeholder="Расскажите о своём опыте: сколько лет в профессии, какие вопросы решаете, с какими инспекциями работаете"
-              placeholderTextColor={colors.placeholder}
-              value={description}
-              onChangeText={(t) => {
-                if (t.length <= 1000) setDescription(t);
-              }}
-              multiline
-              editable={!isLoading}
-            />
-            <Text className="text-xs text-slate-400 text-right mb-4">
-              {description.length}/1000
-            </Text>
+            <View className="mb-4">
+              <Input
+                label="О себе"
+                placeholder="Расскажите о своём опыте: сколько лет в профессии, какие вопросы решаете, с какими инспекциями работаете"
+                value={description}
+                onChangeText={(t) => {
+                  if (t.length <= 1000) setDescription(t);
+                }}
+                multiline
+                editable={!isLoading}
+              />
+              <Text className="text-xs text-slate-400 text-right mt-1">
+                {description.length}/1000
+              </Text>
+            </View>
 
             {/* Phone */}
-            <Text className="text-sm text-slate-500 mb-1">Телефон</Text>
-            <TextInput
-              accessibilityLabel="Телефон"
-              style={{
-                height: 48,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                color: colors.text,
-                marginBottom: 16,
-              }}
-              placeholder="+7 (___) ___-__-__"
-              placeholderTextColor={colors.placeholder}
-              value={phone}
-              onChangeText={(t) => setPhone(formatPhone(t))}
-              keyboardType="phone-pad"
-              editable={!isLoading}
-            />
+            <View className="mb-4">
+              <Input
+                label="Телефон"
+                placeholder="+7 (___) ___-__-__"
+                value={phone}
+                onChangeText={(t) => setPhone(formatPhone(t))}
+                keyboardType="phone-pad"
+                editable={!isLoading}
+              />
+            </View>
 
             {/* Telegram */}
-            <Text className="text-sm text-slate-500 mb-1">Telegram</Text>
-            <TextInput
-              accessibilityLabel="Telegram"
-              style={{
-                height: 48,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                color: colors.text,
-                marginBottom: 16,
-              }}
-              placeholder="@username"
-              placeholderTextColor={colors.placeholder}
-              value={telegram}
-              onChangeText={setTelegram}
-              autoCapitalize="none"
-              editable={!isLoading}
-            />
+            <View className="mb-4">
+              <Input
+                label="Telegram"
+                placeholder="@username"
+                value={telegram}
+                onChangeText={setTelegram}
+                autoCapitalize="none"
+                editable={!isLoading}
+              />
+            </View>
 
             {/* WhatsApp */}
-            <Text className="text-sm text-slate-500 mb-1">WhatsApp</Text>
-            <TextInput
-              accessibilityLabel="WhatsApp"
-              style={{
-                height: 48,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                color: colors.text,
-                marginBottom: 16,
-              }}
-              placeholder="+7 (___) ___-__-__"
-              placeholderTextColor={colors.placeholder}
-              value={whatsapp}
-              onChangeText={(t) => setWhatsapp(formatPhone(t))}
-              keyboardType="phone-pad"
-              editable={!isLoading}
-            />
+            <View className="mb-4">
+              <Input
+                label="WhatsApp"
+                placeholder="+7 (___) ___-__-__"
+                value={whatsapp}
+                onChangeText={(t) => setWhatsapp(formatPhone(t))}
+                keyboardType="phone-pad"
+                editable={!isLoading}
+              />
+            </View>
 
             {/* Office address */}
-            <Text className="text-sm text-slate-500 mb-1">Адрес офиса</Text>
-            <TextInput
-              accessibilityLabel="Адрес офиса"
-              style={{
-                height: 48,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                color: colors.text,
-                marginBottom: 16,
-              }}
-              placeholder="г. Москва, ул. Примерная, д. 1, оф. 100"
-              placeholderTextColor={colors.placeholder}
-              value={officeAddress}
-              onChangeText={setOfficeAddress}
-              editable={!isLoading}
-            />
+            <View className="mb-4">
+              <Input
+                label="Адрес офиса"
+                placeholder="г. Москва, ул. Примерная, д. 1, оф. 100"
+                value={officeAddress}
+                onChangeText={setOfficeAddress}
+                editable={!isLoading}
+              />
+            </View>
 
             {/* Working hours */}
-            <Text className="text-sm text-slate-500 mb-1">Часы работы</Text>
-            <TextInput
-              accessibilityLabel="Часы работы"
-              style={{
-                height: 48,
-                borderRadius: 12,
-                backgroundColor: colors.background,
-                borderWidth: 1,
-                borderColor: colors.border,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                color: colors.text,
-                marginBottom: 24,
-              }}
-              placeholder="Пн-Пт 9:00-18:00"
-              placeholderTextColor={colors.placeholder}
-              value={workingHours}
-              onChangeText={setWorkingHours}
-              editable={!isLoading}
-            />
+            <View className="mb-6">
+              <Input
+                label="Часы работы"
+                placeholder="Пн-Пт 9:00-18:00"
+                value={workingHours}
+                onChangeText={setWorkingHours}
+                editable={!isLoading}
+              />
+            </View>
 
             {error ? (
               <Text className="text-xs text-red-600 text-center mb-4">

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -5,7 +5,6 @@ import {
   ScrollView,
   Pressable,
   ActivityIndicator,
-  TextInput,
   Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -15,6 +14,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import { API_URL, api, apiPost } from "@/lib/api";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { colors } from "@/lib/theme";
@@ -294,39 +294,17 @@ export default function NewRequest() {
               <Text className="text-sm font-medium text-slate-700 mb-1.5">
                 Заголовок <Text className="text-red-500">*</Text>
               </Text>
-              <TextInput
-                accessibilityLabel="Заголовок заявки"
+              <Input
+                placeholder="Кратко опишите суть проблемы"
                 value={title}
                 onChangeText={setTitle}
-                placeholder="Кратко опишите суть проблемы"
+                error={(submitted || title.length > 0) && !titleValid
+                  ? (title.trim().length < 3 ? "Минимум 3 символа" : "Максимум 100 символов")
+                  : undefined}
                 maxLength={100}
                 editable={!atLimit && !submitting}
-                placeholderTextColor={colors.textSecondary}
-                style={{
-                  height: 48,
-                  borderWidth: 1,
-                  borderColor:
-                    (submitted || title.length > 0) && !titleValid
-                      ? colors.error
-                      : colors.border,
-                  borderRadius: 12,
-                  paddingHorizontal: 16,
-                  fontSize: 16,
-                  backgroundColor: atLimit ? colors.background : colors.surface,
-                  color: colors.text,
-                  outlineWidth: 0,
-                } as any}
               />
-              <View className="flex-row justify-between mt-1">
-                {(submitted || title.length > 0) && !titleValid ? (
-                  <Text className="text-xs text-red-600">
-                    {title.trim().length < 3 ? "Минимум 3 символа" : "Максимум 100 символов"}
-                  </Text>
-                ) : (
-                  <View />
-                )}
-                <Text className="text-xs text-slate-400">{title.length}/100</Text>
-              </View>
+              <Text className="text-xs text-slate-400 text-right mt-1">{title.length}/100</Text>
             </View>
 
             {/* City select */}
@@ -508,45 +486,19 @@ export default function NewRequest() {
               <Text className="text-sm font-medium text-slate-700 mb-1.5">
                 Описание <Text className="text-red-500">*</Text>
               </Text>
-              <TextInput
-                accessibilityLabel="Описание заявки"
+              <Input
+                placeholder="Подробно опишите ситуацию: что произошло, какие документы получили, что требует инспекция, какая помощь нужна"
                 value={description}
                 onChangeText={setDescription}
-                placeholder="Подробно опишите ситуацию: что произошло, какие документы получили, что требует инспекция, какая помощь нужна"
                 multiline
+                error={(submitted || description.length > 0) && !descriptionValid
+                  ? (description.trim().length < 10 ? "Минимум 10 символов" : "Максимум 2000 символов")
+                  : undefined}
                 maxLength={2000}
                 editable={!atLimit && !submitting}
-                placeholderTextColor={colors.textSecondary}
-                style={{
-                  minHeight: 120,
-                  borderWidth: 1,
-                  borderColor:
-                    (submitted || description.length > 0) && !descriptionValid
-                      ? colors.error
-                      : colors.border,
-                  borderRadius: 12,
-                  paddingHorizontal: 16,
-                  paddingTop: 12,
-                  paddingBottom: 12,
-                  fontSize: 16,
-                  backgroundColor: atLimit ? colors.background : colors.surface,
-                  color: colors.text,
-                  textAlignVertical: "top",
-                  outlineWidth: 0,
-                } as any}
+                containerStyle={{ minHeight: 120 }}
               />
-              <View className="flex-row justify-between mt-1">
-                {(submitted || description.length > 0) && !descriptionValid ? (
-                  <Text className="text-xs text-red-600">
-                    {description.trim().length < 10
-                      ? "Минимум 10 символов"
-                      : "Максимум 2000 символов"}
-                  </Text>
-                ) : (
-                  <View />
-                )}
-                <Text className="text-xs text-slate-400">{description.length}/2000</Text>
-              </View>
+              <Text className="text-xs text-slate-400 text-right mt-1">{description.length}/2000</Text>
             </View>
 
             {/* File upload */}

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -7,7 +7,6 @@ import {
   ActivityIndicator,
   Alert,
   Switch,
-  TextInput,
   Image,
   Platform,
 } from "react-native";
@@ -17,6 +16,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiPatch } from "@/lib/api";
@@ -250,43 +250,23 @@ export default function ClientSettings() {
             )}
 
             {/* Name fields */}
-            <Text className="text-sm font-medium text-slate-900 mb-1">Имя</Text>
-            <TextInput
-              accessibilityLabel="Имя"
-              value={firstName}
-              onChangeText={setFirstName}
-              placeholder="Введите имя"
-              style={{
-                height: 48,
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 12,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                backgroundColor: colors.background,
-                color: colors.text,
-                marginBottom: 12,
-              }}
-            />
+            <View className="mb-3">
+              <Input
+                label="Имя"
+                value={firstName}
+                onChangeText={setFirstName}
+                placeholder="Введите имя"
+              />
+            </View>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">Фамилия</Text>
-            <TextInput
-              accessibilityLabel="Фамилия"
-              value={lastName}
-              onChangeText={setLastName}
-              placeholder="Введите фамилию"
-              style={{
-                height: 48,
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 12,
-                paddingHorizontal: 16,
-                fontSize: 16,
-                backgroundColor: colors.background,
-                color: colors.text,
-                marginBottom: 12,
-              }}
-            />
+            <View className="mb-3">
+              <Input
+                label="Фамилия"
+                value={lastName}
+                onChangeText={setLastName}
+                placeholder="Введите фамилию"
+              />
+            </View>
 
             {/* Email (read-only) */}
             <Text className="text-sm font-medium text-slate-900 mb-1">

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import {
   View,
   Text,
-  TextInput,
   ScrollView,
   Pressable,
   Switch,
@@ -17,6 +16,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { API_URL, apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
@@ -67,18 +67,6 @@ interface SpecialistProfileData {
   } | null;
   fnsServices: FnsServiceItem[];
 }
-
-const INPUT_STYLE = {
-  height: 48,
-  borderWidth: 1,
-  borderColor: colors.border,
-  borderRadius: 12,
-  paddingHorizontal: 16,
-  fontSize: 16,
-  color: colors.text,
-  backgroundColor: colors.background,
-  marginBottom: 12,
-} as const;
 
 export default function SpecialistSettings() {
   const router = useRouter();
@@ -417,27 +405,25 @@ export default function SpecialistSettings() {
               Личные данные
             </Text>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">Имя</Text>
-            <TextInput
-              accessibilityLabel="Имя"
-              value={firstName}
-              onChangeText={setFirstName}
-              placeholder="Введите имя"
-              placeholderTextColor={colors.placeholder}
-              maxLength={50}
-              style={INPUT_STYLE}
-            />
+            <View className="mb-3">
+              <Input
+                label="Имя"
+                value={firstName}
+                onChangeText={setFirstName}
+                placeholder="Введите имя"
+                maxLength={50}
+              />
+            </View>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">Фамилия</Text>
-            <TextInput
-              accessibilityLabel="Фамилия"
-              value={lastName}
-              onChangeText={setLastName}
-              placeholder="Введите фамилию"
-              placeholderTextColor={colors.placeholder}
-              maxLength={50}
-              style={INPUT_STYLE}
-            />
+            <View className="mb-3">
+              <Input
+                label="Фамилия"
+                value={lastName}
+                onChangeText={setLastName}
+                placeholder="Введите фамилию"
+                maxLength={50}
+              />
+            </View>
 
             {/* Email read-only */}
             <Text className="text-sm font-medium text-slate-900 mb-1">
@@ -451,35 +437,20 @@ export default function SpecialistSettings() {
             </View>
 
             {/* Description */}
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              О себе
-            </Text>
-            <TextInput
-              accessibilityLabel="О себе"
-              value={description}
-              onChangeText={setDescription}
-              placeholder="Расскажите о своём опыте и специализации..."
-              placeholderTextColor={colors.placeholder}
-              multiline
-              numberOfLines={4}
-              maxLength={500}
-              style={{
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 12,
-                paddingHorizontal: 16,
-                paddingVertical: 12,
-                fontSize: 16,
-                color: colors.text,
-                backgroundColor: colors.background,
-                marginBottom: 4,
-                minHeight: 96,
-                textAlignVertical: "top",
-              }}
-            />
-            <Text className="text-xs text-slate-400 text-right mb-4">
-              {description.length}/500
-            </Text>
+            <View className="mb-4">
+              <Input
+                label="О себе"
+                value={description}
+                onChangeText={setDescription}
+                placeholder="Расскажите о своём опыте и специализации..."
+                multiline
+                numberOfLines={4}
+                maxLength={500}
+              />
+              <Text className="text-xs text-slate-400 text-right mt-1">
+                {description.length}/500
+              </Text>
+            </View>
 
             {/* FNS & Services */}
             <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">
@@ -606,33 +577,32 @@ export default function SpecialistSettings() {
                     ))}
                   </View>
                 )}
-                <Text className="text-sm font-medium text-slate-900 mb-1">Значение</Text>
-                <TextInput
-                  accessibilityLabel="Значение контакта"
-                  value={newContactValue}
-                  onChangeText={setNewContactValue}
-                  placeholder={
-                    newContactType === "phone" || newContactType === "whatsapp"
-                      ? "+7 (___) ___-__-__"
-                      : newContactType === "telegram"
-                      ? "@username"
-                      : newContactType === "email"
-                      ? "email@example.com"
-                      : newContactType === "vk"
-                      ? "vk.com/username"
-                      : "https://example.com"
-                  }
-                  placeholderTextColor={colors.placeholder}
-                  autoCapitalize="none"
-                  keyboardType={
-                    newContactType === "phone" || newContactType === "whatsapp"
-                      ? "phone-pad"
-                      : newContactType === "email"
-                      ? "email-address"
-                      : "default"
-                  }
-                  style={INPUT_STYLE}
-                />
+                <View className="mb-3">
+                  <Input
+                    label="Значение"
+                    value={newContactValue}
+                    onChangeText={setNewContactValue}
+                    placeholder={
+                      newContactType === "phone" || newContactType === "whatsapp"
+                        ? "+7 (___) ___-__-__"
+                        : newContactType === "telegram"
+                        ? "@username"
+                        : newContactType === "email"
+                        ? "email@example.com"
+                        : newContactType === "vk"
+                        ? "vk.com/username"
+                        : "https://example.com"
+                    }
+                    autoCapitalize="none"
+                    keyboardType={
+                      newContactType === "phone" || newContactType === "whatsapp"
+                        ? "phone-pad"
+                        : newContactType === "email"
+                        ? "email-address"
+                        : "default"
+                    }
+                  />
+                </View>
                 <View className="flex-row gap-2">
                   <View className="flex-1">
                     <Button
@@ -679,29 +649,23 @@ export default function SpecialistSettings() {
               Офис
             </Text>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              Адрес офиса
-            </Text>
-            <TextInput
-              accessibilityLabel="Адрес офиса"
-              value={officeAddress}
-              onChangeText={setOfficeAddress}
-              placeholder="Город, улица, дом"
-              placeholderTextColor={colors.placeholder}
-              style={INPUT_STYLE}
-            />
+            <View className="mb-3">
+              <Input
+                label="Адрес офиса"
+                value={officeAddress}
+                onChangeText={setOfficeAddress}
+                placeholder="Город, улица, дом"
+              />
+            </View>
 
-            <Text className="text-sm font-medium text-slate-900 mb-1">
-              Часы работы
-            </Text>
-            <TextInput
-              accessibilityLabel="Часы работы"
-              value={workingHours}
-              onChangeText={setWorkingHours}
-              placeholder="Пн-Пт 9:00-18:00"
-              placeholderTextColor={colors.placeholder}
-              style={INPUT_STYLE}
-            />
+            <View className="mb-3">
+              <Input
+                label="Часы работы"
+                value={workingHours}
+                onChangeText={setWorkingHours}
+                placeholder="Пн-Пт 9:00-18:00"
+              />
+            </View>
 
             {/* Save button */}
             <View className="mt-2 mb-4">

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -5,7 +5,6 @@ import {
   FlatList,
   Pressable,
   ActivityIndicator,
-  TextInput,
   KeyboardAvoidingView,
   Platform,
   Alert,
@@ -18,6 +17,7 @@ import * as Linking from "expo-linking";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import MessageBubble from "@/components/MessageBubble";
 import { Avatar } from "@/components/ui";
+import Input from "@/components/ui/Input";
 import { API_URL, api, apiPost, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -433,27 +433,15 @@ export default function ChatThread() {
               />
             </Pressable>
 
-            {/* Text input — inline style only (no className on TextInput) */}
-            <TextInput
+            {/* Text input */}
+            <Input
               accessibilityLabel="Введите сообщение"
+              placeholder="Введите сообщение..."
               value={text}
               onChangeText={setText}
-              placeholder="Введите сообщение..."
-              placeholderTextColor={colors.placeholder}
               multiline
-              style={{
-                flex: 1,
-                minHeight: 40,
-                maxHeight: 120,
-                paddingHorizontal: 12,
-                paddingVertical: 8,
-                fontSize: 16,
-                color: colors.text,
-                backgroundColor: colors.background,
-                borderRadius: 20,
-                borderWidth: 1,
-                borderColor: colors.border,
-              }}
+              style={{ flex: 1 }}
+              containerStyle={{ borderRadius: 20, minHeight: 40, maxHeight: 120 }}
             />
 
             {/* Send button */}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { View, Text, TextInput, type TextInputProps } from "react-native";
+import { View, Text, TextInput, type TextInputProps, type ViewStyle } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { colors } from "../../lib/theme";
 
@@ -13,6 +13,17 @@ export interface InputProps {
   secureTextEntry?: boolean;
   multiline?: boolean;
   keyboardType?: TextInputProps["keyboardType"];
+  editable?: boolean;
+  autoCapitalize?: TextInputProps["autoCapitalize"];
+  autoComplete?: TextInputProps["autoComplete"];
+  autoCorrect?: boolean;
+  onSubmitEditing?: TextInputProps["onSubmitEditing"];
+  returnKeyType?: TextInputProps["returnKeyType"];
+  maxLength?: number;
+  numberOfLines?: number;
+  accessibilityLabel?: string;
+  style?: ViewStyle;
+  containerStyle?: ViewStyle;
 }
 
 export default function Input({
@@ -25,6 +36,17 @@ export default function Input({
   secureTextEntry,
   multiline,
   keyboardType,
+  editable = true,
+  autoCapitalize,
+  autoComplete,
+  autoCorrect,
+  onSubmitEditing,
+  returnKeyType,
+  maxLength,
+  numberOfLines,
+  accessibilityLabel,
+  style,
+  containerStyle,
 }: InputProps) {
   const [focused, setFocused] = useState(false);
 
@@ -33,15 +55,15 @@ export default function Input({
     : focused
       ? colors.accent
       : colors.border;
-  const bgColor = error ? colors.errorBg : colors.surface;
+  const bgColor = error ? colors.errorBg : !editable ? colors.background : colors.surface;
 
   return (
-    <View>
+    <View style={style}>
       {label && (
         <Text className="text-sm font-medium text-slate-700 mb-1.5">{label}</Text>
       )}
       <View
-        style={{
+        style={[{
           flexDirection: "row",
           alignItems: "center",
           height: multiline ? undefined : 48,
@@ -51,7 +73,7 @@ export default function Input({
           borderColor,
           backgroundColor: bgColor,
           paddingHorizontal: 12,
-        }}
+        }, containerStyle]}
       >
         {icon && (
           <FontAwesome
@@ -62,7 +84,7 @@ export default function Input({
           />
         )}
         <TextInput
-          accessibilityLabel={label || placeholder}
+          accessibilityLabel={accessibilityLabel || label || placeholder}
           value={value}
           onChangeText={onChangeText}
           placeholder={placeholder}
@@ -70,13 +92,22 @@ export default function Input({
           secureTextEntry={secureTextEntry}
           multiline={multiline}
           keyboardType={keyboardType}
+          editable={editable}
+          autoCapitalize={autoCapitalize}
+          autoComplete={autoComplete}
+          autoCorrect={autoCorrect}
+          onSubmitEditing={onSubmitEditing}
+          returnKeyType={returnKeyType}
+          maxLength={maxLength}
+          numberOfLines={numberOfLines}
+          textAlignVertical={multiline ? "top" : undefined}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
           style={{
             flex: 1,
             fontSize: 16,
             color: colors.text,
-            paddingVertical: multiline ? 12 : 0,
+            paddingVertical: multiline ? 8 : 0,
             borderWidth: 0,
             outlineWidth: 0,
             outlineStyle: 'none' as any,


### PR DESCRIPTION
## Summary
- Extends `<Input />` component with new props: `editable`, `autoCapitalize`, `autoComplete`, `onSubmitEditing`, `maxLength`, `containerStyle`, `style`
- Migrates 8 screens to use `<Input />`: AuthEmail, OnboardingName, OnboardingProfile, ClientSettings, SpecialistSettings, AdminSettings, MyRequestsNew, ChatThread
- Removes duplicate `INPUT_STYLE` const from SpecialistSettings
- Net: -210 lines (252 insertions, 462 deletions)

## Test plan
- [ ] Auth email screen — input shows error state, submit on enter works
- [ ] Onboarding name — validation errors shown per field
- [ ] Onboarding profile — multiline bio, phone/telegram/whatsapp/address/hours fields
- [ ] Client settings — firstName/lastName save correctly
- [ ] Specialist settings — all fields + contact add form works
- [ ] Admin settings — numeric fields render and save
- [ ] New request — title/description validation + counters shown
- [ ] Chat thread — message input has correct bubble shape (borderRadius: 20)

Closes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)