### PR TITLE
polish: auth + onboarding screens visual polish

### DIFF
--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -13,32 +13,42 @@ export default function CreateScreen() {
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
         <ResponsiveContainer>
           {/* Header */}
-          <View className="pt-2 pb-3">
-            <Text className="text-2xl font-bold text-gray-900">Create Listing</Text>
-            <Text className="text-sm text-gray-500 mt-1">Step 1 of 3 — Photos</Text>
+          <View className="pt-4 pb-4">
+            <Text className="text-2xl font-bold text-text-base">Новое объявление</Text>
+            <Text className="text-sm text-text-mute mt-1 leading-5">Шаг 1 из 3 — Фотографии</Text>
           </View>
 
           {/* Progress Bar */}
-          <View className="mb-6">
-            <View className="h-1.5 rounded-full bg-gray-100">
-              <View className="h-1.5 rounded-full bg-blue-600 w-1/3" />
+          <View className="mb-8">
+            <View className="h-1.5 rounded-full bg-border">
+              <View className="h-1.5 rounded-full bg-accent w-1/3" />
+            </View>
+            <View className="flex-row justify-between mt-1.5">
+              <Text className="text-xs text-accent font-medium">Фото</Text>
+              <Text className="text-xs text-text-mute">Детали</Text>
+              <Text className="text-xs text-text-mute">Публикация</Text>
             </View>
           </View>
 
           {/* Photo Grid */}
-          <View className="mb-6">
-            <Text className="text-base font-semibold text-gray-900 mb-3">
-              Add photos
+          <View className="mb-8">
+            <Text className="text-base font-semibold text-text-base mb-1">
+              Добавьте фотографии
             </Text>
-            <Text className="text-sm text-gray-500 mb-4">
-              Add up to 10 photos. First photo will be the cover.
+            <Text className="text-sm text-text-mute mb-4 leading-5">
+              До 10 фотографий. Первая будет обложкой объявления.
             </Text>
 
             <View className="flex-row flex-wrap">
               {/* Add Photo Button */}
-              <Pressable accessibilityRole="button" accessibilityLabel="Добавить фото" className="w-[31%] aspect-square m-[1%] rounded-xl border-2 border-dashed border-blue-300 bg-blue-50 items-center justify-center">
-                <Camera size={24} color={colors.blue500} />
-                <Text className="text-xs text-blue-600 mt-1 font-medium">Add photo</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Добавить фото"
+                className="w-[31%] aspect-square m-[1%] rounded-xl items-center justify-center active:opacity-80"
+                style={{ borderWidth: 2, borderStyle: "dashed", borderColor: colors.primary, backgroundColor: colors.accentSoft }}
+              >
+                <Camera size={24} color={colors.primary} />
+                <Text className="text-xs text-accent mt-1.5 font-semibold">Добавить</Text>
               </Pressable>
 
               {/* Placeholder slots */}
@@ -48,9 +58,10 @@ export default function CreateScreen() {
                 PLACEHOLDER_SLOTS.map((i) => (
                   <View
                     key={i}
-                    className="w-[31%] aspect-square m-[1%] rounded-xl bg-gray-100 items-center justify-center"
+                    className="w-[31%] aspect-square m-[1%] rounded-xl items-center justify-center"
+                    style={{ backgroundColor: colors.surface2 }}
                   >
-                    <ImageIcon size={20} color={colors.textSecondary} />
+                    <ImageIcon size={20} color={colors.textMuted} />
                   </View>
                 ))
               )}
