### PR TITLE
feat(design): Iteration 6 — universal Desktop Template (20+ pages)

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -11,7 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
 import { ChevronUp, ChevronDown, Flag } from "lucide-react-native";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import { Badge, EmptyState, ErrorState, LoadingState } from "@/components/ui";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, overlay } from "@/lib/theme";
@@ -304,10 +304,10 @@ export default function AdminComplaints() {
       </View>
 
       {loading ? (
-        <ResponsiveContainer>
+        <DesktopScreen>
           <LoadingState variant="skeleton" lines={5} />
           <LoadingState variant="skeleton" lines={5} />
-        </ResponsiveContainer>
+        </DesktopScreen>
       ) : error ? (
         <View className="flex-1 items-center justify-center">
           <ErrorState
@@ -316,7 +316,7 @@ export default function AdminComplaints() {
           />
         </View>
       ) : (
-        <ResponsiveContainer>
+        <DesktopScreen>
           <FlatList
             data={complaints}
             keyExtractor={(item) => item.id}
@@ -345,7 +345,7 @@ export default function AdminComplaints() {
               ) : null
             }
           />
-        </ResponsiveContainer>
+        </DesktopScreen>
       )}
     </SafeAreaView>
   );

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -3,7 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useEffect, useState, useCallback } from "react";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
@@ -146,7 +146,7 @@ export default function AdminDashboard() {
       />
       {loading ? (
         <ScrollView className="flex-1">
-          <ResponsiveContainer>
+          <DesktopScreen>
             <View className="py-4 gap-3">
               {Array.from({ length: 4 }).map((_, i) => (
                 <View key={i} className="bg-white rounded-xl overflow-hidden border border-border">
@@ -154,7 +154,7 @@ export default function AdminDashboard() {
                 </View>
               ))}
             </View>
-          </ResponsiveContainer>
+          </DesktopScreen>
         </ScrollView>
       ) : error ? (
         <View className="flex-1 items-center justify-center">
@@ -164,7 +164,7 @@ export default function AdminDashboard() {
         <ScrollView className="flex-1">
           {/* Accent hero section */}
           <View className="bg-accent px-4 pt-5 pb-6">
-            <ResponsiveContainer>
+            <DesktopScreen>
               <Text className="text-2xl font-bold text-white">
                 Панель администратора
               </Text>
@@ -174,10 +174,10 @@ export default function AdminDashboard() {
               >
                 Обзор ключевых метрик платформы
               </Text>
-            </ResponsiveContainer>
+            </DesktopScreen>
           </View>
 
-          <ResponsiveContainer>
+          <DesktopScreen>
             <View className="py-4 gap-3">
               {/* Stats grid */}
               <View className="flex-row flex-wrap gap-3">
@@ -243,7 +243,7 @@ export default function AdminDashboard() {
                 </View>
               </View>
             </View>
-          </ResponsiveContainer>
+          </DesktopScreen>
         </ScrollView>
       )}
     </SafeAreaView>

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -2,7 +2,7 @@ import { View, Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CheckCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import { colors, overlay } from "@/lib/theme";
 
 export default function AdminModeration() {
@@ -35,7 +35,7 @@ export default function AdminModeration() {
         </Text>
       </View>
 
-      <ResponsiveContainer>
+      <DesktopScreen>
         <View className="flex-1">
           <EmptyState
             icon={CheckCircle}
@@ -43,7 +43,7 @@ export default function AdminModeration() {
             subtitle="Нет элементов, требующих модерации"
           />
         </View>
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -11,7 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
 import { Users } from "lucide-react-native";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -280,7 +280,7 @@ export default function AdminUsers() {
       </View>
 
       {loading ? (
-        <ResponsiveContainer>
+        <DesktopScreen>
           <View className="py-2">
             {Array.from({ length: 5 }).map((_, i) => (
               <View key={i} className="mx-4 mb-3 bg-white rounded-2xl overflow-hidden border border-border">
@@ -288,7 +288,7 @@ export default function AdminUsers() {
               </View>
             ))}
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       ) : error ? (
         <View className="flex-1 items-center justify-center">
           <ErrorState message="Не удалось загрузить пользователей" onRetry={() => fetchUsers(search, filter, 1)} />
@@ -301,7 +301,7 @@ export default function AdminUsers() {
           }}
           scrollEventThrottle={400}
         >
-          <ResponsiveContainer>
+          <DesktopScreen>
             <View className="py-2">
               {users.length === 0 ? (
                 <EmptyState
@@ -424,7 +424,7 @@ export default function AdminUsers() {
                 </View>
               )}
             </View>
-          </ResponsiveContainer>
+          </DesktopScreen>
         </ScrollView>
       )}
     </SafeAreaView>

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -10,7 +10,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import RequestCard from "@/components/RequestCard";
 import { FileText, MessageSquare, Plus } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
@@ -91,7 +91,7 @@ export default function ClientDashboard() {
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
         }
       >
-        <ResponsiveContainer>
+        <DesktopScreen>
           {/* Hero greeting — accent banner */}
           <View
             className="rounded-2xl px-5 py-5 mb-4 mt-4"
@@ -252,7 +252,7 @@ export default function ClientDashboard() {
               )}
             </View>
           )}
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(client-tabs)/messages.tsx
+++ b/app/(client-tabs)/messages.tsx
@@ -252,12 +252,17 @@ export default function ClientMessages() {
 
   // Desktop: 2-column layout
   if (isDesktop) {
+    const isWide = width >= 1024;
     return (
       <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
         <HeaderHome />
-        <View className="flex-1 flex-row">
+        <View className="flex-1 items-center">
+          <View
+            className="flex-1 flex-row w-full"
+            style={{ maxWidth: isWide ? 1200 : "100%", borderWidth: isWide ? 1 : 0, borderColor: colors.border, borderRadius: isWide ? 12 : 0, overflow: "hidden", marginTop: isWide ? 24 : 0, marginBottom: isWide ? 24 : 0 }}
+          >
           {/* Thread list panel */}
-          <View style={{ maxWidth: 300, flex: 1, borderRightWidth: 1, borderRightColor: colors.border }}>
+          <View style={{ maxWidth: 320, flex: 1, borderRightWidth: 1, borderRightColor: colors.border }}>
             <FlatList
               data={sorted}
               keyExtractor={(item) => item.id}
@@ -298,6 +303,7 @@ export default function ClientMessages() {
                 subtitle="Нажмите на переписку слева, чтобы открыть её"
               />
             )}
+          </View>
           </View>
         </View>
       </SafeAreaView>

--- a/app/(client-tabs)/requests.tsx
+++ b/app/(client-tabs)/requests.tsx
@@ -13,7 +13,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import StatusBadge from "@/components/StatusBadge";
 import { FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
@@ -345,7 +345,7 @@ export default function MyRequests() {
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <HeaderHome />
-      <ResponsiveContainer>
+      <DesktopScreen>
         {/* Accent hero */}
         <View className="rounded-2xl px-5 py-5 mb-5 mt-2" style={{ backgroundColor: colors.accent }}>
           <Text className="text-xl font-bold text-white mb-0.5">Мои заявки</Text>
@@ -362,7 +362,7 @@ export default function MyRequests() {
         </View>
 
         {renderContent()}
-      </ResponsiveContainer>
+      </DesktopScreen>
 
       {/* Toast */}
       <Toast message="Заявка закрыта" visible={toast} />

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -12,7 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { TriangleAlert, List } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
@@ -134,7 +134,7 @@ export default function SpecialistDashboard() {
           notificationCount={0}
           onSettingsPress={() => router.push("/settings/specialist" as never)}
         />
-        <ResponsiveContainer>
+        <DesktopScreen>
           <View className="py-4 gap-3">
             {Array.from({ length: 4 }).map((_, i) => (
               <View key={i} className="bg-white rounded-xl overflow-hidden border border-border">
@@ -142,7 +142,7 @@ export default function SpecialistDashboard() {
               </View>
             ))}
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </SafeAreaView>
     );
   }
@@ -179,7 +179,7 @@ export default function SpecialistDashboard() {
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
         }
       >
-        <ResponsiveContainer>
+        <DesktopScreen>
           <View className="py-4">
             {/* Hero banner */}
             <View className="rounded-2xl px-5 py-5 mb-4" style={{ backgroundColor: colors.accent }}>
@@ -300,7 +300,7 @@ export default function SpecialistDashboard() {
 
             <View className="h-8" />
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(specialist-tabs)/promotion.tsx
+++ b/app/(specialist-tabs)/promotion.tsx
@@ -3,12 +3,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Rocket, User, ChevronRight } from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import { colors } from "@/lib/theme";
 
 export default function PromotionScreen() {
   const router = useRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const _isDesktop = width >= 640;
 
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
@@ -17,8 +18,7 @@ export default function PromotionScreen() {
         onSettingsPress={() => router.push("/settings/specialist" as never)}
       />
       <ScrollView className="flex-1">
-        <View style={{ width: "100%", alignItems: "center" }}>
-        <View style={{ width: "100%", maxWidth: isDesktop ? 680 : undefined, paddingHorizontal: isDesktop ? 24 : 16 }}>
+        <DesktopScreen>
           <View className="py-4">
             <Text className="text-2xl font-bold text-text-base mb-2">Продвижение</Text>
             <Text className="text-sm text-text-mute mb-6">
@@ -67,8 +67,7 @@ export default function PromotionScreen() {
 
             <View className="h-8" />
           </View>
-        </View>
-        </View>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(specialist-tabs)/requests.tsx
+++ b/app/(specialist-tabs)/requests.tsx
@@ -10,7 +10,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import RequestCard from "@/components/RequestCard";
 import FilterBar from "@/components/FilterBar";
 import { TriangleAlert, FileText } from "lucide-react-native";
@@ -145,7 +145,7 @@ export default function SpecialistPublicRequests() {
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       <HeaderHome />
-      <ResponsiveContainer>
+      <DesktopScreen>
         {/* Accent hero */}
         <View className="rounded-2xl px-5 py-5 mb-4 mt-2" style={{ backgroundColor: colors.accent }}>
           <Text className="text-xl font-bold text-white mb-0.5">Публичные заявки</Text>
@@ -223,7 +223,7 @@ export default function SpecialistPublicRequests() {
             }
           />
         )}
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/(specialist-tabs)/threads.tsx
+++ b/app/(specialist-tabs)/threads.tsx
@@ -10,7 +10,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderHome from "@/components/HeaderHome";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import { MessageCircle, CheckCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -82,7 +82,7 @@ export default function SpecialistMyThreads() {
   const unreadTotal = threads.reduce((sum, t) => sum + t.unreadCount, 0);
 
   const FilterBar = (
-    <ResponsiveContainer>
+    <DesktopScreen>
       <View className="flex-row items-center gap-2 mt-4 mb-3">
         <Text className="text-2xl font-bold text-text-base flex-1">
           Мои диалоги
@@ -110,7 +110,7 @@ export default function SpecialistMyThreads() {
           onPress={() => setFilter("unread")}
         />
       </View>
-    </ResponsiveContainer>
+    </DesktopScreen>
   );
 
   return (
@@ -120,21 +120,21 @@ export default function SpecialistMyThreads() {
       {loading ? (
         <View className="flex-1">
           {FilterBar}
-          <ResponsiveContainer>
+          <DesktopScreen>
             <LoadingState variant="skeleton" lines={5} />
             <LoadingState variant="skeleton" lines={5} />
             <LoadingState variant="skeleton" lines={5} />
-          </ResponsiveContainer>
+          </DesktopScreen>
         </View>
       ) : error ? (
         <View className="flex-1">
           {FilterBar}
-          <ResponsiveContainer>
+          <DesktopScreen>
             <ErrorState
               message="Не удалось загрузить диалоги"
               onRetry={handleRetry}
             />
-          </ResponsiveContainer>
+          </DesktopScreen>
         </View>
       ) : (
         <FlatList
@@ -146,7 +146,7 @@ export default function SpecialistMyThreads() {
           }
           ListHeaderComponent={<>{FilterBar}</>}
           ListEmptyComponent={
-            <ResponsiveContainer>
+            <DesktopScreen>
               {threads.length === 0 ? (
                 <EmptyState
                   icon={MessageCircle}
@@ -164,7 +164,7 @@ export default function SpecialistMyThreads() {
                   subtitle="Все сообщения прочитаны"
                 />
               )}
-            </ResponsiveContainer>
+            </DesktopScreen>
           }
           ListFooterComponent={<View className="h-8" />}
           renderItem={({ item }) => (

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -3,7 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { FileText, Lightbulb } from "lucide-react-native";
 import { colors } from "@/lib/theme";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 
 export default function CreateScreen() {
@@ -13,7 +13,7 @@ export default function CreateScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
-        <ResponsiveContainer>
+        <DesktopScreen>
           {/* Header */}
           <View className="pt-4 pb-4">
             <Text className="text-2xl font-bold text-text-base">Новая заявка специалисту</Text>
@@ -60,7 +60,7 @@ export default function CreateScreen() {
             label="Создать заявку"
             onPress={() => router.push("/requests/new" as never)}
           />
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -84,7 +84,7 @@ export default function HomeScreen() {
   const router = useRouter();
   const isDesktop = width >= 640;
   const containerStyle = isDesktop
-    ? { maxWidth: 960, width: "100%" as const, alignSelf: "center" as const }
+    ? { maxWidth: 1200, width: "100%" as const, alignSelf: "center" as const, paddingHorizontal: 16 }
     : undefined;
 
   return (

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -75,8 +75,9 @@ function ConversationItem({
 export default function MessagesScreen() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
+  const isWideDesktop = width >= 1024;
   const containerStyle = isDesktop
-    ? { maxWidth: 720, width: "100%" as const, alignSelf: "center" as const }
+    ? { maxWidth: isWideDesktop ? 1200 : 720, width: "100%" as const, alignSelf: "center" as const, paddingHorizontal: isWideDesktop ? 32 : 0 }
     : undefined;
 
   return (

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -6,7 +6,7 @@ import {
 } from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, textStyle } from "@/lib/theme";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import EmptyState from "@/components/ui/EmptyState";
 
 // Tax-domain menu items (NOT marketplace listings).
@@ -31,7 +31,7 @@ export default function ProfileScreen() {
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <ScrollView className="flex-1" contentContainerClassName="pb-10">
-        <ResponsiveContainer>
+        <DesktopScreen>
           {/* Profile Header Card */}
           <View
             className="bg-white mx-4 mt-6 rounded-2xl border border-border px-6 py-8 items-center mb-4"
@@ -142,7 +142,7 @@ export default function ProfileScreen() {
           </View>
 
           <Text className="text-xs text-text-dim text-center mt-2 mb-4">Версия 1.0.0</Text>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -6,7 +6,7 @@ import {
   FileSearch, Briefcase, ShieldCheck, Gavel, Globe2, Users, type LucideIcon
 } from "lucide-react-native";
 import { colors } from "@/lib/theme";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import EmptyState from "@/components/ui/EmptyState";
 
 // Recent searches — tax-domain, not marketplace.
@@ -48,7 +48,7 @@ export default function SearchScreen() {
       </View>
 
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
-        <ResponsiveContainer>
+        <DesktopScreen>
           {/* Search Input */}
           <View className="mt-4 mb-4">
             <View className="flex-row items-center bg-white border border-border rounded-xl px-3 h-12">
@@ -153,7 +153,7 @@ export default function SearchScreen() {
               ))}
             </View>
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/admin/settings.tsx
+++ b/app/admin/settings.tsx
@@ -10,7 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback } from "react";
 import { Settings } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import ErrorState from "@/components/ui/ErrorState";
@@ -120,7 +120,7 @@ export default function AdminSettings() {
         </View>
       ) : (
         <ScrollView className="flex-1">
-          <ResponsiveContainer>
+          <DesktopScreen maxWidth={860}>
             <View className="py-4 gap-4">
               {SETTINGS_FIELDS.length === 0 ? (
                 <EmptyState icon={Settings} title="Нет настроек" subtitle="Настройки системы недоступны" />
@@ -145,7 +145,7 @@ export default function AdminSettings() {
                 />
               </View>
             </View>
-          </ResponsiveContainer>
+          </DesktopScreen>
         </ScrollView>
       )}
     </SafeAreaView>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -3,7 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { ArrowLeft, BellOff, MessageCircle, Mail, MapPin, Clock, Bell, type LucideIcon } from "lucide-react-native";
 import { useState, useEffect, useCallback } from "react";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import LoadingState from "@/components/ui/LoadingState";
 import ErrorState from "@/components/ui/ErrorState";
 import EmptyState from "@/components/ui/EmptyState";
@@ -224,7 +224,7 @@ export default function NotificationsScreen() {
         </View>
       </View>
 
-      <ResponsiveContainer>
+      <DesktopScreen>
         {loading ? (
           <View className="pt-4 px-4">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -266,7 +266,7 @@ export default function NotificationsScreen() {
             }
           />
         )}
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -6,7 +6,7 @@ import { User } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import { colors, overlay, textStyle } from "@/lib/theme";
@@ -67,7 +67,7 @@ export default function OnboardingNameScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
-      <ResponsiveContainer>
+      <DesktopScreen maxWidth={720}>
         <View className="flex-1">
           <ScrollView
             className="flex-1"
@@ -182,7 +182,7 @@ export default function OnboardingNameScreen() {
             />
           </View>
         </View>
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -14,7 +14,7 @@ import { Pencil, Camera } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { API_URL, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -161,7 +161,7 @@ export default function OnboardingProfileScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
-      <ResponsiveContainer>
+      <DesktopScreen maxWidth={720}>
         <View className="flex-1">
         <ScrollView
           className="flex-1"
@@ -387,7 +387,7 @@ export default function OnboardingProfileScreen() {
           </Pressable>
         </View>
         </View>
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -11,7 +11,7 @@ import { useState, useEffect, useCallback } from "react";
 import { X, Plus } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import { colors } from "@/lib/theme";
 
@@ -157,7 +157,7 @@ export default function OnboardingWorkAreaScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
-      <ResponsiveContainer>
+      <DesktopScreen maxWidth={720}>
         <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: isDesktop ? 64 : 40 }}>
           <View className="pt-8">
             {/* Progress indicator */}
@@ -380,7 +380,7 @@ export default function OnboardingWorkAreaScreen() {
             />
           </View>
         </ScrollView>
-      </ResponsiveContainer>
+      </DesktopScreen>
     </SafeAreaView>
   );
 }

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -11,7 +11,7 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import FilterBar from "@/components/FilterBar";
 import { Inbox } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -9,7 +9,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { MapPin } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import EmptyState from "@/components/ui/EmptyState";
@@ -196,7 +196,7 @@ export default function NewRequest() {
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={{ paddingBottom: 24 }}
       >
-        <ResponsiveContainer>
+        <DesktopScreen maxWidth={720}>
           <View className="py-4">
 
             {/* Limit banner */}
@@ -291,7 +291,7 @@ export default function NewRequest() {
             ) : null}
 
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
 
       {/* Sticky submit button */}

--- a/app/settings/client.tsx
+++ b/app/settings/client.tsx
@@ -14,7 +14,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Pencil, FileText, ChevronRight, LogOut, Trash2, Bell } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import EmptyState from "@/components/ui/EmptyState";
@@ -207,7 +207,7 @@ export default function ClientSettings() {
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Настройки" />
       <ScrollView className="flex-1" keyboardShouldPersistTaps="handled">
-        <ResponsiveContainer>
+        <DesktopScreen maxWidth={860}>
           <View className="py-6">
 
             {/* Avatar */}
@@ -402,7 +402,7 @@ export default function ClientSettings() {
             </Text>
 
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useState } from "react";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { colors } from "@/lib/theme";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 
 function SettingRow({
   icon: Icon,
@@ -65,7 +65,7 @@ export default function SettingsScreen() {
   return (
     <SafeAreaView className="flex-1 bg-white">
       <ScrollView className="flex-1" contentContainerClassName="pb-8">
-        <ResponsiveContainer>
+        <DesktopScreen maxWidth={860}>
         {/* Header */}
         <View className="flex-row items-center pt-2 pb-3 border-b border-border">
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="w-11 h-11 items-center justify-center -ml-2 mr-1">
@@ -135,7 +135,7 @@ export default function SettingsScreen() {
             />
           </>
         )}
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/settings/specialist.tsx
+++ b/app/settings/specialist.tsx
@@ -13,7 +13,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Pencil, Plus, LogOut, Tag } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import ResponsiveContainer from "@/components/ResponsiveContainer";
+import DesktopScreen from "@/components/layout/DesktopScreen";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import EmptyState from "@/components/ui/EmptyState";
@@ -193,7 +193,7 @@ export default function SpecialistSettings() {
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <HeaderBack title="Настройки специалиста" />
       <ScrollView className="flex-1" keyboardShouldPersistTaps="handled">
-        <ResponsiveContainer>
+        <DesktopScreen maxWidth={860}>
           <View className="py-4">
 
             {/* Avatar centered */}
@@ -432,7 +432,7 @@ export default function SpecialistSettings() {
             </Text>
 
           </View>
-        </ResponsiveContainer>
+        </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -52,6 +52,8 @@ export default function SpecialistsCatalog() {
   const router = useRouter();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
+  const isWide = width >= 1024;
+  const gridCols = isWide ? 3 : isDesktop ? 2 : 1;
 
   const [cities, setCities] = useState<CityOption[]>([]);
   const [services, setServices] = useState<ServiceOption[]>([]);
@@ -221,8 +223,9 @@ export default function SpecialistsCatalog() {
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Специалисты" />
-      <View style={{ backgroundColor: colors.accent, paddingHorizontal: 16, paddingTop: 20, paddingBottom: 20 }}>
-        <Text style={{ ...textStyle.h3, color: "#ffffff", marginBottom: 2 }}>Каталог специалистов</Text>
+      <View style={{ backgroundColor: colors.accent, width: "100%", alignItems: "center" }}>
+        <View style={{ width: "100%", maxWidth: isWide ? 1200 : isDesktop ? 900 : undefined, paddingHorizontal: isWide ? 32 : 16, paddingTop: 20, paddingBottom: 20 }}>
+        <Text style={{ ...(isWide ? textStyle.h1 : textStyle.h3), color: "#ffffff", marginBottom: 4 }}>Каталог специалистов</Text>
         <Text style={{ ...textStyle.small, color: overlay.white75 }}>Практики с опытом в вашей ИФНС. Выбирайте по инспекции, городу и типу проверки.</Text>
         <View className="flex-row mt-4 gap-3">
           <View className="flex-1 rounded-xl px-3 py-2.5" style={{ backgroundColor: overlay.white15 }}>
@@ -233,6 +236,7 @@ export default function SpecialistsCatalog() {
             <Text className="text-xs" style={{ color: overlay.white70 }}>Готовы помочь</Text>
             <Text className="text-xl font-bold text-white">Сейчас</Text>
           </View>
+        </View>
         </View>
       </View>
 
@@ -275,21 +279,21 @@ export default function SpecialistsCatalog() {
         />
       ) : (
         <FlatList
-          key={isDesktop ? "grid-2" : "grid-1"}
+          key={`grid-${gridCols}`}
           data={specialists}
           keyExtractor={(item) => item.id}
-          numColumns={isDesktop ? 2 : 1}
-          columnWrapperStyle={isDesktop ? { gap: 12, paddingHorizontal: 16 } : undefined}
+          numColumns={gridCols}
+          columnWrapperStyle={gridCols > 1 ? { gap: 16, paddingHorizontal: isWide ? 32 : 16 } : undefined}
           contentContainerStyle={{
-            paddingHorizontal: isDesktop ? 0 : 16,
-            paddingBottom: 32,
-            paddingTop: 8,
-            maxWidth: isDesktop ? 900 : undefined,
+            paddingHorizontal: gridCols > 1 ? 0 : 16,
+            paddingBottom: 48,
+            paddingTop: 16,
+            maxWidth: isWide ? 1200 : isDesktop ? 900 : undefined,
             alignSelf: isDesktop ? ("center" as const) : undefined,
             width: "100%" as const,
           }}
           renderItem={({ item }) => (
-            <View style={isDesktop ? { flex: 1 } : undefined}>
+            <View style={gridCols > 1 ? { flex: 1 } : undefined}>
               <SpecialistCard
                 id={item.id}
                 firstName={item.firstName}

--- a/components/layout/DesktopScreen.tsx
+++ b/components/layout/DesktopScreen.tsx
@@ -1,0 +1,184 @@
+import React from "react";
+import { View, Text, useWindowDimensions } from "react-native";
+import { colors, spacing, textStyle } from "@/lib/theme";
+
+/**
+ * DesktopScreen — universal layout template that kills "mobile-stretched-to-
+ * desktop" across interior pages.
+ *
+ * Desktop (>=1024px):
+ *   - centered content at max-w 1200px (configurable via `maxWidth`)
+ *   - large H1 + optional subtitle (top-left)
+ *   - optional header actions (top-right)
+ *   - optional right-side sidebar (2/3 main + 1/3 sidebar)
+ *   - optional filter bar below title
+ *   - generous horizontal padding (32px)
+ *   - 24-32px vertical rhythm between sections
+ *
+ * Tablet (640-1023px):
+ *   - centered content at 720px
+ *   - sidebar stacks below main (if provided)
+ *   - H2-sized title
+ *
+ * Mobile (<640px):
+ *   - pass-through: no max-width, minimal horizontal padding
+ *   - existing mobile UX (HeaderHome + bottom tabs) remains untouched
+ *
+ * Drop-in replacement for `<ResponsiveContainer>`: it does not add any
+ * ScrollView of its own, so callers keep full control over their scroll /
+ * RefreshControl behavior. Place it INSIDE the ScrollView / SafeAreaView.
+ */
+
+const DESKTOP_BP = 1024;
+const TABLET_BP = 640;
+
+interface DesktopScreenProps {
+  title?: string;
+  subtitle?: string;
+  headerActions?: React.ReactNode;
+  sidebar?: React.ReactNode;
+  filters?: React.ReactNode;
+  maxWidth?: number;
+  fullWidth?: boolean;
+  children: React.ReactNode;
+}
+
+export default function DesktopScreen({
+  title,
+  subtitle,
+  headerActions,
+  sidebar,
+  filters,
+  maxWidth = 1200,
+  fullWidth = false,
+  children,
+}: DesktopScreenProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= DESKTOP_BP;
+  const isTablet = width >= TABLET_BP;
+
+  // Mobile: pass-through (preserve bottom-tab mobile UX).
+  if (!isTablet) {
+    return <View className="flex-1 px-4">{children}</View>;
+  }
+
+  const effectiveMaxWidth = fullWidth
+    ? 100000
+    : isDesktop
+      ? maxWidth
+      : 720;
+
+  const horizontalPadding = isDesktop ? spacing.xl : spacing.lg;
+  const topPadding = isDesktop ? spacing.xl : spacing.lg;
+  const bottomPadding = isDesktop ? spacing.xxl : spacing.xl;
+
+  const hasHeader = Boolean(title || subtitle || headerActions);
+
+  return (
+    <View
+      style={{
+        width: "100%",
+        alignItems: "center",
+        flex: 1,
+      }}
+    >
+      <View
+        style={{
+          width: "100%",
+          maxWidth: effectiveMaxWidth,
+          paddingHorizontal: horizontalPadding,
+          paddingTop: topPadding,
+          paddingBottom: bottomPadding,
+          flex: 1,
+        }}
+      >
+        {hasHeader && (
+          <View
+            style={{
+              flexDirection: "row",
+              justifyContent: "space-between",
+              alignItems: "flex-start",
+              marginBottom: spacing.lg,
+              flexWrap: "wrap",
+              gap: spacing.md,
+            }}
+          >
+            <View style={{ flex: 1, minWidth: 240 }}>
+              {title ? (
+                <Text
+                  style={{
+                    ...(isDesktop ? textStyle.h1 : textStyle.h2),
+                    color: colors.text,
+                  }}
+                >
+                  {title}
+                </Text>
+              ) : null}
+              {subtitle ? (
+                <Text
+                  style={{
+                    ...textStyle.body,
+                    color: colors.textSecondary,
+                    marginTop: spacing.xs,
+                  }}
+                >
+                  {subtitle}
+                </Text>
+              ) : null}
+            </View>
+            {headerActions ? (
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  gap: spacing.sm,
+                }}
+              >
+                {headerActions}
+              </View>
+            ) : null}
+          </View>
+        )}
+
+        {filters ? (
+          <View
+            style={{
+              marginBottom: spacing.lg,
+              paddingVertical: spacing.md,
+              paddingHorizontal: spacing.md,
+              backgroundColor: colors.surface,
+              borderRadius: 12,
+              borderWidth: 1,
+              borderColor: colors.border,
+            }}
+          >
+            {filters}
+          </View>
+        ) : null}
+
+        {sidebar && isDesktop ? (
+          <View
+            style={{
+              flexDirection: "row",
+              gap: spacing.xl,
+              alignItems: "flex-start",
+              flex: 1,
+            }}
+          >
+            <View style={{ flex: 2, minWidth: 0 }}>{children}</View>
+            <View style={{ flex: 1, minWidth: 260, maxWidth: 360 }}>
+              {sidebar}
+            </View>
+          </View>
+        ) : (
+          <View style={{ flex: 1, minWidth: 0 }}>
+            {children}
+            {sidebar && !isDesktop ? (
+              <View style={{ marginTop: spacing.lg }}>{sidebar}</View>
+            ) : null}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Global fix: builds `components/layout/DesktopScreen.tsx` (184 LOC) as a universal desktop template with title/subtitle/headerActions/sidebar/filters/maxWidth props and 3 breakpoints (mobile pass-through, tablet 720, desktop 1200).
- Applies it to 23 interior pages via `ResponsiveContainer -> DesktopScreen` swap + manual widen on 4 more pages that used custom containers.
- Kills mosaic P0 "mobile-stretched-to-desktop" at scale (previous iterations fixed 1 page each for +1 score delta).

## Test plan
- [x] \`npx tsc --noEmit\` passes (frontend + api)
- [ ] Mosaic flash shows overall/desktopNativeness delta >= +2
- [ ] Desktop 1440: pages centered at 1200, proper rhythm
- [ ] Tablet 768: pages at 720 max-w
- [ ] Mobile 430: bottom-tab UX unchanged (pass-through)

## Out of scope
- \`/specialists/[id]\` (Iter 5 redesign)
- \`/auth/*\`, \`/legal/*\`, \`/brand\`, landing \`/\`
- Dynamic routes \`/requests/[id]/*\`