### PR TITLE
fix(polish): empty states + header tap targets on web

### DIFF
--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -12,7 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
 import EmptyState from "@/components/ui/EmptyState";
-import { MessageSquare } from "lucide-react-native";
+import { MessageSquare, MessagesSquare } from "lucide-react-native";
 import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
 import InlineChatView from "@/components/InlineChatView";
@@ -277,9 +277,13 @@ export default function ClientMessages() {
               }
               contentContainerStyle={{ flexGrow: 1 }}
               ListEmptyComponent={
-                <View className="flex-1 items-center justify-center py-16 px-4">
-                  <Text className="text-sm text-center text-text-mute">Нет сообщений</Text>
-                </View>
+                <EmptyState
+                  icon={MessageSquare}
+                  title="Нет сообщений"
+                  subtitle="Когда специалисты откликнутся на ваши заявки, сообщения появятся здесь"
+                  actionLabel="Найти специалиста"
+                  onAction={() => router.push("/specialists" as never)}
+                />
               }
             />
           </View>
@@ -288,9 +292,11 @@ export default function ClientMessages() {
             {selectedThreadId ? (
               <InlineChatView threadId={selectedThreadId} />
             ) : (
-              <View className="flex-1 items-center justify-center">
-                <Text className="text-sm text-text-mute">Выберите диалог</Text>
-              </View>
+              <EmptyState
+                icon={MessagesSquare}
+                title="Выберите диалог"
+                subtitle="Нажмите на переписку слева, чтобы открыть её"
+              />
             )}
           </View>
         </View>

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -132,10 +132,11 @@ export default function OnboardingNameScreen() {
               accessibilityRole="button"
               accessibilityLabel="Принять условия использования"
               onPress={() => setAgreed(!agreed)}
-              className="flex-row items-start"
+              className="flex-row items-center"
+              style={{ minHeight: 44 }}
             >
               <View
-                className={`w-5 h-5 rounded border-2 mt-0.5 items-center justify-center ${
+                className={`w-5 h-5 rounded border-2 items-center justify-center ${
                   agreed
                     ? "bg-accent border-accent"
                     : "border-border bg-white"
@@ -145,15 +146,19 @@ export default function OnboardingNameScreen() {
                   <Text className="text-white text-xs font-bold">✓</Text>
                 )}
               </View>
-              <Text className="flex-1 ml-3 text-xs text-text-mute leading-5">
-                Я принимаю{" "}
-                <Text
-                  className="text-accent font-medium underline"
+              <View className="flex-1 ml-3 flex-row flex-wrap">
+                <Text className="text-xs text-text-mute leading-5">Я принимаю </Text>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Условия использования"
                   onPress={() => router.push("/legal/terms" as never)}
+                  style={{ minHeight: 44, justifyContent: "center" }}
                 >
-                  Условия использования
-                </Text>
-              </Text>
+                  <Text className="text-accent font-medium underline text-xs leading-5">
+                    Условия использования
+                  </Text>
+                </Pressable>
+              </View>
             </Pressable>
           </ScrollView>
 

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -380,7 +380,8 @@ export default function OnboardingProfileScreen() {
             accessibilityLabel="Пропустить"
             onPress={handleSubmit}
             disabled={isLoading || avatarUploading}
-            className="items-center mt-3 py-2"
+            className="items-center mt-3"
+            style={{ minHeight: 44, justifyContent: "center" }}
           >
             <Text className="text-sm text-text-mute">Пропустить</Text>
           </Pressable>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -78,7 +78,7 @@ export default function Header() {
   // Desktop header
   return (
     <View className="flex-row items-center justify-between px-6 h-16 bg-white border-b" style={{ borderBottomColor: colors.border }}>
-      <Pressable accessibilityRole="button" accessibilityLabel="Главная" onPress={() => router.push("/" as never)} className="h-11 items-center justify-center">
+      <Pressable accessibilityRole="button" accessibilityLabel="Главная" onPress={() => router.push("/" as never)} className="px-2 items-center justify-center" style={{ minHeight: 44 }}>
         <Text className="text-xl font-bold" style={{ color: colors.primary }}>P2PTax</Text>
       </Pressable>
 
@@ -90,7 +90,8 @@ export default function Header() {
             accessibilityRole="button"
             accessibilityLabel={link.label}
             onPress={() => router.push(link.href as never)}
-            className="h-11 px-2 items-center justify-center"
+            className="px-2 items-center justify-center"
+            style={{ minHeight: 44 }}
           >
             <Text className="text-sm font-medium" style={{ color: colors.textSecondary }}>{link.label}</Text>
           </Pressable>


### PR DESCRIPTION
## Summary
- Messages desktop: proper EmptyState with icon + CTA instead of bare text (content: 4 → target 8+)
- Onboarding/name: terms checkbox row min-height 44; terms link wrapped in Pressable with min-height
- Onboarding/profile: skip button min-height 44 (was ~30px)
- Header: inline `style={{ minHeight: 44 }}` on desktop nav Pressables (NativeWind h-11 class not reliable on web)

## Test plan
- [ ] Messages desktop shows icon + title + subtitle + "Найти специалиста" button when empty
- [ ] Onboarding name: terms checkbox row is 44px tall; terms link is tappable
- [ ] Onboarding profile: skip button is min 44px tall
- [ ] Header desktop: vizor reports 0 tiny-tap problems for all (tabs)/* pages
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)