### PR TITLE
fix: center ErrorState vertically (complaints + specialist-dashboard)

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -309,10 +309,12 @@ export default function AdminComplaints() {
           <LoadingState variant="skeleton" lines={5} />
         </ResponsiveContainer>
       ) : error ? (
-        <ErrorState
-          message="Не удалось загрузить жалобы"
-          onRetry={() => fetchComplaints(filter, 1)}
-        />
+        <View className="flex-1 items-center justify-center">
+          <ErrorState
+            message="Не удалось загрузить жалобы"
+            onRetry={() => fetchComplaints(filter, 1)}
+          />
+        </View>
       ) : (
         <ResponsiveContainer>
           <FlatList

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -153,13 +153,15 @@ export default function SpecialistDashboard() {
         <HeaderHome
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
-        <ErrorState
-          message="Не удалось загрузить заявки"
-          onRetry={() => {
-            setLoading(true);
-            fetchData().finally(() => setLoading(false));
-          }}
-        />
+        <View className="flex-1 items-center justify-center">
+          <ErrorState
+            message="Не удалось загрузить заявки"
+            onRetry={() => {
+              setLoading(true);
+              fetchData().finally(() => setLoading(false));
+            }}
+          />
+        </View>
       </SafeAreaView>
     );
   }


### PR DESCRIPTION
## Summary
- Wrap ErrorState in `flex-1 items-center justify-center` in both screens
- Matches admin-dashboard pattern (desktop responsive: 3 → 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)