### PR TITLE
fix(button): static style array to fix backgroundColor on React Native Web

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import { Pressable, Text, ActivityIndicator } from "react-native";
+import { useState } from "react";
 import { type LucideIcon } from "lucide-react-native";
 import { colors } from "../../lib/theme";
 
@@ -21,6 +22,8 @@ export default function Button({
   fullWidth = true,
   icon: Icon,
 }: ButtonProps) {
+  const [pressed, setPressed] = useState(false);
+
   const widthClass = fullWidth ? "w-full" : "px-6";
   const opacityClass = disabled || loading ? "opacity-40" : "";
 
@@ -33,6 +36,14 @@ export default function Button({
         ? { backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }
         : { backgroundColor: colors.danger };
 
+  const shadowStyle = variant === "primary" && !pressed
+    ? { shadowColor: colors.primary, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.2, shadowRadius: 4, elevation: 3 }
+    : undefined;
+
+  const pressStyle = pressed
+    ? { opacity: 0.9, transform: [{ scale: 0.98 as const }] }
+    : undefined;
+
   const textColorValue =
     variant === "primary" || variant === "destructive" ? "#ffffff" : colors.text;
 
@@ -44,15 +55,11 @@ export default function Button({
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
+      onPressIn={() => setPressed(true)}
+      onPressOut={() => setPressed(false)}
       disabled={disabled || loading}
       className={baseContainerClass}
-      style={({ pressed }) => [
-        variantStyle,
-        variant === "primary" && !pressed
-          ? { shadowColor: colors.primary, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.2, shadowRadius: 4, elevation: 3 }
-          : undefined,
-        pressed ? { opacity: 0.9, transform: [{ scale: 0.98 }] } : undefined,
-      ]}
+      style={[variantStyle, shadowStyle, pressStyle]}
     >
       {loading ? (
         <ActivityIndicator color={iconColor} />


### PR DESCRIPTION
## Summary
- Root cause: Pressable's function-style `style={({ pressed }) => [...]}` does NOT apply `backgroundColor` on initial render in React Native Web
- All primary buttons were rendering as invisible (white text on transparent background)
- Secondary buttons appeared as plain dark text (dark text color saved them visually)
- Fix: static `style={[variantStyle, shadowStyle, pressStyle]}` array + manual `onPressIn`/`onPressOut` state for press animation

## Impact
Every screen with a Button component should now show properly styled buttons:
- Primary: solid blue (#2256c2) with white text
- Secondary: white card with gray border and dark text
- All onboarding, auth, empty state, error state CTAs become visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)