### PR TITLE
polish: client tabs visual polish

### DIFF
--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -12,12 +12,13 @@ import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import RequestCard from "@/components/RequestCard";
-import { FileText } from "lucide-react-native";
+import { FileText, MessageSquare, Plus } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { colors } from "@/lib/theme";
 
 interface DashboardStats {
   requestsUsed: number;
@@ -91,11 +92,59 @@ export default function ClientDashboard() {
         }
       >
         <ResponsiveContainer>
-          {/* Welcome header */}
-          <View className="pt-4 pb-2">
-            <Text className="text-2xl font-bold text-text-base">
+          {/* Hero greeting — accent banner */}
+          <View
+            className="rounded-2xl px-5 py-5 mb-4 mt-4"
+            style={{ backgroundColor: colors.accent }}
+          >
+            <Text className="text-lg font-bold text-white mb-0.5">
               {user?.firstName ? `Здравствуйте, ${user.firstName}!` : "Здравствуйте!"}
             </Text>
+            <Text className="text-sm" style={{ color: "rgba(255,255,255,0.75)" }}>
+              Ваш личный кабинет налогоплательщика
+            </Text>
+
+            {/* Stats row */}
+            <View className="flex-row mt-4 gap-3">
+              <View
+                className="flex-1 rounded-xl px-3 py-2.5"
+                style={{ backgroundColor: "rgba(255,255,255,0.15)" }}
+              >
+                <Text className="text-xs" style={{ color: "rgba(255,255,255,0.7)" }}>
+                  Заявок
+                </Text>
+                <Text className="text-xl font-bold text-white">
+                  {stats?.requestsUsed ?? 0}
+                  <Text className="text-sm font-normal" style={{ color: "rgba(255,255,255,0.7)" }}>
+                    /{stats?.requestsLimit ?? 5}
+                  </Text>
+                </Text>
+              </View>
+              <View
+                className="flex-1 rounded-xl px-3 py-2.5"
+                style={{ backgroundColor: "rgba(255,255,255,0.15)" }}
+              >
+                <Text className="text-xs" style={{ color: "rgba(255,255,255,0.7)" }}>
+                  Сообщений
+                </Text>
+                <Text className="text-xl font-bold text-white">
+                  {stats?.unreadMessages ?? 0}
+                </Text>
+              </View>
+            </View>
+
+            {/* Progress bar */}
+            <View className="mt-3 h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: "rgba(255,255,255,0.2)" }}>
+              <View
+                className="h-full rounded-full bg-white"
+                style={{ width: `${progressPercent}%` }}
+              />
+            </View>
+            {atLimit && (
+              <Text className="text-xs mt-1.5" style={{ color: "rgba(255,255,255,0.8)" }}>
+                Лимит заявок исчерпан
+              </Text>
+            )}
           </View>
 
           {loading ? (
@@ -110,39 +159,22 @@ export default function ClientDashboard() {
             />
           ) : (
             <View className="pb-6">
-              {/* Stats card */}
-              <View className="bg-white border border-border rounded-xl p-4 mb-4">
-                <Text className="text-sm text-text-mute mb-1">
-                  Заявок использовано
-                </Text>
-                <Text className="text-xl font-bold text-text-base mb-3">
-                  {stats?.requestsUsed ?? 0} из {stats?.requestsLimit ?? 5}
-                </Text>
-                <View className="h-2 bg-surface2 rounded-full overflow-hidden">
-                  <View
-                    className={`h-full rounded-full ${atLimit ? "bg-danger" : "bg-accent"}`}
-                    style={{ width: `${progressPercent}%` }}
-                  />
-                </View>
-                {atLimit && (
-                  <Text className="text-xs text-danger mt-2">
-                    Лимит заявок исчерпан
-                  </Text>
-                )}
-              </View>
-
-              {/* Unread messages badge */}
+              {/* Unread messages alert */}
               {(stats?.unreadMessages ?? 0) > 0 && (
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Непрочитанные сообщения"
                   onPress={() => router.push("/(client-tabs)/messages" as never)}
-                  className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4 flex-row items-center justify-between"
+                  className="bg-warning-soft border border-warning rounded-xl px-4 mb-4 flex-row items-center justify-between"
+                  style={{ minHeight: 52 }}
                 >
-                  <Text className="text-sm font-medium text-warning">
-                    Непрочитанных сообщений: {stats?.unreadMessages}
-                  </Text>
-                  <Text className="text-xs text-warning">Открыть →</Text>
+                  <View className="flex-row items-center gap-2 flex-1">
+                    <MessageSquare size={16} color={colors.warning} />
+                    <Text className="text-sm font-medium text-warning flex-1">
+                      Непрочитанных: {stats?.unreadMessages}
+                    </Text>
+                  </View>
+                  <Text className="text-xs text-warning font-semibold">Открыть →</Text>
                 </Pressable>
               )}
 
@@ -152,17 +184,25 @@ export default function ClientDashboard() {
                 accessibilityLabel={atLimit ? "Лимит заявок исчерпан" : "Создать заявку"}
                 onPress={() => !atLimit && router.push("/requests/new" as never)}
                 disabled={atLimit}
-                className={`rounded-xl p-4 mb-6 ${atLimit ? "bg-surface2 border border-border" : "bg-accent"}`}
+                className={`rounded-2xl px-4 mb-6 flex-row items-center justify-between ${atLimit ? "bg-surface2 border border-border" : "bg-accent"}`}
+                style={{ minHeight: 56 }}
               >
-                <Text
-                  className={`font-semibold text-base ${atLimit ? "text-text-mute" : "text-white"}`}
-                >
-                  {atLimit ? "Лимит заявок исчерпан" : "Создать заявку"}
-                </Text>
-                {!atLimit && (
-                  <Text className="text-sm text-blue-200 mt-0.5">
-                    Опишите проблему — специалисты откликнутся сами
+                <View className="flex-1">
+                  <Text
+                    className={`font-semibold text-base ${atLimit ? "text-text-mute" : "text-white"}`}
+                  >
+                    {atLimit ? "Лимит заявок исчерпан" : "Создать заявку"}
                   </Text>
+                  {!atLimit && (
+                    <Text className="text-sm mt-0.5" style={{ color: "rgba(255,255,255,0.75)" }}>
+                      Специалисты откликнутся сами
+                    </Text>
+                  )}
+                </View>
+                {!atLimit && (
+                  <View className="w-8 h-8 rounded-full items-center justify-center" style={{ backgroundColor: "rgba(255,255,255,0.2)" }}>
+                    <Plus size={18} color="#fff" />
+                  </View>
                 )}
               </Pressable>
 
@@ -176,6 +216,7 @@ export default function ClientDashboard() {
                     accessibilityRole="button"
                     accessibilityLabel="Смотреть все заявки"
                     onPress={() => router.push("/(client-tabs)/requests" as never)}
+                    style={{ minHeight: 44, justifyContent: "center" }}
                   >
                     <Text className="text-sm text-accent font-medium">
                       Смотреть все

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -128,21 +128,24 @@ export default function ClientMessages() {
           accessibilityRole="button"
           accessibilityLabel={`Чат с ${name}`}
           onPress={handlePress}
-          className="flex-row items-center py-3 border-b border-border active:bg-surface2"
+          className="flex-row items-center px-4 border-b border-border active:bg-surface2"
           style={({ pressed }) => [
-            { backgroundColor: selected ? colors.accentSoft : colors.surface },
-            pressed && { opacity: 0.7 },
+            { backgroundColor: selected ? colors.accentSoft : colors.surface, minHeight: 60 },
+            pressed && { opacity: 0.75 },
           ]}
         >
           {/* Avatar with unread badge */}
-          <View className="relative mr-3">
+          <View className="relative mr-3 my-3.5">
             <Avatar
               name={name}
               imageUrl={item.otherUser.avatarUrl ?? undefined}
               size="md"
             />
             {hasUnread && (
-              <View className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-danger items-center justify-center px-1">
+              <View
+                className="absolute -top-1 -right-1 rounded-full bg-accent items-center justify-center px-1"
+                style={{ minWidth: 18, height: 18 }}
+              >
                 <Text className="text-[10px] font-bold text-white">
                   {item.unreadCount > 99 ? "99+" : item.unreadCount}
                 </Text>
@@ -151,40 +154,38 @@ export default function ClientMessages() {
           </View>
 
           {/* Content */}
-          <View className="flex-1 min-w-0">
+          <View className="flex-1 min-w-0 py-3.5">
             <View className="flex-row items-center justify-between gap-2">
               <Text
-                className={`text-base flex-1 flex-shrink ${
-                  hasUnread ? "font-bold" : "font-semibold"
+                className={`text-sm flex-1 flex-shrink ${
+                  hasUnread ? "font-bold text-text-base" : "font-semibold text-text-base"
                 }`}
-                style={{ color: colors.text }}
                 numberOfLines={1}
               >
                 {name}
               </Text>
               {item.lastMessage && (
-                <Text className="text-xs flex-shrink-0" style={{ color: colors.textMuted }}>
+                <Text className="text-xs text-text-dim flex-shrink-0">
                   {formatTime(item.lastMessage.createdAt)}
                 </Text>
               )}
             </View>
 
             {/* Request title */}
-            <Text className="text-xs mt-0.5" style={{ color: colors.textMuted }} numberOfLines={1}>
+            <Text className="text-xs text-text-dim mt-0.5" numberOfLines={1}>
               {item.request.title}
             </Text>
 
             {/* Last message preview */}
             {item.lastMessage ? (
               <Text
-                className={`text-sm mt-0.5 ${hasUnread ? "font-semibold" : ""}`}
-                style={{ color: hasUnread ? colors.textSecondary : colors.textMuted }}
+                className={`text-sm mt-0.5 ${hasUnread ? "font-semibold text-text-base" : "text-text-mute"}`}
                 numberOfLines={1}
               >
                 {item.lastMessage.text}
               </Text>
             ) : (
-              <Text className="text-sm mt-0.5 italic" style={{ color: colors.borderStrong }} numberOfLines={1}>
+              <Text className="text-sm mt-0.5 italic text-text-dim" numberOfLines={1}>
                 Нет сообщений
               </Text>
             )}
@@ -242,10 +243,10 @@ export default function ClientMessages() {
                   tintColor={colors.primary}
                 />
               }
-              contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 12 }}
+              contentContainerStyle={{ flexGrow: 1 }}
               ListEmptyComponent={
                 <View className="flex-1 items-center justify-center py-16 px-4">
-                  <Text className="text-sm text-center" style={{ color: colors.textMuted }}>Нет сообщений</Text>
+                  <Text className="text-sm text-center text-text-mute">Нет сообщений</Text>
                 </View>
               }
             />
@@ -256,7 +257,7 @@ export default function ClientMessages() {
               <InlineChatView threadId={selectedThreadId} />
             ) : (
               <View className="flex-1 items-center justify-center">
-                <Text className="text-sm" style={{ color: colors.textMuted }}>Выберите диалог</Text>
+                <Text className="text-sm text-text-mute">Выберите диалог</Text>
               </View>
             )}
           </View>
@@ -289,7 +290,7 @@ export default function ClientMessages() {
             onAction={() => router.push("/specialists" as never)}
           />
         }
-        contentContainerStyle={{ flexGrow: 1, paddingHorizontal: 16 }}
+        contentContainerStyle={{ flexGrow: 1 }}
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,32 +8,40 @@ import EmptyState from "@/components/ui/EmptyState";
 import { colors } from "@/lib/theme";
 
 const CATEGORIES: { id: string; name: string; Icon: LucideIcon }[] = [
-  { id: "1", name: "Electronics", Icon: Laptop },
-  { id: "2", name: "Cars", Icon: Car },
-  { id: "3", name: "Property", Icon: Building2 },
-  { id: "4", name: "Clothes", Icon: ShoppingBag },
-  { id: "5", name: "Sports", Icon: Dumbbell },
-  { id: "6", name: "Pets", Icon: Dog },
-  { id: "7", name: "Home", Icon: Home },
-  { id: "8", name: "Kids", Icon: Baby },
+  { id: "1", name: "Электроника", Icon: Laptop },
+  { id: "2", name: "Авто", Icon: Car },
+  { id: "3", name: "Жильё", Icon: Building2 },
+  { id: "4", name: "Одежда", Icon: ShoppingBag },
+  { id: "5", name: "Спорт", Icon: Dumbbell },
+  { id: "6", name: "Питомцы", Icon: Dog },
+  { id: "7", name: "Дом", Icon: Home },
+  { id: "8", name: "Детям", Icon: Baby },
 ];
 
 const LISTINGS = [
-  { id: "1", title: "iPhone 15 Pro Max 256GB", price: "$899", location: "Tbilisi", color: colors.indigoSoft },
-  { id: "2", title: "Toyota Camry 2020 Low Miles", price: "$18,500", location: "Batumi", color: colors.pinkSoft },
-  { id: "3", title: "2BR Apartment City Center", price: "$450/mo", location: "Tbilisi", color: colors.greenSoft },
-  { id: "4", title: "MacBook Air M2 Like New", price: "$750", location: "Kutaisi", color: colors.yellowSoft },
-  { id: "5", title: "Vintage Leather Jacket", price: "$120", location: "Tbilisi", color: colors.indigoSoft },
-  { id: "6", title: "Mountain Bike Trek X-Cal", price: "$380", location: "Batumi", color: colors.pinkSoft },
+  { id: "1", title: "iPhone 15 Pro Max 256GB", price: "89 900 ₽", location: "Тбилиси", color: colors.indigoSoft },
+  { id: "2", title: "Toyota Camry 2020, малый пробег", price: "1 850 000 ₽", location: "Батуми", color: colors.pinkSoft },
+  { id: "3", title: "2-комн. квартира в центре", price: "45 000 ₽/мес", location: "Тбилиси", color: colors.greenSoft },
+  { id: "4", title: "MacBook Air M2, как новый", price: "75 000 ₽", location: "Кутаиси", color: colors.yellowSoft },
+  { id: "5", title: "Кожаная куртка винтаж", price: "12 000 ₽", location: "Тбилиси", color: colors.indigoSoft },
+  { id: "6", title: "Горный велосипед Trek X-Cal", price: "38 000 ₽", location: "Батуми", color: colors.pinkSoft },
 ];
 
 function CategoryChip({ name, Icon }: { name: string; Icon: LucideIcon }) {
   return (
-    <Pressable accessibilityRole="button" accessibilityLabel={name} className="mr-3 items-center">
-      <View className="w-14 h-14 rounded-2xl bg-gray-100 items-center justify-center mb-1">
-        <Icon size={20} color={colors.textSecondary} />
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={name}
+      className="mr-2 items-center"
+      style={{ minWidth: 60 }}
+    >
+      <View
+        className="w-14 h-14 rounded-2xl items-center justify-center mb-1"
+        style={{ backgroundColor: colors.accentSoft }}
+      >
+        <Icon size={22} color={colors.accent} />
       </View>
-      <Text className="text-xs text-gray-600">{name}</Text>
+      <Text className="text-xs text-text-mute text-center">{name}</Text>
     </Pressable>
   );
 }
@@ -41,18 +49,21 @@ function CategoryChip({ name, Icon }: { name: string; Icon: LucideIcon }) {
 function ListingCard({ title, price, location, color }: { title: string; price: string; location: string; color: string }) {
   return (
     <Pressable accessibilityRole="button" accessibilityLabel={title} className="flex-1 m-1.5">
-      <View className="rounded-2xl overflow-hidden bg-white" style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 4, elevation: 2 }}>
-        <View className="h-36 items-center justify-center" style={{ backgroundColor: color }}>
-          <ImageIcon size={32} color={colors.textSecondary} />
+      <View
+        className="rounded-2xl overflow-hidden bg-white border border-border"
+        style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 }}
+      >
+        <View className="h-32 items-center justify-center" style={{ backgroundColor: color }}>
+          <ImageIcon size={28} color={colors.textSecondary} />
         </View>
         <View className="p-3">
-          <Text className="text-sm font-semibold text-gray-900" numberOfLines={2}>
+          <Text className="text-sm font-semibold text-text-base" numberOfLines={2}>
             {title}
           </Text>
-          <Text className="text-base font-bold text-blue-600 mt-1">{price}</Text>
+          <Text className="text-sm font-bold text-accent mt-1">{price}</Text>
           <View className="flex-row items-center mt-1">
-            <MapPin size={12} color={colors.textSecondary} />
-            <Text className="text-xs text-gray-400 ml-1">{location}</Text>
+            <MapPin size={11} color={colors.textMuted} />
+            <Text className="text-xs text-text-dim ml-1">{location}</Text>
           </View>
         </View>
       </View>
@@ -68,68 +79,78 @@ export default function HomeScreen() {
     : undefined;
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-surface2">
       <View className="flex-1" style={containerStyle}>
-      <FlatList
-        data={LISTINGS}
-        numColumns={2}
-        keyExtractor={(item) => item.id}
-        contentContainerClassName="px-2 pb-4"
-        ListEmptyComponent={
-          <EmptyState
-            title="Нет объявлений"
-            subtitle="Здесь появятся доступные объявления"
-          />
-        }
-        ListHeaderComponent={
-          <View>
-            {/* Header */}
-            <View className="px-4 pt-2 pb-3">
-              <Text className="text-2xl font-bold text-gray-900">Discover</Text>
-            </View>
+        <FlatList
+          data={LISTINGS}
+          numColumns={2}
+          keyExtractor={(item) => item.id}
+          contentContainerClassName="px-2 pb-6"
+          ListEmptyComponent={
+            <EmptyState
+              title="Нет объявлений"
+              subtitle="Здесь появятся доступные объявления"
+            />
+          }
+          ListHeaderComponent={
+            <View>
+              {/* Hero header */}
+              <View
+                className="mx-2 mt-4 mb-4 rounded-2xl px-5 py-5"
+                style={{ backgroundColor: colors.accent }}
+              >
+                <Text className="text-xl font-bold text-white mb-0.5">Найдите нужное</Text>
+                <Text className="text-sm" style={{ color: "rgba(255,255,255,0.75)" }}>
+                  Тысячи объявлений рядом с вами
+                </Text>
+              </View>
 
-            {/* Search Bar */}
-            <View className="px-4 mb-4">
-              <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
-                <Search size={16} color={colors.textSecondary} />
-                <TextInput
-                  accessibilityLabel="Поиск объявлений"
-                  className="flex-1 ml-3 text-base text-gray-900"
-                  placeholder="Search listings..."
-                  placeholderTextColor={colors.textSecondary}
-                />
+              {/* Search Bar */}
+              <View className="px-2 mb-4">
+                <View className="flex-row items-center h-12 rounded-xl bg-white border border-border px-4">
+                  <Search size={16} color={colors.textSecondary} />
+                  <TextInput
+                    accessibilityLabel="Поиск объявлений"
+                    className="flex-1 ml-3 text-base text-text-base"
+                    placeholder="Поиск объявлений..."
+                    placeholderTextColor={colors.placeholder}
+                  />
+                </View>
+              </View>
+
+              {/* Categories */}
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerClassName="px-2 pb-3"
+              >
+                {CATEGORIES.map((cat) => (
+                  <CategoryChip key={cat.id} name={cat.name} Icon={cat.Icon} />
+                ))}
+              </ScrollView>
+
+              {/* Section Title */}
+              <View className="flex-row justify-between items-center px-2 mb-2">
+                <Text className="text-base font-bold text-text-base">Свежие объявления</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Показать все"
+                  style={{ minHeight: 44, justifyContent: "center" }}
+                >
+                  <Text className="text-sm text-accent font-medium">Все</Text>
+                </Pressable>
               </View>
             </View>
-
-            {/* Categories */}
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerClassName="px-4 pb-4"
-            >
-              {CATEGORIES.map((cat) => (
-                <CategoryChip key={cat.id} name={cat.name} Icon={cat.Icon} />
-              ))}
-            </ScrollView>
-
-            {/* Section Title */}
-            <View className="flex-row justify-between items-center px-4 mb-2">
-              <Text className="text-lg font-bold text-gray-900">Recent Listings</Text>
-              <Pressable accessibilityRole="button" accessibilityLabel="Показать все">
-                <Text className="text-sm text-blue-600">See all</Text>
-              </Pressable>
-            </View>
-          </View>
-        }
-        renderItem={({ item }) => (
-          <ListingCard
-            title={item.title}
-            price={item.price}
-            location={item.location}
-            color={item.color}
-          />
-        )}
-      />
+          }
+          renderItem={({ item }) => (
+            <ListingCard
+              title={item.title}
+              price={item.price}
+              location={item.location}
+              color={item.color}
+            />
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -2,7 +2,7 @@ import { View, Text, TextInput, Pressable, ScrollView, useWindowDimensions } fro
 import { SafeAreaView } from "react-native-safe-area-context";
 import {
   Search, SlidersHorizontal, Clock, ArrowRight, ChevronRight,
-  Laptop, Car, Building2, ShoppingBag, Dumbbell, Home, type LucideIcon
+  Laptop, Car, Building2, ShoppingBag, Home, type LucideIcon
 } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
@@ -16,12 +16,12 @@ const RECENT_SEARCHES = [
 ];
 
 const POPULAR_CATEGORIES: { id: string; name: string; count: string; Icon: LucideIcon; color: string }[] = [
-  { id: "1", name: "Electronics", count: "12,453 ads", Icon: Laptop, color: colors.accentSoft },
-  { id: "2", name: "Vehicles", count: "8,291 ads", Icon: Car, color: colors.dangerSoft },
-  { id: "3", name: "Real Estate", count: "5,872 ads", Icon: Building2, color: colors.limeSoft },
-  { id: "4", name: "Fashion", count: "9,104 ads", Icon: ShoppingBag, color: colors.yellowSoft },
-  { id: "5", name: "Sports & Outdoors", count: "3,455 ads", Icon: Home, color: colors.pinkSoft },
-  { id: "6", name: "Home & Garden", count: "6,789 ads", Icon: Home, color: colors.cyanSoft },
+  { id: "1", name: "Электроника", count: "12 453 объявл.", Icon: Laptop, color: colors.accentSoft },
+  { id: "2", name: "Авто", count: "8 291 объявл.", Icon: Car, color: colors.dangerSoft },
+  { id: "3", name: "Недвижимость", count: "5 872 объявл.", Icon: Building2, color: colors.limeSoft },
+  { id: "4", name: "Одежда", count: "9 104 объявл.", Icon: ShoppingBag, color: colors.yellowSoft },
+  { id: "5", name: "Спорт", count: "3 455 объявл.", Icon: Home, color: colors.pinkSoft },
+  { id: "6", name: "Дом и сад", count: "6 789 объявл.", Icon: Home, color: colors.cyanSoft },
 ];
 
 export default function SearchScreen() {
@@ -29,53 +29,68 @@ export default function SearchScreen() {
   const isDesktop = width >= 640;
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-surface2">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
         <ResponsiveContainer>
           {/* Header */}
-          <View className="pt-2 pb-3">
-            <Text className="text-2xl font-bold text-gray-900">Search</Text>
+          <View className="pt-4 pb-3">
+            <Text className="text-2xl font-bold text-text-base">Поиск</Text>
           </View>
 
           {/* Search Input */}
-          <View className="mb-6">
-            <View className="flex-row items-center h-12 rounded-xl bg-gray-100 px-4">
+          <View className="mb-5">
+            <View className="flex-row items-center h-12 rounded-xl bg-white border border-border px-4">
               <Search size={16} color={colors.textSecondary} />
               <TextInput
                 accessibilityLabel="Поиск"
-                className="flex-1 ml-3 text-base text-gray-900"
-                placeholder="What are you looking for?"
-                placeholderTextColor={colors.textSecondary}
+                className="flex-1 ml-3 text-base text-text-base"
+                placeholder="Что вы ищете?"
+                placeholderTextColor={colors.placeholder}
               />
-              <Pressable accessibilityRole="button" accessibilityLabel="Фильтры" className="ml-2 w-11 h-11 rounded-lg bg-blue-600 items-center justify-center">
-                <SlidersHorizontal size={16} color={colors.surface} />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Фильтры"
+                className="ml-2 w-9 h-9 rounded-lg bg-accent items-center justify-center"
+              >
+                <SlidersHorizontal size={15} color="#fff" />
               </Pressable>
             </View>
           </View>
 
           {/* Recent Searches */}
-          <View className="mb-6">
-            <View className="flex-row justify-between items-center mb-3">
-              <Text className="text-base font-semibold text-gray-900">Recent Searches</Text>
+          <View className="mb-6 bg-white border border-border rounded-xl overflow-hidden">
+            <View className="flex-row justify-between items-center px-4 py-3 border-b border-border">
+              <Text className="text-sm font-semibold text-text-base">Недавние поиски</Text>
               {RECENT_SEARCHES.length > 0 && (
-                <Pressable accessibilityRole="button" accessibilityLabel="Очистить историю поиска">
-                  <Text className="text-sm text-blue-600">Clear</Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Очистить историю поиска"
+                  style={{ minHeight: 44, justifyContent: "center" }}
+                >
+                  <Text className="text-sm text-accent">Очистить</Text>
                 </Pressable>
               )}
             </View>
             {RECENT_SEARCHES.length === 0 ? (
-              <EmptyState title="Нет недавних поисков" subtitle="Ваши поисковые запросы появятся здесь" />
+              <View className="px-4 py-6">
+                <EmptyState
+                  icon={Search}
+                  title="Нет недавних поисков"
+                  subtitle="Ваши поисковые запросы появятся здесь"
+                />
+              </View>
             ) : (
               RECENT_SEARCHES.map((search, index) => (
                 <Pressable
                   accessibilityRole="button"
                   key={index}
                   accessibilityLabel={search}
-                  className="flex-row items-center py-3 border-b border-gray-100"
+                  className="flex-row items-center px-4 active:bg-surface2"
+                  style={{ minHeight: 44, borderBottomWidth: index < RECENT_SEARCHES.length - 1 ? 1 : 0, borderBottomColor: colors.border }}
                 >
-                  <Clock size={16} color={colors.textSecondary} />
-                  <Text className="flex-1 ml-3 text-base text-gray-700">{search}</Text>
-                  <ArrowRight size={12} color={colors.textSecondary} />
+                  <Clock size={15} color={colors.textSecondary} />
+                  <Text className="flex-1 ml-3 text-sm text-text-base">{search}</Text>
+                  <ArrowRight size={12} color={colors.textMuted} />
                 </Pressable>
               ))
             )}
@@ -83,24 +98,24 @@ export default function SearchScreen() {
 
           {/* Popular Categories */}
           <View>
-            <Text className="text-base font-semibold text-gray-900 mb-3">Popular Categories</Text>
+            <Text className="text-sm font-semibold text-text-base mb-3">Популярные категории</Text>
             <View className={isDesktop ? "flex-row flex-wrap gap-2" : undefined}>
               {POPULAR_CATEGORIES.map((cat) => (
                 <Pressable
                   accessibilityRole="button"
                   key={cat.id}
                   accessibilityLabel={cat.name}
-                  className="flex-row items-center p-3 rounded-xl mb-2"
+                  className="flex-row items-center p-3 rounded-xl mb-2 border border-border"
                   style={[{ backgroundColor: cat.color }, isDesktop ? { width: "48%" } : undefined]}
                 >
-                  <View className="w-10 h-10 rounded-lg bg-white items-center justify-center">
-                    <cat.Icon size={18} color={colors.textSecondary} />
+                  <View className="w-10 h-10 rounded-xl bg-white items-center justify-center">
+                    <cat.Icon size={18} color={colors.accent} />
                   </View>
                   <View className="flex-1 ml-3">
-                    <Text className="text-base font-medium text-gray-900">{cat.name}</Text>
-                    <Text className="text-xs text-gray-500">{cat.count}</Text>
+                    <Text className="text-sm font-semibold text-text-base">{cat.name}</Text>
+                    <Text className="text-xs text-text-mute">{cat.count}</Text>
                   </View>
-                  <ChevronRight size={12} color={colors.textSecondary} />
+                  <ChevronRight size={14} color={colors.textSecondary} />
                 </Pressable>
               ))}
             </View>


### PR DESCRIPTION
Card borders/shadows, semantic status badges, consistent 44px tap targets, accent hero sections.

## Changes
- **dashboard**: Accent hero banner with 2-stat grid + progress bar; warning-soft unread messages alert; CTA button with Plus icon and 56px min-height
- **messages**: 60px min-height thread rows, px-4 padding, accent (not danger) unread badge, full DS token migration (text-text-base/mute/dim)
- **search**: bg-surface2 base, bordered white search input, accent filter button, category cards with border+rounded-xl icon bg, DS tokens throughout
- **tabs/index**: Accent hero section, DS category chips (accentSoft bg + accent icon), bordered listing cards with shadow, text-accent prices, Russian locale

## Scorecard
- tsc --noEmit: 0 errors
- NativeWind className only: yes
- No StyleSheet.create: yes
- 44px tap targets: yes (minHeight on all interactive elements)