### PR TITLE
feat(design): Iteration 5 — Specialist Credibility Stack

### DIFF
--- a/api/prisma/migrations/20260423000000_iter5_credibility_stack/migration.sql
+++ b/api/prisma/migrations/20260423000000_iter5_credibility_stack/migration.sql
@@ -1,0 +1,50 @@
+-- AlterTable: SpecialistProfile — credibility stack fields
+ALTER TABLE "specialist_profiles" ADD COLUMN     "certifications" JSONB,
+ADD COLUMN     "ex_fns_end_year" INTEGER,
+ADD COLUMN     "ex_fns_start_year" INTEGER,
+ADD COLUMN     "specializations" JSONB,
+ADD COLUMN     "years_of_experience" INTEGER;
+
+-- CreateTable
+CREATE TABLE "specialist_cases" (
+    "id" TEXT NOT NULL,
+    "specialist_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "amount" INTEGER,
+    "resolved_amount" INTEGER,
+    "days" INTEGER,
+    "status" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "year" INTEGER,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "specialist_cases_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "specialist_reviews" (
+    "id" TEXT NOT NULL,
+    "specialist_id" TEXT NOT NULL,
+    "author_name" TEXT NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "text" TEXT NOT NULL,
+    "category_chips" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "specialist_reviews_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "specialist_cases_specialist_id_idx" ON "specialist_cases"("specialist_id");
+
+-- CreateIndex
+CREATE INDEX "specialist_reviews_specialist_id_idx" ON "specialist_reviews"("specialist_id");
+
+-- AddForeignKey
+ALTER TABLE "specialist_cases" ADD CONSTRAINT "specialist_cases_specialist_id_fkey" FOREIGN KEY ("specialist_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "specialist_reviews" ADD CONSTRAINT "specialist_reviews_specialist_id_fkey" FOREIGN KEY ("specialist_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -34,6 +34,8 @@ model User {
   specialistProfile       SpecialistProfile?
   specialistFns           SpecialistFns[]
   specialistServices      SpecialistService[]
+  specialistCases         SpecialistCase[]
+  specialistReviews       SpecialistReview[]
   requests                Request[]
   clientThreads           Thread[]  @relation("ClientThreads")
   specialistThreads       Thread[]  @relation("SpecialistThreads")
@@ -48,19 +50,61 @@ model User {
 }
 
 model SpecialistProfile {
-  id            String  @id @default(uuid())
-  userId        String  @unique @map("user_id")
-  description   String?
-  phone         String?
-  telegram      String?
-  whatsapp      String?
-  officeAddress String? @map("office_address")
-  workingHours  String? @map("working_hours")
+  id                 String   @id @default(uuid())
+  userId             String   @unique @map("user_id")
+  description        String?
+  phone              String?
+  telegram           String?
+  whatsapp           String?
+  officeAddress      String?  @map("office_address")
+  workingHours       String?  @map("working_hours")
+  // Iteration 5 — credibility stack fields
+  exFnsStartYear     Int?     @map("ex_fns_start_year")
+  exFnsEndYear       Int?     @map("ex_fns_end_year")
+  yearsOfExperience  Int?     @map("years_of_experience")
+  specializations    Json?    // array of strings
+  certifications     Json?    // array of strings
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   contactMethods ContactMethod[]
 
   @@map("specialist_profiles")
+}
+
+model SpecialistCase {
+  id             String   @id @default(uuid())
+  specialistId   String   @map("specialist_id")
+  title          String
+  category       String   // "Выездная проверка" | "Камеральная проверка" | "115-ФЗ" | "ОКК"
+  amount         Int?     // в рублях (доначисления)
+  resolvedAmount Int?     @map("resolved_amount") // в рублях (оспорено)
+  days           Int?     // срок решения
+  status         String   // "resolved" | "in_progress"
+  description    String
+  year           Int?
+  order          Int      @default(0)
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  specialist User @relation(fields: [specialistId], references: [id], onDelete: Cascade)
+
+  @@index([specialistId])
+  @@map("specialist_cases")
+}
+
+model SpecialistReview {
+  id             String   @id @default(uuid())
+  specialistId   String   @map("specialist_id")
+  authorName     String   @map("author_name")
+  rating         Int      // 1..5
+  date           DateTime
+  text           String
+  categoryChips  Json?    @map("category_chips") // array of strings
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  specialist User @relation(fields: [specialistId], references: [id], onDelete: Cascade)
+
+  @@index([specialistId])
+  @@map("specialist_reviews")
 }
 
 model ContactMethod {

--- a/api/prisma/seed-specialists.ts
+++ b/api/prisma/seed-specialists.ts
@@ -17,6 +17,25 @@ const prisma = new PrismaClient();
 
 // ─── SPECIALISTS (18 total) ─────────────────────────────────────────
 
+type CaseSeed = {
+  title: string;
+  category: string;
+  amount: number | null;
+  resolvedAmount: number | null;
+  days: number | null;
+  status: "resolved" | "in_progress";
+  description: string;
+  year: number | null;
+};
+
+type ReviewSeed = {
+  authorName: string;
+  rating: number;
+  daysAgo: number; // offset from now
+  text: string;
+  categoryChips: string[];
+};
+
 const SPECIALISTS: Array<{
   email: string;
   firstName: string;
@@ -28,6 +47,14 @@ const SPECIALISTS: Array<{
   telegram?: string;
   officeAddress?: string;
   workingHours?: string;
+  // Iteration 5 — credibility stack
+  exFnsStartYear?: number;
+  exFnsEndYear?: number;
+  yearsOfExperience?: number;
+  specializations?: string[];
+  certifications?: string[];
+  cases?: CaseSeed[];
+  reviews?: ReviewSeed[];
 }> = [
   {
     email: "aleksey.voronov@p2ptax-seed.ru",
@@ -40,6 +67,9 @@ const SPECIALISTS: Array<{
     telegram: "@voronov_tax",
     officeAddress: "Москва, Хохловский пер., 9, офис 312",
     workingHours: "Пн-Пт, 10:00-19:00",
+    yearsOfExperience: 8,
+    specializations: ["Камеральные проверки по крипте", "P2P-операции Binance/Bybit", "Ответы на требования ИФНС"],
+    certifications: ["Сертификат ИПБ", "Член Палаты налоговых консультантов", "3 публикации в «Налоговед»"],
   },
   {
     email: "marina.sokolova@p2ptax-seed.ru",
@@ -63,6 +93,11 @@ const SPECIALISTS: Array<{
     telegram: "@petrov_spb",
     officeAddress: "Санкт-Петербург, Красного Текстильщика ул., 10-12",
     workingHours: "Пн-Сб, 10:00-20:00",
+    exFnsStartYear: 2013,
+    exFnsEndYear: 2023,
+    yearsOfExperience: 11,
+    specializations: ["Выездные проверки ИП", "Камеральные проверки", "Сопровождение на допросах в ИФНС"],
+    certifications: ["Советник государственной гражданской службы 2 класса", "Диплом СПбГЭУ", "5 публикаций"],
   },
   {
     email: "elena.kuznetsova@p2ptax-seed.ru",
@@ -120,6 +155,11 @@ const SPECIALISTS: Array<{
     phone: "+7 (812) 240-80-80",
     telegram: "@stepanova_spb",
     workingHours: "Пн-Пт, 9:00-19:00",
+    exFnsStartYear: 2015,
+    exFnsEndYear: 2023,
+    yearsOfExperience: 8,
+    specializations: ["Камеральные проверки", "Выездные проверки ИП", "115-ФЗ блокировки"],
+    certifications: ["Диплом ВАК", "3 публикации в «Налоговая политика»", "Налоговый монитор"],
   },
   // Iteration 4 — additional 10 specialists for richer catalog
   {
@@ -239,6 +279,171 @@ const SPECIALISTS: Array<{
     workingHours: "Пн-Пт, 10:00-19:00",
   },
 ];
+
+// ─── Helpers for generating realistic cases + reviews ──────────────
+
+const FIRST_NAMES_M = ["Андрей", "Михаил", "Дмитрий", "Сергей", "Алексей", "Игорь", "Николай", "Владимир", "Пётр", "Артём"];
+const FIRST_NAMES_F = ["Екатерина", "Марина", "Ольга", "Наталья", "Анастасия", "Татьяна", "Светлана", "Ирина", "Елена"];
+const LAST_INITIAL = ["Н.", "К.", "П.", "С.", "М.", "Т.", "Б.", "В.", "Л.", "Р."];
+
+const REVIEW_TEXTS: Record<string, string[]> = {
+  "Выездная проверка": [
+    "помог(ла) с выездной проверкой ИФНС. Оспорили {amount} доначислений. Грамотно, быстро, без лишней воды. Рекомендую.",
+    "Вели выездную проверку, было очень нервно. {name} всё разложил(а) по полочкам, подготовили документы, результат превзошёл ожидания.",
+    "Отличный специалист. За {days} дней закрыли выездную проверку по УСН. Доначисления снизили с {amount}. Ответственно и по делу.",
+  ],
+  "Камеральная проверка": [
+    "Получил акт камеральной проверки — 1.8 млн доначислений. {name} подготовил(а) возражения, вышли на {amount}. Спасибо огромное.",
+    "Камеральная по 3-НДФЛ, операции с криптой. {name} составил(а) грамотный ответ, ФНС приняла позицию. По срокам — уложились.",
+    "Профессионал. За консультацию по камеральной проверке взял(а) адекватные деньги, помог(ла) разобраться с требованием. Советую.",
+  ],
+  "Отдел оперативного контроля": [
+    "Решение ОКК на 450 тыс штрафа. {name} написал(а) жалобу — отменили полностью. Быстро и по делу.",
+    "Пришёл запрос от ОКК по ККТ. {name} объяснил(а) стратегию, помог(ла) с ответом. Вопрос закрыли без штрафа.",
+    "Помог(ла) с проверкой от ОКК. Чёткая постановка задачи, понятные сроки, адекватная цена.",
+  ],
+  default: [
+    "Отличный налоговый консультант. Всё грамотно, чётко, по делу. Рекомендую.",
+    "Обращался по сложной ситуации с ФНС. {name} разобрал(а) кейс, предложил(а) стратегию — сработало.",
+    "Ответственный специалист, глубокое понимание налогового права. Решили вопрос быстро.",
+  ],
+};
+
+function pickReviewName(seed: number): string {
+  const pool = seed % 2 === 0 ? FIRST_NAMES_M : FIRST_NAMES_F;
+  const fn = pool[seed % pool.length];
+  const ln = LAST_INITIAL[(seed * 3) % LAST_INITIAL.length];
+  return `${fn} ${ln}`;
+}
+
+function generateCasesForSpecialist(
+  firstName: string,
+  cities: string[],
+  fnsCodes: string[],
+  serviceNames: string[],
+  seedIdx: number,
+): CaseSeed[] {
+  // 3-5 cases per specialist, realistic amounts and outcomes based on category
+  const city = cities[0] ?? "Москва";
+  const fnsCode = fnsCodes[0] ?? "7716";
+  const baseYear = 2024;
+
+  const templates: Record<string, CaseSeed[]> = {
+    "Выездная проверка": [
+      {
+        title: `Выездная проверка ИП на УСН в ${city}`,
+        category: "Выездная проверка",
+        amount: 3_200_000 + (seedIdx % 5) * 400_000,
+        resolvedAmount: 2_800_000 + (seedIdx % 5) * 300_000,
+        days: 45 + (seedIdx % 10),
+        status: "resolved",
+        description: `Выездная налоговая проверка по УСН «Доходы» за 2021-2023. Доначислено ${(3_200_000 + (seedIdx % 5) * 400_000).toLocaleString("ru-RU")} ₽. Подготовлены возражения, доказана реальность хозяйственных операций с подрядчиками. В УФНС отменено 87% доначислений.`,
+        year: baseYear,
+      },
+      {
+        title: `Выездная проверка ООО — ИФНС №${fnsCode}`,
+        category: "Выездная проверка",
+        amount: 5_400_000 + (seedIdx % 3) * 800_000,
+        resolvedAmount: 4_100_000 + (seedIdx % 3) * 500_000,
+        days: 62,
+        status: "resolved",
+        description: "Доначисления по НДС и налогу на прибыль из-за операций с «техническими» контрагентами. Подготовили пакет первичных документов, показания свидетелей, техническое обоснование. В арбитраже отстояли 76%.",
+        year: baseYear - 1,
+      },
+    ],
+    "Камеральная проверка": [
+      {
+        title: `Оспаривание камеральной проверки ИФНС №${fnsCode}`,
+        category: "Камеральная проверка",
+        amount: 2_400_000 + (seedIdx % 4) * 200_000,
+        resolvedAmount: 2_100_000 + (seedIdx % 4) * 180_000,
+        days: 23 + (seedIdx % 7),
+        status: "resolved",
+        description: "Клиент-ИП получил акт камеральной проверки по декларации 3-НДФЛ за 2023 год. Доначислено 2.4 млн ₽ по операциям с криптовалютой. Подготовили возражения с подтверждением расходной части (скриншоты из Bybit + банковские выписки), ФНС сняла 87% суммы.",
+        year: baseYear,
+      },
+      {
+        title: "Камеральная по 3-НДФЛ — зарубежный брокер",
+        category: "Камеральная проверка",
+        amount: 780_000,
+        resolvedAmount: 780_000,
+        days: 18,
+        status: "resolved",
+        description: "Клиент декларировал доходы от Interactive Brokers, ФНС запросила пояснения и документы. Подготовили расчёт курсовых разниц по каждой сделке, переводы договоров. Акт пересмотрен — доначислений нет.",
+        year: baseYear,
+      },
+    ],
+    "Отдел оперативного контроля": [
+      {
+        title: "Оспаривание решения ОКК — штраф за ККТ",
+        category: "Отдел оперативного контроля",
+        amount: 450_000,
+        resolvedAmount: 450_000,
+        days: 28,
+        status: "resolved",
+        description: "Сетевой магазин получил решение ОКК о применении ККТ с нарушениями — штраф 450 тыс ₽. Составили жалобу в вышестоящий налоговый орган, указали на процессуальные нарушения. Решение отменено полностью.",
+        year: baseYear,
+      },
+    ],
+  };
+
+  const cases: CaseSeed[] = [];
+  for (const svc of serviceNames) {
+    const pool = templates[svc];
+    if (pool) cases.push(...pool);
+  }
+
+  // Add a "в работе" case
+  if (cases.length >= 2) {
+    cases.push({
+      title: `Сопровождение камеральной проверки — ${city}`,
+      category: "Камеральная проверка",
+      amount: 1_200_000,
+      resolvedAmount: null,
+      days: null,
+      status: "in_progress",
+      description: "Клиент получил требование о пояснениях в рамках камеральной проверки 3-НДФЛ. Готовим ответ, собираем первичные документы. Ожидается завершение в следующем месяце.",
+      year: baseYear,
+    });
+  }
+
+  return cases.slice(0, 4); // cap at 4 per specialist
+}
+
+function generateReviewsForSpecialist(
+  firstName: string,
+  serviceNames: string[],
+  seedIdx: number,
+): ReviewSeed[] {
+  const reviews: ReviewSeed[] = [];
+  const serviceCount = Math.min(serviceNames.length, 3);
+  const reviewCount = 3 + (seedIdx % 3); // 3-5 reviews
+
+  for (let i = 0; i < reviewCount; i++) {
+    const svc = serviceNames[i % Math.max(serviceCount, 1)] ?? "Камеральная проверка";
+    const pool = REVIEW_TEXTS[svc] ?? REVIEW_TEXTS.default;
+    const template = pool[(seedIdx + i) % pool.length];
+
+    const amount = [[ "2.1 млн", "1.8 млн", "950 тыс", "3.4 млн" ][i % 4]][0];
+    const days = 14 + (i + seedIdx) * 3;
+
+    const text = template
+      .replace(/\{name\}/g, firstName)
+      .replace(/\{amount\}/g, amount)
+      .replace(/\{days\}/g, String(days));
+
+    const rating = i === 0 ? 5 : i === 1 ? 5 : 4 + (seedIdx + i) % 2;
+
+    reviews.push({
+      authorName: pickReviewName(seedIdx * 11 + i),
+      rating: Math.min(5, rating),
+      daysAgo: 30 + i * 40 + (seedIdx % 20),
+      text,
+      categoryChips: [svc],
+    });
+  }
+  return reviews;
+}
 
 // ─── REQUESTS (15 total) ────────────────────────────────────────────
 
@@ -516,6 +721,11 @@ async function main() {
         telegram: spec.telegram,
         officeAddress: spec.officeAddress,
         workingHours: spec.workingHours,
+        exFnsStartYear: spec.exFnsStartYear ?? null,
+        exFnsEndYear: spec.exFnsEndYear ?? null,
+        yearsOfExperience: spec.yearsOfExperience ?? null,
+        specializations: spec.specializations ?? undefined,
+        certifications: spec.certifications ?? undefined,
       },
       create: {
         userId: user.id,
@@ -524,6 +734,11 @@ async function main() {
         telegram: spec.telegram,
         officeAddress: spec.officeAddress,
         workingHours: spec.workingHours,
+        exFnsStartYear: spec.exFnsStartYear ?? null,
+        exFnsEndYear: spec.exFnsEndYear ?? null,
+        yearsOfExperience: spec.yearsOfExperience ?? null,
+        specializations: spec.specializations ?? undefined,
+        certifications: spec.certifications ?? undefined,
       },
     });
 
@@ -564,6 +779,83 @@ async function main() {
     specialistCount++;
   }
   console.log(`\n  Specialists: ${specialistCount}`);
+
+  // ─── Specialist Cases + Reviews (Iteration 5) ────────────────────
+  // Wipe + regenerate deterministically per run.
+  await prisma.specialistCase.deleteMany({});
+  await prisma.specialistReview.deleteMany({});
+
+  let caseCount = 0;
+  let reviewCount = 0;
+
+  for (let sIdx = 0; sIdx < SPECIALISTS.length; sIdx++) {
+    const spec = SPECIALISTS[sIdx];
+    const user = specialistUsers[sIdx];
+    if (!user) continue;
+
+    // Derive cities + fnsCodes for this specialist from the seed entry
+    const cities = new Set<string>();
+    for (const code of spec.fnsCodes) {
+      const f = fnsMap[code];
+      if (!f) continue;
+      // cityId → city name via a secondary lookup (skipped — use explicit officeAddress city if available)
+    }
+    const cityHint =
+      spec.officeAddress?.split(",")[0]?.trim() ??
+      null;
+    const cityList = cityHint ? [cityHint] : [];
+
+    // Explicit cases (hand-authored for the spec) or generated
+    const cases =
+      spec.cases ??
+      generateCasesForSpecialist(
+        spec.firstName,
+        cityList,
+        spec.fnsCodes,
+        spec.serviceNames,
+        sIdx,
+      );
+
+    for (let i = 0; i < cases.length; i++) {
+      const c = cases[i];
+      await prisma.specialistCase.create({
+        data: {
+          specialistId: user.id,
+          title: c.title,
+          category: c.category,
+          amount: c.amount,
+          resolvedAmount: c.resolvedAmount,
+          days: c.days,
+          status: c.status,
+          description: c.description,
+          year: c.year,
+          order: i,
+        },
+      });
+      caseCount++;
+    }
+
+    const reviews =
+      spec.reviews ??
+      generateReviewsForSpecialist(spec.firstName, spec.serviceNames, sIdx);
+
+    for (const r of reviews) {
+      const date = new Date(Date.now() - r.daysAgo * 24 * 60 * 60 * 1000);
+      await prisma.specialistReview.create({
+        data: {
+          specialistId: user.id,
+          authorName: r.authorName,
+          rating: r.rating,
+          date,
+          text: r.text,
+          categoryChips: r.categoryChips,
+        },
+      });
+      reviewCount++;
+    }
+  }
+  console.log(`  Cases:       ${caseCount}`);
+  console.log(`  Reviews:     ${reviewCount}`);
 
   // ─── Client pool (5 extra clients beyond Сергей) ─────────────────
   const EXTRA_CLIENTS = [

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -230,7 +230,24 @@ router.get("/:id", async (req: Request, res: Response) => {
       }
     }
 
-    const requestsCount = await prisma.thread.count({ where: { specialistId: id } });
+    const [requestsCount, cases, reviews] = await Promise.all([
+      prisma.thread.count({ where: { specialistId: id } }),
+      prisma.specialistCase.findMany({
+        where: { specialistId: id },
+        orderBy: [{ order: "asc" }, { createdAt: "desc" }],
+      }),
+      prisma.specialistReview.findMany({
+        where: { specialistId: id },
+        orderBy: { date: "desc" },
+      }),
+    ]);
+
+    const averageRating =
+      reviews.length > 0
+        ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
+        : null;
+
+    const profile = specialist.specialistProfile;
 
     res.json({
       id: specialist.id,
@@ -240,17 +257,43 @@ router.get("/:id", async (req: Request, res: Response) => {
       isAvailable: specialist.isAvailable,
       createdAt: specialist.createdAt,
       requestsCount,
-      profile: specialist.specialistProfile
+      profile: profile
         ? {
-            description: specialist.specialistProfile.description,
-            phone: specialist.specialistProfile.phone,
-            telegram: specialist.specialistProfile.telegram,
-            whatsapp: specialist.specialistProfile.whatsapp,
-            officeAddress: specialist.specialistProfile.officeAddress,
-            workingHours: specialist.specialistProfile.workingHours,
+            description: profile.description,
+            phone: profile.phone,
+            telegram: profile.telegram,
+            whatsapp: profile.whatsapp,
+            officeAddress: profile.officeAddress,
+            workingHours: profile.workingHours,
+            exFnsStartYear: profile.exFnsStartYear,
+            exFnsEndYear: profile.exFnsEndYear,
+            yearsOfExperience: profile.yearsOfExperience,
+            specializations: (profile.specializations as string[] | null) ?? null,
+            certifications: (profile.certifications as string[] | null) ?? null,
           }
         : null,
       fnsServices: [...fnsMap.values()],
+      cases: cases.map((c) => ({
+        id: c.id,
+        title: c.title,
+        category: c.category,
+        amount: c.amount,
+        resolvedAmount: c.resolvedAmount,
+        days: c.days,
+        status: c.status,
+        description: c.description,
+        year: c.year,
+      })),
+      reviews: reviews.map((r) => ({
+        id: r.id,
+        authorName: r.authorName,
+        rating: r.rating,
+        date: r.date,
+        text: r.text,
+        categoryChips: (r.categoryChips as string[] | null) ?? [],
+      })),
+      averageRating,
+      reviewCount: reviews.length,
     });
   } catch (error) {
     console.error("specialist detail error:", error);

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   View,
   Text,
@@ -9,40 +9,65 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import Head from "expo-router/head";
-import { AlertCircle, Pencil } from "lucide-react-native";
+import {
+  AlertCircle,
+  Pencil,
+  ShieldCheck,
+  Briefcase,
+  Target,
+  ScrollText,
+  Bookmark,
+} from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
-import SpecialistCard from "@/components/SpecialistCard";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import ProfileHero from "@/components/specialist/ProfileHero";
-import StatsRow from "@/components/specialist/StatsRow";
-import WorkAreaSection from "@/components/specialist/WorkAreaSection";
+import Avatar from "@/components/ui/Avatar";
+import RatingStars from "@/components/ui/RatingStars";
+import MetricCard from "@/components/ui/MetricCard";
+import CaseCard from "@/components/specialist/CaseCard";
+import ReviewCard from "@/components/specialist/ReviewCard";
 import ContactsSection from "@/components/specialist/ContactsSection";
-import type { SpecialistDetail, ContactMethodItem, SimilarSpecialist } from "@/components/specialist/types";
+import WorkAreaSection from "@/components/specialist/WorkAreaSection";
+import type {
+  SpecialistDetail,
+  ContactMethodItem,
+  SpecialistCaseItem,
+} from "@/components/specialist/types";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import { colors, textStyle } from "@/lib/theme";
-import EmptyState from "@/components/ui/EmptyState";
+import { colors, textStyle, spacing } from "@/lib/theme";
 
-function getInitials(firstName: string | null, lastName: string | null): string {
+function getInitials(
+  firstName: string | null,
+  lastName: string | null,
+): string {
   const f = firstName?.[0] || "";
   const l = lastName?.[0] || "";
   return (f + l).toUpperCase() || "?";
 }
+
+const CASE_FILTERS: Array<{ label: string; match: (c: SpecialistCaseItem) => boolean }> = [
+  { label: "Все", match: () => true },
+  { label: "Выездные", match: (c) => /выездн/i.test(c.category) },
+  { label: "Камеральные", match: (c) => /камеральн/i.test(c.category) },
+  { label: "115-ФЗ", match: (c) => /115|блокировк/i.test(c.category) },
+];
 
 export default function SpecialistPublicProfile() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { user, isAuthenticated } = useAuth();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= 1024;
+  const isTablet = width >= 640;
 
   const [specialist, setSpecialist] = useState<SpecialistDetail | null>(null);
   const [contacts, setContacts] = useState<ContactMethodItem[]>([]);
-  const [similar, setSimilar] = useState<SimilarSpecialist[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [caseFilter, setCaseFilter] = useState(0);
+  const [casesExpanded, setCasesExpanded] = useState(false);
 
   const isOwnProfile = !!user && user.id === id;
   const isSpecialist = user?.role === "SPECIALIST";
@@ -50,13 +75,14 @@ export default function SpecialistPublicProfile() {
   useEffect(() => {
     async function load() {
       try {
-        const [specRes, similarRes, contactsRes] = await Promise.all([
+        const [specRes, contactsRes] = await Promise.all([
           api<SpecialistDetail>(`/api/specialists/${id}`, { noAuth: true }),
-          api<{ items: SimilarSpecialist[] }>("/api/specialists/featured", { noAuth: true }),
-          api<{ items: ContactMethodItem[] }>(`/api/specialists/${id}/contacts`, { noAuth: true }),
+          api<{ items: ContactMethodItem[] }>(
+            `/api/specialists/${id}/contacts`,
+            { noAuth: true },
+          ),
         ]);
         setSpecialist(specRes);
-        setSimilar(similarRes.items.filter((s) => s.id !== id));
         setContacts(contactsRes.items);
       } catch (e) {
         setError("Не удалось загрузить профиль");
@@ -68,20 +94,32 @@ export default function SpecialistPublicProfile() {
     if (id) load();
   }, [id]);
 
-  const handleSimilarPress = useCallback(
-    (specId: string) => {
-      router.push(`/specialists/${specId}` as never);
-    },
-    [router]
-  );
-
   const handleWritePress = useCallback(() => {
     if (!isAuthenticated) {
-      router.push("/auth/email" as never);
+      router.push(
+        `/auth/email?returnTo=/specialists/${id}` as never,
+      );
     } else {
       router.push("/requests/new" as never);
     }
-  }, [isAuthenticated, router]);
+  }, [isAuthenticated, router, id]);
+
+  const handleSavePress = useCallback(() => {
+    if (!isAuthenticated) {
+      router.push(
+        `/auth/email?returnTo=/specialists/${id}` as never,
+      );
+    }
+    // Future: POST /api/bookmarks
+  }, [isAuthenticated, router, id]);
+
+  // Filter cases
+  const filteredCases = useMemo(() => {
+    const all = specialist?.cases ?? [];
+    return all.filter(CASE_FILTERS[caseFilter].match);
+  }, [specialist?.cases, caseFilter]);
+
+  const visibleCases = casesExpanded ? filteredCases : filteredCases.slice(0, 3);
 
   if (loading) {
     return (
@@ -98,10 +136,24 @@ export default function SpecialistPublicProfile() {
         <HeaderBack title="Профиль специалиста" />
         <View className="flex-1 items-center justify-center px-6">
           <AlertCircle size={48} color={colors.placeholder} />
-          <Text style={{ ...textStyle.h3, color: colors.text, marginTop: 16, textAlign: "center" }}>
+          <Text
+            style={{
+              ...textStyle.h3,
+              color: colors.text,
+              marginTop: 16,
+              textAlign: "center",
+            }}
+          >
             Специалист не найден
           </Text>
-          <Text style={{ ...textStyle.small, color: colors.textSecondary, marginTop: 8, textAlign: "center" }}>
+          <Text
+            style={{
+              ...textStyle.small,
+              color: colors.textSecondary,
+              marginTop: 8,
+              textAlign: "center",
+            }}
+          >
             Возможно, профиль был удалён или вы перешли по неверной ссылке
           </Text>
           <View className="mt-6">
@@ -117,21 +169,35 @@ export default function SpecialistPublicProfile() {
   }
 
   const name =
-    [specialist.firstName, specialist.lastName].filter(Boolean).join(" ") || "Специалист";
+    [specialist.firstName, specialist.lastName].filter(Boolean).join(" ") ||
+    "Специалист";
   const initials = getInitials(specialist.firstName, specialist.lastName);
 
-  // Collect unique cities from fnsServices
+  // Collect unique cities + FNS codes from fnsServices
   const citySet = new Set<string>();
   const cities: string[] = [];
+  const fnsCodes: string[] = [];
+  const serviceNames = new Set<string>();
   for (const g of specialist.fnsServices) {
     if (!citySet.has(g.city.id)) {
       citySet.add(g.city.id);
       cities.push(g.city.name);
     }
+    fnsCodes.push(g.fns.code);
+    for (const s of g.services) serviceNames.add(s.name);
   }
 
-  const fnsCount = specialist.fnsServices.length;
-  const servicesCount = new Set(specialist.fnsServices.flatMap((g) => g.services.map((s) => s.id))).size;
+  const profile = specialist.profile;
+  const cases = specialist.cases ?? [];
+  const reviews = specialist.reviews ?? [];
+  const reviewCount = specialist.reviewCount ?? reviews.length;
+  const averageRating = specialist.averageRating ?? null;
+
+  const yearsExp =
+    profile?.yearsOfExperience ?? Math.max(1, 2024 - new Date(specialist.createdAt).getFullYear());
+  const specializations = profile?.specializations ?? [];
+  const certifications = profile?.certifications ?? [];
+  const isExFns = profile?.exFnsStartYear && profile?.exFnsEndYear;
 
   const rightAction = isOwnProfile ? (
     <Pressable
@@ -143,119 +209,640 @@ export default function SpecialistPublicProfile() {
     </Pressable>
   ) : undefined;
 
-  const cardShadow = {
+  const ogDescription = profile?.description
+    ? profile.description.slice(0, 160)
+    : `Специалист по налогам ${cities.length > 0 ? `в ${cities[0]}` : ""}`.trim();
+
+  const rolePrimary = "Налоговый консультант";
+  const cityLabel = cities[0] ?? "Россия";
+
+  // ─── Render pieces ─────────────────────────────────────────────────
+
+  const hero = (
+    <View
+      className={`${isTablet ? "flex-row" : "flex-col"} items-start`}
+      style={{ gap: isTablet ? spacing.lg : spacing.base }}
+    >
+      <Avatar
+        name={name}
+        imageUrl={specialist.avatarUrl ?? undefined}
+        size={isTablet ? 160 : 96}
+        tint={colors.accentSoft}
+        inkColor={colors.accentSoftInk}
+      />
+      <View className="flex-1">
+        <Text style={{ ...textStyle.h1, color: colors.text }}>{name}</Text>
+        <Text
+          style={{
+            ...textStyle.body,
+            color: colors.textSecondary,
+            marginTop: 4,
+          }}
+        >
+          {rolePrimary} · {cityLabel}
+        </Text>
+
+        {fnsCodes.length > 0 && (
+          <View
+            className="flex-row flex-wrap mt-3"
+            style={{ gap: 6 }}
+          >
+            {fnsCodes.slice(0, 4).map((code) => (
+              <View
+                key={code}
+                className="px-2 py-1 rounded-md"
+                style={{ backgroundColor: colors.surface2 }}
+              >
+                <Text
+                  style={{
+                    fontSize: 12,
+                    fontFamily: "monospace",
+                    color: colors.textSecondary,
+                    letterSpacing: 0.5,
+                  }}
+                >
+                  ИФНС №{code}
+                </Text>
+              </View>
+            ))}
+            {fnsCodes.length > 4 && (
+              <View
+                className="px-2 py-1 rounded-md"
+                style={{ backgroundColor: colors.surface2 }}
+              >
+                <Text
+                  style={{ fontSize: 12, color: colors.textMuted }}
+                >
+                  +{fnsCodes.length - 4}
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
+
+        <View
+          className="flex-row items-center flex-wrap mt-3"
+          style={{ gap: 10 }}
+        >
+          <RatingStars
+            rating={averageRating ?? 0}
+            size={14}
+            showNumber
+            reviewCount={reviewCount}
+          />
+          {cases.length > 0 && (
+            <>
+              <Text style={{ color: colors.textMuted }}>·</Text>
+              <Text
+                className="text-sm font-semibold"
+                style={{ color: colors.text }}
+              >
+                {cases.length} {cases.length === 1 ? "дело" : cases.length < 5 ? "дела" : "дел"}
+              </Text>
+            </>
+          )}
+        </View>
+
+        {isExFns && (
+          <View
+            className="flex-row items-center self-start mt-3 px-3 py-1.5 rounded-full"
+            style={{ backgroundColor: "#fef3c7", gap: 6 }}
+          >
+            <ShieldCheck size={14} color="#b45309" />
+            <Text
+              className="text-xs font-semibold"
+              style={{ color: "#b45309" }}
+            >
+              Ex-ФНС {profile?.exFnsStartYear}–{profile?.exFnsEndYear}
+            </Text>
+          </View>
+        )}
+
+        <View
+          className={`${isTablet ? "flex-row" : "flex-col"} mt-4`}
+          style={{ gap: 8 }}
+        >
+          {!isOwnProfile && !isSpecialist && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Написать"
+              onPress={handleWritePress}
+              className="rounded-xl px-6 h-11 items-center justify-center flex-row"
+              style={{
+                backgroundColor: colors.primary,
+                alignSelf: isTablet ? "flex-start" : "stretch",
+              }}
+            >
+              <Text className="text-white font-semibold text-sm">Написать</Text>
+              <Text className="text-white text-sm ml-2">· бесплатно</Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+
+  // Credentials 3-up grid
+  const credentialsBlock = (
+    <View className="mt-8">
+      <View
+        className={`${isTablet ? "flex-row" : "flex-col"}`}
+        style={{ gap: spacing.md }}
+      >
+        <MetricCard
+          icon={Briefcase}
+          title="Опыт"
+          value={`${yearsExp} ${yearsExp === 1 ? "год" : yearsExp < 5 ? "года" : "лет"}`}
+          lines={
+            isExFns
+              ? [
+                  `Ex-ФНС ${cities[0] ?? ""}`,
+                  fnsCodes.length > 0
+                    ? `ИФНС ${fnsCodes.slice(0, 2).map((c) => `№${c}`).join(", ")}`
+                    : "",
+                ].filter(Boolean)
+              : [
+                  `Налоговая практика`,
+                  cities.length > 0 ? `Регион: ${cities.join(", ")}` : "",
+                ].filter(Boolean)
+          }
+        />
+        <MetricCard
+          icon={Target}
+          title="Специализация"
+          value={
+            specializations.length > 0
+              ? specializations[0]
+              : [...serviceNames][0] ?? "Налоговая практика"
+          }
+          lines={
+            specializations.length > 0
+              ? specializations.slice(1, 4)
+              : [...serviceNames].slice(1, 4)
+          }
+        />
+        <MetricCard
+          icon={ScrollText}
+          title="Сертификации"
+          value={
+            certifications.length > 0
+              ? certifications[0]
+              : "Практикующий консультант"
+          }
+          lines={certifications.slice(1, 4)}
+        />
+      </View>
+    </View>
+  );
+
+  // Cases section
+  const casesBlock = (
+    <View className="mt-8">
+      <View
+        className="flex-row items-center justify-between mb-4"
+        style={{ gap: 8 }}
+      >
+        <Text style={{ ...textStyle.h2, color: colors.text }}>
+          Избранные дела ({cases.length})
+        </Text>
+      </View>
+
+      {cases.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          className="mb-4"
+        >
+          <View className="flex-row" style={{ gap: 6 }}>
+            {CASE_FILTERS.map((f, i) => {
+              const active = caseFilter === i;
+              return (
+                <Pressable
+                  key={f.label}
+                  onPress={() => setCaseFilter(i)}
+                  accessibilityRole="button"
+                  className="px-3 py-1.5 rounded-full border"
+                  style={{
+                    borderColor: active ? colors.primary : colors.border,
+                    backgroundColor: active ? colors.primary : colors.surface,
+                  }}
+                >
+                  <Text
+                    className="text-xs font-semibold"
+                    style={{
+                      color: active ? "#fff" : colors.textSecondary,
+                    }}
+                  >
+                    {f.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
+      )}
+
+      {cases.length === 0 ? (
+        <View
+          className="rounded-2xl border border-border p-6 items-center"
+          style={{ backgroundColor: colors.surface2 }}
+        >
+          <Text
+            className="text-sm"
+            style={{ color: colors.textSecondary }}
+          >
+            Пока нет опубликованных дел
+          </Text>
+        </View>
+      ) : filteredCases.length === 0 ? (
+        <View
+          className="rounded-2xl border border-border p-6 items-center"
+          style={{ backgroundColor: colors.surface2 }}
+        >
+          <Text
+            className="text-sm"
+            style={{ color: colors.textSecondary }}
+          >
+            Нет дел по выбранному фильтру
+          </Text>
+        </View>
+      ) : (
+        <>
+          {visibleCases.map((c) => (
+            <CaseCard key={c.id} case={c} />
+          ))}
+          {filteredCases.length > 3 && (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setCasesExpanded((v) => !v)}
+              className="items-center justify-center py-3 rounded-xl border border-border"
+              style={{ backgroundColor: colors.surface }}
+            >
+              <Text
+                className="text-sm font-semibold"
+                style={{ color: colors.primary }}
+              >
+                {casesExpanded
+                  ? "Свернуть"
+                  : `Показать ещё ${filteredCases.length - 3}`}
+              </Text>
+            </Pressable>
+          )}
+        </>
+      )}
+    </View>
+  );
+
+  // Reviews section
+  const reviewsBlock = (
+    <View className="mt-8">
+      <View
+        className="flex-row items-end justify-between mb-4"
+        style={{ gap: 8 }}
+      >
+        <Text style={{ ...textStyle.h2, color: colors.text }}>
+          Отзывы клиентов ({reviewCount})
+        </Text>
+        {averageRating !== null && (
+          <View className="items-end">
+            <Text
+              style={{ ...textStyle.h1, color: colors.text, fontSize: 28 }}
+            >
+              {averageRating.toFixed(1)}
+            </Text>
+            <RatingStars rating={averageRating} size={14} />
+          </View>
+        )}
+      </View>
+      {reviews.length === 0 ? (
+        <View
+          className="rounded-2xl border border-border p-6 items-center"
+          style={{ backgroundColor: colors.surface2 }}
+        >
+          <Text
+            className="text-sm"
+            style={{ color: colors.textSecondary }}
+          >
+            Пока нет отзывов
+          </Text>
+        </View>
+      ) : (
+        reviews.slice(0, 3).map((r) => <ReviewCard key={r.id} review={r} />)
+      )}
+    </View>
+  );
+
+  // Services & cities
+  const servicesCitiesBlock = (
+    <View className="mt-8">
+      {serviceNames.size > 0 && (
+        <View className="mb-6">
+          <Text
+            className="uppercase mb-3"
+            style={{
+              fontSize: 11,
+              letterSpacing: 3,
+              color: colors.textSecondary,
+              fontWeight: "600",
+            }}
+          >
+            Услуги
+          </Text>
+          <View className="flex-row flex-wrap" style={{ gap: 6 }}>
+            {[...serviceNames].map((s) => (
+              <View
+                key={s}
+                className="px-3 py-1.5 rounded-full"
+                style={{ backgroundColor: colors.accentSoft }}
+              >
+                <Text
+                  className="text-xs font-medium"
+                  style={{ color: colors.accentSoftInk }}
+                >
+                  {s}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+
+      {cities.length > 0 && (
+        <View>
+          <Text
+            className="uppercase mb-3"
+            style={{
+              fontSize: 11,
+              letterSpacing: 3,
+              color: colors.textSecondary,
+              fontWeight: "600",
+            }}
+          >
+            Города
+          </Text>
+          <View className="flex-row flex-wrap" style={{ gap: 6 }}>
+            {cities.map((city) => (
+              <View
+                key={city}
+                className="px-3 py-1.5 rounded-full border"
+                style={{
+                  backgroundColor: colors.surface,
+                  borderColor: colors.border,
+                }}
+              >
+                <Text
+                  className="text-xs font-medium"
+                  style={{ color: colors.text }}
+                >
+                  {city}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </View>
+      )}
+    </View>
+  );
+
+  // Sidebar / sticky CTA (desktop right column; mobile bottom)
+  const ctaContent = (
+    <View
+      className="rounded-2xl border border-border p-5"
+      style={{
+        backgroundColor: colors.surface,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.06,
+        shadowRadius: 16,
+        elevation: 3,
+      }}
+    >
+      <Text style={{ ...textStyle.h3, color: colors.text, marginBottom: 8 }}>
+        Написать {specialist.firstName ?? "специалисту"}
+      </Text>
+      <Text
+        className="text-sm leading-5 mb-2"
+        style={{ color: colors.textSecondary }}
+      >
+        Ваша заявка будет прочитана в течение рабочего дня.
+      </Text>
+      <View
+        className="flex-row items-center px-2.5 py-1.5 rounded-md self-start mb-4"
+        style={{ backgroundColor: colors.greenSoft, gap: 6 }}
+      >
+        <View
+          className="rounded-full"
+          style={{ width: 6, height: 6, backgroundColor: colors.success }}
+        />
+        <Text
+          className="text-xs font-semibold"
+          style={{ color: colors.success }}
+        >
+          Первое сообщение — бесплатно
+        </Text>
+      </View>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Написать"
+        onPress={handleWritePress}
+        className="items-center justify-center rounded-xl flex-row"
+        style={{
+          backgroundColor: colors.primary,
+          height: 56,
+          shadowColor: colors.primary,
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.2,
+          shadowRadius: 12,
+          elevation: 4,
+        }}
+      >
+        <Text className="text-white font-semibold text-base">Написать</Text>
+      </Pressable>
+
+      {isAuthenticated && !isSpecialist && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Сохранить"
+          onPress={handleSavePress}
+          className="items-center justify-center rounded-xl flex-row mt-2 border border-border"
+          style={{ backgroundColor: colors.surface, height: 44, gap: 6 }}
+        >
+          <Bookmark size={14} color={colors.textSecondary} />
+          <Text
+            className="text-sm font-semibold"
+            style={{ color: colors.textSecondary }}
+          >
+            Сохранить
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+
+  const aboutBlock = profile?.description ? (
+    <View className="mt-8">
+      <Text
+        className="uppercase mb-3"
+        style={{
+          fontSize: 11,
+          letterSpacing: 3,
+          color: colors.textSecondary,
+          fontWeight: "600",
+        }}
+      >
+        О специалисте
+      </Text>
+      <Text
+        className="text-base leading-7"
+        style={{ color: colors.text }}
+      >
+        {profile.description}
+      </Text>
+    </View>
+  ) : null;
+
+  // Cards with lighter shadow for embedded legacy sections
+  const legacyShadow = {
     shadowColor: colors.text,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.06,
-    shadowRadius: 12,
-    elevation: 3,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.04,
+    shadowRadius: 8,
+    elevation: 1,
   };
 
-  const ogDescription = specialist.profile?.description
-    ? specialist.profile.description.slice(0, 160)
-    : `Специалист по налогам P2P ${cities.length > 0 ? `в ${cities[0]}` : ""}`.trim();
+  const mainContent = (
+    <View>
+      {hero}
+      {aboutBlock}
+      {credentialsBlock}
+      {casesBlock}
+      {reviewsBlock}
+      {servicesCitiesBlock}
+      <View className="mt-8">
+        <WorkAreaSection
+          fnsServices={specialist.fnsServices}
+          cardShadow={legacyShadow}
+        />
+        <ContactsSection
+          contacts={contacts}
+          officeAddress={profile?.officeAddress ?? null}
+          workingHours={profile?.workingHours ?? null}
+          cardShadow={legacyShadow}
+        />
+      </View>
+    </View>
+  );
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1" style={{ backgroundColor: "#fafbfc" }}>
       <Head>
-        <title>{name} — специалист по налогам P2P | P2PTax</title>
-        <meta property="og:title" content={`${name} — специалист по налогам P2P | P2PTax`} />
+        <title>{name} — специалист по налогам | P2PTax</title>
+        <meta
+          property="og:title"
+          content={`${name} — специалист по налогам | P2PTax`}
+        />
         <meta property="og:description" content={ogDescription} />
-        <meta property="og:url" content={`https://p2ptax.ru/specialists/${id}`} />
+        <meta
+          property="og:url"
+          content={`https://p2ptax.ru/specialists/${id}`}
+        />
         <meta property="og:type" content="profile" />
       </Head>
       <HeaderBack title="Профиль специалиста" rightAction={rightAction} />
-      <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
-        <ResponsiveContainer>
-          <View className="py-4" style={{ paddingBottom: isDesktop ? 32 : 0 }}>
-            <ProfileHero
-              name={name}
-              initials={initials}
-              cities={cities}
-              isAvailable={specialist.isAvailable}
-              createdAt={specialist.createdAt}
-              isOwnProfile={isOwnProfile}
-              isSpecialist={isSpecialist}
-              onWritePress={handleWritePress}
-            />
-
-            <StatsRow
-              requestsCount={specialist.requestsCount ?? fnsCount}
-              fnsCount={fnsCount}
-              servicesCount={servicesCount}
-            />
-
-            {/* About */}
-            {specialist.profile?.description ? (
-              <View
-                className="bg-white rounded-2xl border border-slate-100 p-4 mx-4 mt-4"
-                style={cardShadow}
-              >
-                <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
-                  О СЕБЕ
-                </Text>
-                <Text className="text-base leading-6" style={{ color: colors.textSecondary }}>
-                  {specialist.profile.description}
-                </Text>
-              </View>
-            ) : null}
-
-            <WorkAreaSection fnsServices={specialist.fnsServices} cardShadow={cardShadow} />
-
-            <ContactsSection
-              contacts={contacts}
-              officeAddress={specialist.profile?.officeAddress ?? null}
-              workingHours={specialist.profile?.workingHours ?? null}
-              cardShadow={cardShadow}
-            />
-
-            {/* Reviews */}
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: isDesktop ? 48 : 120,
+        }}
+      >
+        <View
+          className="w-full items-center"
+          style={{ paddingHorizontal: isDesktop ? 32 : 16, paddingTop: 16 }}
+        >
+          <View
+            className={`${isDesktop ? "flex-row" : "flex-col"} w-full`}
+            style={{
+              maxWidth: 1200,
+              gap: isDesktop ? spacing.xl : 0,
+            }}
+          >
+            {/* Main column */}
             <View
-              className="bg-white rounded-2xl border border-slate-100 p-4 mx-4 mt-4"
-              style={cardShadow}
+              className="flex-1"
+              style={{ maxWidth: isDesktop ? 860 : undefined }}
             >
-              <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
-                ОТЗЫВЫ
-              </Text>
-              <EmptyState title="Пока нет отзывов" subtitle="Отзывы появятся после завершения первых заявок" />
+              {mainContent}
             </View>
 
-            {/* Similar specialists */}
-            <View className="mx-4 mt-4 mb-4">
-              <Text style={{ color: colors.textMuted, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
-                ПОХОЖИЕ СПЕЦИАЛИСТЫ
-              </Text>
-              {similar.length === 0 ? (
-                <EmptyState title="Нет похожих специалистов" subtitle="В вашем регионе пока нет других специалистов" />
-              ) : (
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  {similar.slice(0, 5).map((s) => (
-                    <SpecialistCard
-                      key={s.id}
-                      id={s.id}
-                      firstName={s.firstName}
-                      lastName={s.lastName}
-                      avatarUrl={s.avatarUrl}
-                      services={s.services}
-                      cities={s.cities}
-                      onPress={handleSimilarPress}
-                      variant="horizontal"
-                    />
-                  ))}
-                </ScrollView>
-              )}
-            </View>
-
-            {/* Own profile banner */}
-            {isOwnProfile && (
-              <View className="mx-4 mt-2 mb-4 rounded-xl py-3.5 items-center" style={{ backgroundColor: colors.surface2 }}>
-                <Text className="text-sm font-semibold" style={{ color: colors.textSecondary }}>Это вы</Text>
+            {/* Right sidebar (desktop only) */}
+            {isDesktop && !isOwnProfile && !isSpecialist && (
+              <View style={{ width: 320 }}>
+                <View
+                  style={{
+                    position: "sticky" as "relative",
+                    top: 24,
+                  }}
+                >
+                  {ctaContent}
+                </View>
               </View>
             )}
-
           </View>
-        </ResponsiveContainer>
+        </View>
+
+        {/* Own profile banner */}
+        {isOwnProfile && (
+          <View
+            className="mx-4 mt-6 mb-4 rounded-xl py-3.5 items-center"
+            style={{ backgroundColor: colors.surface2 }}
+          >
+            <Text
+              className="text-sm font-semibold"
+              style={{ color: colors.textSecondary }}
+            >
+              Это вы
+            </Text>
+          </View>
+        )}
       </ScrollView>
+
+      {/* Mobile sticky bottom CTA */}
+      {!isDesktop && !isOwnProfile && !isSpecialist && (
+        <View
+          className="border-t border-border"
+          style={{
+            backgroundColor: colors.surface,
+            paddingHorizontal: 16,
+            paddingTop: 12,
+            paddingBottom: 16,
+            shadowColor: colors.text,
+            shadowOffset: { width: 0, height: -2 },
+            shadowOpacity: 0.06,
+            shadowRadius: 10,
+            elevation: 6,
+          }}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Написать"
+            onPress={handleWritePress}
+            className="items-center justify-center rounded-xl flex-row"
+            style={{
+              backgroundColor: colors.primary,
+              height: 52,
+            }}
+          >
+            <Text className="text-white font-semibold text-base">
+              Написать
+            </Text>
+            <Text className="text-white text-sm ml-2 opacity-80">
+              · первое сообщение бесплатно
+            </Text>
+          </Pressable>
+        </View>
+      )}
     </SafeAreaView>
   );
 }

--- a/components/specialist/CaseCard.tsx
+++ b/components/specialist/CaseCard.tsx
@@ -1,0 +1,202 @@
+import { View, Text } from "react-native";
+import { FileText, CheckCircle2, Clock } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+
+export interface SpecialistCaseData {
+  id: string;
+  title: string;
+  category: string;
+  amount: number | null;
+  resolvedAmount: number | null;
+  days: number | null;
+  status: string; // "resolved" | "in_progress"
+  description: string;
+  year: number | null;
+}
+
+export interface CaseCardProps {
+  case: SpecialistCaseData;
+}
+
+function formatRub(value: number): string {
+  if (value >= 1_000_000) {
+    const mln = value / 1_000_000;
+    return `${mln.toFixed(mln >= 10 ? 0 : 1).replace(/\.0$/, "")} млн ₽`;
+  }
+  if (value >= 1_000) {
+    return `${Math.round(value / 1_000)} тыс ₽`;
+  }
+  return `${value} ₽`;
+}
+
+/**
+ * Vertical case-history card displayed on the specialist profile.
+ * Shows doначисления vs оспорено, days, status, short description.
+ */
+export default function CaseCard({ case: c }: CaseCardProps) {
+  const isResolved = c.status === "resolved";
+  const resolvedPct =
+    c.amount && c.resolvedAmount && c.amount > 0
+      ? Math.round((c.resolvedAmount / c.amount) * 100)
+      : null;
+
+  return (
+    <View
+      className="bg-white rounded-2xl border border-border p-4 mb-3"
+      style={{
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.04,
+        shadowRadius: 8,
+        elevation: 1,
+      }}
+    >
+      {/* Title row */}
+      <View className="flex-row items-start mb-3" style={{ gap: 10 }}>
+        <View
+          className="items-center justify-center rounded-lg flex-shrink-0"
+          style={{
+            width: 36,
+            height: 36,
+            backgroundColor: colors.accentSoft,
+          }}
+        >
+          <FileText size={18} color={colors.primary} />
+        </View>
+        <View className="flex-1">
+          <Text
+            className="font-semibold text-base leading-6"
+            style={{ color: colors.text }}
+          >
+            {c.title}
+          </Text>
+          <Text
+            className="text-xs mt-0.5"
+            style={{ color: colors.textMuted, letterSpacing: 0.5 }}
+          >
+            {c.category}
+          </Text>
+        </View>
+      </View>
+
+      {/* Metrics row */}
+      {(c.amount || c.resolvedAmount || c.days) && (
+        <View
+          className="flex-row flex-wrap py-3 border-y border-border mb-3"
+          style={{ gap: 20 }}
+        >
+          {c.amount != null && (
+            <View>
+              <Text
+                className="uppercase"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: 1.5,
+                  color: colors.textMuted,
+                  marginBottom: 2,
+                }}
+              >
+                Доначислено
+              </Text>
+              <Text
+                className="font-semibold text-base"
+                style={{ color: colors.text }}
+              >
+                {formatRub(c.amount)}
+              </Text>
+            </View>
+          )}
+          {c.resolvedAmount != null && (
+            <View>
+              <Text
+                className="uppercase"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: 1.5,
+                  color: colors.textMuted,
+                  marginBottom: 2,
+                }}
+              >
+                Оспорено
+              </Text>
+              <View className="flex-row items-baseline" style={{ gap: 6 }}>
+                <Text
+                  className="font-semibold text-base"
+                  style={{ color: colors.success }}
+                >
+                  {formatRub(c.resolvedAmount)}
+                </Text>
+                {resolvedPct != null && (
+                  <Text
+                    className="text-xs font-semibold"
+                    style={{ color: colors.success }}
+                  >
+                    {resolvedPct}%
+                  </Text>
+                )}
+              </View>
+            </View>
+          )}
+          {c.days != null && (
+            <View>
+              <Text
+                className="uppercase"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: 1.5,
+                  color: colors.textMuted,
+                  marginBottom: 2,
+                }}
+              >
+                Срок
+              </Text>
+              <Text
+                className="font-semibold text-base"
+                style={{ color: colors.text }}
+              >
+                {c.days} {c.days === 1 ? "день" : c.days < 5 ? "дня" : "дней"}
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* Status + year */}
+      <View
+        className="flex-row items-center mb-3"
+        style={{ gap: 8 }}
+      >
+        <View
+          className="flex-row items-center px-2.5 py-1 rounded-full"
+          style={{
+            backgroundColor: isResolved ? colors.greenSoft : colors.yellowSoft,
+            gap: 4,
+          }}
+        >
+          {isResolved ? (
+            <CheckCircle2 size={12} color={colors.success} />
+          ) : (
+            <Clock size={12} color={colors.warning} />
+          )}
+          <Text
+            className="text-xs font-semibold"
+            style={{
+              color: isResolved ? colors.success : colors.warning,
+            }}
+          >
+            {isResolved ? "Решено" : "В работе"}
+            {c.year ? ` · ${c.year}` : ""}
+          </Text>
+        </View>
+      </View>
+
+      {/* Description */}
+      <Text
+        className="text-sm leading-6"
+        style={{ color: colors.textSecondary }}
+      >
+        {c.description}
+      </Text>
+    </View>
+  );
+}

--- a/components/specialist/ReviewCard.tsx
+++ b/components/specialist/ReviewCard.tsx
@@ -1,0 +1,111 @@
+import { View, Text } from "react-native";
+import RatingStars from "@/components/ui/RatingStars";
+import { colors } from "@/lib/theme";
+
+export interface SpecialistReviewData {
+  id: string;
+  authorName: string;
+  rating: number;
+  date: string; // ISO
+  text: string;
+  categoryChips: string[];
+}
+
+export interface ReviewCardProps {
+  review: SpecialistReviewData;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ru-RU", {
+    year: "numeric",
+    month: "long",
+  });
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+/**
+ * Social-proof review card. Shows author initials, 5-star rating, review
+ * date, full testimonial text (not truncated), and linked category chips.
+ */
+export default function ReviewCard({ review }: ReviewCardProps) {
+  return (
+    <View
+      className="bg-white rounded-2xl border border-border p-4 mb-3"
+      style={{
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.04,
+        shadowRadius: 8,
+        elevation: 1,
+      }}
+    >
+      {/* Header row */}
+      <View className="flex-row items-center mb-2" style={{ gap: 10 }}>
+        <View
+          className="items-center justify-center rounded-full"
+          style={{
+            width: 36,
+            height: 36,
+            backgroundColor: colors.accentSoft,
+          }}
+        >
+          <Text
+            className="text-sm font-semibold"
+            style={{ color: colors.accentSoftInk }}
+          >
+            {getInitials(review.authorName)}
+          </Text>
+        </View>
+        <View className="flex-1">
+          <Text
+            className="font-semibold text-sm"
+            style={{ color: colors.text }}
+          >
+            {review.authorName}
+          </Text>
+          <Text className="text-xs" style={{ color: colors.textMuted }}>
+            {formatDate(review.date)}
+          </Text>
+        </View>
+        <RatingStars rating={review.rating} size={14} />
+      </View>
+
+      {/* Text */}
+      <Text
+        className="text-sm leading-6 mb-3"
+        style={{ color: colors.text }}
+      >
+        «{review.text}»
+      </Text>
+
+      {/* Category chips */}
+      {review.categoryChips.length > 0 && (
+        <View className="flex-row flex-wrap" style={{ gap: 6 }}>
+          {review.categoryChips.map((chip) => (
+            <View
+              key={chip}
+              className="px-2.5 py-1 rounded-full"
+              style={{ backgroundColor: colors.surface2 }}
+            >
+              <Text
+                className="text-xs font-medium"
+                style={{ color: colors.textSecondary }}
+              >
+                {chip}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/specialist/types.ts
+++ b/components/specialist/types.ts
@@ -11,6 +11,33 @@ export interface SpecialistProfile {
   whatsapp: string | null;
   officeAddress: string | null;
   workingHours: string | null;
+  // Iteration 5 — credibility fields
+  exFnsStartYear?: number | null;
+  exFnsEndYear?: number | null;
+  yearsOfExperience?: number | null;
+  specializations?: string[] | null;
+  certifications?: string[] | null;
+}
+
+export interface SpecialistCaseItem {
+  id: string;
+  title: string;
+  category: string;
+  amount: number | null;
+  resolvedAmount: number | null;
+  days: number | null;
+  status: string;
+  description: string;
+  year: number | null;
+}
+
+export interface SpecialistReviewItem {
+  id: string;
+  authorName: string;
+  rating: number;
+  date: string;
+  text: string;
+  categoryChips: string[];
 }
 
 export interface ContactMethodItem {
@@ -31,6 +58,11 @@ export interface SpecialistDetail {
   profile: SpecialistProfile | null;
   fnsServices: FnsServiceGroup[];
   requestsCount?: number;
+  // Iteration 5
+  cases?: SpecialistCaseItem[];
+  reviews?: SpecialistReviewItem[];
+  averageRating?: number | null;
+  reviewCount?: number;
 }
 
 export interface SimilarSpecialist {

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,17 +1,38 @@
 import { View, Text, Image } from "react-native";
 import { colors } from "../../lib/theme";
 
+export type AvatarSize = "sm" | "md" | "lg" | "xl" | "xxl" | number;
+
 export interface AvatarProps {
   name: string;
   imageUrl?: string;
-  size?: "sm" | "md" | "lg";
+  size?: AvatarSize;
+  /** Override background tint when no imageUrl. Defaults to accentSoft. */
+  tint?: string;
+  /** Override initials text color. Defaults to accentSoftInk. */
+  inkColor?: string;
 }
 
 const sizeMap = {
-  sm: { wh: 36, textClass: "text-xs font-semibold" },
-  md: { wh: 44, textClass: "text-sm font-semibold" },
-  lg: { wh: 64, textClass: "text-xl font-semibold" },
+  sm: 36,
+  md: 44,
+  lg: 64,
+  xl: 96,
+  xxl: 160,
 } as const;
+
+function resolveSize(size: AvatarSize): number {
+  if (typeof size === "number") return size;
+  return sizeMap[size];
+}
+
+function textClassFor(wh: number): string {
+  if (wh >= 120) return "text-4xl font-bold";
+  if (wh >= 80) return "text-3xl font-bold";
+  if (wh >= 60) return "text-xl font-semibold";
+  if (wh >= 40) return "text-sm font-semibold";
+  return "text-xs font-semibold";
+}
 
 function getInitials(name: string): string {
   return name
@@ -22,8 +43,17 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
-export default function Avatar({ name, imageUrl, size = "md" }: AvatarProps) {
-  const { wh, textClass } = sizeMap[size];
+export default function Avatar({
+  name,
+  imageUrl,
+  size = "md",
+  tint,
+  inkColor,
+}: AvatarProps) {
+  const wh = resolveSize(size);
+  const textClass = textClassFor(wh);
+  const bg = tint ?? colors.primary;
+  const ink = inkColor ?? "#ffffff";
 
   if (imageUrl) {
     return (
@@ -47,10 +77,12 @@ export default function Avatar({ name, imageUrl, size = "md" }: AvatarProps) {
       style={{
         width: wh,
         height: wh,
-        backgroundColor: colors.primary,
+        backgroundColor: bg,
       }}
     >
-      <Text className={`${textClass} text-white`}>{getInitials(name)}</Text>
+      <Text className={textClass} style={{ color: ink }}>
+        {getInitials(name)}
+      </Text>
     </View>
   );
 }

--- a/components/ui/MetricCard.tsx
+++ b/components/ui/MetricCard.tsx
@@ -1,0 +1,89 @@
+import { View, Text } from "react-native";
+import { type LucideIcon } from "lucide-react-native";
+import { colors, textStyle } from "@/lib/theme";
+
+export interface MetricCardProps {
+  icon: LucideIcon;
+  title: string;
+  value: string;
+  lines?: string[];
+  iconColor?: string;
+  iconBg?: string;
+}
+
+/**
+ * Credentials block card: icon + title + big value + bulleted body lines.
+ * Used in the specialist profile credentials 3-up grid.
+ */
+export default function MetricCard({
+  icon: Icon,
+  title,
+  value,
+  lines = [],
+  iconColor,
+  iconBg,
+}: MetricCardProps) {
+  return (
+    <View
+      className="bg-white rounded-2xl border border-border p-4 flex-1"
+      style={{
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.04,
+        shadowRadius: 10,
+        elevation: 2,
+        minHeight: 180,
+      }}
+    >
+      <View
+        className="items-center justify-center rounded-xl mb-3"
+        style={{
+          width: 40,
+          height: 40,
+          backgroundColor: iconBg ?? colors.accentSoft,
+        }}
+      >
+        <Icon size={20} color={iconColor ?? colors.primary} />
+      </View>
+
+      <Text
+        className="uppercase mb-2"
+        style={{
+          fontSize: 11,
+          letterSpacing: 2,
+          color: colors.textSecondary,
+          fontWeight: "600",
+        }}
+      >
+        {title}
+      </Text>
+
+      <Text style={{ ...textStyle.h3, color: colors.text, marginBottom: 8 }}>
+        {value}
+      </Text>
+
+      {lines.map((line, i) => (
+        <View
+          key={i}
+          className="flex-row items-start mt-1"
+          style={{ gap: 6 }}
+        >
+          <View
+            className="rounded-full mt-1.5 flex-shrink-0"
+            style={{
+              width: 4,
+              height: 4,
+              backgroundColor: colors.textMuted,
+            }}
+          />
+          <Text
+            className="text-sm flex-1"
+            style={{ color: colors.textSecondary, lineHeight: 20 }}
+          >
+            {line}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/ui/RatingStars.tsx
+++ b/components/ui/RatingStars.tsx
@@ -1,0 +1,62 @@
+import { View, Text } from "react-native";
+import { Star, StarHalf } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+
+export interface RatingStarsProps {
+  rating: number; // 0..5, supports halves (4.5 etc.)
+  size?: number;
+  showNumber?: boolean;
+  reviewCount?: number;
+  color?: string;
+}
+
+/**
+ * Reusable 5-star rating display. Used on specialist cards, review cards,
+ * and profile hero. Supports half-star granularity.
+ */
+export default function RatingStars({
+  rating,
+  size = 14,
+  showNumber = false,
+  reviewCount,
+  color = "#f59e0b",
+}: RatingStarsProps) {
+  const clamped = Math.max(0, Math.min(5, rating));
+  const full = Math.floor(clamped);
+  const hasHalf = clamped - full >= 0.25 && clamped - full < 0.75;
+  const rounded = hasHalf ? full + 0.5 : Math.round(clamped);
+  const fullStars = Math.floor(rounded);
+  const halfStar = rounded - fullStars >= 0.5;
+  const emptyStars = 5 - fullStars - (halfStar ? 1 : 0);
+
+  return (
+    <View className="flex-row items-center" style={{ gap: 2 }}>
+      {Array.from({ length: fullStars }).map((_, i) => (
+        <Star key={`f${i}`} size={size} color={color} fill={color} />
+      ))}
+      {halfStar && <StarHalf size={size} color={color} fill={color} />}
+      {Array.from({ length: emptyStars }).map((_, i) => (
+        <Star key={`e${i}`} size={size} color={colors.borderStrong} />
+      ))}
+      {showNumber && (
+        <Text
+          className="text-sm font-semibold ml-1"
+          style={{ color: colors.text }}
+        >
+          {clamped.toFixed(1)}
+        </Text>
+      )}
+      {reviewCount !== undefined && (
+        <Text className="text-sm ml-1" style={{ color: colors.textSecondary }}>
+          ({reviewCount}{" "}
+          {reviewCount === 1
+            ? "отзыв"
+            : reviewCount < 5
+            ? "отзыва"
+            : "отзывов"}
+          )
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -6,6 +6,8 @@ export { default as Badge } from "./Badge";
 export { default as EmptyState } from "./EmptyState";
 export { default as ErrorState } from "./ErrorState";
 export { default as LoadingState } from "./LoadingState";
+export { default as MetricCard } from "./MetricCard";
+export { default as RatingStars } from "./RatingStars";
 export { default as Text } from "./Text";
 
 export type { ButtonProps } from "./Button";
@@ -16,4 +18,6 @@ export type { BadgeProps } from "./Badge";
 export type { EmptyStateProps } from "./EmptyState";
 export type { ErrorStateProps } from "./ErrorState";
 export type { LoadingStateProps } from "./LoadingState";
+export type { MetricCardProps } from "./MetricCard";
+export type { RatingStarsProps } from "./RatingStars";
 export type { TextProps } from "./Text";


### PR DESCRIPTION
## Summary

Complete rewrite of `/specialists/[id]` per Pro conceptual move #2 ("Specialist Credibility Stack", impact 10/10).

- **Hero**: 160x160 avatar, H1 name, role/city, ФНС number chips (monospace), rating with reviews count, cases count, **Ex-ФНС YYYY-YYYY amber pill badge**, Написать CTA.
- **About**: full bio paragraph.
- **Credentials 3-up**: Опыт / Специализация / Сертификации — `MetricCard` (icon + title + big value + bullets).
- **Case History**: filter chips (Все / Выездные / Камеральные / 115-ФЗ), vertical `CaseCard` feed showing Доначислено vs Оспорено (with %), срок, status pill (зелёный Решено / amber В работе), year, краткое описание. Expand/collapse beyond 3.
- **Reviews**: big average rating, `ReviewCard` with author initials, 5-star, date, full text (not truncated), linked category chips.
- **Services & Cities**: chip-lists.
- **Right sticky sidebar (desktop)** / **sticky bottom bar (mobile)**: 56px CTA, "Первое сообщение — бесплатно" green pill, secondary Сохранить bookmark.

## New reusable components (exported from `components/ui` + `components/specialist`)
- `RatingStars` — 5-star display with half-star support, review count.
- `MetricCard` — icon + title + big value + bulleted body.
- `CaseCard` — case history card.
- `ReviewCard` — review card.
- `Avatar` enhanced: numeric sizes (96, 160) + soft-tint variant.

## Prisma schema changes
- `SpecialistProfile` + `ex_fns_start_year`, `ex_fns_end_year`, `years_of_experience`, `specializations JSONB`, `certifications JSONB`.
- New `specialist_cases` table.
- New `specialist_reviews` table.
- Migration: `20260423000000_iter5_credibility_stack`.

## Seed
- 68 cases (avg 3.8/specialist) with realistic amounts (2.4 млн ₽ доначислено → 2.1 млн ₽ оспорено, etc.).
- 72 reviews (avg 4/specialist) with realistic Russian testimonials.
- Ex-ФНС flag set for Дмитрий Петров (СПб, 2013-2023), Ольга Степанова (СПб, 2015-2023).

## Test plan
- [x] `tsc --noEmit` — both frontend and backend pass with 0 errors.
- [x] Prisma migration applied.
- [x] Seed ran successfully (68 cases, 72 reviews).
- [x] `GET /api/specialists/:id` now returns `cases`, `reviews`, `averageRating`, `reviewCount`, and new profile fields.
- [ ] After merge, visually verify desktop hero + sidebar + case cards render correctly at 1280×800 and mobile sticky CTA at 430px via comet/metromap mosaic-diff.

## Out of scope
- Bookmark persistence (POST /api/bookmarks stub).
- Review submission flow.
- Admin moderation of cases/reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)