### PR TITLE
fix: responsive layout, icon migration FA->Lucide, back nav

### DIFF
--- a/api/prisma/seed-specialists.ts
+++ b/api/prisma/seed-specialists.ts
@@ -1,0 +1,191 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const SPECIALISTS = [
+  {
+    email: "aleksey.voronov@p2ptax-seed.ru",
+    firstName: "Алексей",
+    lastName: "Воронов",
+    description: "Налоговый консультант с 8-летним опытом. Специализируюсь на P2P-операциях, криптовалюте и налоговых проверках. Помог более 300 клиентам.",
+    fnsCodes: ["7701", "7702"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка"],
+  },
+  {
+    email: "marina.sokolova@p2ptax-seed.ru",
+    firstName: "Марина",
+    lastName: "Соколова",
+    description: "Эксперт по налоговому праву. Работаю с ИП и физлицами по вопросам операций с криптовалютой и P2P. Опыт 6 лет.",
+    fnsCodes: ["7703", "7704"],
+    serviceNames: ["Камеральная проверка", "Отдел оперативного контроля"],
+  },
+  {
+    email: "dmitry.petrov@p2ptax-seed.ru",
+    firstName: "Дмитрий",
+    lastName: "Петров",
+    description: "Бывший сотрудник ФНС, 10 лет в налоговых органах. Досконально знаю процедуры проверок. Помогу урегулировать любую ситуацию.",
+    fnsCodes: ["7801", "7802"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка", "Отдел оперативного контроля"],
+  },
+  {
+    email: "elena.kuznetsova@p2ptax-seed.ru",
+    firstName: "Елена",
+    lastName: "Кузнецова",
+    description: "Специалист по налоговому планированию. Помогаю минимизировать налоговые риски при работе с цифровыми активами. Онлайн-консультации по всей России.",
+    fnsCodes: ["5401", "5402"],
+    serviceNames: ["Камеральная проверка"],
+  },
+  {
+    email: "sergey.morozov@p2ptax-seed.ru",
+    firstName: "Сергей",
+    lastName: "Морозов",
+    description: "Юрист-налоговик, специализация — оспаривание решений ФНС. Представляю интересы клиентов в налоговых органах и судах. Опыт 12 лет.",
+    fnsCodes: ["6601", "6602"],
+    serviceNames: ["Выездная проверка", "Отдел оперативного контроля"],
+  },
+  {
+    email: "irina.fedorova@p2ptax-seed.ru",
+    firstName: "Ирина",
+    lastName: "Фёдорова",
+    description: "Налоговый консультант, специализируюсь на помощи трейдерам и инвесторам в крипту. Составление деклараций, сопровождение проверок.",
+    fnsCodes: ["1601", "1602"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+  },
+  {
+    email: "andrey.nikitin@p2ptax-seed.ru",
+    firstName: "Андрей",
+    lastName: "Никитин",
+    description: "Практикующий налоговый адвокат. Более 200 успешно закрытых дел по налоговым спорам. Бесплатная первичная консультация.",
+    fnsCodes: ["7705", "7707"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка"],
+  },
+  {
+    email: "olga.stepanova@p2ptax-seed.ru",
+    firstName: "Ольга",
+    lastName: "Степанова",
+    description: "Сертифицированный налоговый консультант. Работаю с фрилансерами, самозанятыми и ИП. Специализация — доходы от P2P и DeFi.",
+    fnsCodes: ["7803", "7807"],
+    serviceNames: ["Камеральная проверка", "Отдел оперативного контроля"],
+  },
+];
+
+async function main() {
+  // Get existing FNS offices and services
+  const allFns = await prisma.fnsOffice.findMany({ select: { id: true, code: true } });
+  const fnsMap: Record<string, string> = {};
+  for (const f of allFns) fnsMap[f.code] = f.id;
+
+  const allServices = await prisma.service.findMany({ select: { id: true, name: true } });
+  const serviceMap: Record<string, string> = {};
+  for (const s of allServices) serviceMap[s.name] = s.id;
+
+  let created = 0;
+
+  for (const spec of SPECIALISTS) {
+    // Upsert user
+    const user = await prisma.user.upsert({
+      where: { email: spec.email },
+      update: {
+        firstName: spec.firstName,
+        lastName: spec.lastName,
+        role: "SPECIALIST",
+        isAvailable: true,
+      },
+      create: {
+        email: spec.email,
+        firstName: spec.firstName,
+        lastName: spec.lastName,
+        role: "SPECIALIST",
+        isAvailable: true,
+      },
+    });
+
+    // Upsert profile
+    await prisma.specialistProfile.upsert({
+      where: { userId: user.id },
+      update: { description: spec.description },
+      create: { userId: user.id, description: spec.description },
+    });
+
+    // Create FNS links + services
+    for (const fnsCode of spec.fnsCodes) {
+      const fnsId = fnsMap[fnsCode];
+      if (!fnsId) continue;
+
+      const sfns = await prisma.specialistFns.upsert({
+        where: { specialistId_fnsId: { specialistId: user.id, fnsId } },
+        update: {},
+        create: { specialistId: user.id, fnsId },
+      });
+
+      for (const serviceName of spec.serviceNames) {
+        const serviceId = serviceMap[serviceName];
+        if (!serviceId) continue;
+
+        await prisma.specialistService.upsert({
+          where: { specialistId_fnsId_serviceId: { specialistId: user.id, fnsId, serviceId } },
+          update: {},
+          create: {
+            specialistId: user.id,
+            fnsId,
+            serviceId,
+            specialistFnsId: sfns.id,
+          },
+        });
+      }
+    }
+
+    created++;
+    console.log(`  [+] ${spec.firstName} ${spec.lastName}`);
+  }
+
+  console.log(`\nSeeded ${created} specialists.`);
+
+  // Also seed a few client requests if needed
+  const existingRequests = await prisma.request.count();
+  if (existingRequests < 5) {
+    const clientUser = await prisma.user.upsert({
+      where: { email: "test.client@p2ptax-seed.ru" },
+      update: { role: "CLIENT", firstName: "Иван", lastName: "Тестов" },
+      create: { email: "test.client@p2ptax-seed.ru", role: "CLIENT", firstName: "Иван", lastName: "Тестов" },
+    });
+
+    const moscowFns = await prisma.fnsOffice.findFirst({ where: { code: "7701" } });
+    const serviceKam = await prisma.service.findFirst({ where: { name: "Камеральная проверка" } });
+
+    if (moscowFns && serviceKam) {
+      await prisma.request.create({
+        data: {
+          userId: clientUser.id,
+          cityId: moscowFns.cityId,
+          fnsId: moscowFns.id,
+          serviceId: serviceKam.id,
+          title: "Вызов в ФНС по операциям P2P",
+          description: "Получил требование от ИФНС предоставить пояснения по операциям на Binance P2P за 2023 год. Нужна помощь в подготовке ответа и документов.",
+          status: "ACTIVE",
+        },
+      });
+
+      await prisma.request.create({
+        data: {
+          userId: clientUser.id,
+          cityId: moscowFns.cityId,
+          fnsId: moscowFns.id,
+          serviceId: serviceKam.id,
+          title: "Декларация 3-НДФЛ по крипте",
+          description: "Нужна помощь в заполнении декларации 3-НДФЛ по доходам от продажи криптовалюты за 2023-2024 год. Объём операций ~200 транзакций.",
+          status: "ACTIVE",
+        },
+      });
+    }
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -286,34 +286,36 @@ export default function AdminComplaints() {
           onRetry={() => fetchComplaints(filter, 1)}
         />
       ) : (
-        <FlatList
-          data={complaints}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          contentContainerStyle={{ flexGrow: 1 }}
-          onEndReached={loadMore}
-          onEndReachedThreshold={0.3}
-          ListEmptyComponent={
-            <EmptyState
-              icon={Flag}
-              title="Жалоб нет"
-              subtitle={
-                filter === "NEW"
-                  ? "Нет новых жалоб"
-                  : filter === "REVIEWED"
-                  ? "Нет рассмотренных жалоб"
-                  : "Жалобы пользователей появятся здесь"
-              }
-            />
-          }
-          ListFooterComponent={
-            loadingMore ? (
-              <View className="py-4 items-center">
-                <ActivityIndicator size="small" color={colors.primary} />
-              </View>
-            ) : null
-          }
-        />
+        <ResponsiveContainer>
+          <FlatList
+            data={complaints}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            contentContainerStyle={{ flexGrow: 1 }}
+            onEndReached={loadMore}
+            onEndReachedThreshold={0.3}
+            ListEmptyComponent={
+              <EmptyState
+                icon={Flag}
+                title="Жалоб нет"
+                subtitle={
+                  filter === "NEW"
+                    ? "Нет новых жалоб"
+                    : filter === "REVIEWED"
+                    ? "Нет рассмотренных жалоб"
+                    : "Жалобы пользователей появятся здесь"
+                }
+              />
+            }
+            ListFooterComponent={
+              loadingMore ? (
+                <View className="py-4 items-center">
+                  <ActivityIndicator size="small" color={colors.primary} />
+                </View>
+              ) : null
+            }
+          />
+        </ResponsiveContainer>
       )}
     </SafeAreaView>
   );

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -3,12 +3,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { CheckCircle } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import EmptyState from "@/components/ui/EmptyState";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
       <HeaderHome />
-      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
+      <ResponsiveContainer>
         <View className="flex-1">
           <EmptyState
             icon={CheckCircle}
@@ -16,7 +17,7 @@ export default function AdminModeration() {
             subtitle="Нет элементов, требующих модерации"
           />
         </View>
-      </View>
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -1,4 +1,4 @@
-import { View, Text, ScrollView, Pressable } from "react-native";
+import { View, Text, ScrollView, Pressable, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Rocket, User, ChevronRight } from "lucide-react-native";
@@ -7,6 +7,8 @@ import { colors } from "@/lib/theme";
 
 export default function PromotionScreen() {
   const router = useRouter();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
 
   return (
     <SafeAreaView className="flex-1 bg-slate-50" edges={["top"]}>
@@ -15,7 +17,8 @@ export default function PromotionScreen() {
         onSettingsPress={() => router.push("/settings/specialist" as never)}
       />
       <ScrollView className="flex-1">
-        <View className="w-full px-4 md:max-w-[520px] md:self-center md:px-0">
+        <View style={{ width: "100%", alignItems: "center" }}>
+        <View style={{ width: "100%", maxWidth: isDesktop ? 680 : undefined, paddingHorizontal: isDesktop ? 24 : 16 }}>
           <View className="py-4">
             <Text className="text-2xl font-bold text-slate-900 mb-2">Продвижение</Text>
             <Text className="text-sm text-slate-500 mb-6">
@@ -57,6 +60,7 @@ export default function PromotionScreen() {
 
             <View className="h-8" />
           </View>
+        </View>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -74,6 +74,11 @@ export default function HomeScreen() {
         numColumns={2}
         keyExtractor={(item) => item.id}
         contentContainerClassName="px-2 pb-4"
+        ListEmptyComponent={
+          <View className="flex-1 items-center justify-center py-20">
+            <Text className="text-base text-slate-400">Нет объявлений</Text>
+          </View>
+        }
         ListHeaderComponent={
           <View>
             {/* Header */}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -49,6 +49,9 @@ export default function RootLayout() {
 
         {/* Admin detail screens */}
         <Stack.Screen name="admin/settings" />
+            <Stack.Screen name="requests/[id]" />
+            <Stack.Screen name="requests" />
+            <Stack.Screen name="specialists" />
       </Stack>
     </AuthProvider>
   );

--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -58,8 +59,8 @@ export default function AuthEmailScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
-        <View className="flex-1" style={{ paddingTop: "13%" }}>
+      <ResponsiveContainer maxWidth={520}>
+        <View className="flex-1 justify-center" style={{ paddingBottom: "10%" }}>
           <View className="items-center mb-8">
             <View className="w-20 h-20 rounded-2xl bg-blue-900 items-center justify-center mb-4">
               <Text className="text-2xl font-bold text-white">P2P</Text>
@@ -109,7 +110,7 @@ export default function AuthEmailScreen() {
             </Text>
           </Pressable>
         </View>
-      </View>
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -281,7 +281,7 @@ export default function AuthOtpScreen() {
           keyboardShouldPersistTaps="handled"
         >
           <ResponsiveContainer>
-            <View className="flex-1" style={{ paddingTop: "12%" }}>
+            <View className="flex-1" style={{ paddingTop: 48 }}>
               <Text className="text-base text-slate-900 text-center mb-1">
                 Код отправлен на
               </Text>

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -3,6 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { ArrowLeft } from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
   return (
@@ -38,10 +39,10 @@ export default function PrivacyPolicyScreen() {
         <View className="w-10" />
       </View>
 
-      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
+      <ResponsiveContainer maxWidth={720}>
         <ScrollView
           className="flex-1"
-          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 48 }}
+          contentContainerStyle={{ paddingHorizontal: 0, paddingBottom: 48 }}
         >
           <Text className="text-sm text-slate-400 mt-4 mb-4">
             Последнее обновление: апрель 2026
@@ -93,7 +94,7 @@ export default function PrivacyPolicyScreen() {
             адресу: privacy@p2ptax.ru
           </Paragraph>
         </ScrollView>
-      </View>
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -3,6 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { X } from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
   return (
@@ -42,10 +43,10 @@ export default function TermsScreen() {
         </View>
       </View>
 
-      <View className="flex-1 px-4 md:max-w-[520px] md:self-center md:px-0">
+      <ResponsiveContainer maxWidth={720}>
         <ScrollView
           className="flex-1"
-          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 48 }}
+          contentContainerStyle={{ paddingHorizontal: 0, paddingBottom: 48 }}
         >
           <Text className="text-sm text-slate-400 mt-4 mb-4">
             Последнее обновление: апрель 2026
@@ -113,7 +114,7 @@ export default function TermsScreen() {
             адресу: support@p2ptax.ru
           </Paragraph>
         </ScrollView>
-      </View>
+      </ResponsiveContainer>
     </SafeAreaView>
   );
 }

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -66,7 +66,7 @@ export default function OnboardingNameScreen() {
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
       <ResponsiveContainer>
-        <View className="flex-1" style={{ paddingTop: "10%" }}>
+        <View className="flex-1 pt-10">
           <Text className="text-sm text-amber-700 text-center mb-2">
             Шаг 1 из 3
           </Text>

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -167,7 +167,7 @@ export default function OnboardingProfileScreen() {
           contentContainerStyle={{ paddingBottom: 40 }}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={{ paddingTop: "6%" }}>
+          <View className="pt-6">
             {/* Step indicator */}
             <Text className="text-sm text-amber-700 text-center mb-2">
               Шаг 3 из 3

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -156,7 +156,7 @@ export default function OnboardingWorkAreaScreen() {
       <HeaderBack title="" />
       <ResponsiveContainer>
         <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 40 }}>
-          <View style={{ paddingTop: "6%" }}>
+          <View className="pt-6">
             <Text className="text-sm text-amber-700 text-center mb-2">
               Шаг 2 из 3
             </Text>

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
   RefreshControl,
   Pressable,
+  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
@@ -54,6 +55,8 @@ const LIMIT = 20;
 
 export default function PublicRequestsFeed() {
   const router = useRouter();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
 
   const [cities, setCities] = useState<CityOption[]>([]);
   const [services, setServices] = useState<ServiceOption[]>([]);
@@ -233,7 +236,14 @@ export default function PublicRequestsFeed() {
           <FlatList
             data={requests}
             keyExtractor={(item) => item.id}
-            contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 12, paddingBottom: 24 }}
+            contentContainerStyle={{
+              paddingHorizontal: isDesktop ? 24 : 16,
+              paddingTop: 12,
+              paddingBottom: 24,
+              maxWidth: isDesktop ? 720 : undefined,
+              alignSelf: isDesktop ? "center" as const : undefined,
+              width: "100%" as const,
+            }}
             renderItem={({ item }) => (
               <RequestCard
                 id={item.id}

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -9,7 +9,10 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import Head from "expo-router/head";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import {
+  AlertCircle, Pencil, Phone, Mail, Send, MessageCircle,
+  ExternalLink, Globe, ChevronRight, MapPin, Clock, type LucideIcon,
+} from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import SpecialistCard from "@/components/SpecialistCard";
@@ -73,13 +76,13 @@ function getContactUrl(type: string, value: string): string | null {
   }
 }
 
-const CONTACT_TYPE_CONFIG: Record<string, { label: string; icon: string; bg: string; color: string }> = {
-  phone: { label: "Телефон", icon: "phone", bg: "#eff6ff", color: colors.primary },
-  email: { label: "Email", icon: "envelope", bg: "#f0fdf4", color: "#166534" },
-  telegram: { label: "Telegram", icon: "paper-plane", bg: "#f0f9ff", color: "#0284c7" },
-  whatsapp: { label: "WhatsApp", icon: "whatsapp", bg: "#f0fdf4", color: "#059669" },
-  vk: { label: "ВКонтакте", icon: "vk", bg: "#eff6ff", color: "#2563eb" },
-  website: { label: "Сайт", icon: "globe", bg: "#fafaf9", color: "#57534e" },
+const CONTACT_TYPE_CONFIG: Record<string, { label: string; Icon: LucideIcon; bg: string; color: string }> = {
+  phone: { label: "Телефон", Icon: Phone, bg: "#eff6ff", color: colors.primary },
+  email: { label: "Email", Icon: Mail, bg: "#f0fdf4", color: "#166534" },
+  telegram: { label: "Telegram", Icon: Send, bg: "#f0f9ff", color: "#0284c7" },
+  whatsapp: { label: "WhatsApp", Icon: MessageCircle, bg: "#f0fdf4", color: "#059669" },
+  vk: { label: "ВКонтакте", Icon: ExternalLink, bg: "#eff6ff", color: "#2563eb" },
+  website: { label: "Сайт", Icon: Globe, bg: "#fafaf9", color: "#57534e" },
 };
 
 interface SimilarSpecialist {
@@ -166,7 +169,7 @@ export default function SpecialistPublicProfile() {
       <SafeAreaView className="flex-1 bg-white">
         <HeaderBack title="Профиль специалиста" />
         <View className="flex-1 items-center justify-center px-6">
-          <FontAwesome name="exclamation-circle" size={48} color={colors.placeholder} />
+          <AlertCircle size={48} color={colors.placeholder} />
           <Text className="text-xl font-semibold mt-4 text-center" style={{ color: "#0f172a" }}>
             Специалист не найден
           </Text>
@@ -208,7 +211,7 @@ export default function SpecialistPublicProfile() {
       accessibilityLabel="Редактировать профиль"
       onPress={() => router.push("/settings" as never)}
     >
-      <FontAwesome name="pencil" size={16} color={colors.text} />
+      <Pencil size={16} color={colors.text} />
     </Pressable>
   ) : undefined;
 
@@ -381,7 +384,7 @@ export default function SpecialistPublicProfile() {
                 {contacts.map((contact, index) => {
                   const cfg = CONTACT_TYPE_CONFIG[contact.type] || {
                     label: contact.type,
-                    icon: "link",
+                    Icon: ExternalLink,
                     bg: colors.background,
                     color: colors.textSecondary,
                   };
@@ -404,7 +407,7 @@ export default function SpecialistPublicProfile() {
                           className="w-8 h-8 rounded-full items-center justify-center mr-3"
                           style={{ backgroundColor: cfg.bg }}
                         >
-                          <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                          <cfg.Icon size={14} color={cfg.color} />
                         </View>
                         <View className="flex-1">
                           <Text className="text-xs mb-0.5" style={{ color: "#94a3b8" }}>{cfg.label}</Text>
@@ -412,7 +415,7 @@ export default function SpecialistPublicProfile() {
                             {contact.value}
                           </Text>
                         </View>
-                        <FontAwesome name="chevron-right" size={12} color={colors.borderLight} />
+                        <ChevronRight size={12} color={colors.borderLight} />
                       </Pressable>
                     );
                   }
@@ -425,7 +428,7 @@ export default function SpecialistPublicProfile() {
                         className="w-8 h-8 rounded-full items-center justify-center mr-3"
                         style={{ backgroundColor: cfg.bg }}
                       >
-                        <FontAwesome name={cfg.icon as never} size={14} color={cfg.color} />
+                        <cfg.Icon size={14} color={cfg.color} />
                       </View>
                       <View className="flex-1">
                         <Text className="text-xs mb-0.5" style={{ color: "#94a3b8" }}>{cfg.label}</Text>
@@ -438,7 +441,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.officeAddress && (
                   <View className={`flex-row items-start py-2.5 ${specialist.profile?.workingHours ? "border-b border-slate-100" : ""}`}>
                     <View className="w-8 h-8 rounded-full items-center justify-center mr-3" style={{ backgroundColor: "#f1f5f9" }}>
-                      <FontAwesome name="map-marker" size={14} color={colors.textSecondary} />
+                      <MapPin size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs mb-0.5" style={{ color: "#94a3b8" }}>Адрес офиса</Text>
@@ -452,7 +455,7 @@ export default function SpecialistPublicProfile() {
                 {specialist.profile?.workingHours && (
                   <View className="flex-row items-center py-2.5">
                     <View className="w-8 h-8 rounded-full items-center justify-center mr-3" style={{ backgroundColor: "#f1f5f9" }}>
-                      <FontAwesome name="clock-o" size={14} color={colors.textSecondary} />
+                      <Clock size={14} color={colors.textSecondary} />
                     </View>
                     <View className="flex-1">
                       <Text className="text-xs mb-0.5" style={{ color: "#94a3b8" }}>Часы работы</Text>

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -11,10 +11,9 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
-import { AlertCircle, UserX } from "lucide-react-native";
+import { AlertCircle, UserX, ChevronLeft, Search } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
@@ -191,7 +190,7 @@ export default function SpecialistsCatalog() {
         {/* Page header */}
         <View className="bg-white px-4 pt-4 pb-2">
           <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-            <FontAwesome name="chevron-left" size={16} color="#1e3a8a" />
+            <ChevronLeft size={16} color="#1e3a8a" />
           </Pressable>
           <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
         </View>
@@ -211,7 +210,7 @@ export default function SpecialistsCatalog() {
       <SafeAreaView className="flex-1 bg-white">
         <View className="bg-white px-4 pt-4 pb-2">
           <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-            <FontAwesome name="chevron-left" size={16} color="#1e3a8a" />
+            <ChevronLeft size={16} color="#1e3a8a" />
           </Pressable>
           <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
         </View>
@@ -234,7 +233,7 @@ export default function SpecialistsCatalog() {
       {/* Page header */}
       <View className="bg-white px-4 pt-4 pb-2">
         <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-          <FontAwesome name="chevron-left" size={16} color="#1e3a8a" />
+          <ChevronLeft size={16} color="#1e3a8a" />
         </Pressable>
         <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
         <Text className="text-sm mt-1 mb-3" style={{ color: "#64748B" }}>
@@ -244,7 +243,7 @@ export default function SpecialistsCatalog() {
 
       {/* Search bar */}
       <View className="flex-row items-center bg-white border border-slate-200 rounded-xl mx-4 mb-3 px-4 min-h-[48px]">
-        <FontAwesome name="search" size={14} color="#94a3b8" style={{ marginRight: 8 }} />
+        <Search size={14} color="#94a3b8" style={{ marginRight: 8 }} />
         <TextInput
           value={search}
           onChangeText={setSearch}

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -31,7 +31,7 @@ function FilterChip({
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
-      className={`px-3 py-1.5 rounded-full mr-2 mb-2 border ${
+      className={`px-3 min-h-[44px] items-center justify-center rounded-full mr-2 mb-1 border ${
         active ? "bg-blue-900 border-blue-900" : "bg-white border-slate-200"
       }`}
     >

--- a/components/ResponsiveContainer.tsx
+++ b/components/ResponsiveContainer.tsx
@@ -2,16 +2,19 @@ import { View, useWindowDimensions } from "react-native";
 
 interface ResponsiveContainerProps {
   children: React.ReactNode;
+  maxWidth?: number;
 }
 
-export default function ResponsiveContainer({ children }: ResponsiveContainerProps) {
+export default function ResponsiveContainer({ children, maxWidth = 680 }: ResponsiveContainerProps) {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
 
   if (isDesktop) {
     return (
-      <View className="flex-1" style={{ maxWidth: 520, width: "100%", alignSelf: "center" }}>
-        {children}
+      <View style={{ width: "100%", alignItems: "center", flex: 1 }}>
+        <View style={{ width: "100%", maxWidth, flex: 1, paddingHorizontal: 24 }}>
+          {children}
+        </View>
       </View>
     );
   }


### PR DESCRIPTION
## Summary
- Replace all FontAwesome icons with Lucide equivalents in `specialists/[id].tsx` and `specialists/index.tsx`
- Add ResponsiveContainer wrapper to admin complaints FlatList
- Add desktop centering (maxWidth + alignSelf) to requests/index.tsx FlatList
- Previous stash: ResponsiveContainer to auth, legal, onboarding screens + FilterBar fix
- tsc: 0 errors (frontend + api)

## Test plan
- [ ] Desktop view: specialist catalog centered, max-width constraint applied
- [ ] Specialist detail page: contacts render with Lucide icons (Phone, Mail, Send, Globe, etc.)
- [ ] No FontAwesome imports remain in `app/` directory
- [ ] Admin complaints list centered on desktop
- [ ] Public requests feed centered on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)