### PR TITLE
fix(auth): OTP functional setState + flow test fix

### DIFF
--- a/app/auth/otp.tsx
+++ b/app/auth/otp.tsx
@@ -74,6 +74,14 @@ export default function AuthOtpScreen() {
     return () => clearTimeout(t);
   }, [email]);
 
+  // Auto-submit when all digits filled (handles rapid batched input from Playwright/paste)
+  useEffect(() => {
+    if (digits.every(d => d !== "") && !isLoading) {
+      handleVerify(digits.join(""));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [digits]);
+
   const routeByRole = useCallback(
     (user: UserData) => {
       if (user.role === "CLIENT") {
@@ -153,21 +161,15 @@ export default function AuthOtpScreen() {
 
     if (!/^\d*$/.test(value)) return;
 
-    const newDigits = [...digits];
-    newDigits[index] = value.slice(-1);
-    setDigits(newDigits);
+    setDigits(prev => {
+      const newDigits = [...prev];
+      newDigits[index] = value.slice(-1);
+      return newDigits;
+    });
     setError("");
 
     if (value && index < CODE_LENGTH - 1) {
       inputRefs.current[index + 1]?.focus();
-    }
-
-    // Auto-submit when 6th digit entered
-    if (index === CODE_LENGTH - 1 && value) {
-      const code = newDigits.join("");
-      if (code.length === CODE_LENGTH) {
-        handleVerify(code);
-      }
     }
   };
 

--- a/tests/flows/01-login.flow
+++ b/tests/flows/01-login.flow
@@ -1,13 +1,11 @@
 # P2PTax — login flow (OTP, dev code 000000)
-# selectors avoid whitespace because vizor's fill parser splits on whitespace
-# Role is not persisted to DB (client-side only), so role choice appears on every login
+# test.client@p2ptax-seed.ru has CLIENT role in DB, goes straight to dashboard after OTP
+# type fires key events that React handles one-by-one; useEffect auto-submits when all 6 filled
 goto http://localhost:8081/auth/email
 wait-for [aria-label="Email адрес"]
 fill [placeholder="your@email.com"] test.client@p2ptax-seed.ru
 click [aria-label="Продолжить"]
 wait-for input[maxlength="6"]
-fill input[maxlength="6"] 000000
-wait-for [aria-label="Мне нужна помощь с налоговой"]
-click [aria-label="Мне нужна помощь с налоговой"]
-wait 2000
+type input[maxlength="6"] 000000
+wait 4000
 assert-url /dashboard


### PR DESCRIPTION
## Summary
- Fix OTP digit input: use functional `setDigits(prev => ...)` to prevent React 18 batching race where rapid key events lost all but the last digit
- Move auto-submit to `useEffect` on `digits` — fires after all batched updates commit
- Update `01-login.flow` to use `type` (not fill) + remove stale role-selection step (seed users have role already)

## Root cause
React 18 automatic batching: when Playwright's `pressSequentially` fires 6 key events rapidly, all 6 `setDigits([...digits])` calls see the same stale `digits = ['','','','','','']`. Last call wins → only index 5 set → `isCodeFull=false` → button stays disabled.

## Test plan
- [ ] Manual OTP entry: type single digits still works
- [ ] Paste full 6-digit code auto-submits
- [ ] Flow test `01-login.flow` passes
- [ ] TypeScript: 0 errors