### PR TITLE
fix(ui): Button fullWidth=false gets px-6 padding

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -21,7 +21,7 @@ export default function Button({
   fullWidth = true,
   icon: Icon,
 }: ButtonProps) {
-  const widthClass = fullWidth ? "w-full" : "";
+  const widthClass = fullWidth ? "w-full" : "px-6";
   const opacityClass = disabled || loading ? "opacity-40" : "";
 
   const baseContainerClass = `rounded-xl h-12 flex-row items-center justify-center ${widthClass} ${opacityClass}`;


### PR DESCRIPTION
## Summary
- Without horizontal padding, `Button` with `fullWidth=false` collapsed to text width, making it invisible as a button
- `ErrorState` "Повторить" and `EmptyState` action buttons were affected
- Fix: use `px-6` when `fullWidth=false` instead of empty string

## Impact
All error/empty states across the app will now show visible button shape for the action button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)