### PR TITLE
fix(api): mount /api/stats before contactsRoutes

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -40,6 +40,10 @@ app.use("/api/onboarding", onboardingRoutes);
 app.use("/api/specialists", specialistsRoutes);
 app.use("/api/requests", requestsRoutes);
 app.use("/api", referenceRoutes);
+// Register /api/stats BEFORE contactsRoutes — contactsRoutes is mounted at
+// /api with a global authMiddleware, which incorrectly auth-protects any
+// later /api/* handlers passing through it.
+app.use("/api/stats", statsRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/user", userRoutes);
 app.use("/api/specialist", specialistRoutes);
@@ -47,7 +51,6 @@ app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/notifications", notificationsRoutes);
 app.use("/api", contactsRoutes);
-app.use("/api/stats", statsRoutes);
 
 app.listen(PORT, () => {
   // Start BullMQ worker (graceful degradation if Valkey unavailable)


### PR DESCRIPTION
Route order bug discovered after iter 7 merge. contactsRoutes (mounted at /api) has a global authMiddleware that fell through to my new /api/stats routes, breaking public endpoints.

## Test
- curl localhost:3812/api/stats/landing-counts works (was returning 401)
- curl localhost:3812/api/stats/recent-wins?limit=6 returns items

🤖 Generated with [Claude Code](https://claude.com/claude-code)