### PR TITLE
polish: settings + profile + notifications + requests visual polish

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -23,88 +23,107 @@ export default function ProfileScreen() {
   const isDesktop = width >= 640;
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
-      <ScrollView className="flex-1" contentContainerClassName="pb-8">
+    <SafeAreaView className="flex-1 bg-surface2">
+      <ScrollView className="flex-1" contentContainerClassName="pb-10">
         <ResponsiveContainer>
-        {/* Profile Header */}
-        <View className="items-center pt-6 pb-8 border-b border-gray-100">
-          <View className="w-20 h-20 rounded-full bg-blue-100 items-center justify-center mb-3">
-            <User size={32} color="#3b82f6" />
-          </View>
-          <Text className="text-xl font-bold text-gray-900">John Doe</Text>
-          <Text className="text-sm text-gray-500 mt-0.5">john@example.com</Text>
-
-          {/* Rating */}
-          <View className="flex-row items-center mt-2">
-            {[1, 2, 3, 4, 5].map((star) => (
-              <Star
-                key={star}
-                size={14}
-                color="#f59e0b"
-                fill={star <= 4 ? "#f59e0b" : "none"}
-              />
-            ))}
-            <Text className="text-sm text-gray-500 ml-1.5">4.5 (23 reviews)</Text>
-          </View>
-
-          {/* Stats */}
-          <View className={`flex-row mt-4${isDesktop ? " border border-border rounded-xl px-4 py-2 bg-white" : ""}`}>
-            <View className="items-center px-6">
-              <Text className="text-lg font-bold text-gray-900">12</Text>
-              <Text className="text-xs text-gray-500">Listings</Text>
+          {/* Profile Header Card */}
+          <View className="bg-white mx-4 mt-6 rounded-2xl border border-border px-6 py-8 items-center mb-4">
+            {/* Avatar */}
+            <View className="w-20 h-20 rounded-full bg-accent-soft items-center justify-center mb-3">
+              <User size={32} color={colors.accent} />
             </View>
-            <View className="w-px bg-gray-200" />
-            <View className="items-center px-6">
-              <Text className="text-lg font-bold text-gray-900">47</Text>
-              <Text className="text-xs text-gray-500">Sold</Text>
+            <Text className="text-xl font-bold text-text-base mt-1">John Doe</Text>
+            <Text className="text-sm text-text-mute mt-1">john@example.com</Text>
+
+            {/* Rating */}
+            <View className="flex-row items-center mt-2.5">
+              {[1, 2, 3, 4, 5].map((star) => (
+                <Star
+                  key={star}
+                  size={14}
+                  color="#f59e0b"
+                  fill={star <= 4 ? "#f59e0b" : "none"}
+                />
+              ))}
+              <Text className="text-sm text-text-mute ml-1.5">4.5 (23 reviews)</Text>
             </View>
-            <View className="w-px bg-gray-200" />
-            <View className="items-center px-6">
-              <Text className="text-lg font-bold text-gray-900">2y</Text>
-              <Text className="text-xs text-gray-500">Member</Text>
+
+            {/* Stats */}
+            <View
+              className={`flex-row mt-5 border border-border rounded-xl overflow-hidden${isDesktop ? " px-2 py-1 bg-white" : ""}`}
+            >
+              <View className="items-center px-6 py-2">
+                <Text className="text-lg font-bold text-text-base">12</Text>
+                <Text className="text-xs text-text-mute mt-0.5">Listings</Text>
+              </View>
+              <View className="w-px bg-border" />
+              <View className="items-center px-6 py-2">
+                <Text className="text-lg font-bold text-text-base">47</Text>
+                <Text className="text-xs text-text-mute mt-0.5">Sold</Text>
+              </View>
+              <View className="w-px bg-border" />
+              <View className="items-center px-6 py-2">
+                <Text className="text-lg font-bold text-text-base">2y</Text>
+                <Text className="text-xs text-text-mute mt-0.5">Member</Text>
+              </View>
             </View>
           </View>
-        </View>
 
-        {/* Menu Items */}
-        <View className="mt-4">
-          {MENU_ITEMS.length === 0 ? (
-            <EmptyState icon={List} title="Нет разделов" subtitle="Разделы профиля недоступны" />
-          ) : (
-            MENU_ITEMS.map((item) => (
-              <Pressable
-                accessibilityRole="button"
-                key={item.id}
-                accessibilityLabel={item.label}
-                className="flex-row items-center px-4 py-4 active:bg-gray-50"
-              >
-                <View className="w-10 h-10 rounded-lg bg-gray-100 items-center justify-center">
-                  <item.Icon size={18} color={colors.textSecondary} />
-                </View>
-                <Text className="flex-1 ml-3 text-base text-gray-900">{item.label}</Text>
-                {item.badge && (
-                  <View className="bg-blue-100 rounded-full px-2.5 py-0.5 mr-2">
-                    <Text className="text-xs font-medium text-blue-600">{item.badge}</Text>
+          {/* Section label */}
+          <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2 mt-2">
+            Menu
+          </Text>
+
+          {/* Menu Items Card */}
+          <View className="bg-white mx-4 rounded-2xl border border-border overflow-hidden mb-4">
+            {MENU_ITEMS.length === 0 ? (
+              <EmptyState icon={List} title="Нет разделов" subtitle="Разделы профиля недоступны" />
+            ) : (
+              MENU_ITEMS.map((item, index) => (
+                <Pressable
+                  accessibilityRole="button"
+                  key={item.id}
+                  accessibilityLabel={item.label}
+                  className={`flex-row items-center px-4 py-3.5 min-h-[50px] active:bg-surface2${
+                    index < MENU_ITEMS.length - 1 ? " border-b border-border" : ""
+                  }`}
+                >
+                  <View className="w-9 h-9 rounded-xl bg-accent-soft items-center justify-center">
+                    <item.Icon size={17} color={colors.accent} />
                   </View>
-                )}
-                <ChevronRight size={12} color={colors.textSecondary} />
-              </Pressable>
-            ))
-          )}
-        </View>
+                  <Text className="flex-1 ml-3 text-base font-medium text-text-base">{item.label}</Text>
+                  {item.badge && (
+                    <View className="bg-accent-soft rounded-full px-2.5 py-0.5 mr-2">
+                      <Text className="text-xs font-semibold text-accent">{item.badge}</Text>
+                    </View>
+                  )}
+                  <ChevronRight size={16} color={colors.textMuted} />
+                </Pressable>
+              ))
+            )}
+          </View>
 
-        {/* Logout */}
-        <View className="mt-4">
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Выйти"
-            onPress={signOut}
-            className="flex-row items-center justify-center h-12 rounded-xl border border-red-200 active:bg-red-50"
-          >
-            <LogOut size={16} color={colors.error} />
-            <Text className="text-base font-medium text-red-500 ml-2">Log out</Text>
-          </Pressable>
-        </View>
+          {/* Account section */}
+          <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2">
+            Account
+          </Text>
+
+          {/* Logout Card */}
+          <View className="bg-white mx-4 rounded-2xl border border-border overflow-hidden mb-4">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Выйти"
+              onPress={signOut}
+              className="flex-row items-center px-4 py-3.5 min-h-[50px] active:bg-danger-soft"
+            >
+              <View className="w-9 h-9 rounded-xl items-center justify-center" style={{ backgroundColor: colors.dangerSoft }}>
+                <LogOut size={17} color={colors.danger} />
+              </View>
+              <Text className="flex-1 ml-3 text-base font-medium text-danger">Log out</Text>
+            </Pressable>
+          </View>
+
+          <Text className="text-xs text-text-dim text-center mt-2 mb-4">Version 1.0.0</Text>
         </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -29,18 +29,18 @@ interface NotificationsResponse {
   limit: number;
 }
 
-function iconForType(type: string): { Icon: LucideIcon; color: string } {
+function iconForType(type: string): { Icon: LucideIcon; color: string; bg: string } {
   switch (type) {
     case "new_response":
-      return { Icon: MessageCircle, color: colors.primary };
+      return { Icon: MessageCircle, color: colors.primary, bg: colors.accentSoft };
     case "new_message":
-      return { Icon: Mail, color: colors.primary };
+      return { Icon: Mail, color: colors.primary, bg: colors.accentSoft };
     case "new_request_in_city":
-      return { Icon: MapPin, color: colors.success };
+      return { Icon: MapPin, color: colors.success, bg: colors.greenSoft };
     case "promo_expiring":
-      return { Icon: Clock, color: colors.accent };
+      return { Icon: Clock, color: colors.warning, bg: colors.yellowSoft };
     default:
-      return { Icon: Bell, color: colors.text };
+      return { Icon: Bell, color: colors.textSecondary, bg: colors.surface2 };
   }
 }
 
@@ -65,34 +65,45 @@ function NotificationRow({
   item: NotificationItem;
   onPress: (id: string) => void;
 }) {
-  const { Icon: NotifIcon, color: notifColor } = iconForType(item.type);
+  const { Icon: NotifIcon, color: notifColor, bg: notifBg } = iconForType(item.type);
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={item.title}
       onPress={() => onPress(item.id)}
-      className={`flex-row items-start px-4 py-3.5 border-b border-surface2 active:bg-surface2 ${
-        !item.isRead ? "bg-surface2/50" : ""
-      }`}
+      className="active:bg-surface2"
     >
       <View
-        className="w-10 h-10 rounded-full items-center justify-center mt-0.5"
-        style={{ backgroundColor: colors.background }}
+        className={`flex-row items-start px-4 py-4 bg-white border border-border rounded-xl mb-3${
+          !item.isRead ? " border-l-2" : ""
+        }`}
+        style={!item.isRead ? { borderLeftColor: colors.primary } : undefined}
       >
-        <NotifIcon size={16} color={notifColor} />
-      </View>
-      <View className="flex-1 ml-3">
-        <View className="flex-row items-center justify-between">
-          <Text className={`text-sm ${!item.isRead ? "font-bold text-text-base" : "font-medium text-text-base"}`}>
-            {item.title}
-          </Text>
-          <Text className="text-xs text-text-mute">{formatTime(item.createdAt)}</Text>
+        {/* Icon chip */}
+        <View
+          className="w-10 h-10 rounded-full items-center justify-center mt-0.5 flex-shrink-0"
+          style={{ backgroundColor: notifBg }}
+        >
+          <NotifIcon size={18} color={notifColor} />
         </View>
-        <Text className={`text-sm mt-0.5 ${!item.isRead ? "text-text-base" : "text-text-mute"}`} numberOfLines={2}>
-          {item.body}
-        </Text>
+
+        <View className="flex-1 ml-3">
+          <View className="flex-row items-start justify-between gap-2">
+            <Text
+              className="text-sm font-semibold text-text-base flex-1"
+              numberOfLines={1}
+            >
+              {item.title}
+            </Text>
+            <Text className="text-xs text-text-dim mt-0.5 flex-shrink-0">
+              {formatTime(item.createdAt)}
+            </Text>
+          </View>
+          <Text className="text-sm text-text-mute mt-1 leading-5" numberOfLines={2}>
+            {item.body}
+          </Text>
+        </View>
       </View>
-      {!item.isRead && <View className="w-2 h-2 rounded-full bg-warning mt-2 ml-2" />}
     </Pressable>
   );
 }
@@ -135,7 +146,6 @@ export default function NotificationsScreen() {
   const handleMarkRead = useCallback(async (id: string) => {
     const item = notifications.find((n) => n.id === id);
     if (!item || item.isRead) return;
-    // Optimistic update
     setNotifications((prev) =>
       prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
     );
@@ -143,7 +153,6 @@ export default function NotificationsScreen() {
     try {
       await apiPatch(`/api/notifications/${id}/read`, {});
     } catch {
-      // Revert on failure
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? { ...n, isRead: false } : n))
       );
@@ -154,13 +163,11 @@ export default function NotificationsScreen() {
   const handleMarkAllRead = useCallback(async () => {
     const prevNotifications = notifications;
     const prevUnread = unreadCount;
-    // Optimistic update
     setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
     setUnreadCount(0);
     try {
       await apiPatch("/api/notifications/read-all", {});
     } catch {
-      // Revert on failure
       setNotifications(prevNotifications);
       setUnreadCount(prevUnread);
     }
@@ -168,34 +175,49 @@ export default function NotificationsScreen() {
 
   if (!ready) {
     return (
-      <SafeAreaView className="flex-1 bg-white items-center justify-center">
+      <SafeAreaView className="flex-1 bg-surface2 items-center justify-center">
         <LoadingState variant="spinner" />
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-surface2">
       {/* Header */}
-      <View className="flex-row items-center justify-between px-4 pt-2 pb-3 border-b border-surface2">
+      <View className="flex-row items-center justify-between px-4 pt-2 pb-3 bg-white border-b border-border">
         <View className="flex-row items-center">
-          <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
-            <ArrowLeft size={18} color={colors.text} />
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Назад"
+            onPress={() => router.back()}
+            className="w-11 h-11 items-center justify-center -ml-2 mr-1"
+          >
+            <ArrowLeft size={20} color={colors.text} />
           </Pressable>
-          <Text className="text-2xl font-bold text-text-base">Уведомления</Text>
+          <Text className="text-xl font-bold text-text-base">Уведомления</Text>
+          {unreadCount > 0 && (
+            <View className="bg-accent rounded-full min-w-[20px] h-5 items-center justify-center px-1.5 ml-2">
+              <Text className="text-xs font-bold text-white">{unreadCount}</Text>
+            </View>
+          )}
         </View>
         {unreadCount > 0 && (
-          <Pressable accessibilityRole="button" accessibilityLabel="Прочитать все" onPress={handleMarkAllRead} className="py-3 pl-3">
-            <Text className="text-sm text-accent font-medium">Прочитать все</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Прочитать все"
+            onPress={handleMarkAllRead}
+            className="py-2 pl-3"
+          >
+            <Text className="text-sm text-accent font-semibold">Прочитать все</Text>
           </Pressable>
         )}
       </View>
 
       <ResponsiveContainer>
         {loading ? (
-          <View className="pt-2">
+          <View className="pt-4 px-4">
             {Array.from({ length: 5 }).map((_, i) => (
-              <View key={i} className="mx-4 mb-3">
+              <View key={i} className="mb-3">
                 <LoadingState variant="skeleton" lines={2} />
               </View>
             ))}
@@ -213,6 +235,7 @@ export default function NotificationsScreen() {
           <FlatList
             data={notifications}
             keyExtractor={(item) => item.id}
+            contentContainerStyle={{ padding: 16 }}
             renderItem={({ item }) => (
               <NotificationRow item={item} onPress={handleMarkRead} />
             )}

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -164,7 +164,7 @@ export default function NewRequest() {
 
   if (!ready || loadingInit) {
     return (
-      <SafeAreaView className="flex-1 bg-white">
+      <SafeAreaView className="flex-1 bg-surface2">
         <HeaderBack title="Новая заявка" />
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
@@ -175,7 +175,7 @@ export default function NewRequest() {
 
   if (loadError && cities.length === 0 && services.length === 0) {
     return (
-      <SafeAreaView className="flex-1 bg-white">
+      <SafeAreaView className="flex-1 bg-surface2">
         <HeaderBack title="Новая заявка" />
         <View className="flex-1 items-center justify-center">
           <EmptyState
@@ -189,7 +189,7 @@ export default function NewRequest() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Новая заявка" />
       <ScrollView
         className="flex-1"
@@ -201,83 +201,91 @@ export default function NewRequest() {
 
             {/* Limit banner */}
             {atLimit && (
-              <View className="bg-danger-soft border border-red-200 rounded-xl p-4 mb-4">
-                <Text className="text-danger text-sm font-medium">
-                  Лимит заявок исчерпан ({limitInfo.used}/{limitInfo.limit}). Закройте неактуальные заявки, чтобы создать новую.
+              <View className="bg-danger-soft border border-danger rounded-xl p-4 mb-4 mx-4">
+                <Text className="text-danger text-sm font-semibold mb-0.5">
+                  Лимит заявок исчерпан
+                </Text>
+                <Text className="text-danger text-sm">
+                  {limitInfo.used}/{limitInfo.limit} заявок использовано. Закройте неактуальные, чтобы создать новую.
                 </Text>
               </View>
             )}
 
-            {/* Title */}
-            <View className="mb-4">
-              <Text className="text-sm font-medium text-text-base mb-1.5">
-                Заголовок <Text className="text-danger">*</Text>
-              </Text>
-              <Input
-                placeholder="Кратко опишите суть проблемы"
-                value={title}
-                onChangeText={setTitle}
-                error={(submitted || title.length > 0) && !titleValid
-                  ? (title.trim().length < 3 ? "Минимум 3 символа" : "Максимум 100 символов")
-                  : undefined}
-                maxLength={100}
-                editable={!atLimit && !submitting}
+            {/* Form card */}
+            <View className="bg-white border border-border rounded-2xl mx-4 px-4 pt-4 pb-4 mb-4">
+
+              {/* Title */}
+              <View className="mb-4">
+                <Text className="text-sm font-medium text-text-base mb-1.5">
+                  Заголовок <Text className="text-danger">*</Text>
+                </Text>
+                <Input
+                  placeholder="Кратко опишите суть проблемы"
+                  value={title}
+                  onChangeText={setTitle}
+                  error={(submitted || title.length > 0) && !titleValid
+                    ? (title.trim().length < 3 ? "Минимум 3 символа" : "Максимум 100 символов")
+                    : undefined}
+                  maxLength={100}
+                  editable={!atLimit && !submitting}
+                />
+                <Text className="text-xs text-text-dim text-right mt-1">{title.length}/100</Text>
+              </View>
+
+              <CityFnsServicePicker
+                cities={cities}
+                fnsOffices={fnsOffices}
+                services={services}
+                selectedCity={selectedCity}
+                selectedFns={selectedFns}
+                selectedService={selectedService}
+                cityOpen={cityOpen}
+                fnsOpen={fnsOpen}
+                serviceOpen={serviceOpen}
+                loadingFns={loadingFns}
+                submitted={submitted}
+                disabled={atLimit || submitting}
+                onCitySelect={handleCitySelect}
+                onFnsSelect={handleFnsSelect}
+                onServiceSelect={handleServiceSelect}
+                onServiceClear={() => { setSelectedServiceId(null); setServiceOpen(false); }}
+                onCityOpenChange={setCityOpen}
+                onFnsOpenChange={setFnsOpen}
+                onServiceOpenChange={setServiceOpen}
               />
-              <Text className="text-xs text-text-mute text-right mt-1">{title.length}/100</Text>
-            </View>
 
-            <CityFnsServicePicker
-              cities={cities}
-              fnsOffices={fnsOffices}
-              services={services}
-              selectedCity={selectedCity}
-              selectedFns={selectedFns}
-              selectedService={selectedService}
-              cityOpen={cityOpen}
-              fnsOpen={fnsOpen}
-              serviceOpen={serviceOpen}
-              loadingFns={loadingFns}
-              submitted={submitted}
-              disabled={atLimit || submitting}
-              onCitySelect={handleCitySelect}
-              onFnsSelect={handleFnsSelect}
-              onServiceSelect={handleServiceSelect}
-              onServiceClear={() => { setSelectedServiceId(null); setServiceOpen(false); }}
-              onCityOpenChange={setCityOpen}
-              onFnsOpenChange={setFnsOpen}
-              onServiceOpenChange={setServiceOpen}
-            />
+              {/* Description */}
+              <View className="mb-4">
+                <Text className="text-sm font-medium text-text-base mb-1.5">
+                  Описание <Text className="text-danger">*</Text>
+                </Text>
+                <Input
+                  placeholder="Подробно опишите ситуацию: что произошло, какие документы получили, что требует инспекция, какая помощь нужна"
+                  value={description}
+                  onChangeText={setDescription}
+                  multiline
+                  error={(submitted || description.length > 0) && !descriptionValid
+                    ? (description.trim().length < 10 ? "Минимум 10 символов" : "Максимум 2000 символов")
+                    : undefined}
+                  maxLength={2000}
+                  editable={!atLimit && !submitting}
+                  containerStyle={{ minHeight: 120 }}
+                />
+                <Text className="text-xs text-text-dim text-right mt-1">{description.length}/2000</Text>
+              </View>
 
-            {/* Description */}
-            <View className="mb-4">
-              <Text className="text-sm font-medium text-text-base mb-1.5">
-                Описание <Text className="text-danger">*</Text>
-              </Text>
-              <Input
-                placeholder="Подробно опишите ситуацию: что произошло, какие документы получили, что требует инспекция, какая помощь нужна"
-                value={description}
-                onChangeText={setDescription}
-                multiline
-                error={(submitted || description.length > 0) && !descriptionValid
-                  ? (description.trim().length < 10 ? "Минимум 10 символов" : "Максимум 2000 символов")
-                  : undefined}
-                maxLength={2000}
-                editable={!atLimit && !submitting}
-                containerStyle={{ minHeight: 120 }}
+              <FileUploadSection
+                files={files}
+                disabled={atLimit || submitting}
+                onFilesChange={setFiles}
               />
-              <Text className="text-xs text-text-mute text-right mt-1">{description.length}/2000</Text>
-            </View>
 
-            <FileUploadSection
-              files={files}
-              disabled={atLimit || submitting}
-              onFilesChange={setFiles}
-            />
+            </View>
 
             {/* Submit error */}
             {submitError ? (
-              <View className="bg-danger-soft border border-red-200 rounded-xl p-3 mb-4">
-                <Text className="text-sm font-medium text-danger mb-0.5">Ошибка публикации</Text>
+              <View className="bg-danger-soft border border-danger rounded-xl p-3 mb-4 mx-4">
+                <Text className="text-sm font-semibold text-danger mb-0.5">Ошибка публикации</Text>
                 <Text className="text-sm text-danger">{submitError}</Text>
               </View>
             ) : null}

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -182,7 +182,7 @@ export default function SpecialistSettings() {
 
   if (!ready || loading) {
     return (
-      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
         <HeaderBack title="Настройки специалиста" />
         <LoadingState variant="skeleton" lines={5} />
       </SafeAreaView>
@@ -190,23 +190,26 @@ export default function SpecialistSettings() {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+    <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <HeaderBack title="Настройки специалиста" />
       <ScrollView className="flex-1" keyboardShouldPersistTaps="handled">
         <ResponsiveContainer>
-          <View className="py-6">
+          <View className="py-4">
 
-            <AvatarUploader
-              avatarUrl={avatarUrl}
-              avatarUploading={avatarUploading}
-              initials={initials}
-              onAvatarChange={setAvatarUrl}
-              onUploadStart={() => setAvatarUploading(true)}
-              onUploadEnd={() => setAvatarUploading(false)}
-            />
+            {/* Avatar centered */}
+            <View className="items-center mb-2">
+              <AvatarUploader
+                avatarUrl={avatarUrl}
+                avatarUploading={avatarUploading}
+                initials={initials}
+                onAvatarChange={setAvatarUrl}
+                onUploadStart={() => setAvatarUploading(true)}
+                onUploadEnd={() => setAvatarUploading(false)}
+              />
+            </View>
 
             {/* Availability toggle */}
-            <View className="bg-surface2 border border-border rounded-xl px-4 py-3 mb-6 flex-row items-center justify-between">
+            <View className="bg-white border border-border rounded-2xl mx-4 px-4 py-3.5 mb-4 flex-row items-center justify-between">
               <View className="flex-1 mr-4">
                 <Text className="text-base font-semibold text-text-base">
                   Принимаю заявки
@@ -230,117 +233,121 @@ export default function SpecialistSettings() {
               )}
             </View>
 
-            {/* Name fields */}
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-3">
+            {/* Personal data section */}
+            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2 mt-4">
               Личные данные
             </Text>
 
-            <View className="mb-3">
-              <Input
-                label="Имя"
-                value={firstName}
-                onChangeText={setFirstName}
-                placeholder="Введите имя"
-                maxLength={50}
-              />
-            </View>
+            <View className="bg-white border border-border rounded-2xl mx-4 mb-4 overflow-hidden px-4 pt-3 pb-4">
+              <View className="mb-3">
+                <Input
+                  label="Имя"
+                  value={firstName}
+                  onChangeText={setFirstName}
+                  placeholder="Введите имя"
+                  maxLength={50}
+                />
+              </View>
 
-            <View className="mb-3">
-              <Input
-                label="Фамилия"
-                value={lastName}
-                onChangeText={setLastName}
-                placeholder="Введите фамилию"
-                maxLength={50}
-              />
-            </View>
+              <View className="mb-3">
+                <Input
+                  label="Фамилия"
+                  value={lastName}
+                  onChangeText={setLastName}
+                  placeholder="Введите фамилию"
+                  maxLength={50}
+                />
+              </View>
 
-            {/* Email read-only */}
-            <Text className="text-sm font-medium text-text-base mb-1">
-              Email{" "}
-              <Text className="text-text-mute font-normal">(нельзя изменить)</Text>
-            </Text>
-            <View className="h-12 border border-border rounded-xl bg-surface2 px-4 justify-center mb-4">
-              <Text className="text-base text-text-mute">
-                {data?.email || user?.email || ""}
+              {/* Email read-only */}
+              <Text className="text-sm font-medium text-text-base mb-1.5">
+                Email{" "}
+                <Text className="text-text-mute font-normal">(нельзя изменить)</Text>
               </Text>
+              <View className="h-12 border border-border rounded-xl bg-surface2 px-4 justify-center mb-3">
+                <Text className="text-base text-text-mute">
+                  {data?.email || user?.email || ""}
+                </Text>
+              </View>
+
+              {/* Description */}
+              <View>
+                <Input
+                  label="О себе"
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="Расскажите о своём опыте и специализации..."
+                  multiline
+                  numberOfLines={4}
+                  maxLength={500}
+                />
+                <Text className="text-xs text-text-dim text-right mt-1">
+                  {description.length}/500
+                </Text>
+              </View>
             </View>
 
-            {/* Description */}
-            <View className="mb-4">
-              <Input
-                label="О себе"
-                value={description}
-                onChangeText={setDescription}
-                placeholder="Расскажите о своём опыте и специализации..."
-                multiline
-                numberOfLines={4}
-                maxLength={500}
-              />
-              <Text className="text-xs text-text-mute text-right mt-1">
-                {description.length}/500
-              </Text>
-            </View>
-
-            {/* FNS & Services */}
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-3">
+            {/* FNS & Services section */}
+            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2 mt-2">
               ИФНС и услуги
             </Text>
 
-            {data && data.fnsServices.length > 0 ? (
-              <>
-                {data.fnsServices.map((item) => (
-                  <View
-                    key={item.fns.id}
-                    className="bg-surface2 rounded-xl p-3 mb-2 border border-border"
-                  >
-                    <Text className="text-sm font-semibold text-text-base">
-                      {item.city.name} — {item.fns.name}
-                    </Text>
-                    <Text className="text-xs text-text-mute mb-1">
-                      {item.fns.code}
-                    </Text>
-                    <View className="flex-row flex-wrap gap-1 mt-1">
-                      {item.services.length === 0 ? (
-                        <EmptyState icon={Tag} title="Нет услуг" subtitle="Добавьте услуги для этой инспекции" />
-                      ) : (
-                        item.services.map((s) => (
-                          <View
-                            key={s.id}
-                            className="bg-blue-50 px-2 py-0.5 rounded-full border border-blue-100"
-                          >
-                            <Text className="text-xs text-accent">{s.name}</Text>
-                          </View>
-                        ))
-                      )}
+            <View className="bg-white border border-border rounded-2xl mx-4 mb-4 overflow-hidden px-4 pt-3 pb-4">
+              {data && data.fnsServices.length > 0 ? (
+                <>
+                  {data.fnsServices.map((item) => (
+                    <View
+                      key={item.fns.id}
+                      className="bg-surface2 rounded-xl p-3 mb-2 border border-border"
+                    >
+                      <Text className="text-sm font-semibold text-text-base">
+                        {item.city.name} — {item.fns.name}
+                      </Text>
+                      <Text className="text-xs text-text-mute mb-1">
+                        {item.fns.code}
+                      </Text>
+                      <View className="flex-row flex-wrap gap-1 mt-1">
+                        {item.services.length === 0 ? (
+                          <EmptyState icon={Tag} title="Нет услуг" subtitle="Добавьте услуги для этой инспекции" />
+                        ) : (
+                          item.services.map((s) => (
+                            <View
+                              key={s.id}
+                              className="bg-accent-soft px-2.5 py-0.5 rounded-full"
+                            >
+                              <Text className="text-xs font-medium text-accent">{s.name}</Text>
+                            </View>
+                          ))
+                        )}
+                      </View>
                     </View>
-                  </View>
-                ))}
+                  ))}
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Изменить рабочую зону"
+                    onPress={() => router.push("/onboarding/work-area" as never)}
+                    className="flex-row items-center justify-center py-2 mt-1"
+                  >
+                    <Pencil size={13} color={colors.accent} />
+                    <Text className="text-sm text-accent ml-1.5 font-medium">
+                      Изменить рабочую зону
+                    </Text>
+                  </Pressable>
+                </>
+              ) : (
                 <Pressable
                   accessibilityRole="button"
-                  accessibilityLabel="Изменить рабочую зону"
+                  accessibilityLabel="Добавить рабочую зону"
                   onPress={() => router.push("/onboarding/work-area" as never)}
-                  className="flex-row items-center justify-center py-2 mb-4"
+                  className="flex-row items-center justify-center py-3 border border-dashed border-border rounded-xl"
                 >
-                  <Pencil size={12} color={colors.accent} />
-                  <Text className="text-sm text-warning ml-1 font-medium">
-                    Изменить рабочую зону
+                  <Plus size={14} color={colors.accent} />
+                  <Text className="text-sm text-accent ml-2 font-medium">
+                    Добавить ИФНС и услуги
                   </Text>
                 </Pressable>
-              </>
-            ) : (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Добавить рабочую зону"
-                onPress={() => router.push("/onboarding/work-area" as never)}
-                className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-4"
-              >
-                <Plus size={14} color={colors.accent} />
-                <Text className="text-sm text-warning ml-2 font-medium">
-                  Добавить ИФНС и услуги
-                </Text>
-              </Pressable>
-            )}
+              )}
+            </View>
 
             <ContactMethodsList
               contacts={contacts}
@@ -357,31 +364,33 @@ export default function SpecialistSettings() {
               onShowTypePickerChange={setShowTypePicker}
             />
 
-            {/* Office info */}
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-3 mt-2">
+            {/* Office section */}
+            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2 mt-2">
               Офис
             </Text>
 
-            <View className="mb-3">
-              <Input
-                label="Адрес офиса"
-                value={officeAddress}
-                onChangeText={setOfficeAddress}
-                placeholder="Город, улица, дом"
-              />
-            </View>
+            <View className="bg-white border border-border rounded-2xl mx-4 mb-4 overflow-hidden px-4 pt-3 pb-4">
+              <View className="mb-3">
+                <Input
+                  label="Адрес офиса"
+                  value={officeAddress}
+                  onChangeText={setOfficeAddress}
+                  placeholder="Город, улица, дом"
+                />
+              </View>
 
-            <View className="mb-3">
-              <Input
-                label="Часы работы"
-                value={workingHours}
-                onChangeText={setWorkingHours}
-                placeholder="Пн-Пт 9:00-18:00"
-              />
+              <View>
+                <Input
+                  label="Часы работы"
+                  value={workingHours}
+                  onChangeText={setWorkingHours}
+                  placeholder="Пн-Пт 9:00-18:00"
+                />
+              </View>
             </View>
 
             {/* Save button */}
-            <View className="mt-2 mb-4">
+            <View className="mx-4 mb-4">
               <Button
                 label="Сохранить"
                 onPress={handleSave}
@@ -397,26 +406,28 @@ export default function SpecialistSettings() {
               onEmailChange={setEmailEnabled}
             />
 
-            {/* Account */}
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-3">
+            {/* Account section */}
+            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider px-4 mb-2 mt-2">
               Аккаунт
             </Text>
 
-            <View className="bg-white border border-border rounded-xl mb-8 overflow-hidden">
+            <View className="bg-white border border-border rounded-2xl mx-4 mb-8 overflow-hidden">
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Выйти из аккаунта"
                 onPress={handleLogout}
-                className="flex-row items-center px-4 py-3"
+                className="flex-row items-center px-4 py-3.5 min-h-[50px] active:bg-danger-soft"
               >
-                <LogOut size={16} color={colors.error} />
-                <Text className="text-base text-danger ml-3 flex-1">
+                <View className="w-9 h-9 rounded-xl items-center justify-center" style={{ backgroundColor: colors.dangerSoft }}>
+                  <LogOut size={17} color={colors.error} />
+                </View>
+                <Text className="text-base font-medium text-danger ml-3 flex-1">
                   Выйти из аккаунта
                 </Text>
               </Pressable>
             </View>
 
-            <Text className="text-xs text-text-mute text-center mb-4">
+            <Text className="text-xs text-text-dim text-center mb-4">
               Версия 1.0.0
             </Text>
 


### PR DESCRIPTION
## Summary
- `bg-surface2` page background on all 4 screens for depth
- Section grouping: white `rounded-2xl` cards with `border-border` wrap form sections and menu lists
- Section headers: `uppercase tracking-wider text-xs font-semibold text-text-mute` at `px-4`
- Consistent row min-height `50px`, `py-3.5`, `active:bg-surface2` feedback
- Profile: `bg-accent-soft` avatar chip + icon chips on menu items, badge uses `text-accent` 
- Notifications: card-per-item layout, colored icon bg chips, unread = `border-l-2 border-accent`
- Logout rows: danger-soft bg icon chip

## Test plan
- [ ] settings/specialist: sections visually grouped, availability toggle works, save/logout work
- [ ] profile: avatar chip renders, stats row, menu items tappable
- [ ] notifications: unread indicator visible, mark-read works, empty state shows
- [ ] requests/new: form in card, limit banner, submit button sticky

🤖 Generated with [Claude Code](https://claude.com/claude-code)