### PR TITLE
polish: card shadows + landing color fix for score improvement

### DIFF
--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -26,7 +26,8 @@ export default function PromotionScreen() {
             </Text>
 
             {/* Placeholder card */}
-            <View className="bg-white border border-border rounded-xl p-6 items-center">
+            <View className="bg-white border border-border rounded-xl p-6 items-center"
+              style={{ shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 }}>
               <View
                 className="w-16 h-16 rounded-full items-center justify-center mb-4"
                 style={{ backgroundColor: colors.accentSoft }}

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -28,7 +28,10 @@ export default function RequestCard({
       accessibilityLabel={title}
       onPress={() => onPress(id)}
       className="bg-white border border-border rounded-xl p-4 mb-3"
-      style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
+      style={({ pressed }) => [
+        { shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
+        pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
+      ]}
     >
       <View className="flex-row items-center justify-between mb-2">
         <Text className="text-lg font-semibold text-text-base flex-1 mr-2" numberOfLines={1}>

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -78,7 +78,10 @@ export default function SpecialistCard({
       accessibilityLabel={name}
       onPress={() => onPress(id)}
       className="bg-white border border-border rounded-2xl p-4 mb-3"
-      style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
+      style={({ pressed }) => [
+        { shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
+        pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
+      ]}
     >
       {/* Avatar */}
       <View

--- a/components/landing/HowItWorksSection.tsx
+++ b/components/landing/HowItWorksSection.tsx
@@ -22,7 +22,7 @@ export default function HowItWorksSection({ isDesktop }: HowItWorksSectionProps)
         >
           <Text
             className="text-sm font-semibold uppercase text-center mb-3"
-            style={{ color: colors.warning, letterSpacing: 4 }}
+            style={{ color: colors.primary, letterSpacing: 4 }}
           >
             Почему P2PTax
           </Text>


### PR DESCRIPTION
## Summary
- `SpecialistCard` vertical: subtle shadow (`shadowOpacity: 0.06`) — improves polish perception
- `RequestCard`: same subtle shadow — fixes `polish:7` on `/requests` and `/(specialist-tabs)/requests`
- `promotion.tsx` card: subtle shadow
- `HowItWorksSection`: label color `colors.warning` (amber) → `colors.primary` (blue) — removes off-brand amber from monochromatic blue palette, targets `color:6` on landing page

## Expected impact
- `polish:7` → `8` on screens with cards
- `color:6` → `7+` on `/` landing page (removes amber break in blue palette)

🤖 Generated with [Claude Code](https://claude.com/claude-code)