### PR TITLE
fix: hardcoded colors + font sizes (#1240)

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import { BarChart2, Users, Shield, Flag } from "lucide-react-native";
-import { colors } from "@/lib/theme";
+import { colors, fontSizeValue } from "@/lib/theme";
 
 export default function AdminTabsLayout() {
   const { width } = useWindowDimensions();
@@ -16,7 +16,7 @@ export default function AdminTabsLayout() {
           : { display: "none" },
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.placeholder,
-        tabBarLabelStyle: { fontSize: 12 },
+        tabBarLabelStyle: { fontSize: fontSizeValue.tabBar },
       }}
     >
       <Tabs.Screen

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -8,7 +8,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors, overlay } from "@/lib/theme";
+import { colors, overlay, shadowColor } from "@/lib/theme";
 
 
 interface Stats {
@@ -35,7 +35,7 @@ function StatCard({
     <View
       className="bg-white border border-border rounded-2xl p-5 flex-1"
       style={{
-        shadowColor: "#000",
+        shadowColor: shadowColor.dark,
         shadowOffset: { width: 0, height: 3 },
         shadowOpacity: 0.09,
         shadowRadius: 8,
@@ -76,7 +76,7 @@ function RankList({
     <View
       className="bg-white border border-border rounded-2xl p-5"
       style={{
-        shadowColor: "#000",
+        shadowColor: shadowColor.dark,
         shadowOffset: { width: 0, height: 3 },
         shadowOpacity: 0.09,
         shadowRadius: 8,

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -17,7 +17,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors, overlay, radiusValue } from "@/lib/theme";
+import { colors, overlay, radiusValue, fontSizeValue } from "@/lib/theme";
 
 
 type RoleFilter = "ALL" | "CLIENT" | "SPECIALIST" | "BANNED";
@@ -234,7 +234,7 @@ export default function AdminUsers() {
             height: 44,
             paddingHorizontal: 14,
             color: colors.surface,
-            fontSize: 15,
+            fontSize: fontSizeValue.md,
             outlineWidth: 0,
           }}
           placeholder="Поиск по email или имени..."

--- a/app/(client-tabs)/_layout.tsx
+++ b/app/(client-tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import { LayoutGrid, FileText, MessageCircle } from "lucide-react-native";
-import { colors } from "@/lib/theme";
+import { colors, fontSizeValue } from "@/lib/theme";
 
 export default function ClientTabsLayout() {
   const { width } = useWindowDimensions();
@@ -16,7 +16,7 @@ export default function ClientTabsLayout() {
           : { display: "none" },
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.placeholder,
-        tabBarLabelStyle: { fontSize: 12 },
+        tabBarLabelStyle: { fontSize: fontSizeValue.tabBar },
       }}
     >
       <Tabs.Screen

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -18,7 +18,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, overlay } from "@/lib/theme";
+import { colors, overlay, shadowColor } from "@/lib/theme";
 
 interface DashboardStats {
   requestsUsed: number;
@@ -201,7 +201,7 @@ export default function ClientDashboard() {
                 </View>
                 {!atLimit && (
                   <View className="w-8 h-8 rounded-full items-center justify-center" style={{ backgroundColor: overlay.white20 }}>
-                    <Plus size={18} color="#fff" />
+                    <Plus size={18} color={colors.surface} />
                   </View>
                 )}
               </Pressable>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -2,7 +2,7 @@ import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import { Home, Search, PlusSquare, MessageCircle, User } from "lucide-react-native";
 import Header from "@/components/Header";
-import { colors } from "@/lib/theme";
+import { colors, fontSizeValue } from "@/lib/theme";
 
 export default function TabLayout() {
   const { width } = useWindowDimensions();
@@ -24,7 +24,7 @@ export default function TabLayout() {
             paddingTop: 4,
           },
           tabBarLabelStyle: {
-            fontSize: 12,
+            fontSize: fontSizeValue.tabBar,
             fontWeight: "500",
           },
           headerShown: false,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -60,7 +60,7 @@ function ListingCard({ title, price, location, color }: { title: string; price: 
         }}
       >
         <View className="h-36 items-center justify-center relative" style={{ backgroundColor: color }}>
-          <ImageIcon size={32} color="rgba(0,0,0,0.15)" />
+          <ImageIcon size={32} color={overlay.dark15} />
         </View>
         <View className="p-3 pb-4">
           <Text className="text-sm font-semibold text-text-base mb-1" numberOfLines={2}>{title}</Text>

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -18,7 +18,7 @@ import { api } from "@/lib/api";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import EmptyState from "@/components/ui/EmptyState";
-import { colors, radiusValue } from "@/lib/theme";
+import { colors, radiusValue, fontSizeValue } from "@/lib/theme";
 
 const CODE_LENGTH = 6;
 const RESEND_SECONDS = 60;
@@ -324,7 +324,7 @@ export default function AuthOtpScreen() {
                             ? colors.accentSoft
                             : colors.surface2,
                         textAlign: "center",
-                        fontSize: 24,
+                        fontSize: fontSizeValue.xl,
                         fontWeight: "700",
                         color: error ? colors.error : colors.text,
                         outlineWidth: 0,

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -15,7 +15,7 @@ import Button from "@/components/ui/Button";
 import { Send } from "lucide-react-native";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, radiusValue } from "@/lib/theme";
+import { colors, radiusValue, fontSizeValue } from "@/lib/theme";
 
 interface RequestSummary {
   id: string;
@@ -217,7 +217,7 @@ export default function SpecialistConfirmWrite() {
               borderRadius: radiusValue.md,
               paddingHorizontal: 14,
               paddingVertical: 12,
-              fontSize: 16,
+              fontSize: fontSizeValue.base,
               color: colors.text,
               backgroundColor: isLimitReached ? colors.background : colors.surface,
               textAlignVertical: "top",

--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { MOCK_SPECIALISTS } from "./mockData";
-import { colors } from "@/lib/theme";
+import { colors, fontSizeValue } from "@/lib/theme";
 
 interface PlatformStats {
   specialistsCount: number;
@@ -36,7 +36,7 @@ export default function HeroSection({ isDesktop, onCreateRequest, onViewCatalog,
               className="flex-row items-center self-start mb-6 rounded-full px-4"
               style={{ backgroundColor: colors.accentSoft, paddingVertical: 8 }}
             >
-              <Text style={{ color: colors.primary, fontSize: 10, marginRight: 6 }}>●</Text>
+              <Text style={{ color: colors.primary, fontSize: fontSizeValue.xs, marginRight: 6 }}>●</Text>
               <Text className="text-sm font-medium" style={{ color: colors.primary }}>
                 Сейчас на связи · {stats?.specialistsCount ?? 47} специалистов в {stats?.citiesCount ?? 12} городах
               </Text>

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { View, Text, TextInput, type TextInputProps, type ViewStyle } from "react-native";
 import { type LucideIcon } from "lucide-react-native";
-import { colors, radiusValue } from "../../lib/theme";
+import { colors, radiusValue, fontSizeValue } from "../../lib/theme";
 
 export interface InputProps {
   label?: string;
@@ -104,7 +104,7 @@ export default function Input({
           onBlur={() => setFocused(false)}
           style={{
             flex: 1,
-            fontSize: 16,
+            fontSize: fontSizeValue.base,
             color: colors.text,
             paddingVertical: multiline ? 8 : 0,
             borderWidth: 0,

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -87,6 +87,22 @@ export const AVATAR_COLORS = [
   '#8b5cf6', // violet
 ] as const
 
+// Font size scale — numeric values for inline style={{ fontSize }}
+export const fontSizeValue = {
+  xs: 10,    // micro labels, decorative bullets
+  sm: 11,    // compact chips, secondary captions
+  tabBar: 12, // tab bar labels
+  md: 15,    // search inputs, secondary body
+  base: 16,  // primary inputs, body text
+  xl: 24,    // OTP digits, display numbers
+} as const
+
+// Shadow color tokens
+export const shadowColor = {
+  dark: '#000000',   // standard card/modal shadow
+  accent: 'rgba(34,86,194,0.1)', // accent glow
+} as const
+
 // Semantic overlay tokens — for rgba on colored backgrounds
 export const overlay = {
   white10: 'rgba(255,255,255,0.1)',
@@ -98,4 +114,5 @@ export const overlay = {
   white80: 'rgba(255,255,255,0.8)',
   white20: 'rgba(255,255,255,0.2)',
   accent10: 'rgba(34,86,194,0.1)',
+  dark15: 'rgba(0,0,0,0.15)',  // image placeholder icon tint
 } as const


### PR DESCRIPTION
Closes #1240

Layer 1 test-pyramid style-report fix:
- Replace 3 hardcoded hex/rgba colors with theme tokens (`shadowColor.dark`, `colors.surface`, `overlay.dark15`)
- Replace 6 hardcoded font sizes with `fontSizeValue` tokens (xs/tabBar/md/base/xl)
- Add `fontSizeValue`, `shadowColor` exports to `lib/theme.ts`
- Add `overlay.dark15` token for rgba(0,0,0,0.15)

tsc --noEmit: 0 errors