### PR TITLE
fix: add error state UI with retry to 3 admin screens (#1173)

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useCallback } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import ErrorState from "@/components/ui/ErrorState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -80,9 +81,11 @@ export default function AdminDashboard() {
   const { token } = useAuth();
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   const fetchStats = useCallback(async () => {
     if (!token) return;
+    setError(false);
     try {
       const res = await fetch(`${API_URL}/api/admin/stats`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -90,9 +93,11 @@ export default function AdminDashboard() {
       if (res.ok) {
         const data = await res.json();
         setStats(data);
+      } else {
+        setError(true);
       }
     } catch {
-      // ignore
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -110,6 +115,10 @@ export default function AdminDashboard() {
       {loading ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : error ? (
+        <View className="flex-1 items-center justify-center">
+          <ErrorState message="Не удалось загрузить статистику" onRetry={fetchStats} />
         </View>
       ) : (
         <ScrollView className="flex-1">

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -12,6 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import ErrorState from "@/components/ui/ErrorState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -62,6 +63,7 @@ export default function AdminUsers() {
   const [users, setUsers] = useState<UserItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(false);
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<RoleFilter>("ALL");
   const [page, setPage] = useState(1);
@@ -72,8 +74,10 @@ export default function AdminUsers() {
   const fetchUsers = useCallback(
     async (q: string, role: RoleFilter, p: number, append = false) => {
       if (!token) return;
-      if (p === 1) setLoading(true);
-      else setLoadingMore(true);
+      if (p === 1) {
+        setLoading(true);
+        setError(false);
+      } else setLoadingMore(true);
 
       try {
         const params = new URLSearchParams();
@@ -89,9 +93,11 @@ export default function AdminUsers() {
           const data = await res.json();
           setUsers((prev) => (append ? [...prev, ...data.items] : data.items));
           setHasMore(data.hasMore);
+        } else if (p === 1) {
+          setError(true);
         }
       } catch {
-        // ignore
+        if (p === 1) setError(true);
       } finally {
         setLoading(false);
         setLoadingMore(false);
@@ -263,6 +269,10 @@ export default function AdminUsers() {
       {loading ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : error ? (
+        <View className="flex-1 items-center justify-center">
+          <ErrorState message="Не удалось загрузить пользователей" onRetry={() => fetchUsers(search, filter, 1)} />
         </View>
       ) : (
         <ScrollView

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -12,6 +12,7 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import ErrorState from "@/components/ui/ErrorState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -38,9 +39,11 @@ export default function AdminSettings() {
   const [values, setValues] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(false);
 
   const fetchSettings = useCallback(async () => {
     if (!token) return;
+    setError(false);
     try {
       const res = await fetch(`${API_URL}/api/admin/settings`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -48,9 +51,11 @@ export default function AdminSettings() {
       if (res.ok) {
         const data = await res.json();
         setValues(data);
+      } else {
+        setError(true);
       }
     } catch {
-      // ignore
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -106,6 +111,10 @@ export default function AdminSettings() {
       {loading ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : error ? (
+        <View className="flex-1 items-center justify-center">
+          <ErrorState message="Не удалось загрузить настройки" onRetry={fetchSettings} />
         </View>
       ) : (
         <ScrollView className="flex-1">


### PR DESCRIPTION
## Summary
- AdminDashboard, AdminUsers, AdminSettings had silent `// ignore` catch blocks with zero user feedback on API failure
- Added `error` state + `ErrorState` component (with retry button) to all 3 screens
- Consistent pattern: loading → error (with retry) → content
- Note: AdminModeration is a static stub (no data fetching) — not applicable; Settings was added as the actual 3rd screen that fetches data

## Test plan
- [ ] Verify each screen shows error message + retry button when API is unreachable
- [ ] Verify retry button re-triggers fetch and recovers on success
- [ ] `tsc --noEmit` passes (0 errors — verified before commit)
- [ ] No regressions on normal data load flow

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)