### PR TITLE
fix: empty name greeting + post-OTP redirect

### DIFF
--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -91,7 +91,7 @@ export default function ClientDashboard() {
           {/* Welcome header */}
           <View className="pt-4 pb-2">
             <Text className="text-2xl font-bold text-slate-900">
-              Здравствуйте, {user?.firstName ?? ""}!
+              {user?.firstName ? `Здравствуйте, ${user.firstName}!` : "Здравствуйте!"}
             </Text>
           </View>
 

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -202,8 +202,8 @@ export default function AuthOtpScreen() {
     if (role === "SPECIALIST") {
       router.replace("/onboarding/name" as never);
     } else {
-      // CLIENT — go to new request creation
-      router.replace("/requests/new" as never);
+      // CLIENT — go to dashboard
+      router.replace("/(client-tabs)/dashboard" as never);
     }
   };
 


### PR DESCRIPTION
## Fixes
- Greeting: show 'Здравствуйте!' when name is empty (was 'Здравствуйте, !')
- Post-OTP redirect: goes to correct dashboard by role (was redirecting to /requests/new)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>