### PR TITLE
polish(r3): home listing cards + messages premium polish

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,7 +5,7 @@ import {
   ImageIcon, MapPin, Search, type LucideIcon
 } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 const CATEGORIES: { id: string; name: string; Icon: LucideIcon }[] = [
   { id: "1", name: "Электроника", Icon: Laptop },
@@ -48,32 +48,25 @@ function CategoryChip({ name, Icon }: { name: string; Icon: LucideIcon }) {
 
 function ListingCard({ title, price, location, color }: { title: string; price: string; location: string; color: string }) {
   return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={title}
-      className="flex-1 m-1.5"
-      style={{ minHeight: 44 }}
-    >
+    <Pressable className="flex-1 m-1.5" style={{ minHeight: 44 }} accessibilityRole="button" accessibilityLabel={title}>
       <View
         className="rounded-2xl overflow-hidden bg-white border border-border"
         style={{
           shadowColor: colors.text,
-          shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.07,
-          shadowRadius: 5,
-          elevation: 2,
+          shadowOffset: { width: 0, height: 3 },
+          shadowOpacity: 0.10,
+          shadowRadius: 8,
+          elevation: 4,
         }}
       >
-        <View className="h-32 items-center justify-center" style={{ backgroundColor: color }}>
-          <ImageIcon size={28} color={colors.textSecondary} />
+        <View className="h-36 items-center justify-center relative" style={{ backgroundColor: color }}>
+          <ImageIcon size={32} color="rgba(0,0,0,0.15)" />
         </View>
-        <View className="p-3">
-          <Text className="text-base font-semibold text-text-base" numberOfLines={2}>
-            {title}
-          </Text>
-          <Text className="text-lg font-bold text-accent mt-1">{price}</Text>
-          <View className="flex-row items-center mt-1">
-            <MapPin size={12} color={colors.textMuted} />
+        <View className="p-3 pb-4">
+          <Text className="text-sm font-semibold text-text-base mb-1" numberOfLines={2}>{title}</Text>
+          <Text className="text-base font-bold text-accent mb-1.5">{price}</Text>
+          <View className="flex-row items-center">
+            <MapPin size={11} color={colors.textMuted} />
             <Text className="text-xs text-text-mute ml-1">{location}</Text>
           </View>
         </View>
@@ -108,11 +101,14 @@ export default function HomeScreen() {
               {/* Hero header */}
               <View
                 className="mx-2 mt-4 mb-4 rounded-2xl px-5 py-5"
-                style={{ backgroundColor: colors.accent }}
+                style={{ backgroundColor: colors.accent, minHeight: 100 }}
               >
-                <Text className="text-2xl font-bold text-white mb-0.5">Найдите нужное</Text>
-                <Text className="text-sm" style={{ color: "rgba(255,255,255,0.80)" }}>
+                <Text className="text-2xl font-bold text-white mb-1">Найдите нужное</Text>
+                <Text className="text-sm" style={{ color: overlay.white80 }}>
                   Тысячи объявлений рядом с вами
+                </Text>
+                <Text className="text-xs mt-1" style={{ color: overlay.white50 }}>
+                  Электроника, авто, жильё и многое другое
                 </Text>
               </View>
 

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -2,7 +2,7 @@ import { View, Text, Pressable, FlatList, useWindowDimensions } from "react-nati
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MessageCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
-import { AVATAR_COLORS } from "@/lib/theme";
+import { AVATAR_COLORS, colors, overlay } from "@/lib/theme";
 
 const CONVERSATIONS = [
   { id: "1", name: "Alex K.", avatar: "A", lastMessage: "Is the iPhone still available?", time: "2m ago", unread: true },
@@ -26,18 +26,29 @@ function ConversationItem({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={`Чат с ${name}`}
-      className="flex-row items-center px-4 border-b border-border active:bg-surface2"
-      style={{ minHeight: 72, paddingVertical: 16 }}
+      className="flex-row items-center active:bg-surface2"
+      style={[
+        { minHeight: 72, paddingVertical: 16, paddingHorizontal: 16, borderBottomWidth: 1, borderBottomColor: colors.border },
+        unread ? { borderLeftWidth: 3, borderLeftColor: colors.primary, backgroundColor: overlay.accent10 } : {},
+      ]}
     >
       <View
         className="w-12 h-12 rounded-full items-center justify-center"
-        style={{ backgroundColor: avatarColor }}
+        style={{
+          backgroundColor: avatarColor,
+          borderWidth: 2,
+          borderColor: '#ffffff',
+          shadowColor: colors.text,
+          shadowOpacity: 0.1,
+          shadowRadius: 4,
+          shadowOffset: { width: 0, height: 1 },
+        }}
       >
         <Text className="text-lg font-bold text-white">{avatar}</Text>
       </View>
       <View className="flex-1 ml-3">
         <View className="flex-row justify-between items-center mb-0.5">
-          <Text className={`text-base ${unread ? "font-bold text-text-base" : "font-semibold text-text-base"}`}>
+          <Text className={`text-base ${unread ? "font-bold text-accent" : "font-semibold text-text-base"}`}>
             {name}
           </Text>
           <Text className={`text-xs ${unread ? "text-accent font-semibold" : "text-text-dim"}`}>
@@ -70,15 +81,23 @@ export default function MessagesScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <View className="flex-1" style={containerStyle}>
-        <View className="px-4 pt-2 pb-3 border-b border-border bg-white">
+        <View className="px-4 pt-3 pb-3 border-b border-border bg-white flex-row items-center justify-between">
           <Text className="text-2xl font-bold text-text-base">Сообщения</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Написать новое сообщение"
+            className="bg-accent-soft rounded-full px-3 py-1.5 justify-center items-center"
+            style={{ minHeight: 44, minWidth: 44 }}
+          >
+            <Text className="text-sm font-semibold text-accent">+ Написать</Text>
+          </Pressable>
         </View>
 
         <FlatList
           data={CONVERSATIONS}
           keyExtractor={(item) => item.id}
           renderItem={({ item, index }) => <ConversationItem {...item} index={index} />}
-          contentContainerStyle={{ paddingBottom: 20 }}
+          contentContainerStyle={{ paddingBottom: 32 }}
           ListEmptyComponent={
             <EmptyState
               icon={MessageCircle}


### PR DESCRIPTION
## Summary
- ListingCard: deeper shadow (0.10/8px), taller image (h-36), subtler placeholder icon, tighter text spacing
- Hero banner: min-height 100px, overlay.white80 token, added secondary tagline
- Messages: compose button in header, unread rows get left accent border + accent10 bg, avatar border+shadow, unread name text-accent
- contentContainerStyle paddingBottom 32

## Verification
- `npx tsc --noEmit` passes with 0 errors