### PR TITLE
fix: tab bar label font size 12px (fix typography score)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -19,6 +19,13 @@ export default function TabLayout() {
             display: isMobile ? "flex" : "none",
             borderTopWidth: 1,
             borderTopColor: colors.border,
+            height: 60,
+            paddingBottom: 8,
+            paddingTop: 4,
+          },
+          tabBarLabelStyle: {
+            fontSize: 12,
+            fontWeight: "500",
           },
           headerShown: false,
         }}


### PR DESCRIPTION
Fixes typography:5 issue in all /(tabs)/* screens. Tab bar labels were rendering below 12px, causing AI design scorer to rate typography as 5/10. Setting fontSize:12 + fontWeight:500 + proper padding on the tab bar.