### PR TITLE
feat(landing): real URL routing (no more hash router)

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -41,9 +41,9 @@ const ACCENTS = {
   violet:{ accent:'#7c3aed', ink:'#ffffff' },
 };
 
-function parseHash() {
-  const h = window.location.hash.replace(/^#/, '') || '/';
-  const parts = h.split('/').filter(Boolean);
+function parsePath() {
+  const p = window.location.pathname || '/';
+  const parts = p.split('/').filter(Boolean);
   if (parts.length === 0) return { name: 'home' };
   if (parts[0] === 'catalog') return { name: 'catalog' };
   if (parts[0] === 'specialist' && parts[1]) return { name: 'specialist', id: parts[1] };
@@ -57,14 +57,19 @@ function App() {
   const [newReqOpen, setNewReqOpen] = useState(false);
   const [success, setSuccess] = useState(null);
 
-  const [route, setRoute] = useState(parseHash());
+  const [route, setRoute] = useState(parsePath());
   useEffect(() => {
-    const h = () => { setRoute(parseHash()); window.scrollTo(0,0); };
-    window.addEventListener('hashchange', h);
-    return () => window.removeEventListener('hashchange', h);
+    const h = () => { setRoute(parsePath()); window.scrollTo(0,0); };
+    window.addEventListener('popstate', h);
+    return () => window.removeEventListener('popstate', h);
   }, []);
 
-  const nav = (path) => { window.location.hash = path; };
+  const nav = (path) => {
+    if (window.location.pathname === path) return;
+    window.history.pushState(null, '', path);
+    setRoute(parsePath());
+    window.scrollTo(0,0);
+  };
 
   const [searchState, setSearchState] = useState({ city:null, fns:null, service:null });
   const [tweaks, setTweaks] = useState(TWEAK_DEFAULTS);

--- a/landing/overlays.jsx
+++ b/landing/overlays.jsx
@@ -501,15 +501,22 @@ function PageShell({ crumbs, title, action, children }) {
     <section className="page">
       <div className="page-bar">
         <div className="container page-bar-inner">
-          <button className="btn btn-ghost btn-sm" onClick={()=>history.length > 1 ? history.back() : (window.location.hash = '/')}>
+          <button className="btn btn-ghost btn-sm" onClick={()=>history.length > 1 ? history.back() : (window.history.pushState(null,'','/'), window.dispatchEvent(new PopStateEvent('popstate')))}>
             ← Назад
           </button>
           <nav className="crumbs">
-            <a href="#/" onClick={(e)=>{e.preventDefault(); window.location.hash='/';}}>Главная</a>
+            <a href="/" onClick={(e)=>{e.preventDefault(); window.history.pushState(null,'','/'); window.dispatchEvent(new PopStateEvent('popstate'));}}>Главная</a>
             {crumbs && crumbs.map((c, i) => (
               <React.Fragment key={i}>
                 <span className="crumb-sep">/</span>
-                {c.href ? <a href={c.href}>{c.label}</a> : <span className="crumb-cur">{c.label}</span>}
+                {c.href ? (
+                  <a href={c.href} onClick={(e)=>{
+                    e.preventDefault();
+                    if (c.onClick) return c.onClick();
+                    window.history.pushState(null,'', c.href);
+                    window.dispatchEvent(new PopStateEvent('popstate'));
+                  }}>{c.label}</a>
+                ) : <span className="crumb-cur">{c.label}</span>}
               </React.Fragment>
             ))}
           </nav>
@@ -591,11 +598,11 @@ function SpecialistPage({ id, onBack, onCatalog, onMessage }) {
   const s = OV_SPECIALISTS.find(x => x.id === id);
   if (!s) {
     return (
-      <PageShell crumbs={[{label:'Каталог', href:'#/catalog'}, {label:'Специалист не найден'}]}>
+      <PageShell crumbs={[{label:'Каталог', href:'/catalog'}, {label:'Специалист не найден'}]}>
         <div className="container" style={{padding:'48px 0'}}>
           <h1>Специалист не найден</h1>
           <p className="dim">Возможно, ссылка устарела. Попробуйте вернуться в каталог.</p>
-          <a className="btn btn-primary" href="#/catalog">В каталог</a>
+          <a className="btn btn-primary" href="/catalog" onClick={(e)=>{e.preventDefault(); onCatalog && onCatalog();}}>В каталог</a>
         </div>
       </PageShell>
     );
@@ -603,7 +610,7 @@ function SpecialistPage({ id, onBack, onCatalog, onMessage }) {
   return (
     <PageShell
       crumbs={[
-        {label:'Каталог', href:'#/catalog'},
+        {label:'Каталог', href:'/catalog', onClick: onCatalog},
         {label: s.first + ' ' + s.last}
       ]}
       action={<button className="btn btn-primary" onClick={()=>onMessage(s.id)}>Написать →</button>}

--- a/nginx-p2ptax.conf
+++ b/nginx-p2ptax.conf
@@ -20,6 +20,20 @@ server {
         try_files /index.html =404;
     }
 
+    # Landing prototype SPA routes — serve landing/index.html for client-side routing
+    location = /catalog {
+        root /var/www/p2ptax/landing;
+        try_files /index.html =404;
+    }
+    location ~ ^/specialist(/.*)?$ {
+        root /var/www/p2ptax/landing;
+        try_files /index.html =404;
+    }
+    location ~ ^/chat(/.*)?$ {
+        root /var/www/p2ptax/landing;
+        try_files /index.html =404;
+    }
+
     # Landing prototype static assets (served directly from landing/)
     location = /styles.css      { root /var/www/p2ptax/landing; }
     location = /components.jsx  { root /var/www/p2ptax/landing; }


### PR DESCRIPTION
## Summary
- Заменил hash-router (#/catalog) на реальные URL (/catalog, /specialist/:id, /chat/:id) через pushState/popstate
- PageShell crumbs перехватывают клик — никаких full-reload
- nginx: SPA fallback для landing routes -> landing/index.html

## Phase 1 of оживление
URL routing is done. Next phases (parallel):
- [ ] API integration (cities/FNS/services из админки вместо data.js)
- [ ] Z-index fixes across overlays
- [ ] Mobile responsive overhaul

## Test plan
- [ ] Open https://p2ptax.smartlaunchhub.com/ — home loads
- [ ] Click Каталог — URL becomes /catalog, no reload, back button works
- [ ] Direct hit /specialist/am — loads profile page
- [ ] Direct hit /chat/am — loads chat page