### PR TITLE
polish: specialist + admin screens visual hierarchy

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -159,12 +159,15 @@ export default function AdminComplaints() {
     const isReviewing = reviewingId === item.id;
 
     return (
-      <View>
+      <View
+        className="bg-white border border-border rounded-xl mb-3 overflow-hidden"
+        style={{ shadowColor: '#0b1424', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3 }}
+      >
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={`Жалоба от ${userName(item.reporter)}`}
           onPress={() => setExpandedId(isExpanded ? null : item.id)}
-          className="bg-white border-b border-border px-4 py-3"
+          className="bg-white px-4 py-3 min-h-[44px]"
         >
           <View className="flex-row items-start justify-between mb-1">
             <View className="flex-1 mr-3">
@@ -202,7 +205,7 @@ export default function AdminComplaints() {
         </Pressable>
 
         {isExpanded && (
-          <View className="bg-surface2 px-4 py-3 border-b border-border">
+          <View className="bg-surface2 px-4 py-3 border-t border-border">
             <Text className="text-xs text-text-mute mb-1">
               ID жалобы: <Text className="text-text-base">{item.id}</Text>
             </Text>
@@ -226,14 +229,14 @@ export default function AdminComplaints() {
                 accessibilityLabel="Рассмотрено"
                 onPress={() => markReviewed(item)}
                 disabled={isReviewing}
-                className={`px-3 py-2 rounded-lg self-start ${
+                className={`px-4 rounded-lg self-start min-h-[44px] justify-center items-center ${
                   isReviewing ? "bg-surface2" : "bg-success"
                 }`}
               >
                 {isReviewing ? (
                   <ActivityIndicator size="small" color={colors.surface} />
                 ) : (
-                  <Text className="text-xs text-white font-medium">Рассмотрено</Text>
+                  <Text className="text-sm text-white font-medium">Рассмотрено</Text>
                 )}
               </Pressable>
             )}
@@ -251,22 +254,22 @@ export default function AdminComplaints() {
       </View>
 
       {/* Filter tabs */}
-      <View className="bg-white border-b border-border px-4 py-2 flex-row gap-2">
+      <View className="bg-white border-b border-border px-4 py-2.5 flex-row gap-2">
         {FILTER_OPTIONS.map((opt) => (
           <Pressable
             accessibilityRole="button"
             key={opt.key}
             accessibilityLabel={opt.label}
             onPress={() => setFilter(opt.key)}
-            className={`px-3 py-1.5 rounded-full border ${
+            className={`px-3 py-1.5 rounded-full border min-h-[44px] justify-center ${
               filter === opt.key
                 ? "bg-accent border-accent"
-                : "bg-white border-border"
+                : "bg-surface2 border-border"
             }`}
           >
             <Text
               className={`text-sm ${
-                filter === opt.key ? "text-white font-medium" : "text-text-base"
+                filter === opt.key ? "text-white font-medium" : "text-text-mute"
               }`}
             >
               {opt.label}
@@ -291,7 +294,7 @@ export default function AdminComplaints() {
             data={complaints}
             keyExtractor={(item) => item.id}
             renderItem={renderItem}
-            contentContainerStyle={{ flexGrow: 1 }}
+            contentContainerStyle={{ flexGrow: 1, padding: 16, paddingTop: 12 }}
             onEndReached={loadMore}
             onEndReachedThreshold={0.3}
             ListEmptyComponent={

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -1,14 +1,25 @@
-import { View } from "react-native";
+import { View, Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CheckCircle } from "lucide-react-native";
-import HeaderHome from "@/components/HeaderHome";
 import EmptyState from "@/components/ui/EmptyState";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
+import { colors } from "@/lib/theme";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      <HeaderHome />
+      {/* Header */}
+      <View className="bg-accent px-4 h-14 flex-row items-center justify-between">
+        <Text className="text-lg font-bold text-white">Модерация</Text>
+      </View>
+
+      {/* Section separator */}
+      <View className="bg-white border-b border-border px-4 py-3">
+        <Text className="text-sm text-text-mute">
+          Контент, требующий проверки перед публикацией
+        </Text>
+      </View>
+
       <ResponsiveContainer>
         <View className="flex-1">
           <EmptyState

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -210,12 +210,12 @@ export default function SpecialistDashboard() {
                 accessibilityRole="button"
                 accessibilityLabel="Перейти в настройки"
                 onPress={() => router.push("/settings/specialist" as never)}
-                className="bg-amber-50 border border-amber-300 rounded-xl p-4 mb-4"
+                className="bg-warning-soft border border-warning rounded-xl p-4 mb-4 min-h-[44px]"
               >
                 <View className="flex-row items-start">
                   <TriangleAlert
                     size={16}
-                    color={colors.accent}
+                    color={colors.warning}
                     style={{ marginTop: 2 }}
                   />
                   <View className="flex-1 ml-2">
@@ -235,13 +235,19 @@ export default function SpecialistDashboard() {
 
             {/* Stats row */}
             <View className="flex-row gap-3 mb-6" style={isDesktop ? { maxWidth: 400 } : undefined}>
-              <View className="flex-1 bg-white border border-border rounded-xl p-4">
+              <View
+                className="flex-1 bg-white border border-border rounded-xl p-4"
+                style={{ shadowColor: '#0b1424', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3 }}
+              >
                 <Text className="text-2xl font-bold text-text-base">
                   {stats?.threadsTotal ?? 0}
                 </Text>
                 <Text className="text-xs text-text-mute mt-1">Всего диалогов</Text>
               </View>
-              <View className="flex-1 bg-white border border-border rounded-xl p-4">
+              <View
+                className="flex-1 bg-white border border-border rounded-xl p-4"
+                style={{ shadowColor: '#0b1424', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 3 }}
+              >
                 <Text className="text-2xl font-bold text-accent">
                   {stats?.newMessages ?? 0}
                 </Text>
@@ -251,13 +257,14 @@ export default function SpecialistDashboard() {
 
             {/* Section header */}
             <View className="flex-row items-center justify-between mb-3">
-              <Text className="text-lg font-semibold text-text-base">
+              <Text className="text-sm font-semibold text-text-mute uppercase tracking-wider">
                 Подходящие заявки
               </Text>
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Мои обращения"
                 onPress={() => router.push("/(specialist-tabs)/threads" as never)}
+                className="min-h-[44px] justify-center px-1"
               >
                 <Text className="text-sm text-accent font-medium">
                   Мои обращения
@@ -315,8 +322,14 @@ function RequestCard({
       accessibilityRole="button"
       accessibilityLabel={item.title}
       onPress={onPress}
-      className="bg-white border border-border rounded-xl p-4 mb-3"
-      style={({ pressed }) => pressed ? { opacity: 0.92 } : undefined}
+      className="bg-white border border-border rounded-xl p-4 mb-3 min-h-[44px]"
+      style={({ pressed }) => ({
+        opacity: pressed ? 0.92 : 1,
+        shadowColor: '#0b1424',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.06,
+        shadowRadius: 3,
+      })}
     >
       {/* Title + status */}
       <View className="flex-row items-start justify-between mb-2">
@@ -338,8 +351,8 @@ function RequestCard({
           <Text className="text-xs text-text-mute">{item.fns.name}</Text>
         </View>
         {item.service ? (
-          <View className="bg-blue-50 px-2 py-0.5 rounded-full">
-            <Text className="text-xs text-blue-700">{item.service}</Text>
+          <View className="bg-accent-soft px-2 py-0.5 rounded-full">
+            <Text className="text-xs text-accent">{item.service}</Text>
           </View>
         ) : null}
         {!item.isMyRegion ? (
@@ -357,8 +370,8 @@ function RequestCard({
       {/* Action */}
       {hasThread ? (
         <View className="flex-row items-center justify-between">
-          <View className="bg-emerald-50 border border-emerald-200 px-3 py-1 rounded-full">
-            <Text className="text-xs text-emerald-700 font-medium">
+          <View className="bg-success-soft border border-success px-3 py-1 rounded-full">
+            <Text className="text-xs text-success font-medium">
               Вы уже откликнулись
             </Text>
           </View>


### PR DESCRIPTION
## Summary
- Stats cards + request cards: added shadow (shadowOpacity 0.06) for depth
- Section heading: changed to `text-sm font-semibold text-text-mute uppercase tracking-wider`
- Standby banner: replaced `bg-amber-50/border-amber-300` with DS tokens `bg-warning-soft/border-warning`
- Service chip: replaced `bg-blue-50/text-blue-700` with `bg-accent-soft/text-accent`
- "Вы уже откликнулись" badge: replaced emerald-* raw classes with `bg-success-soft/text-success`
- Nav link: added `min-h-[44px] justify-center` for 44px tap target
- Complaints filter chips: inactive now `bg-surface2 text-text-mute`, active `bg-accent text-white`
- Complaint rows: converted flat `border-b` list to `rounded-xl border mb-3` cards with shadow
- "Рассмотрено" button: min-h-[44px], larger text (sm)
- FlatList: padding 16px so cards have breathing room
- Moderation: added `bg-accent` header + border-b section with descriptive subtitle (was bare HeaderHome)

## Test plan
- [ ] `tsc --noEmit` passes (verified: 0 errors)
- [ ] Specialist dashboard: stats cards have subtle shadow, section label is muted uppercase
- [ ] Specialist dashboard: warning banner uses DS warning tokens
- [ ] Admin complaints: cards are rounded with shadow, chips toggle correctly
- [ ] Admin moderation: consistent blue header matches complaints screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)