### PR TITLE
feat(landing): оживление — API + z-index + mobile

### DIFF
--- a/landing/api.js
+++ b/landing/api.js
@@ -1,0 +1,136 @@
+// api.js — thin fetch client for P2PTax landing.
+// Hydrates window.PT_* with live data from backend, keeps static fallbacks
+// in place so the landing still renders when the API is slow or down.
+(function(){
+  // Allow override via <meta name="pt-api-base" content="...">; default to same-origin /api.
+  const meta = document.querySelector('meta[name="pt-api-base"]');
+  const API_BASE = (meta && meta.content) || '/api';
+
+  const TIMEOUT_MS = 6000;
+
+  async function jget(path) {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+    try {
+      const r = await fetch(API_BASE + path, { signal: ctrl.signal, credentials: 'omit' });
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return await r.json();
+    } finally {
+      clearTimeout(t);
+    }
+  }
+
+  // Turn API shapes into the shapes components expect (matching the static fallbacks).
+  function mapCity(c) {
+    return {
+      id: c.slug || c.id,
+      _id: c.id,          // keep UUID for later calls
+      slug: c.slug,
+      name: c.name,
+      fns_count: c.officesCount || 0,
+      specialists: 0,     // backend does not expose this yet
+    };
+  }
+
+  function mapFns(f, cityId) {
+    return {
+      id: f.id,
+      code: f.name || f.code,
+      area: f.address || '',
+      cityId: cityId,
+    };
+  }
+
+  function mapService(s) {
+    return {
+      id: s.slug || s.id,
+      _id: s.id,
+      name: s.name,
+      short: s.shortName || s.short || s.name,
+      hint: s.description || s.hint || '',
+      color: s.color || 'oklch(0.65 0.02 260)',
+    };
+  }
+
+  function mapSpecialist(s) {
+    const first = s.firstName || s.first || '';
+    const last = s.lastName || s.last || '';
+    const init = (first[0] || 'X') + (last[0] || '');
+    const cities = (s.cities || []).map((c) => c.name).filter(Boolean);
+    const services = (s.services || []).map((x) => x.id || x);
+    const fnsLabel = cities.length
+      ? 'ИФНС · ' + cities.join(', ')
+      : 'Рабочие ИФНС — в профиле';
+    // id from server is UUID; expose city/service slugs would require another call.
+    return {
+      id: s.id,
+      first, last,
+      init,
+      role: s.role || 'Специалист',
+      city: (s.cities && s.cities[0] && s.cities[0].id) || null,
+      fns: [], // detail endpoint has richer data
+      fnsLabel,
+      services,
+      online: s.isAvailable !== false,
+      cases: s.casesCount || 0,
+      responseTime: s.responseTime || '< 2 ч',
+      since: s.since || '—',
+      bio: s.bio || '',
+      avatarUrl: s.avatarUrl || null,
+    };
+  }
+
+  async function loadCities() {
+    const r = await jget('/cities');
+    const items = (r.items || r.cities || []).map(mapCity);
+    if (items.length) window.PT_CITIES = items;
+  }
+
+  async function loadServices() {
+    const r = await jget('/services');
+    const items = (r.items || r.services || []).map(mapService);
+    if (items.length) window.PT_SERVICES = items;
+  }
+
+  async function loadSpecialists() {
+    const r = await jget('/specialists?limit=30');
+    const items = (r.items || []).map(mapSpecialist);
+    if (items.length) window.PT_SPECIALISTS = items;
+  }
+
+  async function loadFnsForCities() {
+    const cities = window.PT_CITIES || [];
+    // Don't fan out to every city at boot — just load the first handful (used on home + coverage).
+    const sample = cities.slice(0, 8);
+    const out = {};
+    await Promise.all(sample.map(async (c) => {
+      if (!c.slug) return;
+      try {
+        const r = await jget('/cities/' + encodeURIComponent(c.slug) + '/ifns');
+        const list = (r.items || []).map((f) => mapFns(f, c.id));
+        if (list.length) out[c.id] = list;
+      } catch (e) {
+        // fallback entry already present from static data.js
+      }
+    }));
+    if (Object.keys(out).length) {
+      window.PT_FNS = Object.assign({}, window.PT_FNS || {}, out);
+    }
+  }
+
+  async function hydrate() {
+    // Run independently — any one failing shouldn't kill the others.
+    await Promise.allSettled([
+      loadCities().catch(() => {}),
+      loadServices().catch(() => {}),
+      loadSpecialists().catch(() => {}),
+    ]);
+    // FNS depends on cities slugs, so run after.
+    await loadFnsForCities().catch(() => {});
+    window.dispatchEvent(new CustomEvent('pt:data-ready'));
+  }
+
+  // Kick off immediately; components can re-read from window.PT_* after 'pt:data-ready'.
+  window.PT_API = { hydrate, jget, API_BASE };
+  hydrate();
+})();

