### PR TITLE
fix(polish): legal terms card, EmptyState/ErrorState primary CTA, otp crash fix

### DIFF
--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -59,9 +59,12 @@ export default function AuthOtpScreen() {
     return () => clearTimeout(t);
   }, [resendTimer]);
 
-  // Guard: if no email param, redirect back to email screen
+  // Guard: if no email param, defer redirect so Root Layout is mounted first
   useEffect(() => {
-    if (!email) router.replace('/auth/email' as never);
+    if (!email) {
+      const t = setTimeout(() => router.replace('/auth/email' as never), 0);
+      return () => clearTimeout(t);
+    }
   }, [email, router]);
 
   // Auto-focus first input on mount

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -1,11 +1,11 @@
-import { View, Text, ScrollView, useWindowDimensions } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
   return (
-    <Text className="text-lg font-bold text-text-base mt-6 mb-2">
+    <Text className="text-lg font-semibold text-text-base mt-6 mb-3">
       {children}
     </Text>
   );
@@ -13,87 +13,93 @@ function SectionHeading({ children }: { children: string }) {
 
 function Paragraph({ children }: { children: string }) {
   return (
-    <Text className="text-base text-text-mute leading-7 mb-3">{children}</Text>
+    <Text className="text-base text-text-mute leading-7 mb-4">{children}</Text>
   );
 }
 
 export default function TermsScreen() {
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Пользовательское соглашение" />
 
       <ResponsiveContainer maxWidth={720}>
         <ScrollView
           className="flex-1"
-          contentContainerStyle={{ paddingHorizontal: 0, paddingBottom: 48 }}
+          contentContainerStyle={{ paddingHorizontal: 0, paddingBottom: 32 }}
         >
-          <Text className="text-sm text-text-mute mt-4 mb-4">
-            Последнее обновление: апрель 2026
-          </Text>
+          <View className="bg-white border border-border rounded-2xl p-6 mx-4 mt-4">
+            <Text className="text-xs text-text-dim text-center mb-4">
+              Последнее обновление: апрель 2026
+            </Text>
 
-          <Paragraph>
-            Используя приложение P2PTax, вы соглашаетесь с настоящими Условиями
-            использования. Если вы не согласны с ними, пожалуйста, не
-            используйте наши услуги.
-          </Paragraph>
+            <Paragraph>
+              Используя приложение P2PTax, вы соглашаетесь с настоящими Условиями
+              использования. Если вы не согласны с ними, пожалуйста, не
+              используйте наши услуги.
+            </Paragraph>
 
-          <SectionHeading>1. Общие положения</SectionHeading>
-          <Paragraph>
-            P2PTax — платформа для поиска налоговых специалистов и взаимодействия
-            между клиентами и специалистами по налоговым вопросам. Платформа не
-            оказывает налоговые услуги напрямую.
-          </Paragraph>
+            <SectionHeading>1. Общие положения</SectionHeading>
+            <Paragraph>
+              P2PTax — платформа для поиска налоговых специалистов и взаимодействия
+              между клиентами и специалистами по налоговым вопросам. Платформа не
+              оказывает налоговые услуги напрямую.
+            </Paragraph>
 
-          <SectionHeading>2. Регистрация</SectionHeading>
-          <Paragraph>
-            Для использования платформы необходимо зарегистрироваться, указав
-            действующий адрес электронной почты. Вы несёте ответственность за
-            конфиденциальность своего аккаунта и все действия, совершённые от
-            вашего имени.
-          </Paragraph>
+            <SectionHeading>2. Регистрация</SectionHeading>
+            <Paragraph>
+              Для использования платформы необходимо зарегистрироваться, указав
+              действующий адрес электронной почты. Вы несёте ответственность за
+              конфиденциальность своего аккаунта и все действия, совершённые от
+              вашего имени.
+            </Paragraph>
 
-          <SectionHeading>3. Специалисты</SectionHeading>
-          <Paragraph>
-            Специалисты, размещающие информацию о своих услугах на платформе,
-            самостоятельно несут ответственность за достоверность предоставленных
-            данных, квалификацию и качество оказываемых услуг.
-          </Paragraph>
+            <SectionHeading>3. Специалисты</SectionHeading>
+            <Paragraph>
+              Специалисты, размещающие информацию о своих услугах на платформе,
+              самостоятельно несут ответственность за достоверность предоставленных
+              данных, квалификацию и качество оказываемых услуг.
+            </Paragraph>
 
-          <SectionHeading>4. Клиенты</SectionHeading>
-          <Paragraph>
-            Клиенты самостоятельно выбирают специалистов и несут ответственность
-            за принятые решения. P2PTax не гарантирует результат консультаций и
-            услуг, оказываемых специалистами.
-          </Paragraph>
+            <SectionHeading>4. Клиенты</SectionHeading>
+            <Paragraph>
+              Клиенты самостоятельно выбирают специалистов и несут ответственность
+              за принятые решения. P2PTax не гарантирует результат консультаций и
+              услуг, оказываемых специалистами.
+            </Paragraph>
 
-          <SectionHeading>5. Запрещённые действия</SectionHeading>
-          <Paragraph>
-            Запрещается: размещение ложной информации, мошенничество,
-            оскорбления, спам, нарушение законодательства РФ, а также любые
-            действия, направленные на нарушение работы платформы.
-          </Paragraph>
+            <SectionHeading>5. Запрещённые действия</SectionHeading>
+            <Paragraph>
+              Запрещается: размещение ложной информации, мошенничество,
+              оскорбления, спам, нарушение законодательства РФ, а также любые
+              действия, направленные на нарушение работы платформы.
+            </Paragraph>
 
-          <SectionHeading>6. Ограничение ответственности</SectionHeading>
-          <Paragraph>
-            P2PTax предоставляется «как есть». Мы не несём ответственности за
-            косвенные убытки, упущенную выгоду или ущерб, возникший в результате
-            использования платформы или взаимодействия между пользователями.
-          </Paragraph>
+            <SectionHeading>6. Ограничение ответственности</SectionHeading>
+            <Paragraph>
+              P2PTax предоставляется «как есть». Мы не несём ответственности за
+              косвенные убытки, упущенную выгоду или ущерб, возникший в результате
+              использования платформы или взаимодействия между пользователями.
+            </Paragraph>
 
-          <SectionHeading>7. Изменение условий</SectionHeading>
-          <Paragraph>
-            Мы можем обновлять настоящие Условия. Продолжение использования
-            платформы после внесения изменений означает ваше согласие с новыми
-            условиями.
-          </Paragraph>
+            <SectionHeading>7. Изменение условий</SectionHeading>
+            <Paragraph>
+              Мы можем обновлять настоящие Условия. Продолжение использования
+              платформы после внесения изменений означает ваше согласие с новыми
+              условиями.
+            </Paragraph>
 
-          <SectionHeading>8. Контакты</SectionHeading>
-          <Paragraph>
-            По вопросам, связанным с Условиями использования, обращайтесь по
-            адресу: support@p2ptax.ru
-          </Paragraph>
+            <SectionHeading>8. Контакты</SectionHeading>
+            <Paragraph>
+              По вопросам, связанным с Условиями использования, обращайтесь по
+              адресу: support@p2ptax.ru
+            </Paragraph>
+
+            <Text className="text-xs text-text-dim text-center mt-4 pb-2">
+              P2PTax — безопасная платформа для налоговых вопросов
+            </Text>
+          </View>
+
+          <View className="h-8" />
         </ScrollView>
       </ResponsiveContainer>
     </SafeAreaView>

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -21,22 +21,22 @@ export default function EmptyState({
   return (
     <View className="items-center justify-center py-12 px-8">
       <View
-        className="items-center justify-center rounded-full bg-surface2"
-        style={{ width: 72, height: 72 }}
+        className="items-center justify-center rounded-full"
+        style={{ width: 72, height: 72, backgroundColor: colors.accentSoft }}
       >
-        <Icon size={32} color={colors.placeholder} />
+        <Icon size={32} color={colors.accent} />
       </View>
       <Text className="text-base font-semibold text-text-base mt-4 text-center">
         {title}
       </Text>
       {subtitle && (
-        <Text className="text-sm text-text-mute mt-2 text-center">
+        <Text className="text-sm text-text-mute mt-2 text-center leading-5">
           {subtitle}
         </Text>
       )}
       {actionLabel && onAction && (
-        <View className="mt-4">
-          <Button variant="secondary" label={actionLabel} onPress={onAction} fullWidth={false} />
+        <View className="mt-5">
+          <Button variant="primary" label={actionLabel} onPress={onAction} fullWidth={false} />
         </View>
       )}
     </View>

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -29,7 +29,7 @@ export default function ErrorState({
       {onRetry && (
         <View className="mt-4">
           <Button
-            variant="secondary"
+            variant="primary"
             label="Повторить"
             onPress={onRetry}
             fullWidth={false}


### PR DESCRIPTION
## Summary
- `/legal/terms`: card layout matching privacy page pattern — fixes polish:5→8
- `EmptyState`: accent-soft icon bg + accent icon color + primary action button (was invisible secondary on surface2)
- `ErrorState`: primary button for "Повторить" — same invisible-button fix
- `auth/otp`: defer navigation to next tick to prevent "navigate before Root Layout" crash error overlay

## Impact
- legal/terms expected to go from 8.2 → 8.4+
- All empty state and error state screens should gain ~0.2-0.3 from visible CTA buttons
- auth/otp mobile no longer shows crash overlay (was layout:6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)