### PR TITLE
polish(r3): client-requests hero + threads accent + onboarding polish

### DIFF
--- a/app/(client-tabs)/requests.tsx
+++ b/app/(client-tabs)/requests.tsx
@@ -20,6 +20,7 @@ import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import ErrorState from "@/components/ui/ErrorState";
 import { api, apiPatch } from "@/lib/api";
+import { colors, overlay } from "@/lib/theme";
 
 interface RequestItem {
   id: string;
@@ -159,11 +160,11 @@ function SwipeableCard({ item, onPress, onClose }: SwipeableCardProps) {
           onPress={() => onPress(item.id)}
           className="bg-white border border-border rounded-2xl p-4"
           style={{
-            shadowColor: "#0b1424",
+            shadowColor: colors.text,
             shadowOffset: { width: 0, height: 2 },
-            shadowOpacity: 0.07,
-            shadowRadius: 5,
-            elevation: 2,
+            shadowOpacity: 0.09,
+            shadowRadius: 7,
+            elevation: 3,
             minHeight: 44,
           }}
         >
@@ -202,7 +203,7 @@ function SwipeableCard({ item, onPress, onClose }: SwipeableCardProps) {
 
           {/* Swipe hint for active cards (mobile only) */}
           {isActive && Platform.OS !== "web" && (
-            <Text className="text-[10px] text-text-mute mt-1 text-right">
+            <Text className="text-xs text-text-mute mt-1 text-right">
               ← смахните для закрытия
             </Text>
           )}
@@ -345,16 +346,18 @@ export default function MyRequests() {
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <HeaderHome />
       <ResponsiveContainer>
-        {/* Page title + create button row */}
-        <View className="flex-row items-center justify-between mt-4 mb-4">
-          <Text className="text-2xl font-bold text-text-base">Мои заявки</Text>
+        {/* Accent hero */}
+        <View className="rounded-2xl px-5 py-5 mb-5 mt-2" style={{ backgroundColor: colors.accent }}>
+          <Text className="text-xl font-bold text-white mb-0.5">Мои заявки</Text>
+          <Text className="text-sm mb-4" style={{ color: overlay.white75 }}>Управляйте своими обращениями к специалистам</Text>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Создать заявку"
             onPress={() => router.push("/requests/new" as never)}
-            className="bg-accent rounded-xl px-4 py-2 flex-row items-center"
+            className="rounded-xl px-4 flex-row items-center self-start"
+            style={{ backgroundColor: overlay.white20, minHeight: 44, justifyContent: "center" }}
           >
-            <Text className="text-white font-semibold text-sm">+ Создать</Text>
+            <Text className="text-white font-semibold text-sm">+ Создать заявку</Text>
           </Pressable>
         </View>
 

--- a/app/(specialist-tabs)/threads.tsx
+++ b/app/(specialist-tabs)/threads.tsx
@@ -140,7 +140,7 @@ export default function SpecialistMyThreads() {
         <FlatList
           data={filtered}
           keyExtractor={(item) => item.id}
-          contentContainerStyle={{ flexGrow: 1, paddingBottom: isDesktop ? 32 : 16, paddingHorizontal: 16 }}
+          contentContainerStyle={{ flexGrow: 1, paddingBottom: isDesktop ? 48 : 32, paddingHorizontal: 16 }}
           refreshControl={
             <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
           }
@@ -196,7 +196,7 @@ function FilterChip({
       className={`px-4 py-2 rounded-full border ${
         active ? "bg-accent border-accent" : "bg-white border-border"
       }`}
-      style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+      style={({ pressed }) => [{ minHeight: 44, justifyContent: "center" as const }, pressed && { opacity: 0.7 }]}
     >
       <Text
         className={`text-sm font-medium ${
@@ -250,10 +250,10 @@ function ThreadCard({
       className="flex-row items-center bg-white border border-border rounded-xl p-4 mb-3"
       style={({ pressed }) => [
         {
-          shadowColor: "#000",
+          shadowColor: colors.text,
           shadowOffset: { width: 0, height: 2 },
-          shadowOpacity: 0.08,
-          shadowRadius: 6,
+          shadowOpacity: 0.09,
+          shadowRadius: 8,
           elevation: 3,
           borderLeftWidth: hasUnread ? 3 : 0,
           borderLeftColor: hasUnread ? colors.primary : "transparent",
@@ -271,7 +271,7 @@ function ThreadCard({
             className="absolute -top-0.5 -right-0.5 rounded-full bg-accent items-center justify-center"
             style={{ minWidth: 20, height: 20, paddingHorizontal: 4 }}
           >
-            <Text className="text-[10px] font-bold text-white">
+            <Text className="text-xs font-bold text-white">
               {thread.unreadCount > 99 ? "99+" : thread.unreadCount}
             </Text>
           </View>
@@ -291,7 +291,7 @@ function ThreadCard({
           </Text>
           {isClosed && (
             <View className="bg-accent-soft rounded-full px-2 py-0.5">
-              <Text className="text-[10px] font-medium text-accent">
+              <Text className="text-xs font-medium text-accent">
                 Закрыта
               </Text>
             </View>

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -2,13 +2,14 @@ import { View, Text, Pressable, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useState } from "react";
+import { User } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 export default function OnboardingNameScreen() {
   const router = useRouter();
@@ -70,12 +71,22 @@ export default function OnboardingNameScreen() {
       <HeaderBack title="" />
       <ResponsiveContainer>
         <View className="flex-1 pt-8" style={{ paddingBottom: isDesktop ? 48 : 24 }}>
-          {/* Progress indicator */}
+          {/* Icon */}
+          <View className="items-center mb-5">
+            <View
+              className="rounded-full items-center justify-center"
+              style={{ width: 56, height: 56, backgroundColor: overlay.accent10 }}
+            >
+              <User size={28} color={colors.accent} />
+            </View>
+          </View>
+
+          {/* Progress bar */}
           <View className="mb-6">
             <View className="flex-row justify-center gap-2 mb-3">
-              <View className="h-1.5 w-8 rounded-full bg-accent" />
-              <View className="h-1.5 w-8 rounded-full bg-border" />
-              <View className="h-1.5 w-8 rounded-full bg-border" />
+              <View className="h-2 w-10 rounded-full bg-accent" />
+              <View className="h-2 w-10 rounded-full bg-border" />
+              <View className="h-2 w-10 rounded-full bg-border" />
             </View>
             <Text className="text-sm font-medium text-text-mute text-center">
               Шаг 1 из 3

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -18,7 +18,7 @@ import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 
 export default function OnboardingProfileScreen() {
@@ -164,14 +164,22 @@ export default function OnboardingProfileScreen() {
       <ResponsiveContainer>
         <ScrollView
           className="flex-1"
-          contentContainerStyle={{ paddingBottom: 40 }}
+          contentContainerStyle={{ paddingBottom: 48 }}
           keyboardShouldPersistTaps="handled"
         >
           <View className="pt-6">
-            {/* Step indicator */}
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider text-center mb-2">
-              Шаг 3 из 3
-            </Text>
+            {/* Progress bar */}
+            <View className="mb-5">
+              <View className="flex-row justify-center gap-2 mb-3">
+                <View className="h-2 w-10 rounded-full bg-accent" />
+                <View className="h-2 w-10 rounded-full bg-accent" />
+                <View className="h-2 w-10 rounded-full bg-accent" />
+              </View>
+              <Text className="text-sm font-medium text-text-mute text-center">
+                Шаг 3 из 3
+              </Text>
+            </View>
+
             <Text className="text-2xl font-bold text-text-base text-center mb-1">
               Профиль
             </Text>
@@ -243,8 +251,14 @@ export default function OnboardingProfileScreen() {
             )}
 
             {/* Contacts note */}
-            <View className="bg-accent-soft rounded-xl px-4 py-3 mb-4">
-              <Text className="text-xs text-accent text-center">
+            <View
+              className="bg-accent-soft rounded-xl px-4 py-3 mb-4"
+              style={{
+                borderWidth: 1,
+                borderColor: overlay.accent10,
+              }}
+            >
+              <Text className="text-xs text-accent text-center font-medium">
                 Контакты будут видны всем посетителям платформы
               </Text>
             </View>
@@ -340,9 +354,14 @@ export default function OnboardingProfileScreen() {
             </View>
 
             {error ? (
-              <Text className="text-xs text-danger text-center mb-4">
-                {error}
-              </Text>
+              <View
+                className="mb-4 px-4 py-3 rounded-xl flex-row items-center"
+                style={{ backgroundColor: colors.errorBg, borderWidth: 1, borderColor: colors.danger }}
+              >
+                <Text className="text-sm text-danger leading-5 flex-1">
+                  {error}
+                </Text>
+              </View>
             ) : null}
 
             <Button


### PR DESCRIPTION
## Summary
- **requests.tsx**: Replace flat title+button row with accent hero banner, fix hardcoded shadowColor to `colors.text`, deepen card shadows (0.09/7/3), fix swipe hint `text-[10px]` to `text-xs`
- **threads.tsx**: Fix shadowColor to `colors.text`, increase shadowRadius to 8, boost paddingBottom to 32/48, add minHeight:44 to FilterChip, fix `text-[10px]` badges to `text-xs`
- **onboarding/name.tsx**: Add accent User icon above progress bar, increase progress bar height (h-1.5 to h-2) and width (w-8 to w-10)
- **onboarding/profile.tsx**: Replace plain step text with visual progress bar (3 filled dots), add accent border to contacts note card, upgrade error display to bordered card style, increase scrollview paddingBottom

## Test plan
- [ ] Client requests screen shows accent hero banner with "Создать заявку" button
- [ ] Specialist threads screen has deeper card shadows and minHeight:44 filter chips
- [ ] Onboarding name screen shows User icon and thicker progress bar
- [ ] Onboarding profile screen shows full progress bar and bordered contacts note
- [ ] `npx tsc --noEmit` passes (verified: 0 errors)