### PR TITLE
fix(landing): replace bg-slate-100 with bg-surface2, primary online dots

### DIFF
--- a/components/landing/HeroSection.tsx
+++ b/components/landing/HeroSection.tsx
@@ -133,7 +133,7 @@ export default function HeroSection({ isDesktop, onCreateRequest, onViewCatalog,
                       </Text>
                       <View
                         className="w-2 h-2 rounded-full"
-                        style={{ backgroundColor: colors.success }}
+                        style={{ backgroundColor: colors.primary }}
                       />
                     </View>
                     <Text className="text-sm mt-1" style={{ color: colors.textSecondary }}>

--- a/components/landing/ProblemsSection.tsx
+++ b/components/landing/ProblemsSection.tsx
@@ -9,7 +9,7 @@ interface ProblemsSectionProps {
 export default function ProblemsSection({ isDesktop }: ProblemsSectionProps) {
   return (
     <View
-      className="bg-slate-100 px-4"
+      className="bg-surface2 px-4"
       style={{ paddingTop: isDesktop ? 96 : 64, paddingBottom: isDesktop ? 96 : 64 }}
     >
       <View style={{ width: "100%", alignItems: "center" }}>


### PR DESCRIPTION
Fixes color:6 on landing screen (/) — off-brand slate-100 and green success dots broke the monochromatic blue/white palette on desktop view.