### PR TITLE
fix: migrate icons to lucide-react-native, add responsive layout

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { BarChart2, Users, Shield, Flag } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 export default function AdminTabsLayout() {
@@ -23,36 +23,28 @@ export default function AdminTabsLayout() {
         name="dashboard"
         options={{
           title: "Dashboard",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="bar-chart" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <BarChart2 size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="users"
         options={{
           title: "Users",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="users" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <Users size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="moderation"
         options={{
           title: "Moderation",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="shield" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <Shield size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="complaints"
         options={{
           title: "Жалобы",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="flag" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <Flag size={size} color={color} />,
         }}
       />
     </Tabs>

--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ChevronUp, ChevronDown, Flag } from "lucide-react-native";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import { Badge, EmptyState, ErrorState, LoadingState } from "@/components/ui";
 import { useAuth } from "@/contexts/AuthContext";
@@ -194,11 +194,10 @@ export default function AdminComplaints() {
 
           <View className="flex-row items-center justify-between mt-2">
             <Text className="text-xs text-slate-400">{formatDate(item.createdAt)}</Text>
-            <FontAwesome
-              name={isExpanded ? "chevron-up" : "chevron-down"}
-              size={11}
-              color={colors.placeholder}
-            />
+            {isExpanded
+              ? <ChevronUp size={11} color={colors.placeholder} />
+              : <ChevronDown size={11} color={colors.placeholder} />
+            }
           </View>
         </Pressable>
 
@@ -296,7 +295,7 @@ export default function AdminComplaints() {
           onEndReachedThreshold={0.3}
           ListEmptyComponent={
             <EmptyState
-              icon="flag"
+              icon={Flag}
               title="Жалоб нет"
               subtitle={
                 filter === "NEW"

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -2,7 +2,6 @@ import { View, Text, ScrollView, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useEffect, useState, useCallback } from "react";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import ErrorState from "@/components/ui/ErrorState";

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -1,5 +1,6 @@
 import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { CheckCircle } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import EmptyState from "@/components/ui/EmptyState";
 
@@ -10,7 +11,7 @@ export default function AdminModeration() {
       <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
         <View className="flex-1">
           <EmptyState
-            icon="check-circle"
+            icon={CheckCircle}
             title="Всё чисто"
             subtitle="Нет элементов, требующих модерации"
           />

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Users } from "lucide-react-native";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -293,7 +293,7 @@ export default function AdminUsers() {
             <View className="py-2">
               {users.length === 0 ? (
                 <View className="items-center py-16">
-                  <FontAwesome name="users" size={48} color={colors.placeholder} />
+                  <Users size={48} color={colors.placeholder} />
                   <Text className="text-base text-slate-400 mt-3">
                     Пользователи не найдены
                   </Text>

--- a/app/(client-tabs)/_layout.tsx
+++ b/app/(client-tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { LayoutGrid, FileText, MessageCircle } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 export default function ClientTabsLayout() {
@@ -23,27 +23,21 @@ export default function ClientTabsLayout() {
         name="dashboard"
         options={{
           title: "Dashboard",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="th-large" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <LayoutGrid size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="requests"
         options={{
           title: "My Requests",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="file-text-o" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <FileText size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="messages"
         options={{
           title: "Messages",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="comments-o" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <MessageCircle size={size} color={color} />,
         }}
       />
     </Tabs>

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
+import { FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -182,7 +183,7 @@ export default function ClientDashboard() {
 
               {requests.length === 0 ? (
                 <EmptyState
-                  icon="file-text-o"
+                  icon={FileText}
                   title="У вас пока нет заявок"
                   subtitle="Создайте первую заявку — специалисты из вашего города увидят её и предложат помощь"
                   actionLabel="Создать первую заявку"

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { MessageCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
@@ -220,7 +221,7 @@ export default function ClientMessages() {
           }
           ListEmptyComponent={
             <EmptyState
-              icon="comments-o"
+              icon={MessageCircle}
               title="Нет сообщений"
               subtitle="Когда специалисты откликнутся на ваши заявки, сообщения появятся здесь"
               actionLabel="Найти специалиста"

--- a/app/(client-tabs)/requests.tsx
+++ b/app/(client-tabs)/requests.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
+import { FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import ErrorState from "@/components/ui/ErrorState";
@@ -303,7 +304,7 @@ export default function MyRequests() {
     if (requests.length === 0) {
       return (
         <EmptyState
-          icon="file-text-o"
+          icon={FileText}
           title="Заявок пока нет"
           subtitle="Создайте первую заявку — специалисты из вашего города увидят её и предложат помощь"
           actionLabel="Создать заявку"

--- a/app/(specialist-tabs)/_layout.tsx
+++ b/app/(specialist-tabs)/_layout.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { LayoutGrid, List, MessageCircle, Rocket } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 export default function SpecialistTabsLayout() {
@@ -23,36 +23,28 @@ export default function SpecialistTabsLayout() {
         name="dashboard"
         options={{
           title: "Dashboard",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="th-large" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <LayoutGrid size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="requests"
         options={{
           title: "Public Requests",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="list-alt" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <List size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="threads"
         options={{
           title: "My Threads",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="comments-o" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <MessageCircle size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="promotion"
         options={{
           title: "Продвижение",
-          tabBarIcon: ({ color, size }) => (
-            <FontAwesome name="rocket" size={size} color={color} />
-          ),
+          tabBarIcon: ({ color, size }) => <Rocket size={size} color={color} />,
         }}
       />
     </Tabs>

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { TriangleAlert, List } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import StatusBadge from "@/components/StatusBadge";
@@ -210,8 +210,7 @@ export default function SpecialistDashboard() {
                 className="bg-amber-50 border border-amber-300 rounded-xl p-4 mb-4"
               >
                 <View className="flex-row items-start">
-                  <FontAwesome
-                    name="exclamation-triangle"
+                  <TriangleAlert
                     size={16}
                     color={colors.accent}
                     style={{ marginTop: 2 }}
@@ -266,7 +265,7 @@ export default function SpecialistDashboard() {
             {/* Request list or empty */}
             {requests.length === 0 ? (
               <EmptyState
-                icon="list-alt"
+                icon={List}
                 title="Нет подходящих заявок"
                 subtitle="Расширьте рабочую область, чтобы видеть больше заявок из других городов и инспекций"
                 actionLabel="Расширить рабочую область"

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -1,7 +1,7 @@
 import { View, Text, ScrollView, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Rocket, User, ChevronRight } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import { colors } from "@/lib/theme";
 
@@ -25,7 +25,7 @@ export default function PromotionScreen() {
             {/* Placeholder card */}
             <View className="bg-white border border-slate-200 rounded-xl p-6 items-center">
               <View className="w-16 h-16 rounded-full bg-amber-50 items-center justify-center mb-4">
-                <FontAwesome name="rocket" size={28} color={colors.accent} />
+                <Rocket size={28} color={colors.accent} />
               </View>
               <Text className="text-lg font-semibold text-slate-900 text-center mb-2">
                 Скоро будет доступно
@@ -44,7 +44,7 @@ export default function PromotionScreen() {
               className="bg-blue-900 rounded-xl p-4 mt-4 flex-row items-center"
             >
               <View className="w-10 h-10 rounded-full bg-blue-800 items-center justify-center mr-3">
-                <FontAwesome name="user" size={16} color={colors.surface} />
+                <User size={16} color={colors.surface} />
               </View>
               <View className="flex-1">
                 <Text className="text-white font-semibold text-sm">Заполните профиль</Text>
@@ -52,7 +52,7 @@ export default function PromotionScreen() {
                   Полный профиль повышает доверие клиентов
                 </Text>
               </View>
-              <FontAwesome name="chevron-right" size={12} color="#93c5fd" />
+              <ChevronRight size={12} color="#93c5fd" />
             </Pressable>
 
             <View className="h-8" />

--- a/app/(specialist-tabs)/requests.tsx
+++ b/app/(specialist-tabs)/requests.tsx
@@ -12,6 +12,7 @@ import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
 import FilterBar from "@/components/FilterBar";
+import { TriangleAlert, FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
@@ -163,7 +164,7 @@ export default function SpecialistPublicRequests() {
           </View>
         ) : error ? (
           <EmptyState
-            icon="exclamation-triangle"
+            icon={TriangleAlert}
             title="Ошибка загрузки"
             subtitle={error}
             actionLabel="Повторить"
@@ -174,7 +175,7 @@ export default function SpecialistPublicRequests() {
           />
         ) : requests.length === 0 ? (
           <EmptyState
-            icon="file-text-o"
+            icon={FileText}
             title="Заявок не найдено"
             subtitle="Попробуйте изменить фильтры"
             actionLabel="Сбросить фильтры"

--- a/app/(specialist-tabs)/threads.tsx
+++ b/app/(specialist-tabs)/threads.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { MessageCircle, CheckCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import ErrorState from "@/components/ui/ErrorState";
@@ -130,7 +131,7 @@ export default function SpecialistMyThreads() {
             <ResponsiveContainer>
               {threads.length === 0 ? (
                 <EmptyState
-                  icon="comments-o"
+                  icon={MessageCircle}
                   title="Вы ещё не написали ни одному клиенту"
                   subtitle="Откликнитесь на заявку — клиент увидит ваше сообщение и сможет ответить"
                   actionLabel="Смотреть заявки"
@@ -140,7 +141,7 @@ export default function SpecialistMyThreads() {
                 />
               ) : (
                 <EmptyState
-                  icon="check-circle-o"
+                  icon={CheckCircle}
                   title="Нет непрочитанных"
                   subtitle="Все сообщения прочитаны"
                 />

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,12 +1,8 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Home, Search, PlusSquare, MessageCircle, User } from "lucide-react-native";
 import Header from "@/components/Header";
 import { colors } from "@/lib/theme";
-
-function TabIcon({ name, color }: { name: React.ComponentProps<typeof FontAwesome>["name"]; color: string }) {
-  return <FontAwesome size={22} name={name} color={color} />;
-}
 
 export default function TabLayout() {
   const { width } = useWindowDimensions();
@@ -31,35 +27,35 @@ export default function TabLayout() {
           name="index"
           options={{
             title: "Home",
-            tabBarIcon: ({ color }) => <TabIcon name="home" color={color} />,
+            tabBarIcon: ({ color }) => <Home size={22} color={color} />,
           }}
         />
         <Tabs.Screen
           name="search"
           options={{
             title: "Search",
-            tabBarIcon: ({ color }) => <TabIcon name="search" color={color} />,
+            tabBarIcon: ({ color }) => <Search size={22} color={color} />,
           }}
         />
         <Tabs.Screen
           name="create"
           options={{
             title: "Create",
-            tabBarIcon: ({ color }) => <TabIcon name="plus-square" color={color} />,
+            tabBarIcon: ({ color }) => <PlusSquare size={22} color={color} />,
           }}
         />
         <Tabs.Screen
           name="messages"
           options={{
             title: "Messages",
-            tabBarIcon: ({ color }) => <TabIcon name="comments" color={color} />,
+            tabBarIcon: ({ color }) => <MessageCircle size={22} color={color} />,
           }}
         />
         <Tabs.Screen
           name="profile"
           options={{
             title: "Profile",
-            tabBarIcon: ({ color }) => <TabIcon name="user" color={color} />,
+            tabBarIcon: ({ color }) => <User size={22} color={color} />,
           }}
         />
       </Tabs>

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -1,70 +1,73 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Camera, ImageIcon, Lightbulb } from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 export default function CreateScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
-        {/* Header */}
-        <View className="px-4 pt-2 pb-3">
-          <Text className="text-2xl font-bold text-gray-900">Create Listing</Text>
-          <Text className="text-sm text-gray-500 mt-1">Step 1 of 3 — Photos</Text>
-        </View>
-
-        {/* Progress Bar */}
-        <View className="px-4 mb-6">
-          <View className="h-1.5 rounded-full bg-gray-100">
-            <View className="h-1.5 rounded-full bg-blue-600 w-1/3" />
+        <ResponsiveContainer>
+          {/* Header */}
+          <View className="pt-2 pb-3">
+            <Text className="text-2xl font-bold text-gray-900">Create Listing</Text>
+            <Text className="text-sm text-gray-500 mt-1">Step 1 of 3 — Photos</Text>
           </View>
-        </View>
 
-        {/* Photo Grid */}
-        <View className="px-4 mb-6">
-          <Text className="text-base font-semibold text-gray-900 mb-3">
-            Add photos
-          </Text>
-          <Text className="text-sm text-gray-500 mb-4">
-            Add up to 10 photos. First photo will be the cover.
-          </Text>
+          {/* Progress Bar */}
+          <View className="mb-6">
+            <View className="h-1.5 rounded-full bg-gray-100">
+              <View className="h-1.5 rounded-full bg-blue-600 w-1/3" />
+            </View>
+          </View>
 
-          <View className="flex-row flex-wrap">
-            {/* Add Photo Button */}
-            <Pressable accessibilityRole="button" accessibilityLabel="Добавить фото" className="w-[31%] aspect-square m-[1%] rounded-xl border-2 border-dashed border-blue-300 bg-blue-50 items-center justify-center">
-              <FontAwesome name="camera" size={24} color="#3b82f6" />
-              <Text className="text-xs text-blue-600 mt-1 font-medium">Add photo</Text>
+          {/* Photo Grid */}
+          <View className="mb-6">
+            <Text className="text-base font-semibold text-gray-900 mb-3">
+              Add photos
+            </Text>
+            <Text className="text-sm text-gray-500 mb-4">
+              Add up to 10 photos. First photo will be the cover.
+            </Text>
+
+            <View className="flex-row flex-wrap">
+              {/* Add Photo Button */}
+              <Pressable accessibilityRole="button" accessibilityLabel="Добавить фото" className="w-[31%] aspect-square m-[1%] rounded-xl border-2 border-dashed border-blue-300 bg-blue-50 items-center justify-center">
+                <Camera size={24} color="#3b82f6" />
+                <Text className="text-xs text-blue-600 mt-1 font-medium">Add photo</Text>
+              </Pressable>
+
+              {/* Placeholder slots */}
+              {[1, 2, 3, 4, 5].map((i) => (
+                <View
+                  key={i}
+                  className="w-[31%] aspect-square m-[1%] rounded-xl bg-gray-100 items-center justify-center"
+                >
+                  <ImageIcon size={20} color={colors.textSecondary} />
+                </View>
+              ))}
+            </View>
+          </View>
+
+          {/* Tips */}
+          <View className="p-4 rounded-xl bg-amber-50 border border-amber-200">
+            <View className="flex-row items-center mb-2">
+              <Lightbulb size={16} color="#d97706" />
+              <Text className="text-sm font-semibold text-amber-800 ml-2">Tips for great photos</Text>
+            </View>
+            <Text className="text-sm text-amber-700 leading-5">
+              Use natural light. Show item from multiple angles. Include close-ups of details and any defects.
+            </Text>
+          </View>
+
+          {/* Next Button */}
+          <View className="mt-8">
+            <Pressable accessibilityRole="button" accessibilityLabel="Далее: детали" className="h-14 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
+              <Text className="text-white text-base font-semibold">Next: Details</Text>
             </Pressable>
-
-            {/* Placeholder slots */}
-            {[1, 2, 3, 4, 5].map((i) => (
-              <View
-                key={i}
-                className="w-[31%] aspect-square m-[1%] rounded-xl bg-gray-100 items-center justify-center"
-              >
-                <FontAwesome name="image" size={20} color={colors.textSecondary} />
-              </View>
-            ))}
           </View>
-        </View>
-
-        {/* Tips */}
-        <View className="mx-4 p-4 rounded-xl bg-amber-50 border border-amber-200">
-          <View className="flex-row items-center mb-2">
-            <FontAwesome name="lightbulb-o" size={16} color="#d97706" />
-            <Text className="text-sm font-semibold text-amber-800 ml-2">Tips for great photos</Text>
-          </View>
-          <Text className="text-sm text-amber-700 leading-5">
-            Use natural light. Show item from multiple angles. Include close-ups of details and any defects.
-          </Text>
-        </View>
-
-        {/* Next Button */}
-        <View className="px-4 mt-8">
-          <Pressable accessibilityRole="button" accessibilityLabel="Далее: детали" className="h-14 rounded-xl bg-blue-600 items-center justify-center active:bg-blue-700">
-            <Text className="text-white text-base font-semibold">Next: Details</Text>
-          </Pressable>
-        </View>
+        </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,17 +1,20 @@
-import { View, Text, TextInput, ScrollView, Pressable, FlatList } from "react-native";
+import { View, Text, TextInput, ScrollView, Pressable, FlatList, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  Laptop, Car, Building2, ShoppingBag, Dumbbell, Dog, Home, Baby,
+  ImageIcon, MapPin, Search, type LucideIcon
+} from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
-const CATEGORIES = [
-  { id: "1", name: "Electronics", icon: "laptop" as const },
-  { id: "2", name: "Cars", icon: "car" as const },
-  { id: "3", name: "Property", icon: "building" as const },
-  { id: "4", name: "Clothes", icon: "shopping-bag" as const },
-  { id: "5", name: "Sports", icon: "futbol-o" as const },
-  { id: "6", name: "Pets", icon: "paw" as const },
-  { id: "7", name: "Home", icon: "home" as const },
-  { id: "8", name: "Kids", icon: "child" as const },
+const CATEGORIES: { id: string; name: string; Icon: LucideIcon }[] = [
+  { id: "1", name: "Electronics", Icon: Laptop },
+  { id: "2", name: "Cars", Icon: Car },
+  { id: "3", name: "Property", Icon: Building2 },
+  { id: "4", name: "Clothes", Icon: ShoppingBag },
+  { id: "5", name: "Sports", Icon: Dumbbell },
+  { id: "6", name: "Pets", Icon: Dog },
+  { id: "7", name: "Home", Icon: Home },
+  { id: "8", name: "Kids", Icon: Baby },
 ];
 
 const LISTINGS = [
@@ -23,11 +26,11 @@ const LISTINGS = [
   { id: "6", title: "Mountain Bike Trek X-Cal", price: "$380", location: "Batumi", color: "#fce7f3" },
 ];
 
-function CategoryChip({ name, icon }: { name: string; icon: React.ComponentProps<typeof FontAwesome>["name"] }) {
+function CategoryChip({ name, Icon }: { name: string; Icon: LucideIcon }) {
   return (
     <Pressable accessibilityRole="button" accessibilityLabel={name} className="mr-3 items-center">
       <View className="w-14 h-14 rounded-2xl bg-gray-100 items-center justify-center mb-1">
-        <FontAwesome name={icon} size={20} color="#4b5563" />
+        <Icon size={20} color="#4b5563" />
       </View>
       <Text className="text-xs text-gray-600">{name}</Text>
     </Pressable>
@@ -39,7 +42,7 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
     <Pressable accessibilityRole="button" accessibilityLabel={title} className="flex-1 m-1.5">
       <View className="rounded-2xl overflow-hidden bg-white" style={{ shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 4, elevation: 2 }}>
         <View className="h-36 items-center justify-center" style={{ backgroundColor: color }}>
-          <FontAwesome name="image" size={32} color={colors.textSecondary} />
+          <ImageIcon size={32} color={colors.textSecondary} />
         </View>
         <View className="p-3">
           <Text className="text-sm font-semibold text-gray-900" numberOfLines={2}>
@@ -47,7 +50,7 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
           </Text>
           <Text className="text-base font-bold text-blue-600 mt-1">{price}</Text>
           <View className="flex-row items-center mt-1">
-            <FontAwesome name="map-marker" size={12} color={colors.textSecondary} />
+            <MapPin size={12} color={colors.textSecondary} />
             <Text className="text-xs text-gray-400 ml-1">{location}</Text>
           </View>
         </View>
@@ -57,8 +60,15 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
 }
 
 export default function HomeScreen() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
+  const containerStyle = isDesktop
+    ? { maxWidth: 520, width: "100%" as const, alignSelf: "center" as const }
+    : undefined;
+
   return (
     <SafeAreaView className="flex-1 bg-white">
+      <View className="flex-1" style={containerStyle}>
       <FlatList
         data={LISTINGS}
         numColumns={2}
@@ -74,7 +84,7 @@ export default function HomeScreen() {
             {/* Search Bar */}
             <View className="px-4 mb-4">
               <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
-                <FontAwesome name="search" size={16} color={colors.textSecondary} />
+                <Search size={16} color={colors.textSecondary} />
                 <TextInput
                   accessibilityLabel="Поиск объявлений"
                   className="flex-1 ml-3 text-base text-gray-900"
@@ -91,7 +101,7 @@ export default function HomeScreen() {
               contentContainerClassName="px-4 pb-4"
             >
               {CATEGORIES.map((cat) => (
-                <CategoryChip key={cat.id} name={cat.name} icon={cat.icon} />
+                <CategoryChip key={cat.id} name={cat.name} Icon={cat.Icon} />
               ))}
             </ScrollView>
 
@@ -113,6 +123,7 @@ export default function HomeScreen() {
           />
         )}
       />
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,6 +1,6 @@
-import { View, Text, Pressable, FlatList } from "react-native";
+import { View, Text, Pressable, FlatList, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { MessageCircle } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 const CONVERSATIONS = [
@@ -102,24 +102,32 @@ function ConversationItem({
 }
 
 export default function MessagesScreen() {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
+  const containerStyle = isDesktop
+    ? { maxWidth: 520, width: "100%" as const, alignSelf: "center" as const }
+    : undefined;
+
   return (
     <SafeAreaView className="flex-1 bg-white">
-      {/* Header */}
-      <View className="px-4 pt-2 pb-3 border-b border-gray-100">
-        <Text className="text-2xl font-bold text-gray-900">Messages</Text>
-      </View>
+      <View className="flex-1" style={containerStyle}>
+        {/* Header */}
+        <View className="px-4 pt-2 pb-3 border-b border-gray-100">
+          <Text className="text-2xl font-bold text-gray-900">Messages</Text>
+        </View>
 
-      <FlatList
-        data={CONVERSATIONS}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <ConversationItem {...item} />}
-        ListEmptyComponent={
-          <View className="flex-1 items-center justify-center py-20">
-            <FontAwesome name="comments-o" size={48} color={colors.textSecondary} />
-            <Text className="text-base text-gray-400 mt-4">No messages yet</Text>
-          </View>
-        }
-      />
+        <FlatList
+          data={CONVERSATIONS}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => <ConversationItem {...item} />}
+          ListEmptyComponent={
+            <View className="flex-1 items-center justify-center py-20">
+              <MessageCircle size={48} color={colors.textSecondary} />
+              <Text className="text-base text-gray-400 mt-4">No messages yet</Text>
+            </View>
+          }
+        />
+      </View>
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,15 +1,19 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  User, Star, ChevronRight, LogOut,
+  List, Heart, Settings, HelpCircle, Info, type LucideIcon
+} from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
-const MENU_ITEMS = [
-  { id: "listings", icon: "list-ul" as const, label: "My Listings", badge: "12" },
-  { id: "favorites", icon: "heart-o" as const, label: "Favorites", badge: "5" },
-  { id: "settings", icon: "cog" as const, label: "Settings", badge: null },
-  { id: "help", icon: "question-circle-o" as const, label: "Help & Support", badge: null },
-  { id: "about", icon: "info-circle" as const, label: "About", badge: null },
+const MENU_ITEMS: { id: string; Icon: LucideIcon; label: string; badge: string | null }[] = [
+  { id: "listings", Icon: List, label: "My Listings", badge: "12" },
+  { id: "favorites", Icon: Heart, label: "Favorites", badge: "5" },
+  { id: "settings", Icon: Settings, label: "Settings", badge: null },
+  { id: "help", Icon: HelpCircle, label: "Help & Support", badge: null },
+  { id: "about", Icon: Info, label: "About", badge: null },
 ];
 
 export default function ProfileScreen() {
@@ -18,10 +22,11 @@ export default function ProfileScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
+        <ResponsiveContainer>
         {/* Profile Header */}
         <View className="items-center pt-6 pb-8 border-b border-gray-100">
           <View className="w-20 h-20 rounded-full bg-blue-100 items-center justify-center mb-3">
-            <FontAwesome name="user" size={32} color="#3b82f6" />
+            <User size={32} color="#3b82f6" />
           </View>
           <Text className="text-xl font-bold text-gray-900">John Doe</Text>
           <Text className="text-sm text-gray-500 mt-0.5">john@example.com</Text>
@@ -29,11 +34,11 @@ export default function ProfileScreen() {
           {/* Rating */}
           <View className="flex-row items-center mt-2">
             {[1, 2, 3, 4, 5].map((star) => (
-              <FontAwesome
+              <Star
                 key={star}
-                name={star <= 4 ? "star" : "star-half-empty"}
                 size={14}
                 color="#f59e0b"
+                fill={star <= 4 ? "#f59e0b" : "none"}
               />
             ))}
             <Text className="text-sm text-gray-500 ml-1.5">4.5 (23 reviews)</Text>
@@ -68,7 +73,7 @@ export default function ProfileScreen() {
               className="flex-row items-center px-4 py-4 active:bg-gray-50"
             >
               <View className="w-10 h-10 rounded-lg bg-gray-100 items-center justify-center">
-                <FontAwesome name={item.icon} size={18} color="#4b5563" />
+                <item.Icon size={18} color="#4b5563" />
               </View>
               <Text className="flex-1 ml-3 text-base text-gray-900">{item.label}</Text>
               {item.badge && (
@@ -76,23 +81,24 @@ export default function ProfileScreen() {
                   <Text className="text-xs font-medium text-blue-600">{item.badge}</Text>
                 </View>
               )}
-              <FontAwesome name="chevron-right" size={12} color={colors.textSecondary} />
+              <ChevronRight size={12} color={colors.textSecondary} />
             </Pressable>
           ))}
         </View>
 
         {/* Logout */}
-        <View className="mt-4 px-4">
+        <View className="mt-4">
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Выйти"
             onPress={signOut}
             className="flex-row items-center justify-center h-12 rounded-xl border border-red-200 active:bg-red-50"
           >
-            <FontAwesome name="sign-out" size={16} color={colors.error} />
+            <LogOut size={16} color={colors.error} />
             <Text className="text-base font-medium text-red-500 ml-2">Log out</Text>
           </Pressable>
         </View>
+        </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,7 +1,11 @@
 import { View, Text, TextInput, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  Search, SlidersHorizontal, Clock, ArrowRight, ChevronRight,
+  Laptop, Car, Building2, ShoppingBag, Dumbbell, Home, type LucideIcon
+} from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 const RECENT_SEARCHES = [
   "iPhone 15",
@@ -10,84 +14,86 @@ const RECENT_SEARCHES = [
   "MacBook",
 ];
 
-const POPULAR_CATEGORIES = [
-  { id: "1", name: "Electronics", count: "12,453 ads", icon: "laptop" as const, color: "#eff6ff" },
-  { id: "2", name: "Vehicles", count: "8,291 ads", icon: "car" as const, color: "#fef2f2" },
-  { id: "3", name: "Real Estate", count: "5,872 ads", icon: "building" as const, color: "#f0fdf4" },
-  { id: "4", name: "Fashion", count: "9,104 ads", icon: "shopping-bag" as const, color: "#fefce8" },
-  { id: "5", name: "Sports & Outdoors", count: "3,455 ads", icon: "futbol-o" as const, color: "#fdf4ff" },
-  { id: "6", name: "Home & Garden", count: "6,789 ads", icon: "home" as const, color: "#f0fdfa" },
+const POPULAR_CATEGORIES: { id: string; name: string; count: string; Icon: LucideIcon; color: string }[] = [
+  { id: "1", name: "Electronics", count: "12,453 ads", Icon: Laptop, color: "#eff6ff" },
+  { id: "2", name: "Vehicles", count: "8,291 ads", Icon: Car, color: "#fef2f2" },
+  { id: "3", name: "Real Estate", count: "5,872 ads", Icon: Building2, color: "#f0fdf4" },
+  { id: "4", name: "Fashion", count: "9,104 ads", Icon: ShoppingBag, color: "#fefce8" },
+  { id: "5", name: "Sports & Outdoors", count: "3,455 ads", Icon: Home, color: "#fdf4ff" },
+  { id: "6", name: "Home & Garden", count: "6,789 ads", Icon: Home, color: "#f0fdfa" },
 ];
 
 export default function SearchScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
-        {/* Header */}
-        <View className="px-4 pt-2 pb-3">
-          <Text className="text-2xl font-bold text-gray-900">Search</Text>
-        </View>
-
-        {/* Search Input */}
-        <View className="px-4 mb-6">
-          <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
-            <FontAwesome name="search" size={16} color={colors.textSecondary} />
-            <TextInput
-              accessibilityLabel="Поиск"
-              className="flex-1 ml-3 text-base text-gray-900"
-              placeholder="What are you looking for?"
-              placeholderTextColor={colors.textSecondary}
-            />
-            <Pressable accessibilityRole="button" accessibilityLabel="Фильтры" className="ml-2 w-11 h-11 rounded-lg bg-blue-600 items-center justify-center">
-              <FontAwesome name="sliders" size={16} color="#ffffff" />
-            </Pressable>
+        <ResponsiveContainer>
+          {/* Header */}
+          <View className="pt-2 pb-3">
+            <Text className="text-2xl font-bold text-gray-900">Search</Text>
           </View>
-        </View>
 
-        {/* Recent Searches */}
-        <View className="px-4 mb-6">
-          <View className="flex-row justify-between items-center mb-3">
-            <Text className="text-base font-semibold text-gray-900">Recent Searches</Text>
-            <Pressable accessibilityRole="button" accessibilityLabel="Очистить историю поиска">
-              <Text className="text-sm text-blue-600">Clear</Text>
-            </Pressable>
+          {/* Search Input */}
+          <View className="mb-6">
+            <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
+              <Search size={16} color={colors.textSecondary} />
+              <TextInput
+                accessibilityLabel="Поиск"
+                className="flex-1 ml-3 text-base text-gray-900"
+                placeholder="What are you looking for?"
+                placeholderTextColor={colors.textSecondary}
+              />
+              <Pressable accessibilityRole="button" accessibilityLabel="Фильтры" className="ml-2 w-11 h-11 rounded-lg bg-blue-600 items-center justify-center">
+                <SlidersHorizontal size={16} color="#ffffff" />
+              </Pressable>
+            </View>
           </View>
-          {RECENT_SEARCHES.map((search, index) => (
-            <Pressable
-              accessibilityRole="button"
-              key={index}
-              accessibilityLabel={search}
-              className="flex-row items-center py-3 border-b border-gray-100"
-            >
-              <FontAwesome name="clock-o" size={16} color={colors.textSecondary} />
-              <Text className="flex-1 ml-3 text-base text-gray-700">{search}</Text>
-              <FontAwesome name="arrow-right" size={12} color={colors.textSecondary} />
-            </Pressable>
-          ))}
-        </View>
 
-        {/* Popular Categories */}
-        <View className="px-4">
-          <Text className="text-base font-semibold text-gray-900 mb-3">Popular Categories</Text>
-          {POPULAR_CATEGORIES.map((cat) => (
-            <Pressable
-              accessibilityRole="button"
-              key={cat.id}
-              accessibilityLabel={cat.name}
-              className="flex-row items-center p-3 rounded-xl mb-2"
-              style={{ backgroundColor: cat.color }}
-            >
-              <View className="w-10 h-10 rounded-lg bg-white items-center justify-center">
-                <FontAwesome name={cat.icon} size={18} color="#4b5563" />
-              </View>
-              <View className="flex-1 ml-3">
-                <Text className="text-base font-medium text-gray-900">{cat.name}</Text>
-                <Text className="text-xs text-gray-500">{cat.count}</Text>
-              </View>
-              <FontAwesome name="chevron-right" size={12} color={colors.textSecondary} />
-            </Pressable>
-          ))}
-        </View>
+          {/* Recent Searches */}
+          <View className="mb-6">
+            <View className="flex-row justify-between items-center mb-3">
+              <Text className="text-base font-semibold text-gray-900">Recent Searches</Text>
+              <Pressable accessibilityRole="button" accessibilityLabel="Очистить историю поиска">
+                <Text className="text-sm text-blue-600">Clear</Text>
+              </Pressable>
+            </View>
+            {RECENT_SEARCHES.map((search, index) => (
+              <Pressable
+                accessibilityRole="button"
+                key={index}
+                accessibilityLabel={search}
+                className="flex-row items-center py-3 border-b border-gray-100"
+              >
+                <Clock size={16} color={colors.textSecondary} />
+                <Text className="flex-1 ml-3 text-base text-gray-700">{search}</Text>
+                <ArrowRight size={12} color={colors.textSecondary} />
+              </Pressable>
+            ))}
+          </View>
+
+          {/* Popular Categories */}
+          <View>
+            <Text className="text-base font-semibold text-gray-900 mb-3">Popular Categories</Text>
+            {POPULAR_CATEGORIES.map((cat) => (
+              <Pressable
+                accessibilityRole="button"
+                key={cat.id}
+                accessibilityLabel={cat.name}
+                className="flex-row items-center p-3 rounded-xl mb-2"
+                style={{ backgroundColor: cat.color }}
+              >
+                <View className="w-10 h-10 rounded-lg bg-white items-center justify-center">
+                  <cat.Icon size={18} color="#4b5563" />
+                </View>
+                <View className="flex-1 ml-3">
+                  <Text className="text-base font-medium text-gray-900">{cat.name}</Text>
+                  <Text className="text-xs text-gray-500">{cat.count}</Text>
+                </View>
+                <ChevronRight size={12} color={colors.textSecondary} />
+              </Pressable>
+            ))}
+          </View>
+        </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/brand.tsx
+++ b/app/brand.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { Mail, Search, FileText } from "lucide-react-native";
 import {
   Button,
   Card,
@@ -121,7 +122,7 @@ export default function BrandScreen() {
             <Button label="Загрузка..." loading />
             <Button variant="secondary" label="Отмена" />
             <Button variant="destructive" label="Удалить" />
-            <Button label="Написать" icon="envelope" />
+            <Button label="Написать" icon={Mail} />
           </View>
         </Section>
 
@@ -150,7 +151,7 @@ export default function BrandScreen() {
               placeholder="Поиск специалиста..."
               value={inputIcon}
               onChangeText={setInputIcon}
-              icon="search"
+              icon={Search}
             />
           </View>
         </Section>
@@ -211,7 +212,7 @@ export default function BrandScreen() {
         <Section title="States">
           <View className="mb-3">
             <EmptyState
-              icon="file-text"
+              icon={FileText}
               title="Нет заявок"
               subtitle="Создайте первую заявку"
               actionLabel="Создать"

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { User, Briefcase, MapPin, MessageCircle } from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import SpecialistCard from "@/components/SpecialistCard";
@@ -284,7 +284,7 @@ export default function LandingScreen() {
             <View className="mb-8">
               <View className="flex-row items-center mb-4">
                 <View className="w-7 h-7 rounded-full bg-blue-900/10 items-center justify-center mr-2">
-                  <FontAwesome name="user" size={13} color={colors.primary} />
+                  <User size={13} color={colors.primary} />
                 </View>
                 <Text className="text-base font-semibold text-slate-900">
                   Для клиентов
@@ -317,7 +317,7 @@ export default function LandingScreen() {
             <View>
               <View className="flex-row items-center mb-4">
                 <View className="w-7 h-7 rounded-full bg-amber-700/10 items-center justify-center mr-2">
-                  <FontAwesome name="briefcase" size={13} color={colors.accent} />
+                  <Briefcase size={13} color={colors.accent} />
                 </View>
                 <Text className="text-base font-semibold text-slate-900">
                   Для специалистов
@@ -428,12 +428,12 @@ export default function LandingScreen() {
                   </Text>
                   <View className="flex-row items-center gap-3">
                     <View className="flex-row items-center gap-1">
-                      <FontAwesome name="map-marker" size={11} color={colors.placeholder} />
+                      <MapPin size={11} color={colors.placeholder} />
                       <Text className="text-xs text-slate-400">{r.city.name}</Text>
                     </View>
                     {r.threadsCount > 0 && (
                       <View className="flex-row items-center gap-1">
-                        <FontAwesome name="comments" size={11} color={colors.placeholder} />
+                        <MessageCircle size={11} color={colors.placeholder} />
                         <Text className="text-xs text-slate-400">
                           {r.threadsCount}
                         </Text>

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ArrowLeft } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
@@ -30,7 +30,7 @@ export default function PrivacyPolicyScreen() {
           onPress={() => router.back()}
           className="w-11 h-11 items-center justify-center -ml-2"
         >
-          <FontAwesome name="arrow-left" size={18} color={colors.text} />
+          <ArrowLeft size={18} color={colors.text} />
         </Pressable>
         <Text className="flex-1 text-center text-base font-semibold text-slate-900">
           Политика конфиденциальности

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { X } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 function SectionHeading({ children }: { children: string }) {
@@ -37,7 +37,7 @@ export default function TermsScreen() {
             className="w-11 h-11 items-center justify-center"
             style={({ pressed }) => [pressed && { opacity: 0.7 }]}
           >
-            <FontAwesome name="times" size={20} color={colors.text} />
+            <X size={20} color={colors.text} />
           </Pressable>
         </View>
       </View>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Pressable, FlatList, RefreshControl } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ArrowLeft, BellOff, MessageCircle, Mail, MapPin, Clock, Bell, type LucideIcon } from "lucide-react-native";
 import { useState, useEffect, useCallback } from "react";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import LoadingState from "@/components/ui/LoadingState";
@@ -28,18 +28,18 @@ interface NotificationsResponse {
   limit: number;
 }
 
-function iconForType(type: string): { name: React.ComponentProps<typeof FontAwesome>["name"]; color: string } {
+function iconForType(type: string): { Icon: LucideIcon; color: string } {
   switch (type) {
     case "new_response":
-      return { name: "comments", color: colors.primary };
+      return { Icon: MessageCircle, color: colors.primary };
     case "new_message":
-      return { name: "envelope", color: colors.primary };
+      return { Icon: Mail, color: colors.primary };
     case "new_request_in_city":
-      return { name: "map-marker", color: colors.success };
+      return { Icon: MapPin, color: colors.success };
     case "promo_expiring":
-      return { name: "clock-o", color: colors.accent };
+      return { Icon: Clock, color: colors.accent };
     default:
-      return { name: "bell", color: colors.text };
+      return { Icon: Bell, color: colors.text };
   }
 }
 
@@ -64,7 +64,7 @@ function NotificationRow({
   item: NotificationItem;
   onPress: (id: string) => void;
 }) {
-  const icon = iconForType(item.type);
+  const { Icon: NotifIcon, color: notifColor } = iconForType(item.type);
   return (
     <Pressable
       accessibilityRole="button"
@@ -78,7 +78,7 @@ function NotificationRow({
         className="w-10 h-10 rounded-full items-center justify-center mt-0.5"
         style={{ backgroundColor: colors.background }}
       >
-        <FontAwesome name={icon.name} size={16} color={icon.color} />
+        <NotifIcon size={16} color={notifColor} />
       </View>
       <View className="flex-1 ml-3">
         <View className="flex-row items-center justify-between">
@@ -177,7 +177,7 @@ export default function NotificationsScreen() {
       <View className="flex-row items-center justify-between px-4 pt-2 pb-3 border-b border-slate-50">
         <View className="flex-row items-center">
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
-            <FontAwesome name="arrow-left" size={18} color={colors.text} />
+            <ArrowLeft size={18} color={colors.text} />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Уведомления</Text>
         </View>
@@ -222,7 +222,7 @@ export default function NotificationsScreen() {
             }
             ListEmptyComponent={
               <View className="flex-1 items-center justify-center py-20">
-                <FontAwesome name="bell-slash-o" size={48} color={colors.placeholder} />
+                <BellOff size={48} color={colors.placeholder} />
                 <Text className="text-base text-slate-400 mt-4">Нет уведомлений</Text>
                 <Text className="text-sm text-slate-300 mt-1">Здесь будут ваши уведомления</Text>
               </View>

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -10,7 +10,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState, useRef } from "react";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Pencil, Camera } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { API_URL, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
@@ -209,7 +209,7 @@ export default function OnboardingProfileScreen() {
                     className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
                     style={{ width: 24, height: 24 }}
                   >
-                    <FontAwesome name="pencil" size={12} color={colors.surface} />
+                    <Pencil size={12} color={colors.surface} />
                   </View>
                 </View>
               ) : (
@@ -223,7 +223,7 @@ export default function OnboardingProfileScreen() {
                     borderStyle: "dashed",
                   }}
                 >
-                  <FontAwesome name="camera" size={24} color={colors.placeholder} />
+                  <Camera size={24} color={colors.placeholder} />
                 </View>
               )}
               <Text className="text-sm text-slate-400 mt-2">

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -7,7 +7,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState, useEffect, useCallback } from "react";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { X, Plus } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
@@ -178,7 +178,7 @@ export default function OnboardingWorkAreaScreen() {
                     <Text className="text-xs text-slate-400">{item.cityName}</Text>
                   </View>
                   <Pressable accessibilityRole="button" accessibilityLabel="Удалить отделение" onPress={() => removeFns(item.fnsId)}>
-                    <FontAwesome name="times" size={16} color={colors.placeholder} />
+                    <X size={16} color={colors.placeholder} />
                   </Pressable>
                 </View>
 
@@ -294,7 +294,7 @@ export default function OnboardingWorkAreaScreen() {
                 }}
                 className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-6"
               >
-                <FontAwesome name="plus" size={14} color={colors.accent} />
+                <Plus size={14} color={colors.accent} />
                 <Text className="text-sm text-amber-700 ml-2 font-medium">
                   Добавить город
                 </Text>

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -11,7 +11,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Trash2, File, FileImage, Download } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
@@ -197,7 +197,7 @@ export default function MyRequestDetail() {
             onPress={handleDelete}
             style={({ pressed }) => [pressed && { opacity: 0.7 }]}
           >
-            <FontAwesome name="trash-o" size={18} color={colors.error} />
+            <Trash2 size={18} color={colors.error} />
           </Pressable>
         }
       />
@@ -266,15 +266,10 @@ export default function MyRequestDetail() {
                     className="flex-row items-center bg-slate-50 rounded-xl p-3 mb-2"
                     style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                   >
-                    <FontAwesome
-                      name={
-                        file.mimeType === "application/pdf"
-                          ? "file-pdf-o"
-                          : "file-image-o"
-                      }
-                      size={20}
-                      color={colors.primary}
-                    />
+                    {file.mimeType === "application/pdf"
+                      ? <File size={20} color={colors.primary} />
+                      : <FileImage size={20} color={colors.primary} />
+                    }
                     <View className="ml-3 flex-1">
                       <Text className="text-sm text-slate-900" numberOfLines={1}>
                         {file.filename}
@@ -283,7 +278,7 @@ export default function MyRequestDetail() {
                         {(file.size / 1024).toFixed(0)} КБ
                       </Text>
                     </View>
-                    <FontAwesome name="download" size={14} color={colors.placeholder} />
+                    <Download size={14} color={colors.placeholder} />
                   </Pressable>
                 ))}
               </View>

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -9,6 +9,7 @@ import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
+import { MessageCircle, Send } from "lucide-react-native";
 import { api, ApiError } from "@/lib/api";
 
 interface RequestDetail {
@@ -177,7 +178,7 @@ export default function PublicRequestDetail() {
                 onPress={() =>
                   router.push(`/threads/${request.existingThreadId}` as never)
                 }
-                icon="comment"
+                icon={MessageCircle}
               />
             </ResponsiveContainer>
           </View>
@@ -189,7 +190,7 @@ export default function PublicRequestDetail() {
             <Button
               label="Написать клиенту"
               onPress={() => router.push(`/requests/${id}/write` as never)}
-              icon="send"
+              icon={Send}
             />
           </ResponsiveContainer>
         </View>

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { MessageCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import { api, ApiError } from "@/lib/api";
@@ -209,7 +210,7 @@ export default function RequestMessages() {
           }
           ListEmptyComponent={
             <EmptyState
-              icon="comments-o"
+              icon={MessageCircle}
               title="Пока нет сообщений"
               subtitle="Специалисты увидят вашу заявку и напишут вам первыми"
             />

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -11,6 +11,7 @@ import { useRouter, useLocalSearchParams } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
+import { Send } from "lucide-react-native";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, radiusValue } from "@/lib/theme";
@@ -247,7 +248,7 @@ export default function SpecialistConfirmWrite() {
               onPress={handleSend}
               disabled={!canSubmit}
               loading={sending}
-              icon="send"
+              icon={Send}
             />
             <Button
               variant="secondary"

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import FilterBar from "@/components/FilterBar";
+import { Inbox } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -222,7 +223,7 @@ export default function PublicRequestsFeed() {
           </View>
         ) : requests.length === 0 ? (
           <EmptyState
-            icon="inbox"
+            icon={Inbox}
             title="Заявок не найдено"
             subtitle="Попробуйте изменить фильтры или сбросить их"
             actionLabel={hasFilters ? "Сбросить фильтры" : undefined}

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -12,7 +12,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Pencil, FileText, ChevronRight, LogOut, Trash2 } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
@@ -216,7 +216,7 @@ export default function ClientSettings() {
                       className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
                       style={{ width: 24, height: 24 }}
                     >
-                      <FontAwesome name="pencil" size={12} color={colors.surface} />
+                      <Pencil size={12} color={colors.surface} />
                     </View>
                   </View>
                 ) : (
@@ -340,11 +340,11 @@ export default function ClientSettings() {
                 className="flex-row items-center px-4 py-3"
                 style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
-                <FontAwesome name="file-text-o" size={16} color={colors.placeholder} />
+                <FileText size={16} color={colors.placeholder} />
                 <Text className="text-base text-slate-900 ml-3 flex-1">
                   Условия использования
                 </Text>
-                <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />
+                <ChevronRight size={12} color={colors.borderLight} />
               </Pressable>
             </View>
 
@@ -361,7 +361,7 @@ export default function ClientSettings() {
                 className="flex-row items-center px-4 py-3 border-b border-slate-100"
                 style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
-                <FontAwesome name="sign-out" size={16} color={colors.error} />
+                <LogOut size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Выйти из аккаунта
                 </Text>
@@ -373,7 +373,7 @@ export default function ClientSettings() {
                 className="flex-row items-center px-4 py-3"
                 style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
-                <FontAwesome name="trash-o" size={16} color={colors.error} />
+                <Trash2 size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Удалить аккаунт
                 </Text>

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,18 +1,22 @@
 import { View, Text, Pressable, ScrollView, Switch, ActivityIndicator } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  ArrowLeft, ChevronRight, Bell, Mail, MessageCircle, List,
+  Globe, Moon, AtSign, Trash2, FileText, Info, type LucideIcon
+} from "lucide-react-native";
 import { useState } from "react";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SettingRow({
-  icon,
+  icon: Icon,
   label,
   rightElement,
   onPress,
 }: {
-  icon: React.ComponentProps<typeof FontAwesome>["name"];
+  icon: LucideIcon;
   label: string;
   rightElement?: React.ReactNode;
   onPress?: () => void;
@@ -22,20 +26,20 @@ function SettingRow({
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
-      className="flex-row items-center px-4 py-4 border-b border-slate-50 active:bg-slate-50"
+      className="flex-row items-center py-4 border-b border-slate-50 active:bg-slate-50"
     >
       <View className="w-9 h-9 rounded-lg bg-slate-50 items-center justify-center">
-        <FontAwesome name={icon} size={16} color={colors.text} />
+        <Icon size={16} color={colors.text} />
       </View>
       <Text className="flex-1 ml-3 text-base text-slate-900">{label}</Text>
-      {rightElement || <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />}
+      {rightElement || <ChevronRight size={12} color={colors.borderLight} />}
     </Pressable>
   );
 }
 
 function SectionTitle({ title }: { title: string }) {
   return (
-    <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide px-4 pt-6 pb-2">
+    <Text className="text-xs font-semibold text-slate-400 uppercase tracking-wide pt-6 pb-2">
       {title}
     </Text>
   );
@@ -59,64 +63,66 @@ export default function SettingsScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
+        <ResponsiveContainer>
         {/* Header */}
-        <View className="flex-row items-center px-4 pt-2 pb-3 border-b border-slate-50">
+        <View className="flex-row items-center pt-2 pb-3 border-b border-slate-50">
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
-            <FontAwesome name="arrow-left" size={18} color={colors.text} />
+            <ArrowLeft size={18} color={colors.text} />
           </Pressable>
           <Text className="text-2xl font-bold text-slate-900">Настройки</Text>
         </View>
 
         <SectionTitle title="Уведомления" />
         <SettingRow
-          icon="bell"
+          icon={Bell}
           label="Push-уведомления"
           rightElement={
             <Switch accessibilityLabel="Push-уведомления" value={pushEnabled} onValueChange={setPushEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
         <SettingRow
-          icon="envelope"
+          icon={Mail}
           label="Email-уведомления"
           rightElement={
             <Switch accessibilityLabel="Email-уведомления" value={emailEnabled} onValueChange={setEmailEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
         <SettingRow
-          icon="comments"
+          icon={MessageCircle}
           label="Уведомления о сообщениях"
           rightElement={
             <Switch accessibilityLabel="Уведомления о сообщениях" value={messageEnabled} onValueChange={setMessageEnabled} trackColor={{ false: colors.border, true: colors.primary }} thumbColor={colors.surface} />
           }
         />
         <SettingRow
-          icon="list"
+          icon={List}
           label="Все уведомления"
           onPress={() => router.push("/notifications" as never)}
         />
 
         <SectionTitle title="Настройки" />
-        <SettingRow icon="language" label="Язык" />
-        <SettingRow icon="moon-o" label="Тема" />
+        <SettingRow icon={Globe} label="Язык" />
+        <SettingRow icon={Moon} label="Тема" />
 
         <SectionTitle title="Аккаунт" />
-        <SettingRow icon="envelope-o" label="Сменить email" />
-        <SettingRow icon="trash-o" label="Удалить аккаунт" />
+        <SettingRow icon={AtSign} label="Сменить email" />
+        <SettingRow icon={Trash2} label="Удалить аккаунт" />
 
         <SectionTitle title="О приложении" />
         <SettingRow
-          icon="file-text-o"
+          icon={FileText}
           label="Политика конфиденциальности"
           onPress={() => router.push("/legal/privacy" as never)}
         />
         <SettingRow
-          icon="file-text-o"
+          icon={FileText}
           label="Условия использования"
           onPress={() => router.push("/legal/terms" as never)}
         />
-        <SettingRow icon="info-circle" label="Версия" rightElement={
+        <SettingRow icon={Info} label="Версия" rightElement={
           <Text className="text-sm text-slate-400">1.0.0</Text>
         } />
+        </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Pencil, Plus, LogOut } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
@@ -314,7 +314,7 @@ export default function SpecialistSettings() {
                   onPress={() => router.push("/onboarding/work-area" as never)}
                   className="flex-row items-center justify-center py-2 mb-4"
                 >
-                  <FontAwesome name="pencil" size={12} color={colors.accent} />
+                  <Pencil size={12} color={colors.accent} />
                   <Text className="text-sm text-amber-700 ml-1 font-medium">
                     Изменить рабочую зону
                   </Text>
@@ -327,7 +327,7 @@ export default function SpecialistSettings() {
                 onPress={() => router.push("/onboarding/work-area" as never)}
                 className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
               >
-                <FontAwesome name="plus" size={14} color={colors.accent} />
+                <Plus size={14} color={colors.accent} />
                 <Text className="text-sm text-amber-700 ml-2 font-medium">
                   Добавить ИФНС и услуги
                 </Text>
@@ -401,7 +401,7 @@ export default function SpecialistSettings() {
                 onPress={handleLogout}
                 className="flex-row items-center px-4 py-3"
               >
-                <FontAwesome name="sign-out" size={16} color={colors.error} />
+                <LogOut size={16} color={colors.error} />
                 <Text className="text-base text-red-600 ml-3 flex-1">
                   Выйти из аккаунта
                 </Text>

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -9,7 +9,10 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import Head from "expo-router/head";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  AlertCircle, Pencil, MapPin, Clock, ChevronRight,
+  Phone, Mail, Send, MessageCircle, Globe, type LucideIcon
+} from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
@@ -72,13 +75,13 @@ function getContactUrl(type: string, value: string): string | null {
   }
 }
 
-const CONTACT_TYPE_CONFIG: Record<string, { label: string; icon: string; bg: string; color: string }> = {
-  phone: { label: "Телефон", icon: "phone", bg: "#eff6ff", color: colors.primary },
-  email: { label: "Email", icon: "envelope", bg: "#f0fdf4", color: "#166534" },
-  telegram: { label: "Telegram", icon: "paper-plane", bg: "#f0f9ff", color: "#0284c7" },
-  whatsapp: { label: "WhatsApp", icon: "whatsapp", bg: "#f0fdf4", color: "#059669" },
-  vk: { label: "ВКонтакте", icon: "vk", bg: "#eff6ff", color: "#2563eb" },
-  website: { label: "Сайт", icon: "globe", bg: "#fafaf9", color: "#57534e" },
+const CONTACT_TYPE_CONFIG: Record<string, { label: string; Icon: LucideIcon; bg: string; color: string }> = {
+  phone: { label: "Телефон", Icon: Phone, bg: "#eff6ff", color: colors.primary },
+  email: { label: "Email", Icon: Mail, bg: "#f0fdf4", color: "#166534" },
+  telegram: { label: "Telegram", Icon: Send, bg: "#f0f9ff", color: "#0284c7" },
+  whatsapp: { label: "WhatsApp", Icon: MessageCircle, bg: "#f0fdf4", color: "#059669" },
+  vk: { label: "ВКонтакте", Icon: Globe, bg: "#eff6ff", color: "#2563eb" },
+  website: { label: "Сайт", Icon: Globe, bg: "#fafaf9", color: "#57534e" },
 };
 
 interface SimilarSpecialist {
@@ -165,7 +168,7 @@ export default function SpecialistPublicProfile() {
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Профиль специалиста" />
         <View className="flex-1 items-center justify-center px-6">
-          <FontAwesome name="exclamation-circle" size={48} color={colors.placeholder} />
+          <AlertCircle size={48} color={colors.placeholder} />
           <Text className="text-xl font-semibold text-slate-900 mt-4 text-center">
             Специалист не найден
           </Text>
@@ -204,7 +207,7 @@ export default function SpecialistPublicProfile() {
       accessibilityLabel="Редактировать профиль"
       onPress={() => router.push("/settings" as never)}
     >
-      <FontAwesome name="pencil" size={16} color={colors.text} />
+      <Pencil size={16} color={colors.text} />
     </Pressable>
   ) : undefined;
 
@@ -251,7 +254,7 @@ export default function SpecialistPublicProfile() {
 
               {cities.length > 0 && (
                 <View className="flex-row items-center mt-1.5">
-                  <FontAwesome name="map-marker" size={12} color={colors.placeholder} />
+                  <MapPin size={12} color={colors.placeholder} />
                   <Text className="text-sm text-slate-500 ml-1.5">{cities.join(", ")}</Text>
                 </View>
               )}
@@ -333,7 +336,7 @@ export default function SpecialistPublicProfile() {
                 {contacts.map((contact, index) => {
                   const cfg = CONTACT_TYPE_CONFIG[contact.type] || {
                     label: contact.type,
-                    icon: "link",
+                    Icon: Globe,
                     bg: colors.background,
                     color: colors.textSecondary,
                   };
@@ -356,7 +359,7 @@ export default function SpecialistPublicProfile() {
                           className="w-8 h-8 rounded-full items-center justify-center mr-3"
                           style={{ backgroundColor: cfg.bg }}
                         >
-                          <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                          <cfg.Icon size={14} color={cfg.color} />
                         </View>
                         <View className="flex-1">
                           <Text className="text-xs text-slate-400 mb-0.5">{cfg.label}</Text>
@@ -364,7 +367,7 @@ export default function SpecialistPublicProfile() {
                             {contact.value}
                           </Text>
                         </View>
-                        <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />
+                        <ChevronRight size={12} color={colors.borderLight} />
                       </Pressable>
                     );
                   }
@@ -377,7 +380,7 @@ export default function SpecialistPublicProfile() {
                         className="w-8 h-8 rounded-full items-center justify-center mr-3"
                         style={{ backgroundColor: cfg.bg }}
                       >
-                        <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                        <cfg.Icon size={14} color={cfg.color} />
                       </View>
                       <View className="flex-1">
                         <Text className="text-xs text-slate-400 mb-0.5">{cfg.label}</Text>
@@ -390,7 +393,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.officeAddress && (
                   <View className={`flex-row items-start py-2.5 ${specialist.profile?.workingHours ? "border-b border-slate-100" : ""}`}>
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
-                      <FontAwesome name="map-marker" size={14} color={colors.textSecondary} />
+                      <MapPin size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Адрес офиса</Text>
@@ -404,7 +407,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.workingHours && (
                   <View className="flex-row items-center py-2.5">
                     <View className="w-8 h-8 rounded-full bg-slate-100 items-center justify-center mr-3">
-                      <FontAwesome name="clock-o" size={14} color={colors.textSecondary} />
+                      <Clock size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs text-slate-400 mb-0.5">Часы работы</Text>

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -11,6 +11,7 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
+import { AlertCircle, UserX } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
@@ -175,7 +176,7 @@ export default function SpecialistsCatalog() {
     if (error) {
       return (
         <EmptyState
-          icon="exclamation-circle"
+          icon={AlertCircle}
           title="Не удалось загрузить список"
           subtitle="Проверьте соединение с интернетом и попробуйте снова"
           actionLabel="Повторить"
@@ -190,7 +191,7 @@ export default function SpecialistsCatalog() {
     if (specialists.length === 0) {
       return (
         <EmptyState
-          icon="user-times"
+          icon={UserX}
           title="Специалистов не найдено"
           subtitle="Попробуйте изменить фильтры или выбрать другой город"
           actionLabel={hasFilters ? "Сбросить фильтры" : undefined}

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -14,7 +14,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, router } from "expo-router";
 import * as DocumentPicker from "expo-document-picker";
 import * as Linking from "expo-linking";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ChevronLeft, AlertCircle, User, MessageCircle, File, X, Paperclip, Send } from "lucide-react-native";
 import MessageBubble from "@/components/MessageBubble";
 import { Avatar } from "@/components/ui";
 import Input from "@/components/ui/Input";
@@ -286,7 +286,7 @@ export default function ChatThread() {
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+            <ChevronLeft size={18} color={colors.primary} />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
         </View>
@@ -302,12 +302,12 @@ export default function ChatThread() {
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-slate-100">
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+            <ChevronLeft size={18} color={colors.primary} />
           </Pressable>
           <Text className="text-base font-semibold text-slate-900">Чат</Text>
         </View>
         <View className="flex-1 items-center justify-center px-4">
-          <FontAwesome name="exclamation-circle" size={40} color={colors.error} />
+          <AlertCircle size={40} color={colors.error} />
           <Text className="text-base text-red-600 text-center mt-3">{error}</Text>
           <Pressable
             accessibilityRole="button"
@@ -329,7 +329,7 @@ export default function ChatThread() {
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-slate-100 bg-white">
         <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center" style={({ pressed }) => [pressed && { opacity: 0.7 }]}>
-          <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+          <ChevronLeft size={18} color={colors.primary} />
         </Pressable>
         {otherUser ? (
           <Avatar
@@ -339,7 +339,7 @@ export default function ChatThread() {
           />
         ) : (
           <View className="w-9 h-9 rounded-full bg-slate-200 items-center justify-center">
-            <FontAwesome name="user" size={16} color={colors.placeholder} />
+            <User size={16} color={colors.placeholder} />
           </View>
         )}
         <View className="ml-3 flex-1">
@@ -370,7 +370,7 @@ export default function ChatThread() {
           }}
           ListEmptyComponent={
             <View className="flex-1 items-center justify-center py-16">
-              <FontAwesome name="comments-o" size={48} color={colors.placeholder} />
+              <MessageCircle size={48} color={colors.placeholder} />
               <Text className="text-base text-slate-500 font-medium mt-4">Начните общение</Text>
               <Text className="text-sm text-slate-400 mt-1 text-center px-4">
                 Напишите сообщение, чтобы начать диалог
@@ -396,7 +396,7 @@ export default function ChatThread() {
                 key={i}
                 className="flex-row items-center bg-white border border-slate-200 rounded-lg px-2 py-1 mr-2 mb-1"
               >
-                <FontAwesome name="file-o" size={13} color={colors.primary} />
+                <File size={13} color={colors.primary} />
                 <Text className="text-xs text-slate-700 mx-1 max-w-[90px]" numberOfLines={1}>
                   {f.name}
                 </Text>
@@ -407,7 +407,7 @@ export default function ChatThread() {
                   accessibilityLabel={`Удалить файл ${f.name}`}
                   style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                 >
-                  <FontAwesome name="times" size={11} color={colors.placeholder} />
+                  <X size={11} color={colors.placeholder} />
                 </Pressable>
               </View>
             ))}
@@ -426,8 +426,7 @@ export default function ChatThread() {
               className="w-11 h-11 items-center justify-center mr-1"
               style={({ pressed }) => [pressed && { opacity: 0.7 }]}
             >
-              <FontAwesome
-                name="paperclip"
+              <Paperclip
                 size={20}
                 color={pendingFiles.length >= 3 ? colors.borderLight : colors.textSecondary}
               />
@@ -456,8 +455,7 @@ export default function ChatThread() {
               {sending || uploading ? (
                 <ActivityIndicator size="small" color={colors.primary} />
               ) : (
-                <FontAwesome
-                  name="send"
+                <Send
                   size={20}
                   color={(text.trim() || pendingFiles.length > 0) ? colors.primary : colors.placeholder}
                 />

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -1,5 +1,4 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 
 interface SelectOption {
   id: string;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable, useWindowDimensions } from "react-native";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Menu, Bell } from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { useState } from "react";
 import MobileMenu from "./MobileMenu";
@@ -20,7 +20,7 @@ export default function Header() {
       <>
         <View className="flex-row items-center justify-between px-4 h-14 bg-white border-b border-slate-100">
           <Pressable accessibilityRole="button" accessibilityLabel="Открыть меню" onPress={() => setMenuOpen(true)} className="w-11 h-11 items-center justify-center">
-            <FontAwesome name="bars" size={20} color={colors.text} />
+            <Menu size={20} color={colors.text} />
           </Pressable>
 
           <Text className="text-lg font-bold text-blue-900">P2PTax</Text>
@@ -33,7 +33,7 @@ export default function Header() {
                 onPress={() => router.push("/notifications" as never)}
                 className="w-11 h-11 items-center justify-center"
               >
-                <FontAwesome name="bell-o" size={18} color={colors.text} />
+                <Bell size={18} color={colors.text} />
               </Pressable>
               <Pressable
                 accessibilityRole="button"
@@ -81,7 +81,7 @@ export default function Header() {
             onPress={() => router.push("/notifications" as never)}
             className="w-11 h-11 rounded-lg items-center justify-center active:bg-slate-100"
           >
-            <FontAwesome name="bell-o" size={18} color={colors.text} />
+            <Bell size={18} color={colors.text} />
           </Pressable>
           <Pressable
             accessibilityRole="button"

--- a/components/HeaderBack.tsx
+++ b/components/HeaderBack.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ArrowLeft } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 interface HeaderBackProps {
@@ -19,7 +19,7 @@ export default function HeaderBack({ title, rightAction }: HeaderBackProps) {
         onPress={() => router.back()}
         className="w-11 h-11 items-center justify-center -ml-2"
       >
-        <FontAwesome name="arrow-left" size={18} color={colors.text} />
+        <ArrowLeft size={18} color={colors.text} />
       </Pressable>
       <Text className="flex-1 text-center text-base font-semibold text-slate-900" numberOfLines={1}>
         {title}

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Bell, Settings } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 interface HeaderHomeProps {
@@ -21,7 +21,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
           onPress={() => router.push("/notifications" as never)}
           className="w-11 h-11 items-center justify-center"
         >
-          <FontAwesome name="bell-o" size={18} color={colors.surface} />
+          <Bell size={18} color={colors.surface} />
           {notificationCount > 0 && (
             <View className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-amber-500 items-center justify-center px-1">
               <Text className="text-[9px] font-bold text-white">
@@ -37,7 +37,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
             onPress={onSettingsPress}
             className="w-11 h-11 items-center justify-center"
           >
-            <FontAwesome name="cog" size={18} color={colors.surface} />
+            <Settings size={18} color={colors.surface} />
           </Pressable>
         )}
       </View>

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ImageIcon, File, FileText, Download } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 interface FileAttachment {
@@ -65,8 +65,7 @@ export default function MessageBubble({
             className="mb-1"
           >
             <View className="w-[200px] h-[200px] bg-slate-200 rounded-xl items-center justify-center">
-              <FontAwesome
-                name="image"
+              <ImageIcon
                 size={32}
                 color={isOwn ? colors.surface : colors.textSecondary}
               />
@@ -91,11 +90,10 @@ export default function MessageBubble({
               isOwn ? "bg-blue-800" : "bg-slate-100"
             }`}
           >
-            <FontAwesome
-              name={file.mimeType === "application/pdf" ? "file-pdf-o" : "file-o"}
-              size={18}
-              color={isOwn ? "#93c5fd" : colors.primary}
-            />
+            {file.mimeType === "application/pdf"
+              ? <FileText size={18} color={isOwn ? "#93c5fd" : colors.primary} />
+              : <File size={18} color={isOwn ? "#93c5fd" : colors.primary} />
+            }
             <View className="ml-2 flex-1">
               <Text
                 className={`text-sm ${isOwn ? "text-white" : "text-slate-900"}`}
@@ -109,11 +107,7 @@ export default function MessageBubble({
                 {formatFileSize(file.size)}
               </Text>
             </View>
-            <FontAwesome
-              name="download"
-              size={12}
-              color={isOwn ? "#93c5fd" : colors.placeholder}
-            />
+            <Download size={12} color={isOwn ? "#93c5fd" : colors.placeholder} />
           </Pressable>
         ))}
 

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,14 +1,14 @@
 import { View, Text, Pressable, Modal } from "react-native";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { User, X, Home, FileText, Users, Settings, LogOut, type LucideIcon } from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors } from "@/lib/theme";
 
-const MENU_ITEMS: { label: string; route: string; icon: React.ComponentProps<typeof FontAwesome>["name"] }[] = [
-  { label: "Главная", route: "/", icon: "home" },
-  { label: "Заявки", route: "/requests", icon: "file-text-o" },
-  { label: "Специалисты", route: "/specialists", icon: "users" },
-  { label: "Настройки", route: "/settings", icon: "cog" },
+const MENU_ITEMS: { label: string; route: string; Icon: LucideIcon }[] = [
+  { label: "Главная", route: "/", Icon: Home },
+  { label: "Заявки", route: "/requests", Icon: FileText },
+  { label: "Специалисты", route: "/specialists", Icon: Users },
+  { label: "Настройки", route: "/settings", Icon: Settings },
 ];
 
 interface MobileMenuProps {
@@ -53,7 +53,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
             ) : (
               <>
                 <View className="w-14 h-14 rounded-full bg-slate-50 items-center justify-center mb-3">
-                  <FontAwesome name="user" size={24} color={colors.primary} />
+                  <User size={24} color={colors.primary} />
                 </View>
                 <Text className="text-lg font-bold text-white">Гость</Text>
                 <Text className="text-sm text-slate-50 mt-0.5">Войдите для продолжения</Text>
@@ -63,7 +63,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
 
           {/* Close button */}
           <Pressable accessibilityRole="button" accessibilityLabel="Закрыть меню" onPress={onClose} className="absolute top-12 right-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="times" size={20} color={colors.surface} />
+            <X size={20} color={colors.surface} />
           </Pressable>
 
           {/* Menu items */}
@@ -77,7 +77,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
                 className="flex-row items-center px-5 py-3.5 active:bg-slate-50"
               >
                 <View className="w-8 items-center">
-                  <FontAwesome name={item.icon} size={18} color={colors.textSecondary} />
+                  <item.Icon size={18} color={colors.textSecondary} />
                 </View>
                 <Text className="text-base text-slate-800 ml-3">{item.label}</Text>
               </Pressable>
@@ -88,7 +88,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
           <View className="border-t border-slate-100 px-5 py-4 pb-8">
             {isAuthenticated ? (
               <Pressable accessibilityRole="button" accessibilityLabel="Выйти" onPress={handleLogout} className="flex-row items-center py-3">
-                <FontAwesome name="sign-out" size={18} color={colors.error} />
+                <LogOut size={18} color={colors.error} />
                 <Text className="text-base font-medium text-red-600 ml-3">Выйти</Text>
               </Pressable>
             ) : (

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { MapPin } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 interface SpecialistCardProps {
@@ -83,7 +83,7 @@ export default function SpecialistCard({
           </Text>
           {cities.length > 0 && (
             <View className="flex-row items-center mt-0.5">
-              <FontAwesome name="map-marker" size={10} color={colors.placeholder} />
+              <MapPin size={10} color={colors.placeholder} />
               <Text className="text-xs text-slate-400 ml-1" numberOfLines={1}>
                 {cities.map((c) => c.name).join(", ")}
               </Text>

--- a/components/requests/CityFnsServicePicker.tsx
+++ b/components/requests/CityFnsServicePicker.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable, ScrollView, ActivityIndicator } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ChevronUp, ChevronDown } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 export interface CityOption {
@@ -88,7 +88,9 @@ export default function CityFnsServicePicker({
           <Text className={selectedCity ? "text-slate-900 text-base" : "text-slate-400 text-base"}>
             {selectedCity?.name || "Выберите город"}
           </Text>
-          <FontAwesome name={cityOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
+          {cityOpen
+            ? <ChevronUp size={12} color={colors.placeholder} />
+            : <ChevronDown size={12} color={colors.placeholder} />}
         </Pressable>
         {submitted && !selectedCity && (
           <Text className="text-xs text-red-600 mt-1">Выберите город</Text>
@@ -151,8 +153,10 @@ export default function CityFnsServicePicker({
           </Text>
           {loadingFns ? (
             <ActivityIndicator size="small" color={colors.placeholder} />
+          ) : fnsOpen ? (
+            <ChevronUp size={12} color={colors.placeholder} />
           ) : (
-            <FontAwesome name={fnsOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
+            <ChevronDown size={12} color={colors.placeholder} />
           )}
         </Pressable>
         {submitted && selectedCity && !selectedFns && (
@@ -204,7 +208,7 @@ export default function CityFnsServicePicker({
           <Text className={selectedService ? "text-slate-900 text-base" : "text-slate-400 text-base"}>
             {selectedService?.name || "Не знаю / не указывать"}
           </Text>
-          <FontAwesome name={serviceOpen ? "chevron-up" : "chevron-down"} size={12} color={colors.placeholder} />
+          {serviceOpen ? <ChevronUp size={12} color={colors.placeholder} /> : <ChevronDown size={12} color={colors.placeholder} />}
         </Pressable>
         {serviceOpen && (
           <View

--- a/components/requests/FileUploadSection.tsx
+++ b/components/requests/FileUploadSection.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback } from "react";
 import { View, Text, Pressable, ActivityIndicator, Platform } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { FileImage, File, X, Plus } from "lucide-react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -112,11 +112,10 @@ export default function FileUploadSection({
           key={`file-${index}`}
           className="flex-row items-center bg-slate-50 border border-slate-200 rounded-xl px-3 py-2.5 mb-2"
         >
-          <FontAwesome
-            name={file.mimeType === "application/pdf" ? "file-pdf-o" : "file-image-o"}
-            size={18}
-            color={file.error ? colors.error : colors.primary}
-          />
+          {file.mimeType === "application/pdf"
+            ? <File size={18} color={file.error ? colors.error : colors.primary} />
+            : <FileImage size={18} color={file.error ? colors.error : colors.primary} />
+          }
           <View className="flex-1 mx-2">
             <Text className="text-sm text-slate-900" numberOfLines={1}>
               {file.name}
@@ -140,7 +139,7 @@ export default function FileUploadSection({
               onPress={() => handleRemoveFile(index)}
               className="w-11 h-11 items-center justify-center"
             >
-              <FontAwesome name="times" size={14} color={colors.placeholder} />
+              <X size={14} color={colors.placeholder} />
             </Pressable>
           )}
         </View>
@@ -153,7 +152,7 @@ export default function FileUploadSection({
           onPress={handleAddFilePress}
           className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl active:bg-slate-50"
         >
-          <FontAwesome name="plus" size={13} color={colors.accent} />
+          <Plus size={13} color={colors.accent} />
           <Text className="text-sm text-amber-700 ml-2 font-medium">
             + Прикрепить файл
           </Text>

--- a/components/requests/SpecialistRecommendations.tsx
+++ b/components/requests/SpecialistRecommendations.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { ChevronRight } from "lucide-react-native";
 import Avatar from "@/components/ui/Avatar";
 import { colors } from "@/lib/theme";
 
@@ -84,7 +84,7 @@ export default function SpecialistRecommendations({
                   </Text>
                 )}
               </View>
-              <FontAwesome name="chevron-right" size={12} color={colors.placeholder} />
+              <ChevronRight size={12} color={colors.placeholder} />
             </View>
           </Pressable>
         );

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -8,7 +8,7 @@ import {
   Alert,
   Platform,
 } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Pencil } from "lucide-react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { API_URL } from "@/lib/api";
 import { colors } from "@/lib/theme";
@@ -108,7 +108,7 @@ export default function AvatarUploader({
               className="absolute bottom-0 right-0 bg-blue-900 rounded-full items-center justify-center"
               style={{ width: 24, height: 24 }}
             >
-              <FontAwesome name="pencil" size={12} color={colors.surface} />
+              <Pencil size={12} color={colors.surface} />
             </View>
           </View>
         ) : (

--- a/components/settings/ContactMethodsList.tsx
+++ b/components/settings/ContactMethodsList.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable, Alert } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Trash2, ChevronDown, Plus } from "lucide-react-native";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import { apiPost, apiDelete } from "@/lib/api";
@@ -120,7 +120,7 @@ export default function ContactMethodsList({
             onPress={() => handleDeleteContact(contact.id)}
             className="ml-2 p-2"
           >
-            <FontAwesome name="trash-o" size={16} color={colors.error} />
+            <Trash2 size={16} color={colors.error} />
           </Pressable>
         </View>
       ))}
@@ -137,7 +137,7 @@ export default function ContactMethodsList({
             <Text className="text-base text-slate-900">
               {CONTACT_TYPE_LABELS[newContactType]}
             </Text>
-            <FontAwesome name="chevron-down" size={12} color={colors.placeholder} />
+            <ChevronDown size={12} color={colors.placeholder} />
           </Pressable>
           {showTypePicker && (
             <View className="bg-white border border-slate-200 rounded-xl overflow-hidden mb-3">
@@ -221,7 +221,7 @@ export default function ContactMethodsList({
           onPress={() => onAddingContactChange(true)}
           className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
         >
-          <FontAwesome name="plus" size={14} color={colors.primary} />
+          <Plus size={14} color={colors.primary} />
           <Text className="text-sm text-blue-900 ml-2 font-medium">
             Добавить контакт
           </Text>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,5 +1,5 @@
 import { Pressable, Text, ActivityIndicator } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { type LucideIcon } from "lucide-react-native";
 import { colors } from "../../lib/theme";
 
 export interface ButtonProps {
@@ -9,7 +9,7 @@ export interface ButtonProps {
   loading?: boolean;
   disabled?: boolean;
   fullWidth?: boolean;
-  icon?: React.ComponentProps<typeof FontAwesome>["name"];
+  icon?: LucideIcon;
 }
 
 const variantStyles = {
@@ -37,7 +37,7 @@ export default function Button({
   loading = false,
   disabled = false,
   fullWidth = true,
-  icon,
+  icon: Icon,
 }: ButtonProps) {
   const styles = variantStyles[variant];
   const widthClass = fullWidth ? "w-full" : "";
@@ -61,9 +61,8 @@ export default function Button({
         <ActivityIndicator color={styles.iconColor} />
       ) : (
         <>
-          {icon && (
-            <FontAwesome
-              name={icon}
+          {Icon && (
+            <Icon
               size={18}
               color={styles.iconColor}
               style={{ marginRight: 8 }}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,10 +1,10 @@
 import { View, Text } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Inbox, type LucideIcon } from "lucide-react-native";
 import Button from "./Button";
 import { colors } from "../../lib/theme";
 
 export interface EmptyStateProps {
-  icon?: React.ComponentProps<typeof FontAwesome>["name"];
+  icon?: LucideIcon;
   title: string;
   subtitle?: string;
   actionLabel?: string;
@@ -12,7 +12,7 @@ export interface EmptyStateProps {
 }
 
 export default function EmptyState({
-  icon = "inbox",
+  icon: Icon = Inbox,
   title,
   subtitle,
   actionLabel,
@@ -24,7 +24,7 @@ export default function EmptyState({
         className="items-center justify-center rounded-full bg-slate-100"
         style={{ width: 72, height: 72 }}
       >
-        <FontAwesome name={icon} size={32} color={colors.placeholder} />
+        <Icon size={32} color={colors.placeholder} />
       </View>
       <Text className="text-base font-semibold text-slate-900 mt-4 text-center">
         {title}

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -1,5 +1,5 @@
 import { View, Text } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { AlertCircle } from "lucide-react-native";
 import Button from "./Button";
 import { colors } from "../../lib/theme";
 
@@ -18,7 +18,7 @@ export default function ErrorState({
         className="items-center justify-center rounded-full bg-red-50"
         style={{ width: 72, height: 72 }}
       >
-        <FontAwesome name="exclamation-circle" size={32} color={colors.error} />
+        <AlertCircle size={32} color={colors.error} />
       </View>
       <Text className="text-base font-medium text-slate-900 mt-4 text-center">
         {message}

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { View, Text, TextInput, type TextInputProps, type ViewStyle } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { type LucideIcon } from "lucide-react-native";
 import { colors, radiusValue } from "../../lib/theme";
 
 export interface InputProps {
@@ -9,7 +9,7 @@ export interface InputProps {
   value: string;
   onChangeText: (text: string) => void;
   error?: string;
-  icon?: React.ComponentProps<typeof FontAwesome>["name"];
+  icon?: LucideIcon;
   secureTextEntry?: boolean;
   multiline?: boolean;
   keyboardType?: TextInputProps["keyboardType"];
@@ -32,7 +32,7 @@ export default function Input({
   value,
   onChangeText,
   error,
-  icon,
+  icon: Icon,
   secureTextEntry,
   multiline,
   keyboardType,
@@ -75,9 +75,8 @@ export default function Input({
           paddingHorizontal: 12,
         }, containerStyle]}
       >
-        {icon && (
-          <FontAwesome
-            name={icon}
+        {Icon && (
+          <Icon
             size={18}
             color={colors.placeholder}
             style={{ marginRight: 8 }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
         "expo-web-browser": "~15.0.10",
+        "lucide-react-native": "^1.8.0",
         "nativewind": "^4.2.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -3445,6 +3446,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -3965,6 +3973,60 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -4095,6 +4157,65 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -4147,6 +4268,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -6209,6 +6343,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react-native": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-1.8.0.tgz",
+      "integrity": "sha512-trgqSA2ghSHUE3yLUBTdhjF1EMbgcJuccI1VXe6zTI2u4tbeUXbtXeHGORRdeGUdC80XBn/XJa1YrG8uvKhpNg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -6223,6 +6368,13 @@
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -6798,6 +6950,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -7983,6 +8148,22 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.15.4",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.4.tgz",
+      "integrity": "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
     "expo-web-browser": "~15.0.10",
+    "lucide-react-native": "^1.8.0",
     "nativewind": "^4.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- Replaced `@expo/vector-icons` with `lucide-react-native` across 52 files (0 remaining)
- Added `ResponsiveContainer` / `useWindowDimensions` to non-responsive screens
- TypeScript: 0 errors, smoke: 88/88 ALL CLEAN

## Test plan
- [ ] Run `metromap test` — expect ALL CLEAN
- [ ] Open app on desktop — screens should be centered, not stretched

🤖 Generated with [Claude Code](https://claude.com/claude-code)