### PR TITLE
fix: metromap — dead-ends, TextInput borders, inline colors #1213

### DIFF
--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -224,6 +224,7 @@ export default function AdminUsers() {
             paddingHorizontal: 14,
             color: colors.surface,
             fontSize: 15,
+            outlineWidth: 0,
           }}
           placeholder="Поиск по email или имени..."
           placeholderTextColor="rgba(255,255,255,0.5)"

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -17,6 +17,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
 import InlineChatView from "@/components/InlineChatView";
 import { apiGet } from "@/lib/api";
+import { colors } from "@/lib/theme";
 
 interface ThreadItem {
   id: string;
@@ -129,7 +130,7 @@ export default function ClientMessages() {
           onPress={handlePress}
           className="flex-row items-center py-3 border-b border-border active:bg-surface2"
           style={({ pressed }) => [
-            { backgroundColor: selected ? "#eff6ff" : "white" },
+            { backgroundColor: selected ? colors.accentSoft : colors.surface },
             pressed && { opacity: 0.7 },
           ]}
         >
@@ -156,20 +157,20 @@ export default function ClientMessages() {
                 className={`text-base flex-1 flex-shrink ${
                   hasUnread ? "font-bold" : "font-semibold"
                 }`}
-                style={{ color: "#0f172a" }}
+                style={{ color: colors.text }}
                 numberOfLines={1}
               >
                 {name}
               </Text>
               {item.lastMessage && (
-                <Text className="text-xs flex-shrink-0" style={{ color: "#94a3b8" }}>
+                <Text className="text-xs flex-shrink-0" style={{ color: colors.textMuted }}>
                   {formatTime(item.lastMessage.createdAt)}
                 </Text>
               )}
             </View>
 
             {/* Request title */}
-            <Text className="text-xs mt-0.5" style={{ color: "#94a3b8" }} numberOfLines={1}>
+            <Text className="text-xs mt-0.5" style={{ color: colors.textMuted }} numberOfLines={1}>
               {item.request.title}
             </Text>
 
@@ -177,13 +178,13 @@ export default function ClientMessages() {
             {item.lastMessage ? (
               <Text
                 className={`text-sm mt-0.5 ${hasUnread ? "font-semibold" : ""}`}
-                style={{ color: hasUnread ? "#334155" : "#94a3b8" }}
+                style={{ color: hasUnread ? colors.textSecondary : colors.textMuted }}
                 numberOfLines={1}
               >
                 {item.lastMessage.text}
               </Text>
             ) : (
-              <Text className="text-sm mt-0.5 italic" style={{ color: "#cbd5e1" }} numberOfLines={1}>
+              <Text className="text-sm mt-0.5 italic" style={{ color: colors.borderStrong }} numberOfLines={1}>
                 Нет сообщений
               </Text>
             )}
@@ -199,7 +200,7 @@ export default function ClientMessages() {
       <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
         <HeaderHome />
         <View className="flex-1 items-center justify-center">
-          <ActivityIndicator size="large" color="#2256c2" />
+          <ActivityIndicator size="large" color={colors.primary} />
         </View>
       </SafeAreaView>
     );
@@ -223,7 +224,7 @@ export default function ClientMessages() {
         <HeaderHome />
         <View className="flex-1 flex-row">
           {/* Thread list panel */}
-          <View style={{ width: 300, borderRightWidth: 1, borderRightColor: "#e2e8f0" }}>
+          <View style={{ maxWidth: 300, flex: 1, borderRightWidth: 1, borderRightColor: colors.border }}>
             <FlatList
               data={sorted}
               keyExtractor={(item) => item.id}
@@ -238,13 +239,13 @@ export default function ClientMessages() {
                 <RefreshControl
                   refreshing={refreshing}
                   onRefresh={handleRefresh}
-                  tintColor="#2256c2"
+                  tintColor={colors.primary}
                 />
               }
               contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 12 }}
               ListEmptyComponent={
                 <View className="flex-1 items-center justify-center py-16 px-4">
-                  <Text className="text-sm text-center" style={{ color: "#94a3b8" }}>Нет сообщений</Text>
+                  <Text className="text-sm text-center" style={{ color: colors.textMuted }}>Нет сообщений</Text>
                 </View>
               }
             />
@@ -255,7 +256,7 @@ export default function ClientMessages() {
               <InlineChatView threadId={selectedThreadId} />
             ) : (
               <View className="flex-1 items-center justify-center">
-                <Text className="text-sm" style={{ color: "#94a3b8" }}>Выберите диалог</Text>
+                <Text className="text-sm" style={{ color: colors.textMuted }}>Выберите диалог</Text>
               </View>
             )}
           </View>
@@ -276,7 +277,7 @@ export default function ClientMessages() {
           <RefreshControl
             refreshing={refreshing}
             onRefresh={handleRefresh}
-            tintColor="#2256c2"
+            tintColor={colors.primary}
           />
         }
         ListEmptyComponent={

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,12 +13,12 @@ export default function TabLayout() {
       <Header />
       <Tabs
         screenOptions={{
-          tabBarActiveTintColor: "#2563eb",
+          tabBarActiveTintColor: colors.primary,
           tabBarInactiveTintColor: colors.textSecondary,
           tabBarStyle: {
             display: isMobile ? "flex" : "none",
             borderTopWidth: 1,
-            borderTopColor: "#f3f4f6",
+            borderTopColor: colors.border,
           },
           headerShown: false,
         }}

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -53,7 +53,7 @@ export default function CreateScreen() {
           {/* Tips */}
           <View className="p-4 rounded-xl bg-amber-50 border border-amber-200">
             <View className="flex-row items-center mb-2">
-              <Lightbulb size={16} color="#d97706" />
+              <Lightbulb size={16} color={colors.warning} />
               <Text className="text-sm font-semibold text-amber-800 ml-2">Tips for great photos</Text>
             </View>
             <Text className="text-sm text-amber-700 leading-5">

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ function CategoryChip({ name, Icon }: { name: string; Icon: LucideIcon }) {
   return (
     <Pressable accessibilityRole="button" accessibilityLabel={name} className="mr-3 items-center">
       <View className="w-14 h-14 rounded-2xl bg-gray-100 items-center justify-center mb-1">
-        <Icon size={20} color="#4b5563" />
+        <Icon size={20} color={colors.textSecondary} />
       </View>
       <Text className="text-xs text-gray-600">{name}</Text>
     </Pressable>

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -44,7 +44,7 @@ export default function SearchScreen() {
                 placeholderTextColor={colors.textSecondary}
               />
               <Pressable accessibilityRole="button" accessibilityLabel="Фильтры" className="ml-2 w-11 h-11 rounded-lg bg-blue-600 items-center justify-center">
-                <SlidersHorizontal size={16} color="#ffffff" />
+                <SlidersHorizontal size={16} color={colors.surface} />
               </Pressable>
             </View>
           </View>
@@ -83,7 +83,7 @@ export default function SearchScreen() {
                 style={{ backgroundColor: cat.color }}
               >
                 <View className="w-10 h-10 rounded-lg bg-white items-center justify-center">
-                  <cat.Icon size={18} color="#4b5563" />
+                  <cat.Icon size={18} color={colors.textSecondary} />
                 </View>
                 <View className="flex-1 ml-3">
                   <Text className="text-base font-medium text-gray-900">{cat.name}</Text>

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -317,6 +317,7 @@ export default function AuthOtpScreen() {
                       fontSize: 22,
                       fontWeight: "700",
                       color: error ? colors.error : colors.text,
+                      outlineWidth: 0,
                     }}
                     value={digit}
                     onChangeText={(v) => handleDigitChange(i, v)}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
+import { colors } from "@/lib/theme";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import HeroSection from "@/components/landing/HeroSection";
@@ -91,7 +92,7 @@ export default function LandingScreen() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-row items-center justify-between h-16 bg-white px-4">
-          <Text className="text-lg font-extrabold" style={{ color: "#2256c2" }}>P2PTax</Text>
+          <Text className="text-lg font-extrabold" style={{ color: colors.primary }}>P2PTax</Text>
         </View>
         <ErrorState
           message="Не удалось загрузить данные. Проверьте соединение с интернетом и попробуйте снова."
@@ -123,14 +124,14 @@ export default function LandingScreen() {
               onPress={handleHome}
               className="min-h-[44px] justify-center"
             >
-              <Text className="text-xl font-extrabold" style={{ color: "#2256c2" }}>P2PTax</Text>
+              <Text className="text-xl font-extrabold" style={{ color: colors.primary }}>P2PTax</Text>
             </Pressable>
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Создать заявку"
               onPress={handleCreateRequest}
               className="rounded-lg px-4 min-h-[44px] items-center justify-center"
-              style={{ backgroundColor: "#2256c2" }}
+              style={{ backgroundColor: colors.primary }}
             >
               <Text className="text-white font-semibold text-sm">Создать заявку</Text>
             </Pressable>

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -1,8 +1,6 @@
-import { View, Text, Pressable, ScrollView } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
-import { ArrowLeft } from "lucide-react-native";
-import { colors } from "@/lib/theme";
+import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
@@ -20,24 +18,9 @@ function Paragraph({ children }: { children: string }) {
 }
 
 export default function PrivacyPolicyScreen() {
-  const router = useRouter();
-
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <View className="flex-row items-center h-14 bg-white border-b border-border px-4">
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Назад"
-          onPress={() => router.back()}
-          className="w-11 h-11 items-center justify-center -ml-2"
-        >
-          <ArrowLeft size={18} color={colors.text} />
-        </Pressable>
-        <Text className="flex-1 text-center text-base font-semibold text-text-base">
-          Политика конфиденциальности
-        </Text>
-        <View className="w-10" />
-      </View>
+      <HeaderBack title="Политика конфиденциальности" />
 
       <ResponsiveContainer maxWidth={720}>
         <ScrollView

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -1,8 +1,6 @@
-import { View, Text, Pressable, ScrollView } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
-import { X } from "lucide-react-native";
-import { colors } from "@/lib/theme";
+import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
@@ -20,28 +18,9 @@ function Paragraph({ children }: { children: string }) {
 }
 
 export default function TermsScreen() {
-  const router = useRouter();
-
   return (
     <SafeAreaView className="flex-1 bg-white">
-      {/* Header with close button */}
-      <View className="flex-row items-center h-14 bg-white border-b border-border px-4">
-        <View className="flex-1" />
-        <Text className="text-base font-semibold text-text-base">
-          Условия использования
-        </Text>
-        <View className="flex-1 items-end">
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Закрыть"
-            onPress={() => router.back()}
-            className="w-11 h-11 items-center justify-center"
-            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
-          >
-            <X size={20} color={colors.text} />
-          </Pressable>
-        </View>
-      </View>
+      <HeaderBack title="Пользовательское соглашение" />
 
       <ResponsiveContainer maxWidth={720}>
         <ScrollView

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -219,6 +219,7 @@ export default function SpecialistConfirmWrite() {
               backgroundColor: isLimitReached ? colors.background : colors.surface,
               textAlignVertical: "top",
               opacity: isLimitReached ? 0.5 : 1,
+              outlineWidth: 0,
             }}
           />
 

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -94,10 +94,10 @@ export default function SpecialistPublicProfile() {
         <HeaderBack title="Профиль специалиста" />
         <View className="flex-1 items-center justify-center px-6">
           <AlertCircle size={48} color={colors.placeholder} />
-          <Text className="text-xl font-semibold mt-4 text-center" style={{ color: "#0f172a" }}>
+          <Text className="text-xl font-semibold mt-4 text-center" style={{ color: colors.text }}>
             Специалист не найден
           </Text>
-          <Text className="text-sm mt-2 text-center leading-5" style={{ color: "#64748B" }}>
+          <Text className="text-sm mt-2 text-center leading-5" style={{ color: colors.textSecondary }}>
             Возможно, профиль был удалён или вы перешли по неверной ссылке
           </Text>
           <View className="mt-6">
@@ -245,7 +245,7 @@ export default function SpecialistPublicProfile() {
             {/* Own profile banner */}
             {isOwnProfile && (
               <View className="mx-4 mt-2 mb-4 rounded-xl py-3.5 items-center" style={{ backgroundColor: "#f1f5f9" }}>
-                <Text className="text-sm font-semibold" style={{ color: "#64748B" }}>Это вы</Text>
+                <Text className="text-sm font-semibold" style={{ color: colors.textSecondary }}>Это вы</Text>
               </View>
             )}
 

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -187,10 +187,10 @@ export default function SpecialistPublicProfile() {
                 className="bg-white rounded-2xl border border-slate-100 p-4 mx-4 mt-4"
                 style={cardShadow}
               >
-                <Text style={{ color: "#94a3b8", fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
+                <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
                   О СЕБЕ
                 </Text>
-                <Text className="text-base leading-6" style={{ color: "#334155" }}>
+                <Text className="text-base leading-6" style={{ color: colors.textSecondary }}>
                   {specialist.profile.description}
                 </Text>
               </View>
@@ -210,10 +210,10 @@ export default function SpecialistPublicProfile() {
               className="bg-white rounded-2xl border border-slate-100 p-4 mx-4 mt-4"
               style={cardShadow}
             >
-              <Text style={{ color: "#94a3b8", fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
+              <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
                 ОТЗЫВЫ
               </Text>
-              <Text className="text-sm italic" style={{ color: "#94a3b8" }}>
+              <Text className="text-sm italic" style={{ color: colors.textMuted }}>
                 Отзывы появятся в следующих версиях
               </Text>
             </View>
@@ -221,7 +221,7 @@ export default function SpecialistPublicProfile() {
             {/* Similar specialists */}
             {similar.length > 0 && (
               <View className="mx-4 mt-4 mb-4">
-                <Text style={{ color: "#94a3b8", fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
+                <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
                   ПОХОЖИЕ СПЕЦИАЛИСТЫ
                 </Text>
                 <ScrollView horizontal showsHorizontalScrollIndicator={false}>
@@ -244,7 +244,7 @@ export default function SpecialistPublicProfile() {
 
             {/* Own profile banner */}
             {isOwnProfile && (
-              <View className="mx-4 mt-2 mb-4 rounded-xl py-3.5 items-center" style={{ backgroundColor: "#f1f5f9" }}>
+              <View className="mx-4 mt-2 mb-4 rounded-xl py-3.5 items-center" style={{ backgroundColor: colors.surface2 }}>
                 <Text className="text-sm font-semibold" style={{ color: colors.textSecondary }}>Это вы</Text>
               </View>
             )}

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   TextInput,
   FlatList,
-  Pressable,
   ActivityIndicator,
   RefreshControl,
   useWindowDimensions,
@@ -13,7 +12,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
-import { AlertCircle, UserX, ChevronLeft, Search } from "lucide-react-native";
+import HeaderBack from "@/components/HeaderBack";
+import { AlertCircle, UserX, Search } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
@@ -187,13 +187,7 @@ export default function SpecialistsCatalog() {
   if (loading && specialists.length === 0) {
     return (
       <SafeAreaView className="flex-1 bg-white">
-        {/* Page header */}
-        <View className="bg-white px-4 pt-4 pb-2">
-          <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-            <ChevronLeft size={16} color="#2256c2" />
-          </Pressable>
-          <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
-        </View>
+        <HeaderBack title="Специалисты" />
         <View className="py-4 px-4">
           {Array.from({ length: 5 }).map((_, i) => (
             <View key={i} className="mb-3 bg-white rounded-2xl overflow-hidden border border-slate-100">
@@ -208,12 +202,7 @@ export default function SpecialistsCatalog() {
   if (error && specialists.length === 0) {
     return (
       <SafeAreaView className="flex-1 bg-white">
-        <View className="bg-white px-4 pt-4 pb-2">
-          <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-            <ChevronLeft size={16} color="#2256c2" />
-          </Pressable>
-          <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
-        </View>
+        <HeaderBack title="Специалисты" />
         <EmptyState
           icon={AlertCircle}
           title="Не удалось загрузить список"
@@ -230,11 +219,8 @@ export default function SpecialistsCatalog() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      {/* Page header */}
-      <View className="bg-white px-4 pt-4 pb-2">
-        <Pressable onPress={() => router.back()} className="min-h-[44px] justify-center mb-2 self-start">
-          <ChevronLeft size={16} color="#2256c2" />
-        </Pressable>
+      <HeaderBack title="Специалисты" />
+      <View className="bg-white px-4 pt-3 pb-2">
         <Text className="font-extrabold text-3xl" style={{ color: "#0f172a" }}>Каталог специалистов</Text>
         <Text className="text-sm mt-1 mb-3" style={{ color: "#64748B" }}>
           Практики с опытом в вашей ИФНС. Выбирайте по инспекции, городу и типу проверки.

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -54,7 +54,7 @@ export default function SpecialistCard({
         </Text>
         <View className="flex-row flex-wrap gap-1 mb-1">
           {services.slice(0, 2).map((s) => (
-            <View key={s.id} className="px-1.5 py-0.5 rounded" style={{ backgroundColor: "rgba(34,86,194,0.1)" }}>
+            <View key={s.id} className="px-1.5 py-0.5 rounded" style={{ backgroundColor: colors.accentSoft }}>
               <Text className="text-[10px]" style={{ color: colors.primary }}>{s.name}</Text>
             </View>
           ))}
@@ -107,7 +107,7 @@ export default function SpecialistCard({
             <View
               key={s.id}
               className="px-2.5 py-1 rounded-full"
-              style={{ backgroundColor: "rgba(34,86,194,0.1)" }}
+              style={{ backgroundColor: colors.accentSoft }}
             >
               <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
             </View>
@@ -118,7 +118,7 @@ export default function SpecialistCard({
       {/* City */}
       {cities.length > 0 && (
         <View className="flex-row items-center mt-2">
-          <FontAwesome name="map-marker" size={10} color="#94a3b8" />
+          <FontAwesome name="map-marker" size={10} color={colors.textMuted} />
           <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
             {cities.map((c) => c.name).join(", ")}
           </Text>

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
 
 interface SpecialistCardProps {
   id: string;
@@ -43,26 +44,26 @@ export default function SpecialistCard({
         accessibilityLabel={name}
         onPress={() => onPress(id)}
         className="bg-white border border-border rounded-xl p-4 mr-3"
-        style={({ pressed }) => [{ width: 200 }, pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
+        style={({ pressed }) => [{ maxWidth: 200, flex: 1 }, pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
       >
-        <View className="w-12 h-12 rounded-full items-center justify-center mb-2" style={{ backgroundColor: "#2256c2" }}>
+        <View className="w-12 h-12 rounded-full items-center justify-center mb-2" style={{ backgroundColor: colors.primary }}>
           <Text className="text-white font-bold text-base">{initials}</Text>
         </View>
-        <Text className="text-base font-semibold mb-1" style={{ color: "#0f172a" }} numberOfLines={1}>
+        <Text className="text-base font-semibold mb-1" style={{ color: colors.text }} numberOfLines={1}>
           {name}
         </Text>
         <View className="flex-row flex-wrap gap-1 mb-1">
           {services.slice(0, 2).map((s) => (
             <View key={s.id} className="px-1.5 py-0.5 rounded" style={{ backgroundColor: "rgba(34,86,194,0.1)" }}>
-              <Text className="text-[10px]" style={{ color: "#2256c2" }}>{s.name}</Text>
+              <Text className="text-[10px]" style={{ color: colors.primary }}>{s.name}</Text>
             </View>
           ))}
           {services.length > 2 && (
-            <Text className="text-[10px]" style={{ color: "#94a3b8" }}>+{services.length - 2}</Text>
+            <Text className="text-[10px]" style={{ color: colors.textMuted }}>+{services.length - 2}</Text>
           )}
         </View>
         {cities.length > 0 && (
-          <Text className="text-xs" style={{ color: "#94a3b8" }} numberOfLines={1}>
+          <Text className="text-xs" style={{ color: colors.textMuted }} numberOfLines={1}>
             {cities.map((c) => c.name).join(", ")}
           </Text>
         )}
@@ -88,13 +89,13 @@ export default function SpecialistCard({
       </View>
 
       {/* Name */}
-      <Text className="text-base font-bold mt-3" style={{ color: "#0f172a" }} numberOfLines={1}>
+      <Text className="text-base font-bold mt-3" style={{ color: colors.text }} numberOfLines={1}>
         {name}
       </Text>
 
       {/* Description */}
       {description ? (
-        <Text className="text-sm mt-1" style={{ color: "#64748B" }} numberOfLines={2}>
+        <Text className="text-sm mt-1" style={{ color: colors.textSecondary }} numberOfLines={2}>
           {description}
         </Text>
       ) : null}
@@ -108,7 +109,7 @@ export default function SpecialistCard({
               className="px-2.5 py-1 rounded-full"
               style={{ backgroundColor: "rgba(34,86,194,0.1)" }}
             >
-              <Text className="text-xs font-medium" style={{ color: "#2256c2" }}>{s.name}</Text>
+              <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
             </View>
           ))}
         </View>
@@ -118,7 +119,7 @@ export default function SpecialistCard({
       {cities.length > 0 && (
         <View className="flex-row items-center mt-2">
           <FontAwesome name="map-marker" size={10} color="#94a3b8" />
-          <Text className="text-xs ml-1" style={{ color: "#94a3b8" }} numberOfLines={1}>
+          <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
             {cities.map((c) => c.name).join(", ")}
           </Text>
         </View>


### PR DESCRIPTION
## Summary
- 2 dead-end screens fixed: legal/privacy.tsx, legal/terms.tsx → HeaderBack added; specialists/index.tsx → replaced custom header with HeaderBack
- TextInput outlineWidth:0 added to 3 files (users.tsx, auth/otp.tsx, requests/write.tsx) — fixes double border on web
- Fixed dimensions: messages.tsx width:300→maxWidth:300+flex:1, SpecialistCard width:200→maxWidth:200+flex:1
- Hardcoded inline hex colors → theme tokens across 8 files

## Test plan
- [ ] metromap dead-ends: 0
- [ ] tsc --noEmit: 0 errors
- [ ] OTP screen on web: no double border on inputs
- [ ] SpecialistCard: flexible width on mobile

Closes #1213
🤖 Generated with [Claude Code](https://claude.com/claude-code)