### PR TITLE
fix(tabs): Pressable width on Все button (41→49px)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -142,7 +142,7 @@ export default function HomeScreen() {
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel="Показать все"
-                  style={{ height: 44, justifyContent: "center", paddingHorizontal: 8 }}
+                  style={{ height: 44, justifyContent: "center", paddingHorizontal: 12 }}
                 >
                   <Text className="text-sm text-accent font-medium">Все</Text>
                 </Pressable>


### PR DESCRIPTION
DOM inspection found the Все button at 41px wide, triggering the heuristic tap-target checker. paddingHorizontal: 8 → 12 fixes it.