### PR TITLE
fix(flows): 01-login.flow reaches /dashboard reliably (#1265)

### DIFF
--- a/tests/flows/01-login.flow
+++ b/tests/flows/01-login.flow
@@ -1,8 +1,13 @@
+# P2PTax — login flow (OTP, dev code 000000)
+# selectors avoid whitespace because vizor's fill parser splits on whitespace
+# Role is not persisted to DB (client-side only), so role choice appears on every login
 goto http://localhost:8081/auth/email
 wait-for [aria-label="Email адрес"]
-fill [aria-label="Email адрес"] serter2069@gmail.com
+fill [placeholder="your@email.com"] test.client@p2ptax-seed.ru
 click [aria-label="Продолжить"]
-wait 3000
-fill [aria-label="Цифра 1 кода подтверждения"] 000000
-wait 3000
+wait-for input[maxlength="6"]
+fill input[maxlength="6"] 000000
+wait-for [aria-label="Мне нужна помощь с налоговой"]
+click [aria-label="Мне нужна помощь с налоговой"]
+wait 2000
 assert-url /dashboard


### PR DESCRIPTION
## Summary
- Use seeded `test.client@p2ptax-seed.ru` instead of `serter2069@gmail.com` so the flow has predictable user state, and click the "Мне нужна помощь с налоговой" role-choice button before asserting `/dashboard` (role is not persisted server-side yet, so the role screen appears on every fresh session).
- Switch to whitespace-free selectors (`[placeholder="your@email.com"]`, `input[maxlength="6"]`) because vizor's line-based flow parser splits `fill` selectors on whitespace and `[aria-label="Email адрес"]` broke at the space between words.
- Add `wait-for` on `input[maxlength="6"]` and on the role-choice button instead of fixed `wait 3000` — faster and more reliable.

Closes #1265.

## Test plan
- [x] `vizor http://localhost:8081 --flow tests/flows/01-login.flow --problems --actions-log` — 10/10 steps pass, lands on `/(client-tabs)/dashboard`.