### PR TITLE
fix: replace local component duplicates with shared imports in 6 screens (#1172)

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { Badge, EmptyState, ErrorState, LoadingState } from "@/components/ui";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors } from "@/lib/theme";
 import { API_URL } from "@/lib/api";
@@ -63,37 +64,6 @@ function formatDate(dateStr: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function StatusBadge({ status }: { status: "NEW" | "REVIEWED" }) {
-  if (status === "NEW") {
-    return (
-      <View className="bg-amber-50 px-2 py-0.5 rounded-lg flex-row items-center">
-        <View
-          style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: colors.accent, marginRight: 5 }}
-        />
-        <Text className="text-xs font-medium text-amber-700">Новая</Text>
-      </View>
-    );
-  }
-  return (
-    <View className="bg-emerald-50 px-2 py-0.5 rounded-lg flex-row items-center">
-      <View
-        style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: colors.success, marginRight: 5 }}
-      />
-      <Text className="text-xs font-medium text-emerald-700">Рассмотрена</Text>
-    </View>
-  );
-}
-
-function SkeletonRow() {
-  return (
-    <View className="bg-white border-b border-slate-100 px-4 py-4">
-      <View className="h-3 bg-slate-200 rounded w-1/3 mb-2" />
-      <View className="h-3 bg-slate-200 rounded w-2/3 mb-2" />
-      <View className="h-3 bg-slate-200 rounded w-1/2" />
-    </View>
-  );
 }
 
 export default function AdminComplaints() {
@@ -211,7 +181,11 @@ export default function AdminComplaints() {
                 ) : null}
               </Text>
             </View>
-            <StatusBadge status={item.status} />
+            <Badge
+              variant={item.status === "NEW" ? "warning" : "success"}
+              label={item.status === "NEW" ? "Новая" : "Рассмотрена"}
+              size="sm"
+            />
           </View>
 
           <Text className="text-sm text-slate-700 mt-1" numberOfLines={isExpanded ? undefined : 2}>
