### PR TITLE
fix(ui): replace sub-12px text sizes (tinyText flow check)

### DIFF
--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -174,7 +174,7 @@ export default function ClientMessages() {
                 className="absolute -top-1 -right-1 rounded-full bg-accent items-center justify-center px-1"
                 style={{ minWidth: 18, height: 18 }}
               >
-                <Text className="text-[10px] font-bold text-white">
+                <Text className="text-xs font-bold text-white">
                   {item.unreadCount > 99 ? "99+" : item.unreadCount}
                 </Text>
               </View>

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -118,7 +118,7 @@ export default function RequestMessages() {
             </Text>
             {hasUnread && (
               <View className="absolute -top-1 -right-1 min-w-[18px] h-[18px] rounded-full bg-danger items-center justify-center px-1">
-                <Text className="text-[10px] font-bold text-white">
+                <Text className="text-xs font-bold text-white">
                   {item.unreadCount > 99 ? "99+" : item.unreadCount}
                 </Text>
               </View>

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -24,7 +24,7 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
           <Bell size={18} color={colors.surface} />
           {notificationCount > 0 && (
             <View className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-warning items-center justify-center px-1">
-              <Text className="text-[9px] font-bold text-white">
+              <Text className="text-[10px] font-bold text-white">
                 {notificationCount > 99 ? "99+" : notificationCount}
               </Text>
             </View>

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -55,11 +55,11 @@ export default function SpecialistCard({
         <View className="flex-row flex-wrap gap-1 mb-1">
           {services.slice(0, 2).map((s) => (
             <View key={s.id} className="px-1.5 py-0.5 rounded" style={{ backgroundColor: colors.accentSoft }}>
-              <Text className="text-[10px]" style={{ color: colors.primary }}>{s.name}</Text>
+              <Text className="text-xs" style={{ color: colors.primary }}>{s.name}</Text>
             </View>
           ))}
           {services.length > 2 && (
-            <Text className="text-[10px]" style={{ color: colors.textMuted }}>+{services.length - 2}</Text>
+            <Text className="text-xs" style={{ color: colors.textMuted }}>+{services.length - 2}</Text>
           )}
         </View>
         {cities.length > 0 && (
@@ -118,7 +118,7 @@ export default function SpecialistCard({
       {/* City */}
       {cities.length > 0 && (
         <View className="flex-row items-center mt-2">
-          <FontAwesome name="map-marker" size={10} color={colors.textMuted} />
+          <FontAwesome name="map-marker" size={12} color={colors.textMuted} />
           <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
             {cities.map((c) => c.name).join(", ")}
           </Text>


### PR DESCRIPTION
## Summary
- `SpecialistCard`: `FontAwesome map-marker size=10` → `size=12` (icon font renders as 10px text on web, counted as tinyText by flow-runner)
- `SpecialistCard` horizontal variant: `text-[10px]` service tags → `text-xs`
- `HeaderHome`: notification badge `text-[9px]` → `text-[10px]`
- `(client-tabs)/messages.tsx`, `requests/[id]/messages.tsx`: unread badges `text-[10px]` → `text-xs`

Fixes `client/specialists` flow test `tinyText: 8 → 0`. Unblocks test-pyramid Layer 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)