--- a/landing/components.jsx
+++ b/landing/components.jsx
@@ -2,16 +2,30 @@
 (function(){
 const { useState, useEffect, useRef, useMemo, Fragment } = React;
 
-const {
-  PT_CITIES: CITIES, PT_FNS: FNS_BY_CITY, PT_SERVICES: SERVICES,
-  PT_SPECIALISTS: SPECIALISTS, PT_SAMPLE_REQUEST: SAMPLE_REQUEST,
-  PT_SAMPLE_MESSAGES: SAMPLE_MESSAGES, PT_SITUATIONS: SITUATIONS,
-  PT_TIMELINE: TIMELINE,
-} = window;
+// Live getters — re-read window.PT_* on every call so api.js hydration is picked up.
+const getCities = () => window.PT_CITIES || [];
+const getFns = () => window.PT_FNS || {};
+const getServices = () => window.PT_SERVICES || [];
+const getSpecialists = () => window.PT_SPECIALISTS || [];
+const SAMPLE_REQUEST = window.PT_SAMPLE_REQUEST;
+const SAMPLE_MESSAGES = window.PT_SAMPLE_MESSAGES;
+const SITUATIONS = window.PT_SITUATIONS;
+const TIMELINE = window.PT_TIMELINE;
 
-const serviceById = (id) => SERVICES.find(s => s.id === id);
-const cityById = (id) => CITIES.find(c => c.id === id);
-const fnsById = (cityId, id) => (FNS_BY_CITY[cityId] || []).find(f => f.id === id);
+const serviceById = (id) => getServices().find(s => s.id === id);
+const cityById = (id) => getCities().find(c => c.id === id);
+const fnsById = (cityId, id) => (getFns()[cityId] || []).find(f => f.id === id);
+
+// bump a local counter when api.js finishes hydrating so components re-render
+function useDataVersion() {
+  const [v, bump] = useState(0);
+  useEffect(() => {
+    const h = () => bump((n) => n + 1);
+    window.addEventListener('pt:data-ready', h);
+    return () => window.removeEventListener('pt:data-ready', h);
+  }, []);
+  return v;
+}
 
 // ---------- primitives ----------
 function Pill({ children, active, onClick, className='' }) {
@@ -108,6 +122,7 @@ function Nav({ onAuth, onCreate, onCatalog }) {
 
 // ---------- hero ----------
 function Hero({ onOpenSearch, onCreate, onCatalog, searchState, setSearchState }) {
+  const dataV = useDataVersion();
   const [openField, setOpenField] = useState(null);
   const [cityQuery, setCityQuery] = useState('');
   const cardRef = useRef(null);
@@ -115,7 +130,7 @@ function Hero({ onOpenSearch, onCreate, onCatalog, searchState, setSearchState }
   const city = searchState.city ? cityById(searchState.city) : null;
   const service = searchState.service ? serviceById(searchState.service) : null;
   const fns = (city && searchState.fns) ? fnsById(city.id, searchState.fns) : null;
-  const fnsOpts = city ? (FNS_BY_CITY[city.id] || []) : [];
+  const fnsOpts = city ? (getFns()[city.id] || []) : [];
 
   useEffect(() => {
     const h = (e) => { if (cardRef.current && !cardRef.current.contains(e.target)) setOpenField(null); };
@@ -124,13 +139,14 @@ function Hero({ onOpenSearch, onCreate, onCatalog, searchState, setSearchState }
   }, []);
 
   const filteredCities = useMemo(() => {
+    const all = getCities();
     const q = cityQuery.trim().toLowerCase();
-    if (!q) return CITIES;
-    return CITIES.filter(c => c.name.toLowerCase().includes(q));
-  }, [cityQuery]);
+    if (!q) return all;
+    return all.filter(c => c.name.toLowerCase().includes(q));
+  }, [cityQuery, dataV]);
 
   const pickCity = (c) => {
-    const list = FNS_BY_CITY[c.id] || [];
+    const list = getFns()[c.id] || [];
     setSearchState({ ...searchState, city: c.id, fns: list.length === 1 ? list[0].id : null });
     setCityQuery(c.name);
     setOpenField(list.length === 1 ? 'service' : 'fns');
@@ -209,7 +225,7 @@ function Hero({ onOpenSearch, onCreate, onCatalog, searchState, setSearchState }
                   <div className={`val ${!service ? 'placeholder' : ''}`}>{service?.short || 'выберите'}</div>
                   {openField === 'service' && (
                     <div className="popover">
-                      {SERVICES.map(s => (
+                      {getServices().map(s => (
                         <div key={s.id} className={`pop-item ${searchState.service===s.id?'selected':''}`}
                           onMouseDown={(e) => { e.preventDefault(); setSearchState({...searchState, service: s.id}); setOpenField(null); }}>
                           <div style={{display:'flex', flexDirection:'column', gap: 2}}>
@@ -238,14 +254,14 @@ function Hero({ onOpenSearch, onCreate, onCatalog, searchState, setSearchState }
           <div>
             <div className="xs mono dim" style={{marginBottom: 14, letterSpacing:'.08em'}}>СЕЙЧАС НА СВЯЗИ</div>
             <div className="spec-stack">
-              {SPECIALISTS.slice(0, 4).map(s => (
+              {getSpecialists().slice(0, 4).map(s => (
                 <div key={s.id} className="spec-card">
                   <Avatar init={s.init} online={s.online} seed={s.id} />
                   <div className="spec-meta">
                     <div className="spec-name">{s.first} {s.last}</div>
                     <div className="spec-desc">{s.fnsLabel}</div>
                   </div>
-                  <div className="spec-tag">{serviceById(s.services[0]).short}</div>
+                  <div className="spec-tag">{(serviceById(s.services[0]) || {short:'—'}).short}</div>
                 </div>
               ))}
               <div className="small dim mono" style={{marginTop: 4, textAlign:'right'}}>
@@ -353,16 +369,17 @@ function HowItWorks({ onCreate }) {
 
 // ---------- catalog preview ----------
 function CatalogPreview({ onCatalog, onOpenSpecialist }) {
+  const dataV = useDataVersion();
   const [cityFilter, setCityFilter] = useState('all');
   const [serviceFilter, setServiceFilter] = useState(null);
 
   const filtered = useMemo(() => {
-    return SPECIALISTS.filter(s => {
+    return getSpecialists().filter(s => {
       if (cityFilter !== 'all' && s.city !== cityFilter) return false;
       if (serviceFilter && !s.services.includes(serviceFilter)) return false;
       return true;
     });
-  }, [cityFilter, serviceFilter]);
+  }, [cityFilter, serviceFilter, dataV]);
 
   return (
     <section className="section">
@@ -379,11 +396,11 @@ function CatalogPreview({ onCatalog, onOpenSpecialist }) {
 
         <div className="cat-toolbar">
           <Pill active={cityFilter==='all'} onClick={()=>setCityFilter('all')}>Все города</Pill>
-          {CITIES.slice(0, 5).map(c => (
+          {getCities().slice(0, 5).map(c => (
             <Pill key={c.id} active={cityFilter===c.id} onClick={()=>setCityFilter(c.id)}>{c.name}</Pill>
           ))}
           <div style={{width: 1, background:'var(--line)', margin:'0 6px'}}></div>
-          {SERVICES.map(s => (
+          {getServices().map(s => (
             <Pill key={s.id} active={serviceFilter===s.id} onClick={()=>setServiceFilter(serviceFilter===s.id?null:s.id)}>
               {s.short}
             </Pill>
@@ -406,6 +423,7 @@ function CatalogPreview({ onCatalog, onOpenSpecialist }) {
               <div className="cat-card-tags">
                 {s.services.map(id => {
                   const srv = serviceById(id);
+                  if (!srv) return null;
                   return <span key={id} className="spec-tag">{srv.short}</span>;
                 })}
               </div>
@@ -428,9 +446,10 @@ function CatalogPreview({ onCatalog, onOpenSpecialist }) {
 
 // ---------- coverage map ----------
 function Coverage() {
+  const dataV = useDataVersion();
   const [sel, setSel] = useState('msk');
   const selCity = cityById(sel);
-  const fns = FNS_BY_CITY[sel] || [];
+  const fns = getFns()[sel] || [];
 
   // simple positioned dots on a stylized "map" rectangle
   const positions = {
@@ -464,10 +483,10 @@ function Coverage() {
                 <line key={'h'+i} x1="0" y1={i*10} x2="100" y2={i*10} stroke="var(--line)" strokeWidth="0.15" />
               ))}
               {/* dots */}
-              {CITIES.map(c => {
+              {getCities().map(c => {
                 const p = positions[c.id];
                 if (!p) return null;
-                const r = Math.min(2.6, 0.8 + Math.sqrt(c.specialists) * 0.45);
+                const r = Math.min(2.6, 0.8 + Math.sqrt(c.specialists || 0) * 0.45);
                 return (
                   <g key={c.id}>
                     <circle cx={p.x} cy={p.y} r={r*2.2}
@@ -489,7 +508,7 @@ function Coverage() {
 
           <div>
             <div className="city-list">
-              {CITIES.map(c => (
+              {getCities().map(c => (
                 <div key={c.id} className={`city-row ${sel===c.id?'selected':''}`} onClick={()=>setSel(c.id)}>
                   <div>
                     <div>{c.name}</div>

--- a/landing/index.html
+++ b/landing/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&family=Geist:wght@300;400;500;600&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="styles.css?v=1776710989778" />
+<link rel="stylesheet" href="styles.css?v=1777000000001" />
 </head>
 <body>
 <div id="root"></div>
@@ -16,9 +16,10 @@
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 
-<script src="data.js?v=1776710989778"></script>
-<script type="text/babel" src="components.jsx?v=1776710989778"></script>
-<script type="text/babel" src="overlays.jsx?v=1776710989778"></script>
+<script src="data.js?v=1777000000001"></script>
+<script src="api.js?v=1777000000001"></script>
+<script type="text/babel" src="components.jsx?v=1777000000001"></script>
+<script type="text/babel" src="overlays.jsx?v=1777000000001"></script>
 <script type="text/babel">
 const { useState, useEffect } = React;
 const {

--- a/landing/index.html
+++ b/landing/index.html
@@ -7,7 +7,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500&family=Geist:wght@300;400;500;600&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="styles.css?v=1777000000001" />
+<link rel="stylesheet" href="styles.css?v=1777000000002" />
 </head>
 <body>
 <div id="root"></div>
@@ -16,10 +16,10 @@
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
 
-<script src="data.js?v=1777000000001"></script>
-<script src="api.js?v=1777000000001"></script>
-<script type="text/babel" src="components.jsx?v=1777000000001"></script>
-<script type="text/babel" src="overlays.jsx?v=1777000000001"></script>
+<script src="data.js?v=1777000000002"></script>
+<script src="api.js?v=1777000000002"></script>
+<script type="text/babel" src="components.jsx?v=1777000000002"></script>
+<script type="text/babel" src="overlays.jsx?v=1777000000002"></script>
 <script type="text/babel">
 const { useState, useEffect } = React;
 const {

--- a/landing/overlays.jsx
+++ b/landing/overlays.jsx
@@ -1,11 +1,28 @@
 /* overlays.jsx — prototype overlays: auth, new-request, catalog, profile, chat */
 const {
-  PT_CITIES: OV_CITIES, PT_FNS: OV_FNS, PT_SERVICES: OV_SERVICES,
-  PT_SPECIALISTS: OV_SPECIALISTS, PT_SAMPLE_REQUEST: OV_REQ, PT_SAMPLE_MESSAGES: OV_MSGS,
+  PT_SAMPLE_REQUEST: OV_REQ, PT_SAMPLE_MESSAGES: OV_MSGS,
   PT_Avatar: Avatar2, PT_Pill: Pill2,
-  PT_serviceById: srvById, PT_cityById: ctyById, PT_fnsById: fnsById2,
 } = window;
+// Live getters — read from window.PT_* at call time so api.js hydration is picked up.
+const OV_getCities = () => window.PT_CITIES || [];
+const OV_getFns = () => window.PT_FNS || {};
+const OV_getServices = () => window.PT_SERVICES || [];
+const OV_getSpecialists = () => window.PT_SPECIALISTS || [];
+const srvById = (id) => OV_getServices().find(s => s.id === id);
+const ctyById = (id) => OV_getCities().find(c => c.id === id);
+const fnsById2 = (cityId, id) => (OV_getFns()[cityId] || []).find(f => f.id === id);
 const { useState: useS, useEffect: useE, useRef: useR, useMemo: useM, Fragment: Fr } = React;
+
+// hook to force re-render when api.js finishes hydrating
+function useOVDataVersion() {
+  const [v, bump] = useS(0);
+  useE(() => {
+    const h = () => bump((n) => n + 1);
+    window.addEventListener('pt:data-ready', h);
+    return () => window.removeEventListener('pt:data-ready', h);
+  }, []);
+  return v;
+}
 
 function Modal({ children, size, onClose }) {
   useE(() => {
@@ -117,7 +134,7 @@ function NewRequestModal({ onClose, onDone, initial }) {
   const set = (k, v) => setForm(prev => ({...prev, [k]: v}));
 
   const city = form.city ? ctyById(form.city) : null;
-  const fnsOpts = city ? (OV_FNS[city.id] || []) : [];
+  const fnsOpts = city ? (OV_getFns()[city.id] || []) : [];
   const singleFns = fnsOpts.length === 1;
 
   // auto-select FNS if only one exists in the picked city
@@ -138,7 +155,7 @@ function NewRequestModal({ onClose, onDone, initial }) {
 
   useE(() => { if (city) setCityQuery(city.name); }, [form.city]);
 
-  const filteredCities = OV_CITIES.filter(c => {
+  const filteredCities = OV_getCities().filter(c => {
     const q = cityQuery.trim().toLowerCase();
     return !q || c.name.toLowerCase().includes(q);
   });
@@ -249,7 +266,7 @@ function NewRequestModal({ onClose, onDone, initial }) {
             <div className="field">
               <label>Тип проверки *</label>
               <div style={{display:'grid', gridTemplateColumns:'repeat(2, 1fr)', gap: 10}}>
-                {OV_SERVICES.map(s => (
+                {OV_getServices().map(s => (
                   <button key={s.id}
                     onClick={()=>set('service', s.id)}
                     style={{padding:'14px 16px', borderRadius: 10, border: '1.5px solid ' + (form.service===s.id?'var(--accent)':'var(--line)'),
@@ -463,7 +480,7 @@ function RequestSuccessModal({ onClose, onOpenChat, data }) {
                 </div>
               )}
               {incoming.map(id => {
-                const s = OV_SPECIALISTS.find(x => x.id === id);
+                const s = OV_getSpecialists().find(x => x.id === id);
                 return (
                   <div key={id} className="spec-card fade-in" style={{cursor:'pointer'}} onClick={()=>onOpenChat(id)}>
                     <Avatar2 init={s.init} online={s.online} />
@@ -534,15 +551,16 @@ function CatalogPage({ onOpen }) {
   const [city, setCity] = useS('all');
   const [svc, setSvc] = useS(null);
   const [q, setQ] = useS('');
+  const dataV = useOVDataVersion();
 
   const list = useM(() => {
-    return OV_SPECIALISTS.filter(s => {
+    return OV_getSpecialists().filter(s => {
       if (city !== 'all' && s.city !== city) return false;
       if (svc && !s.services.includes(svc)) return false;
       if (q && !(`${s.first} ${s.last} ${s.role} ${s.fnsLabel}`).toLowerCase().includes(q.toLowerCase())) return false;
       return true;
     });
-  }, [city, svc, q]);
+  }, [city, svc, q, dataV]);
 
   return (
     <PageShell crumbs={[{label:'Каталог специалистов'}]}>
@@ -558,9 +576,9 @@ function CatalogPage({ onOpen }) {
         </div>
         <div style={{padding:'12px 24px', borderBottom:'1px solid var(--line)', display:'flex', gap: 8, flexWrap:'wrap'}}>
           <Pill2 active={city==='all'} onClick={()=>setCity('all')}>Все города</Pill2>
-          {OV_CITIES.slice(0, 6).map(c => <Pill2 key={c.id} active={city===c.id} onClick={()=>setCity(c.id)}>{c.name}</Pill2>)}
+          {OV_getCities().slice(0, 6).map(c => <Pill2 key={c.id} active={city===c.id} onClick={()=>setCity(c.id)}>{c.name}</Pill2>)}
           <div style={{width: 1, background:'var(--line)', margin:'0 6px'}}></div>
-          {OV_SERVICES.map(s => (
+          {OV_getServices().map(s => (
             <Pill2 key={s.id} active={svc===s.id} onClick={()=>setSvc(svc===s.id?null:s.id)}>{s.short}</Pill2>
           ))}
         </div>
@@ -595,7 +613,7 @@ function CatalogPage({ onOpen }) {
 
 // --- Specialist profile (page) ---
 function SpecialistPage({ id, onBack, onCatalog, onMessage }) {
-  const s = OV_SPECIALISTS.find(x => x.id === id);
+  const s = OV_getSpecialists().find(x => x.id === id);
   if (!s) {
     return (
       <PageShell crumbs={[{label:'Каталог', href:'/catalog'}, {label:'Специалист не найден'}]}>
@@ -680,7 +698,7 @@ function SpecialistPage({ id, onBack, onCatalog, onMessage }) {
 
 // --- Chat (page) ---
 function ChatPage({ specialistId, onBack, onProfile }) {
-  const initial = OV_SPECIALISTS.find(x => x.id === specialistId) || OV_SPECIALISTS[0];
+  const initial = OV_getSpecialists().find(x => x.id === specialistId) || OV_getSpecialists()[0];
   const [active, setActive] = useS(initial.id);
   const [messages, setMessages] = useS({});
   const [input, setInput] = useS('');
@@ -787,8 +805,8 @@ function ChatPage({ specialistId, onBack, onProfile }) {
     setMenuOpen(false);
   };
 
-  const activeSpec = OV_SPECIALISTS.find(x => x.id === active);
-  const list = [initial, ...OV_SPECIALISTS.filter(x=>x.id!==initial.id).slice(0,3)];
+  const activeSpec = OV_getSpecialists().find(x => x.id === active) || initial;
+  const list = [initial, ...OV_getSpecialists().filter(x=>x.id!==initial.id).slice(0,3)];
 
   return (
     <PageShell crumbs={[{label:'Сообщения'}, {label: activeSpec.first + ' ' + activeSpec.last}]}>

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -1060,7 +1060,7 @@ img, svg { display: block; max-width: 100%; }
   height: 640px;
   max-height: calc(100vh - 80px);
 }
-@media (max-width: 720px) { .chat { grid-template-columns: 1fr; } .chat .chat-list { display: none; } }
+@media (max-width: 720px) and (min-width: 641px) { .chat { grid-template-columns: 1fr; } .chat .chat-list { display: none; } }
 .chat-list {
   border-right: 1px solid var(--line);
   overflow-y: auto;
@@ -1534,3 +1534,195 @@ img, svg { display: block; max-width: 100%; }
 
 /* chips: prevent city/service labels from breaking onto two lines */
 .chip { white-space: nowrap; }
+
+/* ============================================================
+   MOBILE RESPONSIVE — ≤640px overhaul
+   Goal: one codebase serves both mobile and desktop.
+   ============================================================ */
+
+/* Tap-target floor (applies everywhere, not just mobile) */
+.btn { min-height: 44px; }
+.btn-sm { min-height: 40px; }
+.kebab-btn { min-height: 40px; min-width: 40px; }
+.close-btn { min-height: 36px; min-width: 36px; }
+
+@media (max-width: 640px) {
+  /* --- type scale --- */
+  body { font-size: 15px; }
+  .hero-title { font-size: clamp(32px, 10vw, 44px); line-height: 1.08; max-width: none; }
+  .section-title { font-size: clamp(26px, 8vw, 34px); line-height: 1.12; }
+  .reality-title { font-size: clamp(30px, 9vw, 44px); line-height: 1.08; }
+  .final-title { font-size: clamp(40px, 14vw, 68px); line-height: 1.02; }
+
+  /* --- layout padding --- */
+  .section { padding: 56px 0; }
+  .hero { padding: 48px 0 64px; }
+  .final-cta { padding: 72px 0; }
+  .section-head { margin-bottom: 32px; }
+
+  /* --- nav: collapse links, keep primary action --- */
+  .nav-inner { height: 56px; gap: 10px; }
+  .nav-links { display: none; }
+  .nav-right { gap: 8px; }
+  .nav-right .btn-subtle { padding: 8px 10px; font-size: 13px; }
+  .nav-right .btn-primary { padding: 10px 14px; font-size: 13px; }
+  .container { padding: 0 16px; }
+
+  /* --- hero: stack picker vertically, full-width CTAs --- */
+  .hero-grid { gap: 32px; }
+  .search-card { padding: 4px; }
+  .search-row {
+    grid-template-columns: 1fr;
+    gap: 1px;
+  }
+  .search-row > *:first-child { border-radius: 11px 11px 0 0; }
+  .search-row .search-field:first-child { border-radius: 11px 11px 0 0; }
+  .search-submit {
+    border-radius: 0 0 11px 11px;
+    padding: 14px 20px;
+    min-height: 48px;
+  }
+  .search-field { padding: 14px 16px; min-height: 60px; }
+
+  /* hero bottom row: stack, go full width */
+  .hero .row { flex-direction: column; align-items: stretch; gap: 12px; }
+  .hero .row .btn { width: 100%; justify-content: center; }
+  .hero .row .small { text-align: center; }
+
+  /* --- specialist stack (hero right side) --- */
+  .spec-card { padding: 12px; gap: 10px; }
+  .spec-card .spec-tag { font-size: 10px; padding: 3px 8px; }
+
+  /* --- situations / steps already stack at 820px — tighten padding --- */
+  .situation { padding: 24px 20px; min-height: auto; }
+  .step { padding: 22px 18px; min-height: auto; }
+  .situation-title { font-size: 26px; }
+  .step-title { font-size: 22px; }
+
+  /* --- catalog toolbar scrolls horizontally on mobile --- */
+  .cat-toolbar {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding: 10px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .cat-toolbar::-webkit-scrollbar { display: none; }
+  .cat-toolbar > * { flex-shrink: 0; }
+  .cat-card { padding: 16px; }
+
+  /* --- coverage: smaller map, list below --- */
+  .coverage-viz { padding: 16px; aspect-ratio: 4/3; }
+  .city-list { max-height: 360px; }
+
+  /* --- reality timeline: single column, narrower day --- */
+  .timeline-item { grid-template-columns: 92px 1fr; gap: 12px; padding: 16px 0; }
+
+  /* --- specialists-cta / cases --- */
+  .specialists-cta { padding: 32px 22px; }
+  .spec-stat { grid-template-columns: 1fr 1fr; gap: 10px; }
+
+  /* --- footer --- */
+  .footer-grid { grid-template-columns: 1fr; gap: 28px; }
+  .legal { flex-direction: column; gap: 8px; }
+
+  /* --- modal: full-screen on mobile --- */
+  .modal-backdrop { padding: 0; align-items: stretch; }
+  .modal,
+  .modal.lg,
+  .modal.xl {
+    max-width: 100%;
+    max-height: 100vh;
+    min-height: 100vh;
+    border-radius: 0;
+    border: 0;
+  }
+  .modal-head { padding: 14px 16px; gap: 8px; flex-wrap: wrap; }
+  .modal-head .step-dots { order: 3; width: 100%; font-size: 11px; }
+  .modal-body { padding: 20px 16px; }
+  .modal-foot {
+    padding: 12px 16px;
+    border-radius: 0;
+    position: sticky;
+    bottom: 0;
+    background: var(--surface-2);
+  }
+  .modal-foot .btn { flex: 1; justify-content: center; }
+  .otp-grid { gap: 6px; }
+  .otp-box { font-size: 20px; }
+
+  /* new-request step 1: force single column even if city picked */
+  .modal-body > .fade-in > div[style*="grid-template-columns"] {
+    grid-template-columns: 1fr !important;
+  }
+  .pub-toggle { grid-template-columns: 1fr; }
+
+  /* --- specialist profile: avatar above name, stacked buttons --- */
+  .prof { padding: 20px; }
+  .prof-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding-bottom: 18px;
+    margin-bottom: 18px;
+  }
+  .prof-head > div[style] { width: 100%; }
+  .prof-stats { grid-template-columns: 1fr 1fr 1fr; padding: 14px; gap: 8px; }
+  .prof-stat-val { font-size: 22px; }
+  .prof-contact { flex-direction: column; align-items: flex-start; gap: 4px; padding: 10px 0; }
+
+  /* page-bar action button full width below crumbs on small screens */
+  .page-bar-inner { flex-wrap: wrap; gap: 10px; }
+  .page-bar-inner > .btn-primary { width: 100%; }
+  .crumbs { font-size: 12px; }
+
+  /* --- chat: full-width body, sticky composer, sidebar becomes top drawer --- */
+  .chat { grid-template-columns: 1fr; height: auto; min-height: calc(100vh - 160px); }
+  .page-card .chat { grid-template-columns: 1fr; }
+  /* reveal chat-list above conversation as a horizontal scroller */
+  .chat .chat-list,
+  .page-card .chat-list {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 10px 12px;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+    -webkit-overflow-scrolling: touch;
+  }
+  .chat-item {
+    grid-template-columns: auto auto;
+    flex: 0 0 auto;
+    border-bottom: 0;
+    padding: 8px 12px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--bg);
+  }
+  .chat-item-last, .chat-item-time { display: none; }
+  .chat-body { padding: 14px 12px; }
+  .msg { max-width: 88%; }
+  .msg-file { min-width: 180px; }
+  .chat-foot {
+    padding: 10px 12px;
+    position: sticky;
+    bottom: 0;
+    background: var(--bg);
+    z-index: var(--z-base);
+  }
+  .chat-attach { width: 44px; height: 44px; }
+  .chat-foot .input { min-height: 44px; }
+
+  /* --- tweaks panel scaling --- */
+  .tweaks-panel { width: calc(100vw - 40px); max-width: 320px; }
+}
+
+/* tighten mid-range (641–760px) — picker rows stay readable */
+@media (max-width: 760px) and (min-width: 641px) {
+  .nav-links { gap: 16px; font-size: 13px; }
+  .search-row { grid-template-columns: 1fr 1fr; }
+  .search-row > *:first-child { border-radius: 11px 0 0 0; }
+  .search-row .search-submit { grid-column: 1 / -1; border-radius: 0 0 11px 11px; }
+}

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -1,3 +1,14 @@
+/* ============ P2PTax — z-index scale ============ */
+:root {
+  --z-base: 1;
+  --z-nav: 50;
+  --z-dropdown: 100;
+  --z-modal-backdrop: 1000;
+  --z-modal: 1001;
+  --z-toast: 2000;
+  --z-tweaks: 3000;
+}
+
 /* ============ P2PTax — design tokens ============ */
 :root, [data-theme="light"] {
   /* Pure white minimal palette */
@@ -109,7 +120,7 @@ img, svg { display: block; max-width: 100%; }
 .nav {
   position: sticky;
   top: 0;
-  z-index: 40;
+  z-index: var(--z-nav);
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(18px) saturate(1.4);
   -webkit-backdrop-filter: blur(18px) saturate(1.4);
@@ -242,7 +253,7 @@ img, svg { display: block; max-width: 100%; }
   padding: 6px;
   box-shadow: var(--shadow-lg);
   position: relative;
-  z-index: 5;
+  z-index: var(--z-base);
 }
 .search-row {
   display: grid;
@@ -346,7 +357,7 @@ img, svg { display: block; max-width: 100%; }
   border-radius: 50%;
   background: var(--success);
   border: 2px solid var(--bg);
-  z-index: 2;
+  z-index: var(--z-base);
 }
 .avatar.xl .online { width: 18px; height: 18px; right: 3px; bottom: 3px; border-width: 3px; }
 .spec-meta { flex: 1; min-width: 0; }
@@ -826,7 +837,7 @@ img, svg { display: block; max-width: 100%; }
   background: color-mix(in oklch, var(--bg) 70%, transparent);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
-  z-index: 100;
+  z-index: var(--z-modal-backdrop);
   display: flex; align-items: center; justify-content: center;
   padding: 20px;
   animation: fadeIn .2s ease;
@@ -845,6 +856,8 @@ img, svg { display: block; max-width: 100%; }
   overflow: auto;
   box-shadow: var(--shadow-lg);
   animation: rise .3s cubic-bezier(.2,.9,.3,1.1);
+  position: relative;
+  z-index: var(--z-modal);
 }
 @keyframes rise {
   from { opacity: 0; transform: translateY(16px) scale(.98); }
@@ -940,7 +953,7 @@ img, svg { display: block; max-width: 100%; }
   background: var(--bg);
   border: 1px solid var(--line-strong);
   border-radius: 10px;
-  z-index: 50;
+  z-index: var(--z-dropdown);
   max-height: 320px;
   overflow-y: auto;
   box-shadow: var(--shadow-lg);
@@ -1165,7 +1178,7 @@ img, svg { display: block; max-width: 100%; }
 
 /* Tweaks panel */
 .tweaks-btn {
-  position: fixed; right: 20px; bottom: 20px; z-index: 60;
+  position: fixed; right: 20px; bottom: 20px; z-index: var(--z-tweaks);
   background: var(--bg);
   border: 1px solid var(--line-strong);
   border-radius: 999px;
@@ -1177,7 +1190,7 @@ img, svg { display: block; max-width: 100%; }
 }
 .tweaks-btn:hover { background: var(--surface-2); }
 .tweaks-panel {
-  position: fixed; right: 20px; bottom: 72px; z-index: 60;
+  position: fixed; right: 20px; bottom: 72px; z-index: var(--z-tweaks);
   width: 300px;
   background: var(--bg);
   border: 1px solid var(--line-strong);
@@ -1255,7 +1268,7 @@ img, svg { display: block; max-width: 100%; }
 .page-bar {
   position: sticky;
   top: 64px;
-  z-index: 40;
+  z-index: var(--z-nav);
   background: #ffffff;
   border-bottom: 1px solid var(--line);
 }
@@ -1338,7 +1351,7 @@ img, svg { display: block; max-width: 100%; }
   border-radius: 12px;
   box-shadow: 0 12px 40px rgba(15, 22, 36, 0.12), 0 2px 6px rgba(15, 22, 36, 0.04);
   padding: 6px;
-  z-index: 60;
+  z-index: var(--z-dropdown);
   display: flex;
   flex-direction: column;
   gap: 2px;


### PR DESCRIPTION
## Summary
Phase 2 of the P2PTax landing "оживление" — three atomic commits, zero
new dependencies, no build step changes (still pure CDN React + Babel).

- **feat(landing): wire reference API** — adds `landing/api.js`, a tiny
  same-origin `/api` client that hydrates `window.PT_*` (cities, FNS by
  city, services, specialists) on boot. Static `data.js` entries stay in
  place as fallbacks, so landing renders even if API is slow/down.
  Components read via live getters and re-render via a `pt:data-ready`
  event hook.
- **fix(landing): normalize z-index stacking** — single scale on `:root`
  (`--z-nav 50`, `--z-dropdown 100`, `--z-modal-backdrop 1000`,
  `--z-modal 1001`, `--z-toast 2000`, `--z-tweaks 3000`). Hardcoded
  numbers in nav, page-bar, modal, popover, kebab menu, tweaks and
  avatar replaced with vars. Modal content now always above its
  backdrop, dropdowns always above page content but below modals.
- **feat(landing): mobile responsive at ≤640px** — tap-target floor
  (44px), nav collapses to login + CTA, hero pickers stack full-width,
  catalog toolbar becomes a horizontal scroller, modals go full-screen,
  specialist profile stacks, chat sidebar becomes a pill strip, composer
  sticky. Font scaling via `clamp()` already in place; tightened at
  narrow widths.

Cache-bust query bumped to `v=1777000000002` in `landing/index.html`.

## Test plan
- [ ] Staging auto-deploys from `development` after merge.
- [ ] Open https://p2ptax.smartlaunchhub.com — home renders; catalog
      shows static fallback specialists immediately, swaps to live data
      once `GET /api/specialists` returns.
- [ ] Resize devtools to 375px width — nav shows only Войти/Создать
      заявку, hero pickers stack vertically, catalog filters scroll
      horizontally, modal goes full-screen.
- [ ] Open auth modal — backdrop sits above nav, modal content above
      backdrop, tweaks panel (edit mode) above everything.
- [ ] With DevTools network throttled to "Offline": landing still
      renders (static fallback data), no console errors from fetch
      rejections (promises are catch-swallowed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)