@@ -58,22 +69,25 @@ export default function CreateScreen() {
           </View>
 
           {/* Tips */}
-          <View className="p-4 rounded-xl bg-amber-50 border border-amber-200">
+          <View className="p-4 rounded-xl border mb-8" style={{ backgroundColor: "#fffbeb", borderColor: "#fde68a" }}>
             <View className="flex-row items-center mb-2">
               <Lightbulb size={16} color={colors.warning} />
-              <Text className="text-sm font-semibold text-amber-800 ml-2">Tips for great photos</Text>
+              <Text className="text-sm font-semibold ml-2" style={{ color: "#92400e" }}>Советы для хороших фото</Text>
             </View>
-            <Text className="text-sm text-amber-700 leading-5">
-              Use natural light. Show item from multiple angles. Include close-ups of details and any defects.
+            <Text className="text-sm leading-5" style={{ color: "#78350f" }}>
+              Используйте естественный свет. Снимайте с разных ракурсов. Покажите детали и возможные дефекты.
             </Text>
           </View>
 
           {/* Next Button */}
-          <View className="mt-8">
-            <Pressable accessibilityRole="button" accessibilityLabel="Далее: детали" className="h-14 rounded-xl bg-accent items-center justify-center active:bg-accent">
-              <Text className="text-white text-base font-semibold">Next: Details</Text>
-            </Pressable>
-          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Далее: детали"
+            className="h-12 rounded-xl items-center justify-center active:opacity-90"
+            style={{ backgroundColor: colors.primary, shadowColor: colors.primary, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.2, shadowRadius: 4, elevation: 3 }}
+          >
+            <Text className="text-white text-base font-semibold">Далее: Детали</Text>
+          </Pressable>
         </ResponsiveContainer>
       </ScrollView>
     </SafeAreaView>

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -216,9 +216,9 @@ export default function AuthOtpScreen() {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <ResponsiveContainer>
-          <View className="flex-1 justify-center">
-            <View className="items-center mb-8">
-              <View className="w-16 h-16 rounded-2xl bg-accent items-center justify-center">
+          <View className="flex-1 justify-center px-2">
+            <View className="items-center mb-10">
+              <View className="w-16 h-16 rounded-2xl bg-accent items-center justify-center" style={{ shadowColor: colors.primary, shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.2, shadowRadius: 8, elevation: 4 }}>
                 <Text className="text-xl font-bold text-white">P2P</Text>
               </View>
             </View>
@@ -226,7 +226,7 @@ export default function AuthOtpScreen() {
             <Text className="text-2xl font-bold text-text-base text-center mb-2">
               Кто вы?
             </Text>
-            <Text className="text-sm text-text-mute text-center mb-8">
+            <Text className="text-base text-text-mute text-center mb-8 leading-6">
               Выберите, как вы будете использовать сервис
             </Text>
 
@@ -234,12 +234,12 @@ export default function AuthOtpScreen() {
               accessibilityRole="button"
               accessibilityLabel="Мне нужна помощь с налоговой"
               onPress={() => handleRoleChoice("CLIENT")}
-              className="border-2 border-border rounded-2xl p-5 mb-4 active:bg-surface2"
+              className="border-2 border-border rounded-2xl p-5 mb-3 active:bg-surface2"
             >
               <Text className="text-base font-semibold text-text-base text-center mb-1">
                 Мне нужна помощь с налоговой
               </Text>
-              <Text className="text-sm text-text-mute text-center">
+              <Text className="text-sm text-text-mute text-center leading-5">
                 Ищу специалиста для решения налоговых вопросов
               </Text>
             </Pressable>
@@ -248,19 +248,20 @@ export default function AuthOtpScreen() {
               accessibilityRole="button"
               accessibilityLabel="Я налоговый специалист"
               onPress={() => handleRoleChoice("SPECIALIST")}
-              className="bg-accent rounded-2xl p-5 active:bg-accent"
+              className="rounded-2xl p-5 active:opacity-90"
               style={{
+                backgroundColor: colors.primary,
                 shadowColor: colors.primary,
-                shadowOffset: { width: 0, height: 2 },
-                shadowOpacity: 0.25,
-                shadowRadius: 4,
-                elevation: 3,
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.3,
+                shadowRadius: 8,
+                elevation: 4,
               }}
             >
               <Text className="text-base font-semibold text-white text-center mb-1">
                 Я налоговый специалист
               </Text>
-              <Text className="text-sm text-blue-300 text-center">
+              <Text className="text-sm text-center leading-5" style={{ color: colors.accentSoft }}>
                 Помогаю клиентам с налоговыми вопросами
               </Text>
             </Pressable>
@@ -284,7 +285,11 @@ export default function AuthOtpScreen() {
         >
           <ResponsiveContainer>
             <View className="flex-1" style={{ paddingTop: 48 }}>
-              <Text className="text-base text-text-base text-center mb-1">
+              {/* Heading */}
+              <Text className="text-2xl font-bold text-text-base text-center mb-2">
+                Введите код
+              </Text>
+              <Text className="text-base text-text-mute text-center leading-6 mb-1">
                 Код отправлен на
               </Text>
               <Text className="text-base font-semibold text-text-base text-center mb-8">
@@ -292,7 +297,7 @@ export default function AuthOtpScreen() {
               </Text>
 
               {/* 6 separate digit inputs */}
-              <View className="flex-row justify-center gap-2 mb-4">
+              <View className="flex-row justify-center gap-3 mb-2">
                 {digits.length === 0 ? (
                   <EmptyState icon={Mail} title="Код недоступен" subtitle="Не удалось инициализировать поля ввода" />
                 ) : (
@@ -305,9 +310,9 @@ export default function AuthOtpScreen() {
                       }}
                       style={{
                         width: 48,
-                        height: 52,
+                        height: 56,
                         borderRadius: radiusValue.md,
-                        borderWidth: error ? 1.5 : 1,
+                        borderWidth: error ? 2 : digit ? 2 : 1.5,
                         borderColor: error
                           ? colors.error
                           : digit
@@ -317,9 +322,9 @@ export default function AuthOtpScreen() {
                           ? colors.errorBg
                           : digit
                             ? colors.accentSoft
-                            : colors.background,
+                            : colors.surface2,
                         textAlign: "center",
-                        fontSize: 22,
+                        fontSize: 24,
                         fontWeight: "700",
                         color: error ? colors.error : colors.text,
                         outlineWidth: 0,
@@ -338,12 +343,13 @@ export default function AuthOtpScreen() {
                 )}
               </View>
 
+              {/* Error / spacer */}
               {error ? (
-                <Text className="text-sm text-danger text-center mb-4">
+                <Text className="text-sm text-danger text-center mt-3 mb-4 leading-5">
                   {error}
                 </Text>
               ) : (
-                <View style={{ height: 20, marginBottom: 16 }} />
+                <View style={{ height: 28, marginBottom: 16 }} />
               )}
 
               {/* Verify button */}
@@ -364,19 +370,19 @@ export default function AuthOtpScreen() {
                 }
                 onPress={handleResend}
                 disabled={resendTimer > 0 || isResending}
-                className="mt-4 py-3 items-center"
+                className="mt-5 py-3 items-center"
               >
                 {isResending ? (
                   <ActivityIndicator color={colors.textSecondary} size="small" />
                 ) : resendTimer > 0 ? (
-                  <Text className="text-sm text-text-mute text-center">
+                  <Text className="text-sm text-text-mute text-center leading-5">
                     Отправить повторно через{" "}
-                    <Text className="font-medium text-text-mute">
+                    <Text className="font-semibold text-text-base">
                       {resendTimer} сек
                     </Text>
                   </Text>
                 ) : (
-                  <Text className="text-sm text-accent font-medium underline text-center">
+                  <Text className="text-base text-accent font-semibold text-center">
                     Отправить код повторно
                   </Text>
                 )}

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -8,6 +8,7 @@ import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import { colors } from "@/lib/theme";
 
 export default function OnboardingNameScreen() {
   const router = useRouter();
@@ -68,15 +69,27 @@ export default function OnboardingNameScreen() {
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
       <ResponsiveContainer>
-        <View className="flex-1 pt-10" style={{ paddingBottom: isDesktop ? 48 : 24 }}>
-          <Text className="text-sm text-warning text-center mb-2">
-            Шаг 1 из 3
-          </Text>
-          <Text className="text-2xl font-bold text-text-base text-center mb-6">
+        <View className="flex-1 pt-8" style={{ paddingBottom: isDesktop ? 48 : 24 }}>
+          {/* Progress indicator */}
+          <View className="mb-6">
+            <View className="flex-row justify-center gap-2 mb-3">
+              <View className="h-1.5 w-8 rounded-full bg-accent" />
+              <View className="h-1.5 w-8 rounded-full bg-border" />
+              <View className="h-1.5 w-8 rounded-full bg-border" />
+            </View>
+            <Text className="text-sm font-medium text-text-mute text-center">
+              Шаг 1 из 3
+            </Text>
+          </View>
+
+          <Text className="text-2xl font-bold text-text-base text-center mb-2">
             Ваше имя
           </Text>
+          <Text className="text-base text-text-mute text-center leading-6 mb-8">
+            Это имя увидят клиенты в вашем профиле
+          </Text>
 
-          <View className="mb-3">
+          <View className="mb-4">
             <Input
               label="Имя"
               placeholder="Иван"
@@ -88,7 +101,7 @@ export default function OnboardingNameScreen() {
             />
           </View>
 
-          <View className="mb-4">
+          <View className="mb-6">
             <Input
               label="Фамилия"
               placeholder="Петров"
@@ -105,13 +118,13 @@ export default function OnboardingNameScreen() {
             accessibilityRole="button"
             accessibilityLabel="Принять условия использования"
             onPress={() => setAgreed(!agreed)}
-            className="flex-row items-start mb-6"
+            className="flex-row items-start mb-8"
           >
             <View
-              className={`w-5 h-5 rounded border mt-0.5 items-center justify-center ${
+              className={`w-5 h-5 rounded border-2 mt-0.5 items-center justify-center ${
                 agreed
                   ? "bg-accent border-accent"
-                  : "border-slate-300 bg-white"
+                  : "border-border bg-white"
               }`}
             >
               {agreed && (
@@ -121,7 +134,7 @@ export default function OnboardingNameScreen() {
             <Text className="flex-1 ml-3 text-sm text-text-mute leading-5">
               Я принимаю{" "}
               <Text
-                className="text-accent underline"
+                className="text-accent font-medium underline"
                 onPress={() => router.push("/legal/terms" as never)}
               >
                 Условия использования
@@ -130,9 +143,11 @@ export default function OnboardingNameScreen() {
           </Pressable>
 
           {error ? (
-            <Text className="text-xs text-danger text-center mb-4">
-              {error}
-            </Text>
+            <View className="mb-4 px-4 py-3 rounded-xl" style={{ backgroundColor: colors.errorBg }}>
+              <Text className="text-sm text-danger text-center leading-5">
+                {error}
+              </Text>
+            </View>
           ) : null}
 
           <Button

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -159,31 +159,54 @@ export default function OnboardingWorkAreaScreen() {
       <HeaderBack title="" />
       <ResponsiveContainer>
         <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: isDesktop ? 64 : 40 }}>
-          <View className="pt-6">
-            <Text className="text-sm text-warning text-center mb-2">
-              Шаг 2 из 3
-            </Text>
-            <Text className="text-2xl font-bold text-text-base text-center mb-6">
+          <View className="pt-8">
+            {/* Progress indicator */}
+            <View className="mb-6">
+              <View className="flex-row justify-center gap-2 mb-3">
+                <View className="h-1.5 w-8 rounded-full bg-accent" />
+                <View className="h-1.5 w-8 rounded-full bg-accent" />
+                <View className="h-1.5 w-8 rounded-full bg-border" />
+              </View>
+              <Text className="text-sm font-medium text-text-mute text-center">
+                Шаг 2 из 3
+              </Text>
+            </View>
+
+            <Text className="text-2xl font-bold text-text-base text-center mb-2">
               Рабочая зона
+            </Text>
+            <Text className="text-base text-text-mute text-center leading-6 mb-8">
+              Укажите отделения ФНС, в которых вы работаете
             </Text>
 
             {/* Selected FNS offices with services */}
             {selectedFns.map((item) => (
               <View
                 key={item.fnsId}
-                className="border border-border rounded-xl p-3 mb-3"
+                className="border border-border rounded-xl p-4 mb-3"
+                style={{ backgroundColor: colors.surface2 }}
               >
-                <View className="flex-row items-center justify-between mb-2">
-                  <View className="flex-1 mr-2">
-                    <Text className="text-sm font-semibold text-text-base">
+                <View className="flex-row items-start justify-between mb-3">
+                  <View className="flex-1 mr-3">
+                    <Text className="text-sm font-semibold text-text-base leading-5">
                       {item.fnsName}
                     </Text>
-                    <Text className="text-xs text-text-mute">{item.cityName}</Text>
+                    <Text className="text-sm text-text-mute mt-0.5">{item.cityName}</Text>
                   </View>
-                  <Pressable accessibilityRole="button" accessibilityLabel="Удалить отделение" onPress={() => removeFns(item.fnsId)}>
-                    <X size={16} color={colors.placeholder} />
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Удалить отделение"
+                    onPress={() => removeFns(item.fnsId)}
+                    className="w-7 h-7 rounded-full items-center justify-center"
+                    style={{ backgroundColor: colors.border }}
+                  >
+                    <X size={14} color={colors.textSecondary} />
                   </Pressable>
                 </View>
+
+                <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-2">
+                  Услуги
+                </Text>
 
                 {/* Service checkboxes */}
                 {services.map((svc) => {
@@ -194,13 +217,13 @@ export default function OnboardingWorkAreaScreen() {
                       key={svc.id}
                       accessibilityLabel={svc.name}
                       onPress={() => toggleService(item.fnsId, svc.id)}
-                      className="flex-row items-center py-1.5"
+                      className={`flex-row items-center py-2 px-3 rounded-lg mb-1 ${isChecked ? "bg-accent-soft" : "bg-white"}`}
                     >
                       <View
-                        className={`w-5 h-5 rounded border items-center justify-center ${
+                        className={`w-5 h-5 rounded border-2 items-center justify-center ${
                           isChecked
                             ? "bg-accent border-accent"
-                            : "border-slate-300 bg-white"
+                            : "border-border bg-white"
                         }`}
                       >
                         {isChecked && (
@@ -209,7 +232,7 @@ export default function OnboardingWorkAreaScreen() {
                           </Text>
                         )}
                       </View>
-                      <Text className="ml-2 text-sm text-text-base">
+                      <Text className={`ml-2.5 text-sm leading-5 ${isChecked ? "text-accent font-medium" : "text-text-base"}`}>
                         {svc.name}
                       </Text>
                     </Pressable>
@@ -217,16 +240,21 @@ export default function OnboardingWorkAreaScreen() {
                 })}
 
                 {item.serviceIds.length === 0 && (
-                  <Text className="text-xs text-danger mt-1">
-                    Выберите хотя бы одну услугу
-                  </Text>
+                  <View className="mt-2 px-3 py-2 rounded-lg" style={{ backgroundColor: colors.errorBg }}>
+                    <Text className="text-sm text-danger">
+                      Выберите хотя бы одну услугу
+                    </Text>
+                  </View>
                 )}
               </View>
             ))}
 
             {/* City picker dropdown */}
             {showCityPicker && (
-              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden">
+              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden bg-white">
+                <View className="px-4 py-2.5 border-b border-border">
+                  <Text className="text-sm font-semibold text-text-base">Выберите город</Text>
+                </View>
                 <ScrollView nestedScrollEnabled>
                   {cities.map((city) => (
                     <Pressable
@@ -234,7 +262,7 @@ export default function OnboardingWorkAreaScreen() {
                       key={city.id}
                       accessibilityLabel={city.name}
                       onPress={() => handleCitySelect(city)}
-                      className="px-4 py-3 border-b border-border active:bg-surface2"
+                      className="px-4 py-3.5 border-b border-border active:bg-surface2"
                     >
                       <Text className="text-sm text-text-base">{city.name}</Text>
                     </Pressable>
@@ -252,7 +280,10 @@ export default function OnboardingWorkAreaScreen() {
 
             {/* FNS picker dropdown */}
             {showFnsPicker && selectedCityId && (
-              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden">
+              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden bg-white">
+                <View className="px-4 py-2.5 border-b border-border">
+                  <Text className="text-sm font-semibold text-text-base">Выберите отделение ФНС</Text>
+                </View>
                 <ScrollView nestedScrollEnabled>
                   {fnsOffices
                     .filter(
@@ -265,12 +296,12 @@ export default function OnboardingWorkAreaScreen() {
                         key={fns.id}
                         accessibilityLabel={fns.name}
                         onPress={() => handleFnsSelect(fns)}
-                        className="px-4 py-3 border-b border-border active:bg-surface2"
+                        className="px-4 py-3.5 border-b border-border active:bg-surface2"
                       >
-                        <Text className="text-sm text-text-base">
+                        <Text className="text-sm font-medium text-text-base">
                           {fns.name}
                         </Text>
-                        <Text className="text-xs text-text-mute">
+                        <Text className="text-xs text-text-mute mt-0.5">
                           {fns.code}
                         </Text>
                       </Pressable>
@@ -295,10 +326,10 @@ export default function OnboardingWorkAreaScreen() {
                   setShowCityPicker(true);
                   setShowFnsPicker(false);
                 }}
-                className="flex-row items-center justify-center py-3 border border-dashed border-slate-300 rounded-xl mb-6"
+                className="flex-row items-center justify-center py-3.5 border-2 border-dashed border-border rounded-xl mb-6 active:bg-surface2"
               >
-                <Plus size={14} color={colors.accent} />
-                <Text className="text-sm text-warning ml-2 font-medium">
+                <Plus size={16} color={colors.accent} />
+                <Text className="text-sm text-accent ml-2 font-semibold">
                   Добавить город
                 </Text>
               </Pressable>
@@ -309,7 +340,7 @@ export default function OnboardingWorkAreaScreen() {
                 accessibilityRole="button"
                 accessibilityLabel="Отмена"
                 onPress={() => setShowCityPicker(false)}
-                className="mb-4"
+                className="mb-4 py-2"
               >
                 <Text className="text-sm text-text-mute text-center">
                   Отмена
@@ -325,7 +356,7 @@ export default function OnboardingWorkAreaScreen() {
                   setShowFnsPicker(false);
                   setSelectedCityId(null);
                 }}
-                className="mb-4"
+                className="mb-4 py-2"
               >
                 <Text className="text-sm text-text-mute text-center">
                   Отмена
@@ -334,9 +365,11 @@ export default function OnboardingWorkAreaScreen() {
             )}
 
             {error ? (
-              <Text className="text-xs text-danger text-center mb-4">
-                {error}
-              </Text>
+              <View className="mb-4 px-4 py-3 rounded-xl" style={{ backgroundColor: colors.errorBg }}>
+                <Text className="text-sm text-danger text-center leading-5">
+                  {error}
+                </Text>
+              </View>
             ) : null}
 
             <Button


### PR DESCRIPTION
Typography hierarchy, consistent spacing, prominent CTA buttons.

- **auth/otp**: H2 heading added, digit boxes 56px tall with stronger border states (2px filled when active/error), resend link upgraded to `text-base font-semibold`
- **onboarding/name**: progress dot bar (3 steps), subtitle added, checkbox border-2, error wrapped in errorBg pill, `mb-8` spacing before CTA
- **onboarding/work-area**: matching progress dots, section subtitle, picker dropdown headers, service rows highlight with accent-soft bg when checked, error in errorBg pill, "Add city" button uses `border-accent` dashes
- **(tabs)/create**: localized to Russian, progress bar with step labels, photo button uses accent-soft fill, tips box refined amber tokens, CTA button consistent with design system