### PR TITLE
fix: desktop responsive for complaints + specialist-dashboard

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
+  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -68,6 +69,8 @@ function formatDate(dateStr: string): string {
 
 export default function AdminComplaints() {
   const { token } = useAuth();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
   const [complaints, setComplaints] = useState<ComplaintItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -267,28 +270,37 @@ export default function AdminComplaints() {
       </View>
 
       {/* Filter tabs */}
-      <View className="bg-white border-b border-border px-4 py-2.5 flex-row gap-2">
-        {FILTER_OPTIONS.map((opt) => (
-          <Pressable
-            accessibilityRole="button"
-            key={opt.key}
-            accessibilityLabel={opt.label}
-            onPress={() => setFilter(opt.key)}
-            className={`px-3 py-1.5 rounded-full border min-h-[44px] justify-center ${
-              filter === opt.key
-                ? "bg-accent border-accent"
-                : "bg-surface2 border-border"
-            }`}
-          >
-            <Text
-              className={`text-sm ${
-                filter === opt.key ? "text-white font-medium" : "text-text-mute"
+      <View className="bg-white border-b border-border py-2.5">
+        <View style={{
+          maxWidth: isDesktop ? 680 : undefined,
+          alignSelf: 'center',
+          width: '100%',
+          paddingHorizontal: isDesktop ? 24 : 16,
+          flexDirection: 'row',
+          gap: 8,
+        }}>
+          {FILTER_OPTIONS.map((opt) => (
+            <Pressable
+              accessibilityRole="button"
+              key={opt.key}
+              accessibilityLabel={opt.label}
+              onPress={() => setFilter(opt.key)}
+              className={`px-3 py-1.5 rounded-full border min-h-[44px] justify-center ${
+                filter === opt.key
+                  ? "bg-accent border-accent"
+                  : "bg-surface2 border-border"
               }`}
             >
-              {opt.label}
-            </Text>
-          </Pressable>
-        ))}
+              <Text
+                className={`text-sm ${
+                  filter === opt.key ? "text-white font-medium" : "text-text-mute"
+                }`}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
       </View>
 
       {loading ? (

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -6,6 +6,7 @@ import {
   RefreshControl,
   Pressable,
   Switch,
+  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
@@ -120,6 +121,9 @@ export default function SpecialistDashboard() {
     },
     [updateUser]
   );
+
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
 
   const firstName = user?.firstName ?? "специалист";
 
@@ -271,18 +275,21 @@ export default function SpecialistDashboard() {
                 onAction={() => router.push("/settings/specialist" as never)}
               />
             ) : (
-              requests.map((item) => (
-                <RequestCard
-                  key={item.id}
-                  item={item}
-                  onWrite={() => router.push(`/requests/${item.id}/write` as never)}
-                  onOpenThread={() => {
-                    const tid = item.threadId ?? item.existingThreadId ?? null;
-                    if (tid) router.push(`/threads/${tid}` as never);
-                  }}
-                  onPress={() => router.push(`/requests/${item.id}` as never)}
-                />
-              ))
+              <View style={isDesktop ? { flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginHorizontal: -6 } : undefined}>
+                {requests.map((item) => (
+                  <View key={item.id} style={isDesktop ? { width: '47%', marginHorizontal: 6 } : undefined}>
+                    <RequestCard
+                      item={item}
+                      onWrite={() => router.push(`/requests/${item.id}/write` as never)}
+                      onOpenThread={() => {
+                        const tid = item.threadId ?? item.existingThreadId ?? null;
+                        if (tid) router.push(`/threads/${tid}` as never);
+                      }}
+                      onPress={() => router.push(`/requests/${item.id}` as never)}
+                    />
+                  </View>
+                ))}
+              </View>
             )}
 
             <View className="h-8" />
@@ -314,7 +321,7 @@ function RequestCard({
       className="bg-white border border-border rounded-xl p-4 mb-3 min-h-[44px]"
       style={({ pressed }) => ({
         opacity: pressed ? 0.92 : 1,
-        shadowColor: '#0b1424',
+        shadowColor: colors.text,
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.08,
         shadowRadius: 6,


### PR DESCRIPTION
## Summary
- complaints: filter chips now centered at 680px max-width on desktop (was full-width 1440px)
- specialist/dashboard: request cards 2-column grid on desktop, added useWindowDimensions
- Fixed hardcoded shadowColor → colors.text in RequestCard

## Test plan
- [ ] complaints desktop: filter chips appear left-aligned at 680px, not scattered across 1440px
- [ ] specialist/dashboard desktop: request cards in 2-column grid
- [ ] mobile: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)