@@ -304,30 +278,14 @@ export default function AdminComplaints() {
 
       {loading ? (
         <ResponsiveContainer>
-          {[1, 2, 3, 4, 5].map((i) => (
-            <SkeletonRow key={i} />
-          ))}
+          <LoadingState variant="skeleton" lines={5} />
+          <LoadingState variant="skeleton" lines={5} />
         </ResponsiveContainer>
       ) : error ? (
-        <View className="flex-1 items-center justify-center py-12 px-8">
-          <View
-            className="items-center justify-center rounded-full bg-red-50"
-            style={{ width: 72, height: 72 }}
-          >
-            <FontAwesome name="exclamation-circle" size={32} color={colors.error} />
-          </View>
-          <Text className="text-base font-medium text-slate-900 mt-4 text-center">
-            Не удалось загрузить жалобы
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Повторить"
-            onPress={() => fetchComplaints(filter, 1)}
-            className="mt-4 px-4 py-2 rounded-lg border border-slate-300 bg-white"
-          >
-            <Text className="text-sm text-slate-700">Повторить</Text>
-          </Pressable>
-        </View>
+        <ErrorState
+          message="Не удалось загрузить жалобы"
+          onRetry={() => fetchComplaints(filter, 1)}
+        />
       ) : (
         <FlatList
           data={complaints}
@@ -337,24 +295,17 @@ export default function AdminComplaints() {
           onEndReached={loadMore}
           onEndReachedThreshold={0.3}
           ListEmptyComponent={
-            <View className="flex-1 items-center justify-center py-16">
-              <View
-                className="items-center justify-center rounded-full bg-slate-100"
-                style={{ width: 72, height: 72 }}
-              >
-                <FontAwesome name="flag-o" size={32} color={colors.placeholder} />
-              </View>
-              <Text className="text-base font-semibold text-slate-900 mt-4 text-center">
-                Жалоб нет
-              </Text>
-              <Text className="text-sm text-slate-500 mt-2 text-center">
-                {filter === "NEW"
+            <EmptyState
+              icon="flag"
+              title="Жалоб нет"
+              subtitle={
+                filter === "NEW"
                   ? "Нет новых жалоб"
                   : filter === "REVIEWED"
                   ? "Нет рассмотренных жалоб"
-                  : "Жалобы пользователей появятся здесь"}
-              </Text>
-            </View>
+                  : "Жалобы пользователей появятся здесь"
+              }
+            />
           }
           ListFooterComponent={
             loadingMore ? (

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -12,8 +12,8 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
 import EmptyState from "@/components/ui/EmptyState";
+import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
-import Button from "@/components/ui/Button";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -97,22 +97,13 @@ export default function ClientDashboard() {
           {loading ? (
             <LoadingState variant="skeleton" lines={5} />
           ) : error ? (
-            <View className="items-center justify-center py-16 px-8">
-              <Text className="text-lg font-semibold text-slate-900 text-center mb-2">
-                Не удалось загрузить данные
-              </Text>
-              <Text className="text-sm text-slate-500 text-center mb-6">
-                Проверьте соединение с интернетом и попробуйте снова
-              </Text>
-              <Button
-                label="Повторить"
-                onPress={() => {
-                  setLoading(true);
-                  fetchData().finally(() => setLoading(false));
-                }}
-                fullWidth={false}
-              />
-            </View>
+            <ErrorState
+              message="Не удалось загрузить данные"
+              onRetry={() => {
+                setLoading(true);
+                fetchData().finally(() => setLoading(false));
+              }}
+            />
           ) : (
             <View className="pb-6">
               {/* Stats card */}

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -14,8 +14,8 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
+import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
-import Button from "@/components/ui/Button";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiGet, apiPatch } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -150,25 +150,13 @@ export default function SpecialistDashboard() {
         <HeaderHome
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
-        <View className="flex-1 items-center justify-center px-8">
-          <FontAwesome name="exclamation-circle" size={48} color={colors.placeholder} />
-          <Text className="text-lg font-semibold text-slate-900 mt-4 text-center">
-            Не удалось загрузить заявки
-          </Text>
-          <Text className="text-sm text-slate-500 mt-2 text-center">
-            Проверьте соединение с интернетом и попробуйте снова
-          </Text>
-          <View className="mt-6">
-            <Button
-              label="Повторить"
-              onPress={() => {
-                setLoading(true);
-                fetchData().finally(() => setLoading(false));
-              }}
-              fullWidth={false}
-            />
-          </View>
-        </View>
+        <ErrorState
+          message="Не удалось загрузить заявки"
+          onRetry={() => {
+            setLoading(true);
+            fetchData().finally(() => setLoading(false));
+          }}
+        />
       </SafeAreaView>
     );
   }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   Pressable,
   ScrollView,
-  ActivityIndicator,
   useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -13,7 +12,9 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import SpecialistCard from "@/components/SpecialistCard";
+import StatusBadge from "@/components/StatusBadge";
 import ErrorState from "@/components/ui/ErrorState";
+import LoadingState from "@/components/ui/LoadingState";
 import { colors } from "@/lib/theme";
 
 interface FeaturedSpecialist {
@@ -29,7 +30,7 @@ interface RecentRequest {
   id: string;
   title: string | null;
   description: string;
-  status: string;
+  status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";
   createdAt: string;
   city: { id: string; name: string };
   fns: { id: string; name: string; code: string };
@@ -77,21 +78,6 @@ const SPECIALIST_STEPS = [
     description: "Открывайте диалог, консультируйте и получайте новых клиентов.",
   },
 ];
-
-function StatusBadge({ status }: { status: string }) {
-  if (status === "CLOSING_SOON") {
-    return (
-      <View className="bg-amber-500/10 px-2 py-0.5 rounded">
-        <Text className="text-xs text-amber-600">Скоро закрывается</Text>
-      </View>
-    );
-  }
-  return (
-    <View className="bg-emerald-600/10 px-2 py-0.5 rounded">
-      <Text className="text-xs text-emerald-600">Активна</Text>
-    </View>
-  );
-}
 
 export default function LandingScreen() {
   const router = useRouter();
@@ -163,8 +149,8 @@ export default function LandingScreen() {
 
   if (loading) {
     return (
-      <SafeAreaView className="flex-1 bg-white items-center justify-center">
-        <ActivityIndicator size="large" color={colors.primary} />
+      <SafeAreaView className="flex-1 bg-white">
+        <LoadingState />
       </SafeAreaView>
     );
   }

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -7,6 +7,7 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
+import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { api, ApiError } from "@/lib/api";
 
@@ -28,34 +29,6 @@ interface RequestDetail {
   threadsCount: number;
   hasExistingThread: boolean;
   existingThreadId: string | null;
-}
-
-function DetailSkeleton() {
-  return (
-    <View className="py-4 px-4">
-      <View className="h-7 bg-slate-200 rounded-lg mb-2" style={{ width: "80%" }} />
-      <View className="h-7 bg-slate-200 rounded-lg mb-4" style={{ width: "55%" }} />
-      <View className="h-6 bg-slate-200 rounded-full mb-4" style={{ width: 80 }} />
-      <View className="flex-row gap-2 mb-4">
-        <View className="h-7 bg-slate-200 rounded-lg" style={{ width: 90 }} />
-        <View className="h-7 bg-slate-200 rounded-lg" style={{ width: 130 }} />
-      </View>
-      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "100%" }} />
-      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "92%" }} />
-      <View className="h-4 bg-slate-200 rounded mb-2" style={{ width: "75%" }} />
-      <View className="h-4 bg-slate-200 rounded mb-6" style={{ width: "60%" }} />
-      <View className="border-t border-slate-100 pt-4 gap-3">
-        <View className="flex-row justify-between">
-          <View className="h-4 bg-slate-200 rounded" style={{ width: 60 }} />
-          <View className="h-4 bg-slate-200 rounded" style={{ width: 110 }} />
-        </View>
-        <View className="flex-row justify-between">
-          <View className="h-4 bg-slate-200 rounded" style={{ width: 80 }} />
-          <View className="h-4 bg-slate-200 rounded" style={{ width: 70 }} />
-        </View>
-      </View>
-    </View>
-  );
 }
 
 function MetaRow({
@@ -124,7 +97,7 @@ export default function PublicRequestDetail() {
       <SafeAreaView className="flex-1 bg-slate-50">
         <HeaderBack title="Заявка" />
         <ResponsiveContainer>
-          <DetailSkeleton />
+          <LoadingState variant="skeleton" lines={5} />
         </ResponsiveContainer>
       </SafeAreaView>
     );

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -1,12 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
   ScrollView,
   Pressable,
-  Animated,
   Linking,
-  type DimensionValue,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -16,9 +14,10 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
 import Button from "@/components/ui/Button";
+import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import { colors, radiusValue } from "@/lib/theme";
+import { colors } from "@/lib/theme";
 
 interface FnsServiceGroup {
   fns: { id: string; name: string; code: string };
@@ -102,65 +101,6 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString("ru-RU", { year: "numeric", month: "long" });
 }
 
-function SkeletonBlock({
-  width,
-  height,
-  borderRadius = radiusValue.sm,
-  marginBottom = 0,
-}: {
-  width?: DimensionValue;
-  height: number;
-  borderRadius?: number;
-  marginBottom?: number;
-}) {
-  const opacity = useRef(new Animated.Value(0.3)).current;
-
-  useEffect(() => {
-    const anim = Animated.loop(
-      Animated.sequence([
-        Animated.timing(opacity, { toValue: 0.7, duration: 800, useNativeDriver: true }),
-        Animated.timing(opacity, { toValue: 0.3, duration: 800, useNativeDriver: true }),
-      ])
-    );
-    anim.start();
-    return () => anim.stop();
-  }, [opacity]);
-
-  return (
-    <Animated.View
-      style={[
-        { height, borderRadius, backgroundColor: colors.border, marginBottom, width: width ?? "100%" },
-        { opacity },
-      ]}
-    />
-  );
-}
-
-function ProfileSkeleton() {
-  return (
-    <SafeAreaView className="flex-1 bg-slate-50">
-      <HeaderBack title="Профиль специалиста" />
-      <ScrollView className="flex-1">
-        <ResponsiveContainer>
-          <View className="py-6 items-center">
-            <SkeletonBlock width={88} height={88} borderRadius={44} marginBottom={12} />
-            <SkeletonBlock width={160} height={22} marginBottom={8} />
-            <SkeletonBlock width={100} height={14} marginBottom={24} />
-            <View className="w-full bg-white rounded-2xl p-4 mb-4">
-              <SkeletonBlock height={16} marginBottom={8} />
-              <SkeletonBlock width="85%" height={16} marginBottom={8} />
-              <SkeletonBlock width="70%" height={16} />
-            </View>
-            <View className="w-full bg-white rounded-2xl p-4">
-              <SkeletonBlock height={80} borderRadius={radiusValue.md} />
-            </View>
-          </View>
-        </ResponsiveContainer>
-      </ScrollView>
-    </SafeAreaView>
-  );
-}
-
 export default function SpecialistPublicProfile() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
@@ -212,7 +152,12 @@ export default function SpecialistPublicProfile() {
   }, [isAuthenticated, router]);
 
   if (loading) {
-    return <ProfileSkeleton />;
+    return (
+      <SafeAreaView className="flex-1 bg-slate-50">
+        <HeaderBack title="Профиль специалиста" />
+        <LoadingState variant="skeleton" lines={5} />
+      </SafeAreaView>
+    );
   }
 
   if (error || !specialist) {


### PR DESCRIPTION
## Summary
- Replaced local duplicate components (StatusBadge, SkeletonBlock, ProfileSkeleton, DetailSkeleton) with imports of shared components from `components/ui/` and `components/StatusBadge`
- Replaced inline loading/error/empty state patterns with shared `LoadingState`, `ErrorState`, `EmptyState`, and `Badge` components
- Removed ~170 lines of duplicated code across 6 screens

## Screens changed
| Screen | Local duplicate | Replaced with |
|--------|----------------|---------------|
| `app/index.tsx` | Local `StatusBadge` + inline `ActivityIndicator` | `StatusBadge` + `LoadingState` |
| `app/(admin-tabs)/complaints.tsx` | Local `StatusBadge` + `SkeletonRow` + inline error/empty | `Badge` + `LoadingState` + `ErrorState` + `EmptyState` |
| `app/specialists/[id].tsx` | Local `SkeletonBlock` + `ProfileSkeleton` | `LoadingState` |
| `app/requests/[id]/index.tsx` | Local `DetailSkeleton` | `LoadingState` |
| `app/(specialist-tabs)/dashboard.tsx` | Inline error + inline loading | `ErrorState` + `LoadingState` |
| `app/(client-tabs)/dashboard.tsx` | Inline error state | `ErrorState` |

## Test plan
- [ ] Verify landing page loading and error states render correctly
- [ ] Verify admin complaints page loading, error, and empty states
- [ ] Verify specialist profile skeleton loading
- [ ] Verify request detail skeleton loading
- [ ] Verify specialist dashboard error and loading states
- [ ] Verify client dashboard error state

Closes #1172