### PR TITLE
refactor: AVATAR_COLORS + overlay tokens — eliminate raw rgba/hex

### DIFF
--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -17,7 +17,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors, radiusValue } from "@/lib/theme";
+import { colors, overlay, radiusValue } from "@/lib/theme";
 
 
 type RoleFilter = "ALL" | "CLIENT" | "SPECIALIST" | "BANNED";
@@ -219,7 +219,7 @@ export default function AdminUsers() {
         <TextInput
           accessibilityLabel="Поиск по email или имени"
           style={{
-            backgroundColor: "rgba(255,255,255,0.15)",
+            backgroundColor: overlay.white15,
             borderRadius: radiusValue.md,
             height: 40,
             paddingHorizontal: 14,
@@ -228,7 +228,7 @@ export default function AdminUsers() {
             outlineWidth: 0,
           }}
           placeholder="Поиск по email или имени..."
-          placeholderTextColor="rgba(255,255,255,0.5)"
+          placeholderTextColor={overlay.white50}
           value={search}
           onChangeText={setSearch}
           autoCapitalize="none"

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -2,73 +2,26 @@ import { View, Text, Pressable, FlatList, useWindowDimensions } from "react-nati
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MessageCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
-import { colors } from "@/lib/theme";
+import { AVATAR_COLORS } from "@/lib/theme";
 
 const CONVERSATIONS = [
-  {
-    id: "1",
-    name: "Alex K.",
-    avatar: "A",
-    avatarColor: "#3b82f6",
-    lastMessage: "Is the iPhone still available?",
-    time: "2m ago",
-    unread: true,
-  },
-  {
-    id: "2",
-    name: "Maria S.",
-    avatar: "M",
-    avatarColor: "#ec4899",
-    lastMessage: "Great, I can pick it up tomorrow",
-    time: "1h ago",
-    unread: true,
-  },
-  {
-    id: "3",
-    name: "David R.",
-    avatar: "D",
-    avatarColor: "#10b981",
-    lastMessage: "Can you do $700?",
-    time: "3h ago",
-    unread: false,
-  },
-  {
-    id: "4",
-    name: "Sophie L.",
-    avatar: "S",
-    avatarColor: "#f59e0b",
-    lastMessage: "Thanks for the quick response!",
-    time: "Yesterday",
-    unread: false,
-  },
-  {
-    id: "5",
-    name: "James P.",
-    avatar: "J",
-    avatarColor: "#8b5cf6",
-    lastMessage: "What's the lowest you'd go?",
-    time: "Yesterday",
-    unread: false,
-  },
-  {
-    id: "6",
-    name: "Elena T.",
-    avatar: "E",
-    avatarColor: colors.error,
-    lastMessage: "Sent you the location pin",
-    time: "2 days ago",
-    unread: false,
-  },
+  { id: "1", name: "Alex K.", avatar: "A", lastMessage: "Is the iPhone still available?", time: "2m ago", unread: true },
+  { id: "2", name: "Maria S.", avatar: "M", lastMessage: "Great, I can pick it up tomorrow", time: "1h ago", unread: true },
+  { id: "3", name: "David R.", avatar: "D", lastMessage: "Can you do $700?", time: "3h ago", unread: false },
+  { id: "4", name: "Sophie L.", avatar: "S", lastMessage: "Thanks for the quick response!", time: "Yesterday", unread: false },
+  { id: "5", name: "James P.", avatar: "J", lastMessage: "What's the lowest you'd go?", time: "Yesterday", unread: false },
+  { id: "6", name: "Elena T.", avatar: "E", lastMessage: "Sent you the location pin", time: "2 days ago", unread: false },
 ];
 
 function ConversationItem({
   name,
   avatar,
-  avatarColor,
   lastMessage,
   time,
   unread,
-}: (typeof CONVERSATIONS)[0]) {
+  index,
+}: (typeof CONVERSATIONS)[0] & { index: number }) {
+  const avatarColor = AVATAR_COLORS[index % AVATAR_COLORS.length];
   return (
     <Pressable accessibilityRole="button" accessibilityLabel={`Чат с ${name}`} className="flex-row items-center px-4 py-3 active:bg-gray-50">
       <View
@@ -77,24 +30,24 @@ function ConversationItem({
       >
         <Text className="text-white text-lg font-bold">{avatar}</Text>
       </View>
-      <View className="flex-1 ml-3 border-b border-gray-100 pb-3">
+      <View className="flex-1 ml-3 border-b border-border pb-3">
         <View className="flex-row justify-between items-center">
-          <Text className={`text-base ${unread ? "font-bold text-gray-900" : "font-medium text-gray-900"}`}>
+          <Text className={`text-base ${unread ? "font-bold text-text-base" : "font-medium text-text-base"}`}>
             {name}
           </Text>
-          <Text className={`text-xs ${unread ? "text-blue-600 font-medium" : "text-gray-400"}`}>
+          <Text className={`text-xs ${unread ? "text-accent font-medium" : "text-text-dim"}`}>
             {time}
           </Text>
         </View>
         <View className="flex-row items-center mt-0.5">
           <Text
-            className={`flex-1 text-sm ${unread ? "text-gray-900 font-medium" : "text-gray-500"}`}
+            className={`flex-1 text-sm ${unread ? "text-text-base font-medium" : "text-text-mute"}`}
             numberOfLines={1}
           >
             {lastMessage}
           </Text>
           {unread && (
-            <View className="w-2.5 h-2.5 rounded-full bg-blue-600 ml-2" />
+            <View className="w-2.5 h-2.5 rounded-full bg-accent ml-2" />
           )}
         </View>
       </View>
@@ -112,15 +65,14 @@ export default function MessagesScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <View className="flex-1" style={containerStyle}>
-        {/* Header */}
-        <View className="px-4 pt-2 pb-3 border-b border-gray-100">
-          <Text className="text-2xl font-bold text-gray-900">Messages</Text>
+        <View className="px-4 pt-2 pb-3 border-b border-border">
+          <Text className="text-2xl font-bold text-text-base">Сообщения</Text>
         </View>
 
         <FlatList
           data={CONVERSATIONS}
           keyExtractor={(item) => item.id}
-          renderItem={({ item }) => <ConversationItem {...item} />}
+          renderItem={({ item, index }) => <ConversationItem {...item} index={index} />}
           ListEmptyComponent={
             <EmptyState
               icon={MessageCircle}

--- a/components/landing/CTASection.tsx
+++ b/components/landing/CTASection.tsx
@@ -1,4 +1,5 @@
 import { View, Text, Pressable } from "react-native";
+import { colors, overlay } from "@/lib/theme";
 
 interface CTASectionProps {
   isDesktop: boolean;
@@ -11,7 +12,7 @@ export default function CTASection({ isDesktop, onCreateRequest, onViewCatalog }
     <View
       className="px-4"
       style={{
-        backgroundColor: "#2256c2",
+        backgroundColor: colors.primary,
         paddingTop: isDesktop ? 96 : 64,
         paddingBottom: isDesktop ? 96 : 64,
       }}
@@ -29,7 +30,7 @@ export default function CTASection({ isDesktop, onCreateRequest, onViewCatalog }
           </Text>
           <Text
             className="text-lg text-center mt-4"
-            style={{ color: "rgba(255,255,255,0.8)", lineHeight: 28 }}
+            style={{ color: overlay.white80, lineHeight: 28 }}
           >
             Создайте заявку — это займёт 3 минуты. Специалисты напишут сами.
           </Text>
@@ -50,7 +51,7 @@ export default function CTASection({ isDesktop, onCreateRequest, onViewCatalog }
             >
               <Text
                 className="font-semibold text-base"
-                style={{ color: "#2256c2" }}
+                style={{ color: colors.primary }}
               >
                 Создать заявку →
               </Text>
@@ -63,7 +64,7 @@ export default function CTASection({ isDesktop, onCreateRequest, onViewCatalog }
             >
               <Text
                 className="text-base font-semibold"
-                style={{ color: "rgba(255,255,255,0.8)" }}
+                style={{ color: overlay.white80 }}
               >
                 Смотреть специалистов
               </Text>

--- a/components/landing/FeaturesSection.tsx
+++ b/components/landing/FeaturesSection.tsx
@@ -1,5 +1,6 @@
 import { View, Text } from "react-native";
 import { FEATURES } from "./mockData";
+import { colors, overlay } from "@/lib/theme";
 
 interface FeaturesSectionProps {
   isDesktop: boolean;
@@ -10,7 +11,7 @@ export default function FeaturesSection({ isDesktop }: FeaturesSectionProps) {
     <View
       className="px-4"
       style={{
-        backgroundColor: "#2256c2",
+        backgroundColor: colors.primary,
         paddingTop: isDesktop ? 96 : 64,
         paddingBottom: isDesktop ? 96 : 64,
       }}
@@ -38,7 +39,7 @@ export default function FeaturesSection({ isDesktop }: FeaturesSectionProps) {
                 key={f.title}
                 className="rounded-2xl p-6"
                 style={[
-                  { backgroundColor: "rgba(255,255,255,0.1)" },
+                  { backgroundColor: overlay.white10 },
                   isDesktop
                     ? { flex: 1, minWidth: "45%" }
                     : {},
@@ -48,7 +49,7 @@ export default function FeaturesSection({ isDesktop }: FeaturesSectionProps) {
                 <Text className="text-white font-bold text-lg mb-2">
                   {f.title}
                 </Text>
-                <Text style={{ color: "rgba(255,255,255,0.7)" }}>
+                <Text style={{ color: overlay.white70 }}>
                   {f.text}
                 </Text>
               </View>

--- a/components/landing/FooterSection.tsx
+++ b/components/landing/FooterSection.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable } from "react-native";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface FooterSectionProps {
   isDesktop: boolean;
@@ -43,7 +43,7 @@ export default function FooterSection({ isDesktop, onHome, onViewCatalog, onCrea
                 onPress={onHome}
                 className="min-h-[44px] justify-center"
               >
-                <Text style={{ color: "rgba(255,255,255,0.7)" }}>
+                <Text style={{ color: overlay.white70 }}>
                   О сервисе
                 </Text>
               </Pressable>
@@ -53,7 +53,7 @@ export default function FooterSection({ isDesktop, onHome, onViewCatalog, onCrea
                 onPress={onViewCatalog}
                 className="min-h-[44px] justify-center"
               >
-                <Text style={{ color: "rgba(255,255,255,0.7)" }}>
+                <Text style={{ color: overlay.white70 }}>
                   Специалисты
                 </Text>
               </Pressable>
@@ -63,7 +63,7 @@ export default function FooterSection({ isDesktop, onHome, onViewCatalog, onCrea
                 onPress={onCreateRequest}
                 className="min-h-[44px] justify-center"
               >
-                <Text style={{ color: "rgba(255,255,255,0.7)" }}>
+                <Text style={{ color: overlay.white70 }}>
                   Создать заявку
                 </Text>
               </Pressable>
@@ -75,19 +75,19 @@ export default function FooterSection({ isDesktop, onHome, onViewCatalog, onCrea
             className="mt-8"
             style={{
               borderTopWidth: 1,
-              borderTopColor: "rgba(255,255,255,0.1)",
+              borderTopColor: overlay.white10,
               paddingTop: 24,
             }}
           >
             <Text
               className="text-sm text-center"
-              style={{ color: "rgba(255,255,255,0.5)" }}
+              style={{ color: overlay.white50 }}
             >
               © 2026 P2PTax
             </Text>
             <Text
               className="text-xs text-center mt-2"
-              style={{ color: "rgba(255,255,255,0.3)" }}
+              style={{ color: overlay.white30 }}
             >
               Сервис не оказывает юридических услуг.
             </Text>

--- a/components/specialist/WorkAreaSection.tsx
+++ b/components/specialist/WorkAreaSection.tsx
@@ -1,5 +1,5 @@
 import { View, Text } from "react-native";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 import type { FnsServiceGroup } from "./types";
 
 interface WorkAreaSectionProps {
@@ -32,7 +32,7 @@ export default function WorkAreaSection({ fnsServices, cardShadow }: WorkAreaSec
               <View
                 key={s.id}
                 className="px-2.5 py-1 rounded-lg"
-                style={{ backgroundColor: "rgba(34, 86, 194, 0.1)" }}
+                style={{ backgroundColor: overlay.accent10 }}
               >
                 <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
               </View>

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -77,3 +77,23 @@ export const radiusValue = {
   xl: 24,
   full: 9999, // pills, badges
 } as const
+
+// Cyclic palette for generated avatars — use index % AVATAR_COLORS.length
+export const AVATAR_COLORS = [
+  '#3b82f6', // blue
+  '#ec4899', // pink
+  '#10b981', // emerald
+  '#f59e0b', // amber
+  '#8b5cf6', // violet
+] as const
+
+// Semantic overlay tokens — for rgba on colored backgrounds
+export const overlay = {
+  white10: 'rgba(255,255,255,0.1)',
+  white15: 'rgba(255,255,255,0.15)',
+  white30: 'rgba(255,255,255,0.3)',
+  white50: 'rgba(255,255,255,0.5)',
+  white70: 'rgba(255,255,255,0.7)',
+  white80: 'rgba(255,255,255,0.8)',
+  accent10: 'rgba(34,86,194,0.1)',
+} as const


### PR DESCRIPTION
## Summary
- Add `AVATAR_COLORS` (5-color cycle) and `overlay` (7 rgba tokens) to `lib/theme.ts`
- Replace all hardcoded `rgba(255,255,255,*)` in landing components (Features/CTA/Footer) with `overlay.*`
- Replace `rgba(34,86,194,0.1)` in WorkAreaSection with `overlay.accent10`
- Refactor messages.tsx to cycle `AVATAR_COLORS` by index, fix gray→DS classes
- admin/users.tsx: search bar rgba → `overlay.white15` / `overlay.white50`

**Result:** unique color count reduced to ~6-8 semantic tokens. `tsc --noEmit` passes (0 errors).

## Test plan
- [ ] Messages screen — avatars cycle through 5 colors correctly
- [ ] Landing FeaturesSection — white card overlays still visible on blue background
- [ ] Landing CTASection — muted text still legible
- [ ] Landing FooterSection — nav links and copyright readable
- [ ] admin/users search bar — placeholder visible on accent background
- [ ] tsc: 0 errors frontend + backend