### PR TITLE
fix: standardize border radius using theme tokens (#1176)

### DIFF
--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -14,7 +14,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, radiusValue } from "@/lib/theme";
 
 
 type RoleFilter = "ALL" | "CLIENT" | "SPECIALIST" | "BANNED";
@@ -212,7 +212,7 @@ export default function AdminUsers() {
           accessibilityLabel="Поиск по email или имени"
           style={{
             backgroundColor: "rgba(255,255,255,0.15)",
-            borderRadius: 10,
+            borderRadius: radiusValue.md,
             height: 40,
             paddingHorizontal: 14,
             color: colors.surface,

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -16,7 +16,7 @@ import { useAuth, UserData } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
-import { colors } from "@/lib/theme";
+import { colors, radiusValue } from "@/lib/theme";
 
 const CODE_LENGTH = 6;
 const RESEND_SECONDS = 60;
@@ -295,7 +295,7 @@ export default function AuthOtpScreen() {
                     style={{
                       width: 48,
                       height: 52,
-                      borderRadius: 12,
+                      borderRadius: radiusValue.md,
                       borderWidth: error ? 1.5 : 1,
                       borderColor: error
                         ? colors.error

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -13,7 +13,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors } from "@/lib/theme";
+import { colors, radiusValue } from "@/lib/theme";
 
 interface RequestSummary {
   id: string;
@@ -210,7 +210,7 @@ export default function SpecialistConfirmWrite() {
               minHeight: 140,
               borderWidth: 1,
               borderColor: isLimitReached ? colors.border : colors.borderLight,
-              borderRadius: 12,
+              borderRadius: radiusValue.md,
               paddingHorizontal: 14,
               paddingVertical: 12,
               fontSize: 16,

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -18,7 +18,7 @@ import SpecialistCard from "@/components/SpecialistCard";
 import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, radiusValue } from "@/lib/theme";
 
 interface FnsServiceGroup {
   fns: { id: string; name: string; code: string };
@@ -105,7 +105,7 @@ function formatDate(iso: string): string {
 function SkeletonBlock({
   width,
   height,
-  borderRadius = 8,
+  borderRadius = radiusValue.sm,
   marginBottom = 0,
 }: {
   width?: DimensionValue;
@@ -152,7 +152,7 @@ function ProfileSkeleton() {
               <SkeletonBlock width="70%" height={16} />
             </View>
             <View className="w-full bg-white rounded-2xl p-4">
-              <SkeletonBlock height={80} borderRadius={12} />
+              <SkeletonBlock height={80} borderRadius={radiusValue.md} />
             </View>
           </View>
         </ResponsiveContainer>

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -21,7 +21,7 @@ import Input from "@/components/ui/Input";
 import { API_URL, api, apiPost, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { colors } from "@/lib/theme";
+import { colors, radiusValue } from "@/lib/theme";
 
 
 interface FileAttachment {
@@ -441,7 +441,7 @@ export default function ChatThread() {
               onChangeText={setText}
               multiline
               style={{ flex: 1 }}
-              containerStyle={{ borderRadius: 20, minHeight: 40, maxHeight: 120 }}
+              containerStyle={{ borderRadius: radiusValue.xl, minHeight: 40, maxHeight: 120 }}
             />
 
             {/* Send button */}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { View, Text, TextInput, type TextInputProps, type ViewStyle } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { colors } from "../../lib/theme";
+import { colors, radiusValue } from "../../lib/theme";
 
 export interface InputProps {
   label?: string;
@@ -68,7 +68,7 @@ export default function Input({
           alignItems: "center",
           height: multiline ? undefined : 48,
           minHeight: multiline ? 96 : undefined,
-          borderRadius: 12,
+          borderRadius: radiusValue.md,
           borderWidth: 1,
           borderColor,
           backgroundColor: bgColor,

--- a/components/ui/LoadingState.tsx
+++ b/components/ui/LoadingState.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { View, ActivityIndicator, Animated, type DimensionValue } from "react-native";
-import { colors } from "../../lib/theme";
+import { colors, radiusValue } from "../../lib/theme";
 
 export interface LoadingStateProps {
   variant?: "spinner" | "skeleton";
@@ -40,7 +40,7 @@ function SkeletonLines({ lines }: { lines: number }) {
           style={{
             height: heights[i % heights.length],
             width: widths[i % widths.length],
-            borderRadius: 8,
+            borderRadius: radiusValue.sm,
             backgroundColor: colors.border,
             opacity,
           }}

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -53,3 +53,11 @@ export const radius = {
   lg: 'rounded-2xl',
   full: 'rounded-full',
 } as const
+
+export const radiusValue = {
+  sm: 8,
+  md: 12,    // inputs, buttons
+  lg: 16,    // cards
+  xl: 24,
+  full: 9999, // pills, badges
+} as const


### PR DESCRIPTION
## Summary
- Add `radiusValue` numeric tokens to `lib/theme.ts` (sm=8, md=12, lg=16, xl=24, full=9999)
- Replace all hardcoded `borderRadius` values with `radiusValue` tokens across 7 files
- AdminUsers search input: `10` -> `radiusValue.md` (12px)
- Standardize: inputs=12px, cards=16px, chat input=24px, skeletons=8px
- Circle avatars (`wh/2`) and dot indicators left as-is (geometric derivations)

Closes #1176