### PR TITLE
feat(polish): accent hero banners on 3 screens

### DIFF
--- a/app/(specialist-tabs)/requests.tsx
+++ b/app/(specialist-tabs)/requests.tsx
@@ -17,7 +17,7 @@ import { TriangleAlert, FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -144,9 +144,11 @@ export default function SpecialistPublicRequests() {
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       <HeaderHome />
       <ResponsiveContainer>
-        <Text className="text-2xl font-bold text-text-base mt-4 mb-2">
-          Публичные заявки
-        </Text>
+        {/* Accent hero */}
+        <View className="rounded-2xl px-5 py-5 mb-4 mt-2" style={{ backgroundColor: colors.accent }}>
+          <Text className="text-xl font-bold text-white mb-0.5">Публичные заявки</Text>
+          <Text className="text-sm" style={{ color: overlay.white75 }}>Находите клиентов по своей специализации</Text>
+        </View>
 
         <FilterBar
           cities={cities}

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -19,7 +19,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import RequestCard from "@/components/RequestCard";
 import { api } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -197,6 +197,12 @@ export default function PublicRequestsFeed() {
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Заявки" />
+
+      {/* Accent hero */}
+      <View style={{ backgroundColor: colors.accent, paddingHorizontal: 16, paddingTop: 12, paddingBottom: 12 }}>
+        <Text className="text-xl font-bold text-white mb-0.5">Открытые заявки</Text>
+        <Text className="text-sm" style={{ color: overlay.white75 }}>Задайте вопрос — получите предложения от специалистов</Text>
+      </View>
 
       {/* Filter bar */}
       <View className="bg-white border-b border-border">

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -17,7 +17,7 @@ import { AlertCircle, UserX, Search } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -221,13 +221,9 @@ export default function SpecialistsCatalog() {
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Специалисты" />
-      <View className="bg-white border-b border-border" style={{ alignItems: isDesktop ? "center" : undefined }}>
-        <View style={{ width: "100%", maxWidth: isDesktop ? 900 : undefined, paddingHorizontal: isDesktop ? 24 : 16, paddingTop: 12, paddingBottom: 8 }}>
-          <Text className="font-extrabold text-3xl text-text-base">Каталог специалистов</Text>
-          <Text className="text-sm mt-1 mb-3 text-text-mute">
-            Практики с опытом в вашей ИФНС. Выбирайте по инспекции, городу и типу проверки.
-          </Text>
-        </View>
+      <View style={{ backgroundColor: colors.accent, paddingHorizontal: 16, paddingTop: 12, paddingBottom: 12 }}>
+        <Text className="text-xl font-bold text-white mb-0.5">Каталог специалистов</Text>
+        <Text className="text-sm" style={{ color: overlay.white75 }}>Практики с опытом в вашей ИФНС. Выбирайте по инспекции, городу и типу проверки.</Text>
       </View>
 
       {/* Search bar */}


### PR DESCRIPTION
## Summary
- Add blue accent hero banners to `(specialist-tabs)/requests`, `/requests`, and `/specialists` screens
- Replaces plain white headers — targets `polish:7→8` on affected pages
- Pattern matches existing dashboard/home accent heroes

## Test plan
- [ ] All 3 screens show blue banner at top with white text
- [ ] TypeScript: 0 errors
- [ ] No regressions on other screens