### PR TITLE
polish(r3): admin-dashboard + moderation + client-messages

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -8,7 +8,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 
 interface Stats {
@@ -36,14 +36,14 @@ function StatCard({
       className="bg-white border border-border rounded-2xl p-5 flex-1"
       style={{
         shadowColor: "#000",
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.08,
-        shadowRadius: 6,
-        elevation: 3,
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.09,
+        shadowRadius: 8,
+        elevation: 4,
       }}
     >
-      <Text className="text-3xl font-extrabold text-text-base">{value}</Text>
-      <Text className="text-sm text-text-mute mt-1">{label}</Text>
+      <Text className="text-4xl font-extrabold text-text-base">{value}</Text>
+      <Text className="text-sm text-text-mute mt-1.5">{label}</Text>
     </View>
   );
 
@@ -77,10 +77,10 @@ function RankList({
       className="bg-white border border-border rounded-2xl p-5"
       style={{
         shadowColor: "#000",
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.08,
-        shadowRadius: 6,
-        elevation: 3,
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.09,
+        shadowRadius: 8,
+        elevation: 4,
       }}
     >
       <Text className="text-base font-bold text-text-base mb-3">{title}</Text>
@@ -162,12 +162,23 @@ export default function AdminDashboard() {
         </View>
       ) : (
         <ScrollView className="flex-1">
-          <ResponsiveContainer>
-            <View className="py-4 gap-3">
-              <Text className="text-base font-bold text-text-base mb-1">
+          {/* Accent hero section */}
+          <View className="bg-accent px-4 pt-5 pb-6">
+            <ResponsiveContainer>
+              <Text className="text-2xl font-bold text-white">
                 Панель администратора
               </Text>
+              <Text
+                className="text-sm mt-1"
+                style={{ color: overlay.white75 }}
+              >
+                Обзор ключевых метрик платформы
+              </Text>
+            </ResponsiveContainer>
+          </View>
 
+          <ResponsiveContainer>
+            <View className="py-4 gap-3">
               {/* Stats grid */}
               <View className="flex-row flex-wrap gap-3">
                 <View className="w-full">

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -3,18 +3,33 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { CheckCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      {/* Header */}
-      <View className="bg-accent px-4 h-14 flex-row items-center justify-between">
-        <Text className="text-lg font-bold text-white">Модерация</Text>
+      {/* Accent hero header */}
+      <View className="bg-accent px-4 pt-4 pb-4">
+        <Text className="text-2xl font-bold text-white">Модерация</Text>
+        <Text
+          className="text-sm mt-1"
+          style={{ color: overlay.white75 }}
+        >
+          Управление контентом платформы
+        </Text>
       </View>
 
       {/* Section separator */}
-      <View className="bg-white border-b border-border px-4 py-3">
+      <View
+        className="bg-white border-b border-border px-4 py-3"
+        style={{
+          shadowColor: "#000",
+          shadowOffset: { width: 0, height: 1 },
+          shadowOpacity: 0.05,
+          shadowRadius: 3,
+          elevation: 2,
+        }}
+      >
         <Text className="text-sm text-text-mute">
           Контент, требующий проверки перед публикацией
         </Text>

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -17,7 +17,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
 import InlineChatView from "@/components/InlineChatView";
 import { apiGet } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface ThreadItem {
   id: string;
@@ -131,19 +131,34 @@ export default function ClientMessages() {
           className="flex-row items-center px-4 border-b border-border active:bg-surface2"
           style={({ pressed }) => [
             {
-              backgroundColor: selected ? colors.accentSoft : colors.surface,
+              backgroundColor: selected
+                ? colors.accentSoft
+                : hasUnread
+                  ? overlay.accent10
+                  : colors.surface,
               minHeight: 72,
+              borderLeftWidth: hasUnread ? 3 : 0,
+              borderLeftColor: hasUnread ? colors.primary : "transparent",
               shadowColor: "#000",
               shadowOffset: { width: 0, height: 1 },
-              shadowOpacity: 0.05,
-              shadowRadius: 2,
-              elevation: 1,
+              shadowOpacity: 0.06,
+              shadowRadius: 3,
+              elevation: 2,
             },
             pressed && { opacity: 0.75 },
           ]}
         >
           {/* Avatar with active indicator and unread badge */}
-          <View className="relative mr-3 my-3.5">
+          <View
+            className="relative mr-3 my-3.5"
+            style={{
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.1,
+              shadowRadius: 4,
+              elevation: 3,
+            }}
+          >
             <Avatar
               name={name}
               imageUrl={item.otherUser.avatarUrl ?? undefined}
@@ -178,7 +193,11 @@ export default function ClientMessages() {
                 {name}
               </Text>
               {item.lastMessage && (
-                <Text className="text-xs text-text-dim flex-shrink-0">
+                <Text
+                  className={`text-xs flex-shrink-0 ${
+                    hasUnread ? "text-accent font-semibold" : "text-text-dim"
+                  }`}
+                >
                   {formatTime(item.lastMessage.createdAt)}
                 </Text>
               )}


### PR DESCRIPTION
## Summary
- **Dashboard**: accent hero section with title/subtitle, stat numbers bumped to text-4xl font-extrabold, deeper card shadows (0.09/8/elevation 4)
- **Moderation**: accent hero header with overlay.white75 subtitle, shadow on section separator
- **Client messages**: unread threads get left accent border (3px) + accent10 background, timestamps for unread are accent/semibold, deeper avatar shadows

## Verification
- `npx tsc --noEmit` = 0 errors (frontend + api)
- NativeWind className only, no StyleSheet.create