### PR TITLE
fix: add loading skeleton and inline validation (#1165)

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -1,4 +1,4 @@
-import { View, Text, ScrollView, Pressable, ActivityIndicator } from "react-native";
+import { View, Text, ScrollView, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useEffect, useState, useCallback } from "react";
@@ -6,6 +6,7 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import ErrorState from "@/components/ui/ErrorState";
+import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -113,9 +114,17 @@ export default function AdminDashboard() {
         onSettingsPress={() => router.push("/admin/settings" as never)}
       />
       {loading ? (
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color={colors.primary} />
-        </View>
+        <ScrollView className="flex-1">
+          <ResponsiveContainer>
+            <View className="py-4 gap-3">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <View key={i} className="bg-white rounded-xl overflow-hidden border border-slate-200">
+                  <LoadingState variant="skeleton" lines={3} />
+                </View>
+              ))}
+            </View>
+          </ResponsiveContainer>
+        </ScrollView>
       ) : error ? (
         <View className="flex-1 items-center justify-center">
           <ErrorState message="Не удалось загрузить статистику" onRetry={fetchStats} />

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import ErrorState from "@/components/ui/ErrorState";
+import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
 import { colors, radiusValue } from "@/lib/theme";
@@ -267,9 +268,15 @@ export default function AdminUsers() {
       </View>
 
       {loading ? (
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color={colors.primary} />
-        </View>
+        <ResponsiveContainer>
+          <View className="py-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <View key={i} className="mx-4 mb-3 bg-white rounded-2xl overflow-hidden border border-slate-100">
+                <LoadingState variant="skeleton" lines={4} />
+              </View>
+            ))}
+          </View>
+        </ResponsiveContainer>
       ) : error ? (
         <View className="flex-1 items-center justify-center">
           <ErrorState message="Не удалось загрузить пользователей" onRetry={() => fetchUsers(search, filter, 1)} />

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -5,7 +5,6 @@ import {
   ScrollView,
   RefreshControl,
   Pressable,
-  ActivityIndicator,
   Switch,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -15,6 +14,7 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
+import LoadingState from "@/components/ui/LoadingState";
 import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiGet, apiPatch } from "@/lib/api";
@@ -131,9 +131,15 @@ export default function SpecialistDashboard() {
           notificationCount={0}
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
-        <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color={colors.primary} />
-        </View>
+        <ResponsiveContainer>
+          <View className="py-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <View key={i} className="bg-white rounded-xl overflow-hidden border border-slate-200">
+                <LoadingState variant="skeleton" lines={3} />
+              </View>
+            ))}
+          </View>
+        </ResponsiveContainer>
       </SafeAreaView>
     );
   }

--- a/app/(specialist-tabs)/requests.tsx
+++ b/app/(specialist-tabs)/requests.tsx
@@ -13,6 +13,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
 import FilterBar from "@/components/FilterBar";
 import EmptyState from "@/components/ui/EmptyState";
+import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { colors } from "@/lib/theme";
 
@@ -153,8 +154,12 @@ export default function SpecialistPublicRequests() {
         />
 
         {loading ? (
-          <View className="flex-1 items-center justify-center py-16">
-            <ActivityIndicator size="large" color={colors.primary} />
+          <View className="py-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <View key={i} className="mb-3 bg-white rounded-2xl overflow-hidden border border-slate-100">
+                <LoadingState variant="skeleton" lines={4} />
+              </View>
+            ))}
           </View>
         ) : error ? (
           <EmptyState

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -35,6 +35,11 @@ export default function OnboardingProfileScreen() {
   const [workingHours, setWorkingHours] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{
+    phone?: string;
+    telegram?: string;
+    description?: string;
+  }>({});
 
   // Web-only hidden file input ref
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -104,9 +109,26 @@ export default function OnboardingProfileScreen() {
     }
   };
 
+  const validateFields = () => {
+    const errors: typeof fieldErrors = {};
+    const phoneDigits = phone.replace(/\D/g, "");
+    if (phone.trim() && phoneDigits.length !== 11) {
+      errors.phone = "Введите полный номер телефона";
+    }
+    if (telegram.trim() && !/^@?[a-zA-Z0-9_]{4,}$/.test(telegram.trim())) {
+      errors.telegram = "Некорректный username Telegram";
+    }
+    if (description.trim().length > 1000) {
+      errors.description = "Максимум 1000 символов";
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
   const handleSubmit = async () => {
     if (isLoading) return;
     setError("");
+    if (!validateFields()) return;
     setIsLoading(true);
 
     try {
@@ -235,9 +257,11 @@ export default function OnboardingProfileScreen() {
                 value={description}
                 onChangeText={(t) => {
                   if (t.length <= 1000) setDescription(t);
+                  if (fieldErrors.description) setFieldErrors((e) => ({ ...e, description: undefined }));
                 }}
                 multiline
                 editable={!isLoading}
+                error={fieldErrors.description}
               />
               <Text className="text-xs text-slate-400 text-right mt-1">
                 {description.length}/1000
@@ -250,9 +274,13 @@ export default function OnboardingProfileScreen() {
                 label="Телефон"
                 placeholder="+7 (___) ___-__-__"
                 value={phone}
-                onChangeText={(t) => setPhone(formatPhone(t))}
+                onChangeText={(t) => {
+                  setPhone(formatPhone(t));
+                  if (fieldErrors.phone) setFieldErrors((e) => ({ ...e, phone: undefined }));
+                }}
                 keyboardType="phone-pad"
                 editable={!isLoading}
+                error={fieldErrors.phone}
               />
             </View>
 
@@ -262,9 +290,13 @@ export default function OnboardingProfileScreen() {
                 label="Telegram"
                 placeholder="@username"
                 value={telegram}
-                onChangeText={setTelegram}
+                onChangeText={(t) => {
+                  setTelegram(t);
+                  if (fieldErrors.telegram) setFieldErrors((e) => ({ ...e, telegram: undefined }));
+                }}
                 autoCapitalize="none"
                 editable={!isLoading}
+                error={fieldErrors.telegram}
               />
             </View>
 

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -12,6 +12,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
 import EmptyState from "@/components/ui/EmptyState";
+import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { colors } from "@/lib/theme";
 
@@ -161,8 +162,12 @@ export default function SpecialistsCatalog() {
   const renderContent = () => {
     if (loading) {
       return (
-        <View className="flex-1 items-center justify-center py-16">
-          <ActivityIndicator size="large" color={colors.primary} />
+        <View className="py-4 px-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <View key={i} className="mb-3 bg-white rounded-2xl overflow-hidden border border-slate-100">
+              <LoadingState variant="skeleton" lines={4} />
+            </View>
+          ))}
         </View>
       );
     }


### PR DESCRIPTION
## Changes

- Replace plain `ActivityIndicator` with `LoadingState variant="skeleton"` on 5 screens that fetch data
- Add field-level validation errors (phone, telegram, description) to onboarding profile form

## Screens updated (loading skeleton)
- `app/(admin-tabs)/users.tsx`
- `app/(admin-tabs)/dashboard.tsx`
- `app/(specialist-tabs)/dashboard.tsx`
- `app/(specialist-tabs)/requests.tsx`
- `app/specialists/index.tsx`

## Forms updated (inline validation)
- `app/onboarding/profile.tsx` — phone format, telegram username, description length

Closes #1165