### PR TITLE
fix(flows): fix login flow step-2 failure + data-testid on auth buttons

### DIFF
--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -99,6 +99,7 @@ export default function AuthEmailScreen() {
               onPress={handleContinue}
               disabled={isLoading || !email.trim()}
               loading={isLoading}
+              testID="send-otp"
             />
           </View>
 

--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -361,6 +361,7 @@ export default function AuthOtpScreen() {
                 onPress={() => handleVerify(digits.join(""))}
                 disabled={isLoading || !isCodeFull}
                 loading={isLoading}
+                testID="verify-otp"
               />
 
               {/* Resend link with countdown */}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -11,6 +11,7 @@ export interface ButtonProps {
   disabled?: boolean;
   fullWidth?: boolean;
   icon?: LucideIcon;
+  testID?: string;
 }
 
 export default function Button({
@@ -21,6 +22,7 @@ export default function Button({
   disabled = false,
   fullWidth = true,
   icon: Icon,
+  testID,
 }: ButtonProps) {
   const [pressed, setPressed] = useState(false);
 
@@ -54,6 +56,7 @@ export default function Button({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
+      testID={testID}
       onPress={onPress}
       onPressIn={() => setPressed(true)}
       onPressOut={() => setPressed(false)}

--- a/tests/flows/01-login.flow
+++ b/tests/flows/01-login.flow
@@ -1,0 +1,10 @@
+# P2PTax — login flow (OTP)
+goto http://localhost:8081/auth/email
+wait-for input[type=email]
+fill input[type=email] serter2069@gmail.com
+click [data-testid=send-otp]
+wait 2000
+fill input[type=text] 000000
+click [data-testid=verify-otp]
+wait 2000
+assert-url /dashboard

--- a/tests/flows/README.md
+++ b/tests/flows/README.md
@@ -1,0 +1,28 @@
+# P2PTax Flow Tests (vizor)
+
+Add `.flow` or `.json` files here. Run via:
+```
+vizor http://localhost:8081 --flow tests/flows/01-login.flow --problems
+```
+
+## Flow format (line-based)
+```
+goto <url>
+wait-for <selector>
+fill <selector> <value>
+click <selector>
+assert-url <path>
+assert-text <selector> <text>
+wait <ms>
+screenshot /tmp/name.jpg
+```
+
+## Flow format (JSON)
+```json
+[
+  {"type": "goto", "url": "http://localhost:8081"},
+  {"type": "fill", "selector": "input[type=email]", "value": "test@test.com"},
+  {"type": "click", "selector": "[data-testid=send-otp]"},
+  {"type": "assert-url", "value": "/dashboard"}
+]
+```


### PR DESCRIPTION
## Summary
- Flow test `01-login.flow` failed at step 2 (`wait-for input[type=email]`) because `goto http://localhost:8081` loads the landing page (no email input). Changed to `/auth/email` direct URL.
- Added `testID` prop to `Button` component (renders as `data-testid` on web via React Native Web).
- Added `testID="send-otp"` and `testID="verify-otp"` to auth buttons.

## Test plan
- [ ] `vizor http://localhost:8081 --flow tests/flows/01-login.flow` — all 9 steps pass
- [ ] `tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)