### PR TITLE
fix(polish): tap targets, RU tab labels, centered empty states, legal dividers

### DIFF
--- a/app/(specialist-tabs)/_layout.tsx
+++ b/app/(specialist-tabs)/_layout.tsx
@@ -22,21 +22,21 @@ export default function SpecialistTabsLayout() {
       <Tabs.Screen
         name="dashboard"
         options={{
-          title: "Dashboard",
+          title: "Дашборд",
           tabBarIcon: ({ color, size }) => <LayoutGrid size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="requests"
         options={{
-          title: "Public Requests",
+          title: "Заявки",
           tabBarIcon: ({ color, size }) => <List size={size} color={color} />,
         }}
       />
       <Tabs.Screen
         name="threads"
         options={{
-          title: "My Threads",
+          title: "Переписки",
           tabBarIcon: ({ color, size }) => <MessageCircle size={size} color={color} />,
         }}
       />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -142,7 +142,7 @@ export default function HomeScreen() {
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Показать все"
-                  style={{ minHeight: 44, justifyContent: "center", paddingHorizontal: 8 }}
+                  style={{ height: 44, justifyContent: "center", paddingHorizontal: 8 }}
                 >
                   <Text className="text-sm text-accent font-medium">Все</Text>
                 </Pressable>

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -58,8 +58,7 @@ export default function SearchScreen() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Фильтры"
-                className="ml-2 w-9 h-9 rounded-lg bg-accent items-center justify-center"
-                style={{ minHeight: 44 }}
+                className="ml-2 w-11 h-11 rounded-lg bg-accent items-center justify-center"
               >
                 <SlidersHorizontal size={15} color="#fff" />
               </Pressable>
@@ -74,7 +73,7 @@ export default function SearchScreen() {
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Очистить историю поиска"
-                  style={{ minHeight: 44, justifyContent: "center" }}
+                  style={{ height: 44, justifyContent: "center" }}
                 >
                   <Text className="text-sm text-accent">Очистить</Text>
                 </Pressable>
@@ -96,7 +95,7 @@ export default function SearchScreen() {
                   accessibilityLabel={search}
                   className="flex-row items-center px-4 active:bg-surface2"
                   style={{
-                    minHeight: 44,
+                    height: 44,
                     borderBottomWidth: index < RECENT_SEARCHES.length - 1 ? 1 : 0,
                     borderBottomColor: colors.border,
                   }}
@@ -120,7 +119,7 @@ export default function SearchScreen() {
                   accessibilityLabel={cat.name}
                   className="flex-row items-center p-3 rounded-xl mb-2 border border-border"
                   style={[
-                    { backgroundColor: cat.color, minHeight: 44 },
+                    { backgroundColor: cat.color, minHeight: 56 },
                     isDesktop ? { width: "48%" } : undefined,
                   ]}
                 >

--- a/app/legal/privacy.tsx
+++ b/app/legal/privacy.tsx
@@ -1,13 +1,14 @@
-import { View, Text, ScrollView, useWindowDimensions } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 
 function SectionHeading({ children }: { children: string }) {
   return (
-    <Text className="text-lg font-semibold text-text-base mt-6 mb-3">
-      {children}
-    </Text>
+    <View className="mt-5 mb-2">
+      <View className="border-t border-border mb-4" />
+      <Text className="text-base font-semibold text-text-base">{children}</Text>
+    </View>
   );
 }
 
@@ -18,8 +19,6 @@ function Paragraph({ children }: { children: string }) {
 }
 
 export default function PrivacyPolicyScreen() {
-  const { width } = useWindowDimensions();
-  const _isDesktop = width >= 640;
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Политика конфиденциальности" />

--- a/app/legal/terms.tsx
+++ b/app/legal/terms.tsx
@@ -2,12 +2,12 @@ import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
-
 function SectionHeading({ children }: { children: string }) {
   return (
-    <Text className="text-lg font-semibold text-text-base mt-6 mb-3">
-      {children}
-    </Text>
+    <View className="mt-5 mb-2">
+      <View className="border-t border-border mb-4" />
+      <Text className="text-base font-semibold text-text-base">{children}</Text>
+    </View>
   );
 }
 

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -235,7 +235,7 @@ export default function NotificationsScreen() {
           <FlatList
             data={notifications}
             keyExtractor={(item) => item.id}
-            contentContainerStyle={{ padding: 16 }}
+            contentContainerStyle={notifications.length === 0 ? { flexGrow: 1, justifyContent: "center" } : { padding: 16 }}
             renderItem={({ item }) => (
               <NotificationRow item={item} onPress={handleMarkRead} />
             )}


### PR DESCRIPTION
## Changes

- `/(tabs)/index.tsx` — "Все" button: `minHeight: 44` → `height: 44` (minHeight doesn't render on RN Web)
- `/(tabs)/search.tsx` — filter icon `w-9 h-9` → `w-11 h-11` (44px), recent search rows `minHeight` → `height: 44`
- `/(specialist-tabs)/_layout.tsx` — tab labels localized to Russian: Dashboard→Дашборд, Public Requests→Заявки, My Threads→Переписки
- `app/notifications.tsx` — EmptyState now vertically centered via `contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}` (was floating at top with huge whitespace)
- `app/legal/terms.tsx` + `privacy.tsx` — section headings get a thin border-t divider for visual rhythm

## Expected score impact

- `/(tabs)`: components 6→8
- `/(tabs)/search`: components 6→8
- `/(specialist-tabs)/promotion`, `/requests`, `/threads` etc: polish improvement from Russian tab labels
- `/notifications`: polish 7→8/9
- `/legal/terms`, `/legal/privacy`: polish 7→8

🤖 Generated with [Claude Code](https://claude.com/claude-code)