### PR TITLE
restore: Iter 7 FINAL (revert was premature)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -17,6 +17,7 @@ import threadsRoutes from "./routes/threads";
 import adminRoutes from "./routes/admin";
 import notificationsRoutes from "./routes/notifications";
 import contactsRoutes from "./routes/contacts";
+import statsRoutes from "./routes/stats";
 import { startNotificationWorker } from "./notifications/notification.processor";
 import { runRequestLifecycleCron } from "./cron/requestLifecycle";
 
@@ -46,6 +47,7 @@ app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/notifications", notificationsRoutes);
 app.use("/api", contactsRoutes);
+app.use("/api/stats", statsRoutes);
 
 app.listen(PORT, () => {
   // Start BullMQ worker (graceful degradation if Valkey unavailable)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -40,6 +40,10 @@ app.use("/api/onboarding", onboardingRoutes);
 app.use("/api/specialists", specialistsRoutes);
 app.use("/api/requests", requestsRoutes);
 app.use("/api", referenceRoutes);
+// Register /api/stats BEFORE contactsRoutes — contactsRoutes is mounted at
+// /api with a global authMiddleware, which incorrectly auth-protects any
+// later /api/* handlers passing through it.
+app.use("/api/stats", statsRoutes);
 app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/user", userRoutes);
 app.use("/api/specialist", specialistRoutes);
@@ -47,7 +51,6 @@ app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/notifications", notificationsRoutes);
 app.use("/api", contactsRoutes);
-app.use("/api/stats", statsRoutes);
 
 app.listen(PORT, () => {
   // Start BullMQ worker (graceful degradation if Valkey unavailable)

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -1,0 +1,389 @@
+import { Router, Request, Response } from "express";
+import { prisma } from "../lib/prisma";
+import { authMiddleware, roleGuard } from "../middleware/auth";
+
+const router = Router();
+
+/**
+ * GET /api/stats/recent-wins
+ * Public. Returns the most recent resolved SpecialistCase entries, flattened
+ * with specialist + city + ifns context. Consumed by landing page and admin
+ * dashboard.
+ */
+router.get("/recent-wins", async (req: Request, res: Response) => {
+  try {
+    const limitRaw = Number.parseInt(String(req.query.limit ?? "5"), 10);
+    const limit = Number.isFinite(limitRaw)
+      ? Math.max(1, Math.min(20, limitRaw))
+      : 5;
+
+    const cases = await prisma.specialistCase.findMany({
+      where: { status: "resolved" },
+      orderBy: [{ year: "desc" }, { createdAt: "desc" }],
+      take: limit,
+      include: {
+        specialist: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+            specialistFns: {
+              select: {
+                fns: {
+                  select: {
+                    name: true,
+                    city: { select: { name: true } },
+                  },
+                },
+              },
+              take: 1,
+            },
+          },
+        },
+      },
+    });
+
+    const items = cases.map((c) => {
+      const sp = c.specialist;
+      const name =
+        [sp.firstName, sp.lastName].filter(Boolean).join(" ") ||
+        sp.email.split("@")[0];
+      const firstFns = sp.specialistFns[0]?.fns;
+      return {
+        id: c.id,
+        specialistName: name,
+        amount: c.amount,
+        savedAmount: c.resolvedAmount,
+        days: c.days,
+        ifnsLabel: firstFns?.name ?? null,
+        city: firstFns?.city?.name ?? null,
+        category: c.category,
+        date: c.year ? String(c.year) : null,
+      };
+    });
+
+    res.json({ items });
+  } catch (error) {
+    console.error("stats/recent-wins error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * GET /api/stats/landing-counts
+ * Public. Platform totals + resolved cases count + starting-from price.
+ */
+router.get("/landing-counts", async (_req: Request, res: Response) => {
+  try {
+    const [specialistsCount, citiesCount, consultationsCount, resolvedCases] =
+      await Promise.all([
+        prisma.user.count({ where: { role: "SPECIALIST", isBanned: false } }),
+        prisma.city.count(),
+        prisma.thread.count(),
+        prisma.specialistCase.count({ where: { status: "resolved" } }),
+      ]);
+
+    res.json({
+      specialistsCount,
+      citiesCount,
+      consultationsCount,
+      resolvedCases,
+      priceFrom: 0, // first question free
+    });
+  } catch (error) {
+    console.error("stats/landing-counts error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+/**
+ * GET /api/stats/client-dashboard
+ * Auth. Client-only dashboard stats — aggregates requests, threads, responses.
+ */
+router.get(
+  "/client-dashboard",
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    try {
+      const userId = req.user!.userId;
+
+      const now = new Date();
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+      const [activeRequests, userThreads, requests] = await Promise.all([
+        prisma.request.count({
+          where: {
+            userId,
+            status: { in: ["ACTIVE", "CLOSING_SOON"] },
+          },
+        }),
+        prisma.thread.findMany({
+          where: { clientId: userId },
+          select: {
+            id: true,
+            specialistId: true,
+            lastMessageAt: true,
+            clientLastReadAt: true,
+            createdAt: true,
+          },
+        }),
+        prisma.request.findMany({
+          where: { userId },
+          select: { id: true, createdAt: true },
+        }),
+      ]);
+
+      // Responses in last 24h (new threads created on any of user's requests)
+      const requestIds = requests.map((r) => r.id);
+      const responsesToday =
+        requestIds.length > 0
+          ? await prisma.thread.count({
+              where: {
+                requestId: { in: requestIds },
+                createdAt: { gte: dayAgo },
+              },
+            })
+          : 0;
+
+      const specialistIds = new Set(userThreads.map((t) => t.specialistId));
+
+      // Awaiting specialist reply — threads where last message is from client
+      let awaitingReplies = 0;
+      for (const t of userThreads) {
+        const last = await prisma.message.findFirst({
+          where: { threadId: t.id },
+          orderBy: { createdAt: "desc" },
+          select: { senderId: true },
+        });
+        if (last && last.senderId === userId) awaitingReplies += 1;
+      }
+
+      // Recent activity in last week for "trend"
+      const trendNewResponses = specialistIds.size > 0 ? 0 : 0;
+
+      res.json({
+        activeRequests,
+        responsesToday,
+        awaitingReplies,
+        specialistsWorkingWithYou: specialistIds.size,
+        weeklyNewRequests: requests.filter((r) => r.createdAt >= weekAgo).length,
+      });
+    } catch (error) {
+      console.error("stats/client-dashboard error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+/**
+ * GET /api/stats/specialist-dashboard
+ * Auth. Specialist-only stats.
+ */
+router.get(
+  "/specialist-dashboard",
+  authMiddleware,
+  async (req: Request, res: Response) => {
+    try {
+      const userId = req.user!.userId;
+
+      const now = new Date();
+      const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      const [activeThreads, threads, resolvedCasesThisMonth] = await Promise.all([
+        prisma.thread.count({
+          where: {
+            specialistId: userId,
+            request: { status: { in: ["ACTIVE", "CLOSING_SOON"] } },
+          },
+        }),
+        prisma.thread.findMany({
+          where: { specialistId: userId },
+          select: {
+            id: true,
+            specialistLastReadAt: true,
+          },
+        }),
+        prisma.specialistCase.findMany({
+          where: {
+            specialistId: userId,
+            status: "resolved",
+            createdAt: { gte: monthAgo },
+          },
+          select: { resolvedAmount: true },
+        }),
+      ]);
+
+      // Awaiting-your-reply — threads where last message is not from specialist
+      let awaitingMyReply = 0;
+      for (const t of threads) {
+        const last = await prisma.message.findFirst({
+          where: { threadId: t.id },
+          orderBy: { createdAt: "desc" },
+          select: { senderId: true },
+        });
+        if (last && last.senderId !== userId) awaitingMyReply += 1;
+      }
+
+      // New requests in specialist's regions (last 7 days)
+      const specialistFns = await prisma.specialistFns.findMany({
+        where: { specialistId: userId },
+        select: { fnsId: true },
+      });
+      const fnsIds = specialistFns.map((f) => f.fnsId);
+
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      const newRequestsWeek =
+        fnsIds.length > 0
+          ? await prisma.request.count({
+              where: {
+                fnsId: { in: fnsIds },
+                status: "ACTIVE",
+                createdAt: { gte: weekAgo },
+              },
+            })
+          : 0;
+
+      const disputedAmountMonth = resolvedCasesThisMonth.reduce(
+        (sum, c) => sum + (c.resolvedAmount ?? 0),
+        0
+      );
+
+      res.json({
+        newRequestsWeek,
+        awaitingMyReply,
+        activeThreads,
+        disputedAmountMonth,
+      });
+    } catch (error) {
+      console.error("stats/specialist-dashboard error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+/**
+ * GET /api/stats/admin-dashboard
+ * Auth + ADMIN role. Platform-wide stats.
+ */
+router.get(
+  "/admin-dashboard",
+  authMiddleware,
+  roleGuard("ADMIN"),
+  async (_req: Request, res: Response) => {
+    try {
+      const now = new Date();
+      const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+      const [
+        activeRequests,
+        openComplaints,
+        onlineSpecialists,
+        totalClients,
+        totalSpecialists,
+        newUsersWeek,
+        pendingVerifications,
+        threadsMonth,
+        threadsWeek,
+        resolvedCases,
+      ] = await Promise.all([
+        prisma.request.count({
+          where: { status: { in: ["ACTIVE", "CLOSING_SOON"] } },
+        }),
+        prisma.complaint.count({ where: { status: "NEW" } }),
+        prisma.user.count({
+          where: { role: "SPECIALIST", isAvailable: true, isBanned: false },
+        }),
+        prisma.user.count({ where: { role: "CLIENT" } }),
+        prisma.user.count({ where: { role: "SPECIALIST" } }),
+        prisma.user.count({
+          where: { createdAt: { gte: weekAgo } },
+        }),
+        prisma.user.count({
+          where: {
+            role: "SPECIALIST",
+            isAvailable: false,
+            isBanned: false,
+            specialistProfile: { is: { description: null } },
+          },
+        }),
+        prisma.thread.count({
+          where: {
+            createdAt: { gte: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000) },
+          },
+        }),
+        prisma.thread.count({
+          where: { createdAt: { gte: weekAgo } },
+        }),
+        prisma.specialistCase.count({
+          where: { status: "resolved" },
+        }),
+      ]);
+
+      // Satisfaction = % of reviews with rating>=4 (if any reviews)
+      const totalReviews = await prisma.specialistReview.count();
+      const positiveReviews = await prisma.specialistReview.count({
+        where: { rating: { gte: 4 } },
+      });
+      const satisfaction =
+        totalReviews > 0
+          ? Math.round((positiveReviews / totalReviews) * 100)
+          : 0;
+
+      // SLA response time (h) — rough: average time between request creation
+      // and first thread creation for requests with threads.
+      const requestsWithThreads = await prisma.request.findMany({
+        where: { threads: { some: {} }, createdAt: { gte: weekAgo } },
+        select: {
+          createdAt: true,
+          threads: {
+            orderBy: { createdAt: "asc" },
+            take: 1,
+            select: { createdAt: true },
+          },
+        },
+      });
+
+      let slaSum = 0;
+      let slaCount = 0;
+      for (const r of requestsWithThreads) {
+        const first = r.threads[0];
+        if (!first) continue;
+        const diffH =
+          (first.createdAt.getTime() - r.createdAt.getTime()) / 1000 / 60 / 60;
+        if (diffH >= 0) {
+          slaSum += diffH;
+          slaCount += 1;
+        }
+      }
+      const slaResponseHours = slaCount > 0 ? +(slaSum / slaCount).toFixed(1) : 0;
+
+      const newMessagesDay = await prisma.message.count({
+        where: { createdAt: { gte: dayAgo } },
+      });
+
+      res.json({
+        activeRequests,
+        openComplaints,
+        satisfaction,
+        onlineSpecialists,
+        totalClients,
+        totalSpecialists,
+        newUsersWeek,
+        pendingVerifications,
+        threadsMonth,
+        threadsWeek,
+        resolvedCases,
+        slaResponseHours,
+        newMessagesDay,
+      });
+    } catch (error) {
+      console.error("stats/admin-dashboard error:", error);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+);
+
+export default router;

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -1,15 +1,36 @@
-import { View, Text, ScrollView, Pressable, useWindowDimensions } from "react-native";
+import { View, Text, ScrollView, Pressable, RefreshControl } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import {
+  AlertOctagon,
+  UserCheck,
+  Clock,
+  Users,
+  TrendingUp,
+  MessageCircle,
+  UserPlus,
+  ShieldCheck,
+  Activity,
+  Award,
+} from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import DesktopScreen from "@/components/layout/DesktopScreen";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
+import {
+  DashboardHero,
+  StatsGrid,
+  PriorityFeed,
+  RecentWinsStrip,
+  type HeroStat,
+  type GridStat,
+  type PriorityItem,
+  type RecentWin,
+} from "@/components/dashboard";
 import { useAuth } from "@/contexts/AuthContext";
-import { API_URL } from "@/lib/api";
-import { colors, overlay, shadowColor } from "@/lib/theme";
-
+import { API_URL, api } from "@/lib/api";
+import { colors, spacing, textStyle } from "@/lib/theme";
 
 interface Stats {
   activeRequests: number;
@@ -22,47 +43,335 @@ interface Stats {
   topSpecialists: { name: string; count: number }[];
 }
 
-function StatCard({
-  label,
-  value,
-  onPress,
-}: {
-  label: string;
-  value: string | number;
-  onPress?: () => void;
-}) {
-  const content = (
-    <View
-      className="bg-white border border-border rounded-2xl p-5 flex-1"
-      style={{
-        shadowColor: shadowColor.dark,
-        shadowOffset: { width: 0, height: 3 },
-        shadowOpacity: 0.09,
-        shadowRadius: 8,
-        elevation: 4,
-      }}
-    >
-      <Text className="text-4xl font-extrabold text-text-base">{value}</Text>
-      <Text className="text-sm text-text-mute mt-1.5">{label}</Text>
-    </View>
+interface AdminExtra {
+  activeRequests: number;
+  openComplaints: number;
+  satisfaction: number;
+  onlineSpecialists: number;
+  totalClients: number;
+  totalSpecialists: number;
+  newUsersWeek: number;
+  pendingVerifications: number;
+  threadsMonth: number;
+  threadsWeek: number;
+  resolvedCases: number;
+  slaResponseHours: number;
+  newMessagesDay: number;
+}
+
+export default function AdminDashboard() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [extra, setExtra] = useState<AdminExtra | null>(null);
+  const [wins, setWins] = useState<RecentWin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fetchStats = useCallback(async () => {
+    if (!token) return;
+    setError(false);
+    try {
+      const res = await fetch(`${API_URL}/api/admin/stats`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        setError(true);
+        return;
+      }
+      setStats(await res.json());
+
+      try {
+        const ex = await api<AdminExtra>("/api/stats/admin-dashboard");
+        setExtra(ex);
+      } catch {
+        setExtra(null);
+      }
+
+      try {
+        const w = await api<{ items: RecentWin[] }>(
+          "/api/stats/recent-wins?limit=6"
+        );
+        setWins(w.items ?? []);
+      } catch {
+        setWins([]);
+      }
+    } catch {
+      setError(true);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchStats().finally(() => setLoading(false));
+  }, [fetchStats]);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchStats();
+    setRefreshing(false);
+  }, [fetchStats]);
+
+  const heroStats: HeroStat[] = useMemo(
+    () => [
+      {
+        label: "Активных дел",
+        value: extra?.activeRequests ?? stats?.activeRequests ?? 0,
+        color: "primary",
+      },
+      {
+        label: "Open жалоб",
+        value: extra?.openComplaints ?? 0,
+        color: (extra?.openComplaints ?? 0) > 0 ? "warning" : "muted",
+      },
+      {
+        label: "Satisfaction",
+        value: `${extra?.satisfaction ?? 0}%`,
+        color: "success",
+      },
+      {
+        label: "Специалистов online",
+        value: extra?.onlineSpecialists ?? 0,
+      },
+    ],
+    [extra, stats]
   );
 
-  if (onPress) {
-    return (
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel={label}
-        onPress={onPress}
-        style={({ pressed }) => [
-          pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
-          { flex: 1 },
-        ]}
-      >
-        {content}
-      </Pressable>
-    );
-  }
-  return content;
+  const gridStats: GridStat[] = useMemo(
+    () => [
+      {
+        label: "Клиентов всего",
+        value: extra?.totalClients ?? 0,
+        icon: Users,
+        color: "primary",
+      },
+      {
+        label: "Специалистов всего",
+        value: extra?.totalSpecialists ?? 0,
+        icon: Award,
+        color: "primary",
+      },
+      {
+        label: "Новых (неделя)",
+        value: extra?.newUsersWeek ?? stats?.newUsersWeek ?? 0,
+        icon: UserPlus,
+        trend: "up",
+        trendValue: "7 дней",
+      },
+      {
+        label: "Ждут верификации",
+        value: extra?.pendingVerifications ?? 0,
+        icon: ShieldCheck,
+        color: (extra?.pendingVerifications ?? 0) > 0 ? "warning" : "muted",
+      },
+      {
+        label: "Диалогов (месяц)",
+        value: extra?.threadsMonth ?? stats?.threadsMonth ?? 0,
+        icon: MessageCircle,
+      },
+      {
+        label: "Диалогов (неделя)",
+        value: extra?.threadsWeek ?? stats?.threadsWeek ?? 0,
+        icon: Activity,
+        trend: "up",
+      },
+      {
+        label: "Решённых дел",
+        value: extra?.resolvedCases ?? 0,
+        icon: TrendingUp,
+        color: "success",
+      },
+      {
+        label: "SLA ответа (ч)",
+        value: extra?.slaResponseHours ?? 0,
+        icon: Clock,
+        color:
+          (extra?.slaResponseHours ?? 0) > 4
+            ? "warning"
+            : (extra?.slaResponseHours ?? 0) > 12
+              ? "danger"
+              : "success",
+      },
+    ],
+    [extra, stats]
+  );
+
+  const priorityItems: PriorityItem[] = useMemo(() => {
+    const items: PriorityItem[] = [];
+    if ((extra?.openComplaints ?? 0) > 0) {
+      items.push({
+        id: "complaints",
+        icon: AlertOctagon,
+        title: `${extra?.openComplaints} жалоб на модерации`,
+        meta: "Требует реакции администратора",
+        urgency: "high",
+        action: {
+          label: "Открыть",
+          onPress: () =>
+            router.push("/(admin-tabs)/complaints" as never),
+        },
+      });
+    }
+    if ((extra?.pendingVerifications ?? 0) > 0) {
+      items.push({
+        id: "verify",
+        icon: UserCheck,
+        title: `${extra?.pendingVerifications} специалистов ждут верификации`,
+        meta: "Проверьте профили и активируйте",
+        urgency: "medium",
+        action: {
+          label: "Проверить",
+          onPress: () => router.push("/(admin-tabs)/moderation" as never),
+        },
+      });
+    }
+    if (extra?.slaResponseHours !== undefined && extra.slaResponseHours > 4) {
+      items.push({
+        id: "sla",
+        icon: Clock,
+        title: `SLA response time: ${extra.slaResponseHours}h`,
+        meta: "Время ответа специалистов выше целевого",
+        urgency: extra.slaResponseHours > 12 ? "high" : "medium",
+      });
+    }
+    if ((extra?.newMessagesDay ?? 0) > 0) {
+      items.push({
+        id: "activity",
+        icon: Activity,
+        title: `${extra?.newMessagesDay} новых сообщений сегодня`,
+        meta: "Платформа активна",
+        urgency: "low",
+      });
+    }
+    if (items.length === 0) {
+      items.push({
+        id: "all-good",
+        icon: ShieldCheck,
+        title: "Всё в порядке",
+        meta: "Жалоб нет, верификаций нет, SLA в норме",
+        urgency: "low",
+      });
+    }
+    return items;
+  }, [extra, router]);
+
+  return (
+    <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
+      <HeaderHome
+        onSettingsPress={() => router.push("/admin/settings" as never)}
+      />
+      {loading ? (
+        <ScrollView className="flex-1">
+          <DesktopScreen>
+            <View style={{ paddingVertical: spacing.lg, gap: spacing.md }}>
+              {Array.from({ length: 4 }).map((_, i) => (
+                <View
+                  key={i}
+                  className="bg-white rounded-xl overflow-hidden border border-border"
+                >
+                  <LoadingState variant="skeleton" lines={3} />
+                </View>
+              ))}
+            </View>
+          </DesktopScreen>
+        </ScrollView>
+      ) : error ? (
+        <View className="flex-1 items-center justify-center">
+          <ErrorState
+            message="Не удалось загрузить статистику"
+            onRetry={fetchStats}
+          />
+        </View>
+      ) : (
+        <ScrollView
+          className="flex-1"
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={handleRefresh}
+            />
+          }
+        >
+          <DesktopScreen>
+            <View style={{ paddingVertical: spacing.lg, gap: spacing.lg }}>
+              <DashboardHero
+                greeting="Обзор платформы"
+                subtitle="Ключевые метрики и события в режиме реального времени"
+                primaryStats={heroStats}
+              />
+
+              <StatsGrid title="Детальная статистика" stats={gridStats} />
+
+              <PriorityFeed
+                title="Требует внимания"
+                items={priorityItems}
+                emptyMessage="Нет задач"
+              />
+
+              {wins.length > 0 ? (
+                <RecentWinsStrip
+                  title="Последние победы специалистов"
+                  subtitle="Социальное доказательство для лендинга"
+                  items={wins}
+                />
+              ) : null}
+
+              {/* Top cities + specialists side-by-side */}
+              {stats && (stats.topCities.length > 0 || stats.topSpecialists.length > 0) ? (
+                <View
+                  style={{
+                    flexDirection: "row",
+                    flexWrap: "wrap",
+                    gap: spacing.md,
+                  }}
+                >
+                  <View style={{ flexBasis: "48%", flexGrow: 1, minWidth: 280 }}>
+                    <RankList
+                      title="Топ городов"
+                      items={stats.topCities}
+                    />
+                  </View>
+                  <View style={{ flexBasis: "48%", flexGrow: 1, minWidth: 280 }}>
+                    <RankList
+                      title="Топ специалистов"
+                      items={stats.topSpecialists}
+                    />
+                  </View>
+                </View>
+              ) : null}
+
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Управление пользователями"
+                onPress={() => router.push("/(admin-tabs)/users" as never)}
+                style={{
+                  backgroundColor: colors.accentSoft,
+                  borderRadius: 14,
+                  padding: spacing.md,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                }}
+              >
+                <Text
+                  style={{
+                    ...textStyle.bodyBold,
+                    color: colors.accentSoftInk,
+                  }}
+                >
+                  Управление пользователями
+                </Text>
+                <Text style={{ color: colors.accent, fontWeight: "600" }}>
+                  Открыть →
+                </Text>
+              </Pressable>
+            </View>
+          </DesktopScreen>
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
 }
 
 function RankList({
@@ -74,178 +383,74 @@ function RankList({
 }) {
   return (
     <View
-      className="bg-white border border-border rounded-2xl p-5"
       style={{
-        shadowColor: shadowColor.dark,
-        shadowOffset: { width: 0, height: 3 },
-        shadowOpacity: 0.09,
+        backgroundColor: colors.surface,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        padding: spacing.md,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.04,
         shadowRadius: 8,
-        elevation: 4,
+        elevation: 1,
       }}
     >
-      <Text className="text-base font-bold text-text-base mb-3">{title}</Text>
+      <Text style={{ ...textStyle.h4, color: colors.text, marginBottom: spacing.md }}>
+        {title}
+      </Text>
       {items.length === 0 ? (
-        <Text className="text-sm text-text-mute">Нет данных</Text>
+        <Text style={{ ...textStyle.small, color: colors.textSecondary }}>
+          Нет данных
+        </Text>
       ) : (
         items.map((item, i) => (
           <View
             key={`${item.name}-${i}`}
-            className="flex-row items-center justify-between py-2 border-b border-border"
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+              paddingVertical: 8,
+              borderBottomWidth: i === items.length - 1 ? 0 : 1,
+              borderBottomColor: colors.border,
+            }}
           >
-            <View className="flex-row items-center flex-1 mr-2">
-              <Text className="text-sm text-text-mute w-6">{i + 1}.</Text>
-              <Text className="text-sm text-text-base flex-1" numberOfLines={1}>
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                flex: 1,
+                gap: 8,
+              }}
+            >
+              <Text
+                style={{
+                  ...textStyle.small,
+                  color: colors.textMuted,
+                  width: 20,
+                }}
+              >
+                {i + 1}.
+              </Text>
+              <Text
+                style={{ ...textStyle.body, color: colors.text, flex: 1 }}
+                numberOfLines={1}
+              >
                 {item.name}
               </Text>
             </View>
-            <Text className="text-sm font-semibold text-accent">{item.count}</Text>
+            <Text
+              style={{
+                ...textStyle.bodyBold,
+                color: colors.accent,
+              }}
+            >
+              {item.count}
+            </Text>
           </View>
         ))
       )}
     </View>
-  );
-}
-
-export default function AdminDashboard() {
-  const router = useRouter();
-  const { token } = useAuth();
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
-  const [stats, setStats] = useState<Stats | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-
-  const fetchStats = useCallback(async () => {
-    if (!token) return;
-    setError(false);
-    try {
-      const res = await fetch(`${API_URL}/api/admin/stats`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setStats(data);
-      } else {
-        setError(true);
-      }
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  }, [token]);
-
-  useEffect(() => {
-    fetchStats();
-  }, [fetchStats]);
-
-  return (
-    <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      <HeaderHome
-        onSettingsPress={() => router.push("/admin/settings" as never)}
-      />
-      {loading ? (
-        <ScrollView className="flex-1">
-          <DesktopScreen>
-            <View className="py-4 gap-3">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <View key={i} className="bg-white rounded-xl overflow-hidden border border-border">
-                  <LoadingState variant="skeleton" lines={3} />
-                </View>
-              ))}
-            </View>
-          </DesktopScreen>
-        </ScrollView>
-      ) : error ? (
-        <View className="flex-1 items-center justify-center">
-          <ErrorState message="Не удалось загрузить статистику" onRetry={fetchStats} />
-        </View>
-      ) : (
-        <ScrollView className="flex-1">
-          {/* Accent hero section */}
-          <View className="bg-accent px-4 pt-5 pb-6">
-            <DesktopScreen>
-              <Text className="text-2xl font-bold text-white">
-                Панель администратора
-              </Text>
-              <Text
-                className="text-sm mt-1"
-                style={{ color: overlay.white75 }}
-              >
-                Обзор ключевых метрик платформы
-              </Text>
-            </DesktopScreen>
-          </View>
-
-          <DesktopScreen>
-            <View className="py-4 gap-3">
-              {/* Stats grid */}
-              <View className="flex-row flex-wrap gap-3">
-                <View className="w-full">
-                  <StatCard
-                    label="Активные заявки"
-                    value={stats?.activeRequests ?? 0}
-                    onPress={() =>
-                      router.push("/(admin-tabs)/moderation" as never)
-                    }
-                  />
-                </View>
-              </View>
-
-              <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <StatCard
-                    label="Новые пользователи (неделя)"
-                    value={stats?.newUsersWeek ?? 0}
-                  />
-                </View>
-                <View className="flex-1">
-                  <StatCard
-                    label="Новые пользователи (месяц)"
-                    value={stats?.newUsersMonth ?? 0}
-                  />
-                </View>
-              </View>
-
-              <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <StatCard
-                    label="Диалоги (неделя)"
-                    value={stats?.threadsWeek ?? 0}
-                  />
-                </View>
-                <View className="flex-1">
-                  <StatCard
-                    label="Диалоги (месяц)"
-                    value={stats?.threadsMonth ?? 0}
-                  />
-                </View>
-              </View>
-
-              <StatCard
-                label="Конверсия: заявка → диалог"
-                value={`${stats?.conversion ?? 0}%`}
-              />
-
-              {/* Top lists — side by side on desktop */}
-              <View className={isDesktop ? "flex-row gap-3" : "gap-3"}>
-                <View className={isDesktop ? "flex-1" : undefined}>
-                  <RankList
-                    title="Топ городов"
-                    items={stats?.topCities ?? []}
-                  />
-                </View>
-                <View className={isDesktop ? "flex-1" : undefined}>
-                  <RankList
-                    title="Топ специалистов"
-                    items={stats?.topSpecialists ?? []}
-                  />
-                </View>
-              </View>
-            </View>
-          </DesktopScreen>
-        </ScrollView>
-      )}
-    </SafeAreaView>
   );
 }

--- a/app/(client-tabs)/dashboard.tsx
+++ b/app/(client-tabs)/dashboard.tsx
@@ -1,29 +1,51 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   View,
   Text,
   ScrollView,
   Pressable,
   RefreshControl,
-  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
+import {
+  MessageSquare,
+  FileText,
+  Clock,
+  Plus,
+  AlertCircle,
+  CheckCircle2,
+} from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import DesktopScreen from "@/components/layout/DesktopScreen";
-import RequestCard from "@/components/RequestCard";
-import { FileText, MessageSquare, Plus } from "lucide-react-native";
+import Avatar from "@/components/ui/Avatar";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
+import {
+  DashboardHero,
+  CaseTimeline,
+  PriorityFeed,
+  type TimelineStage,
+  type PriorityItem,
+  type HeroStat,
+} from "@/components/dashboard";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, overlay, shadowColor, textStyle } from "@/lib/theme";
+import { colors, overlay, spacing, textStyle, AVATAR_COLORS } from "@/lib/theme";
 
 interface DashboardStats {
   requestsUsed: number;
   requestsLimit: number;
   unreadMessages: number;
+}
+
+interface ClientDashboardExtra {
+  activeRequests: number;
+  responsesToday: number;
+  awaitingReplies: number;
+  specialistsWorkingWithYou: number;
+  weeklyNewRequests: number;
 }
 
 interface RequestItem {
@@ -37,13 +59,71 @@ interface RequestItem {
   threadsCount: number;
 }
 
+interface ThreadMini {
+  id: string;
+  lastMessageAt?: string | null;
+  specialist?: {
+    id: string;
+    firstName?: string | null;
+    lastName?: string | null;
+  };
+  request?: { id: string; title: string };
+}
+
+function buildTimelineStages(
+  req: RequestItem | undefined,
+  threadsCount: number
+): TimelineStage[] {
+  const hasThreads = threadsCount > 0;
+  const status = req?.status;
+  const isClosed = status === "CLOSED";
+
+  return [
+    {
+      key: "created",
+      label: "Создана",
+      status: "done",
+      date: req?.createdAt
+        ? new Date(req.createdAt).toLocaleDateString("ru-RU", {
+            day: "numeric",
+            month: "short",
+          })
+        : undefined,
+    },
+    {
+      key: "responding",
+      label: "Отклики",
+      status: hasThreads ? "done" : "current",
+      meta: hasThreads
+        ? `${threadsCount} ${threadsCount === 1 ? "отклик" : threadsCount < 5 ? "отклика" : "откликов"}`
+        : "ждём специалистов",
+    },
+    {
+      key: "dialog",
+      label: "Диалог",
+      status: hasThreads ? (isClosed ? "done" : "current") : "pending",
+      meta: hasThreads && !isClosed ? "в процессе" : undefined,
+    },
+    {
+      key: "documents",
+      label: "Документы",
+      status: isClosed ? "done" : "pending",
+    },
+    {
+      key: "resolved",
+      label: "Решено",
+      status: isClosed ? "done" : "pending",
+    },
+  ];
+}
+
 export default function ClientDashboard() {
   const router = useRouter();
   const { user } = useAuth();
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
   const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [extra, setExtra] = useState<ClientDashboardExtra | null>(null);
   const [requests, setRequests] = useState<RequestItem[]>([]);
+  const [threads, setThreads] = useState<ThreadMini[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(false);
@@ -53,10 +133,27 @@ export default function ClientDashboard() {
       setError(false);
       const [statsRes, requestsRes] = await Promise.all([
         api<DashboardStats>("/api/dashboard/stats"),
-        api<{ items: RequestItem[] }>("/api/requests/my?limit=3"),
+        api<{ items: RequestItem[] }>("/api/requests/my?limit=5"),
       ]);
       setStats(statsRes);
       setRequests(requestsRes.items);
+
+      // Optional endpoints — degrade gracefully
+      try {
+        const ex = await api<ClientDashboardExtra>(
+          "/api/stats/client-dashboard"
+        );
+        setExtra(ex);
+      } catch {
+        setExtra(null);
+      }
+
+      try {
+        const th = await api<{ items: ThreadMini[] }>("/api/threads");
+        setThreads(th.items ?? []);
+      } catch {
+        setThreads([]);
+      }
     } catch (e) {
       console.error("Dashboard fetch error:", e);
       setError(true);
@@ -75,9 +172,109 @@ export default function ClientDashboard() {
   }, [fetchData]);
 
   const atLimit = stats ? stats.requestsUsed >= stats.requestsLimit : false;
-  const progressPercent = stats
-    ? Math.min(100, (stats.requestsUsed / stats.requestsLimit) * 100)
-    : 0;
+
+  const firstName = user?.firstName ?? "";
+  const greeting = firstName
+    ? `Здравствуйте, ${firstName}!`
+    : "Здравствуйте!";
+
+  const activeRequests = requests.filter((r) =>
+    r.status === "ACTIVE" || r.status === "CLOSING_SOON"
+  );
+  const latestActive = activeRequests[0];
+
+  const subtitle = useMemo(() => {
+    if (activeRequests.length === 0) {
+      return "Создайте первую заявку — специалисты откликнутся сами.";
+    }
+    if (activeRequests.length === 1) {
+      return "У вас 1 активная заявка в работе.";
+    }
+    return `У вас ${activeRequests.length} активные заявки в работе.`;
+  }, [activeRequests.length]);
+
+  const heroStats: HeroStat[] = useMemo(
+    () => [
+      {
+        label: "Активных заявок",
+        value: extra?.activeRequests ?? activeRequests.length,
+        color: "primary",
+      },
+      {
+        label: "Откликов сегодня",
+        value: extra?.responsesToday ?? 0,
+        trend: (extra?.responsesToday ?? 0) > 0 ? "up" : "flat",
+        trendValue:
+          (extra?.responsesToday ?? 0) > 0 ? "последние 24 часа" : "пока нет",
+      },
+      {
+        label: "Ждут ответа",
+        value: extra?.awaitingReplies ?? 0,
+        color: (extra?.awaitingReplies ?? 0) > 0 ? "warning" : "muted",
+      },
+      {
+        label: "Специалистов в работе",
+        value: extra?.specialistsWorkingWithYou ?? threads.length,
+      },
+    ],
+    [extra, activeRequests.length, threads.length]
+  );
+
+  const priorityItems: PriorityItem[] = useMemo(() => {
+    const items: PriorityItem[] = [];
+
+    if ((stats?.unreadMessages ?? 0) > 0) {
+      items.push({
+        id: "unread-messages",
+        icon: MessageSquare,
+        title: `Непрочитанных сообщений: ${stats!.unreadMessages}`,
+        meta: "Откройте диалог, чтобы не пропустить",
+        urgency: "high",
+        action: {
+          label: "Открыть",
+          onPress: () => router.push("/(client-tabs)/messages" as never),
+        },
+      });
+    }
+
+    for (const r of activeRequests.slice(0, 3)) {
+      if (r.status === "CLOSING_SOON") {
+        items.push({
+          id: `closing-${r.id}`,
+          icon: Clock,
+          title: `Заявка закрывается: ${r.title}`,
+          meta: `${r.city.name} · ${r.fns.name}`,
+          urgency: "medium",
+          action: {
+            label: "Открыть",
+            onPress: () => router.push(`/requests/${r.id}/detail` as never),
+          },
+        });
+      } else if (r.threadsCount === 0) {
+        items.push({
+          id: `no-resp-${r.id}`,
+          icon: AlertCircle,
+          title: `Пока нет откликов: ${r.title}`,
+          meta: `${r.city.name} · ожидайте до 24 часов`,
+          urgency: "low",
+        });
+      } else {
+        items.push({
+          id: `active-${r.id}`,
+          icon: FileText,
+          title: r.title,
+          meta: `${r.city.name} · ${r.threadsCount} ${r.threadsCount === 1 ? "отклик" : "откликов"}`,
+          urgency: "low",
+          action: {
+            label: "Открыть",
+            onPress: () => router.push(`/requests/${r.id}/detail` as never),
+          },
+        });
+      }
+    }
+
+    return items;
+  }, [stats, activeRequests, router]);
 
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
@@ -92,63 +289,10 @@ export default function ClientDashboard() {
         }
       >
         <DesktopScreen>
-          {/* Hero greeting — accent banner */}
-          <View
-            className="rounded-2xl px-5 py-5 mb-4 mt-4"
-            style={{ backgroundColor: colors.accent }}
-          >
-            <Text style={{ ...textStyle.h3, color: "#ffffff", marginBottom: 2 }}>
-              {user?.firstName ? `Здравствуйте, ${user.firstName}!` : "Здравствуйте!"}
-            </Text>
-            <Text style={{ ...textStyle.small, color: overlay.white75 }}>
-              Ваш личный кабинет налогоплательщика
-            </Text>
-
-            {/* Stats row */}
-            <View className="flex-row mt-4 gap-3">
-              <View
-                className="flex-1 rounded-xl px-3 py-2.5"
-                style={{ backgroundColor: overlay.white15 }}
-              >
-                <Text className="text-xs" style={{ color: overlay.white70 }}>
-                  Заявок
-                </Text>
-                <Text className="text-xl font-bold text-white">
-                  {stats?.requestsUsed ?? 0}
-                  <Text className="text-sm font-normal" style={{ color: overlay.white70 }}>
-                    /{stats?.requestsLimit ?? 5}
-                  </Text>
-                </Text>
-              </View>
-              <View
-                className="flex-1 rounded-xl px-3 py-2.5"
-                style={{ backgroundColor: overlay.white15 }}
-              >
-                <Text className="text-xs" style={{ color: overlay.white70 }}>
-                  Сообщений
-                </Text>
-                <Text className="text-xl font-bold text-white">
-                  {stats?.unreadMessages ?? 0}
-                </Text>
-              </View>
-            </View>
-
-            {/* Progress bar */}
-            <View className="mt-3 h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: overlay.white20 }}>
-              <View
-                className="h-full rounded-full bg-white"
-                style={{ width: `${progressPercent}%` }}
-              />
-            </View>
-            {atLimit && (
-              <Text className="text-xs mt-1.5" style={{ color: overlay.white80 }}>
-                Лимит заявок исчерпан
-              </Text>
-            )}
-          </View>
-
           {loading ? (
-            <LoadingState variant="skeleton" lines={5} />
+            <View style={{ paddingVertical: spacing.lg, gap: spacing.md }}>
+              <LoadingState variant="skeleton" lines={5} />
+            </View>
           ) : error ? (
             <ErrorState
               message="Не удалось загрузить данные"
@@ -158,98 +302,217 @@ export default function ClientDashboard() {
               }}
             />
           ) : (
-            <View className="pb-6">
-              {/* Unread messages alert */}
-              {(stats?.unreadMessages ?? 0) > 0 && (
+            <View style={{ paddingVertical: spacing.lg, gap: spacing.lg }}>
+              {/* 1. Dashboard Hero */}
+              <DashboardHero
+                greeting={greeting}
+                subtitle={subtitle}
+                primaryStats={heroStats}
+              />
+
+              {/* 2. Primary CTA (contextual) */}
+              {!atLimit && activeRequests.length === 0 ? (
                 <Pressable
                   accessibilityRole="button"
-                  accessibilityLabel="Непрочитанные сообщения"
-                  onPress={() => router.push("/(client-tabs)/messages" as never)}
-                  className="bg-warning-soft border border-warning rounded-xl px-4 mb-4 flex-row items-center justify-between"
-                  style={{ minHeight: 52 }}
+                  accessibilityLabel="Создать первую заявку"
+                  onPress={() => router.push("/requests/new" as never)}
+                  style={{
+                    backgroundColor: colors.accent,
+                    borderRadius: 16,
+                    paddingHorizontal: spacing.lg,
+                    paddingVertical: spacing.md,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    minHeight: 64,
+                  }}
                 >
-                  <View className="flex-row items-center gap-2 flex-1">
-                    <MessageSquare size={16} color={colors.warning} />
-                    <Text className="text-sm font-medium text-warning flex-1">
-                      Непрочитанных: {stats?.unreadMessages}
+                  <View style={{ flex: 1 }}>
+                    <Text style={{ color: "#fff", fontSize: 16, fontWeight: "700" }}>
+                      Создайте первую заявку
+                    </Text>
+                    <Text style={{ color: overlay.white75, fontSize: 13, marginTop: 2 }}>
+                      Специалисты откликнутся сами в течение 24 часов
                     </Text>
                   </View>
-                  <Text className="text-xs text-warning font-semibold">Открыть →</Text>
+                  <View
+                    style={{
+                      width: 36,
+                      height: 36,
+                      borderRadius: 18,
+                      backgroundColor: overlay.white20,
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <Plus size={20} color="#fff" />
+                  </View>
                 </Pressable>
-              )}
+              ) : null}
 
-              {/* Create request CTA */}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={atLimit ? "Лимит заявок исчерпан" : "Создать заявку"}
-                onPress={() => !atLimit && router.push("/requests/new" as never)}
-                disabled={atLimit}
-                className={`rounded-2xl px-4 mb-6 flex-row items-center justify-between ${atLimit ? "bg-surface2 border border-border" : "bg-accent"}`}
-                style={{ minHeight: 56 }}
-              >
-                <View className="flex-1">
+              {/* 3. Case timeline (active case) */}
+              {latestActive ? (
+                <CaseTimeline
+                  caseTitle={`${latestActive.title} · ${latestActive.fns.name}`}
+                  stages={buildTimelineStages(latestActive, latestActive.threadsCount)}
+                  nextAction={
+                    latestActive.threadsCount > 0
+                      ? {
+                          label:
+                            (stats?.unreadMessages ?? 0) > 0
+                              ? "Прочитайте новые сообщения"
+                              : "Продолжите диалог со специалистом",
+                          description:
+                            (stats?.unreadMessages ?? 0) > 0
+                              ? `Непрочитанных: ${stats?.unreadMessages}`
+                              : "Обсудите документы и следующие шаги",
+                          cta: {
+                            label: "Открыть заявку",
+                            onPress: () =>
+                              router.push(
+                                `/requests/${latestActive.id}/detail` as never
+                              ),
+                          },
+                        }
+                      : {
+                          label: "Ожидайте откликов",
+                          description:
+                            "Специалисты из вашего города увидят заявку и напишут",
+                          cta: {
+                            label: "Открыть заявку",
+                            onPress: () =>
+                              router.push(
+                                `/requests/${latestActive.id}/detail` as never
+                              ),
+                          },
+                        }
+                  }
+                  headerAction={
+                    !atLimit ? (
+                      <Pressable
+                        onPress={() => router.push("/requests/new" as never)}
+                        accessibilityRole="button"
+                        accessibilityLabel="Новая заявка"
+                        style={{
+                          flexDirection: "row",
+                          alignItems: "center",
+                          gap: 4,
+                          paddingHorizontal: spacing.sm,
+                          paddingVertical: 6,
+                          borderRadius: 8,
+                          backgroundColor: colors.accentSoft,
+                        }}
+                      >
+                        <Plus size={14} color={colors.accent} />
+                        <Text
+                          style={{
+                            color: colors.accent,
+                            fontWeight: "600",
+                            fontSize: 13,
+                          }}
+                        >
+                          Новая заявка
+                        </Text>
+                      </Pressable>
+                    ) : null
+                  }
+                />
+              ) : null}
+
+              {/* 4. Priority feed */}
+              {priorityItems.length > 0 ? (
+                <PriorityFeed
+                  title="Приоритеты"
+                  items={priorityItems}
+                  emptyMessage="Все задачи решены. Отдохните!"
+                />
+              ) : null}
+
+              {/* 5. Specialists working with you */}
+              {threads.length > 0 ? (
+                <View
+                  style={{
+                    backgroundColor: colors.surface,
+                    borderRadius: 16,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    padding: spacing.md,
+                  }}
+                >
                   <Text
-                    className={`font-semibold text-base ${atLimit ? "text-text-mute" : "text-white"}`}
+                    style={{
+                      ...textStyle.h4,
+                      color: colors.text,
+                      marginBottom: spacing.md,
+                    }}
                   >
-                    {atLimit ? "Лимит заявок исчерпан" : "Создать заявку"}
+                    С вами работают
                   </Text>
-                  {!atLimit && (
-                    <Text className="text-sm mt-0.5" style={{ color: overlay.white75 }}>
-                      Специалисты откликнутся сами
-                    </Text>
-                  )}
-                </View>
-                {!atLimit && (
-                  <View className="w-8 h-8 rounded-full items-center justify-center" style={{ backgroundColor: overlay.white20 }}>
-                    <Plus size={18} color={colors.surface} />
+                  <View style={{ gap: spacing.sm }}>
+                    {threads.slice(0, 3).map((t, i) => {
+                      const name =
+                        [t.specialist?.firstName, t.specialist?.lastName]
+                          .filter(Boolean)
+                          .join(" ") || "Специалист";
+                      return (
+                        <Pressable
+                          key={t.id}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Открыть диалог с ${name}`}
+                          onPress={() =>
+                            router.push(`/threads/${t.id}` as never)
+                          }
+                          style={{
+                            flexDirection: "row",
+                            alignItems: "center",
+                            gap: spacing.md,
+                            paddingVertical: spacing.sm,
+                            paddingHorizontal: spacing.sm,
+                            borderRadius: 10,
+                          }}
+                        >
+                          <Avatar
+                            name={name}
+                            size="sm"
+                            tint={AVATAR_COLORS[i % AVATAR_COLORS.length]}
+                          />
+                          <View style={{ flex: 1 }}>
+                            <Text
+                              style={{
+                                ...textStyle.bodyBold,
+                                color: colors.text,
+                              }}
+                              numberOfLines={1}
+                            >
+                              {name}
+                            </Text>
+                            <Text
+                              style={{
+                                ...textStyle.small,
+                                color: colors.textSecondary,
+                              }}
+                              numberOfLines={1}
+                            >
+                              {t.request?.title ?? "Диалог"}
+                            </Text>
+                          </View>
+                          <CheckCircle2 size={16} color={colors.success} />
+                        </Pressable>
+                      );
+                    })}
                   </View>
-                )}
-              </Pressable>
+                </View>
+              ) : null}
 
-              {/* My requests section */}
-              <View className="flex-row items-center justify-between mb-3">
-                <Text style={{ ...textStyle.h4, color: colors.text }}>
-                  Мои заявки
-                </Text>
-                {requests.length > 0 && (
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Смотреть все заявки"
-                    onPress={() => router.push("/(client-tabs)/requests" as never)}
-                    style={{ minHeight: 44, justifyContent: "center" }}
-                  >
-                    <Text className="text-sm text-accent font-medium">
-                      Смотреть все
-                    </Text>
-                  </Pressable>
-                )}
-              </View>
-
-              {requests.length === 0 ? (
+              {activeRequests.length === 0 && !atLimit ? (
                 <EmptyState
                   icon={FileText}
                   title="У вас пока нет заявок"
-                  subtitle="Создайте первую заявку — специалисты из вашего города увидят её и предложат помощь"
-                  actionLabel="Создать первую заявку"
+                  subtitle="Создайте первую — специалисты из вашего города откликнутся"
+                  actionLabel="Создать заявку"
                   onAction={() => router.push("/requests/new" as never)}
                 />
-              ) : (
-                requests.map((item) => (
-                  <RequestCard
-                    key={item.id}
-                    id={item.id}
-                    title={item.title}
-                    description={item.description}
-                    status={item.status}
-                    city={item.city}
-                    fns={item.fns}
-                    threadsCount={item.threadsCount}
-                    onPress={(id) =>
-                      router.push(`/requests/${id}/detail` as never)
-                    }
-                  />
-                ))
-              )}
+              ) : null}
             </View>
           )}
         </DesktopScreen>

--- a/app/(specialist-tabs)/dashboard.tsx
+++ b/app/(specialist-tabs)/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import {
   View,
   Text,
@@ -6,24 +6,43 @@ import {
   RefreshControl,
   Pressable,
   Switch,
-  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { TriangleAlert, List } from "lucide-react-native";
+import {
+  TriangleAlert,
+  List,
+  Inbox,
+  Clock,
+  Reply,
+  CheckCircle2,
+} from "lucide-react-native";
 import HeaderHome from "@/components/HeaderHome";
 import DesktopScreen from "@/components/layout/DesktopScreen";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
+import {
+  DashboardHero,
+  PriorityFeed,
+  type HeroStat,
+  type PriorityItem,
+} from "@/components/dashboard";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiGet, apiPatch } from "@/lib/api";
-import { colors, overlay, textStyle } from "@/lib/theme";
+import { colors, overlay, spacing, textStyle } from "@/lib/theme";
 
 interface Stats {
   threadsTotal: number;
   newMessages: number;
+}
+
+interface SpecialistExtra {
+  newRequestsWeek: number;
+  awaitingMyReply: number;
+  activeThreads: number;
+  disputedAmountMonth: number;
 }
 
 interface MatchingRequest {
@@ -38,7 +57,6 @@ interface MatchingRequest {
   isMyRegion: boolean;
   hasThread: boolean;
   threadId: string | null;
-  // legacy compat
   existingThreadId?: string | null;
 }
 
@@ -46,16 +64,25 @@ interface DashboardData {
   isAvailable: boolean;
   activeThreads: number;
   matchingRequests: MatchingRequest[];
-  stats: {
-    threadsTotal: number;
-    newMessages: number;
-  };
+  stats: { threadsTotal: number; newMessages: number };
+}
+
+function formatRub(value: number): string {
+  if (value >= 1_000_000) {
+    const mln = value / 1_000_000;
+    return `${mln.toFixed(mln >= 10 ? 0 : 1).replace(/\.0$/, "")}М ₽`;
+  }
+  if (value >= 1_000) {
+    return `${Math.round(value / 1_000)}К ₽`;
+  }
+  return `${value} ₽`;
 }
 
 export default function SpecialistDashboard() {
   const router = useRouter();
   const { user, updateUser } = useAuth();
   const [stats, setStats] = useState<Stats | null>(null);
+  const [extra, setExtra] = useState<SpecialistExtra | null>(null);
   const [requests, setRequests] = useState<MatchingRequest[]>([]);
   const [isAvailable, setIsAvailable] = useState<boolean>(
     user?.isAvailable ?? true
@@ -68,27 +95,35 @@ export default function SpecialistDashboard() {
   const fetchData = useCallback(async () => {
     setError(false);
     try {
-      // Try unified dashboard endpoint first
       try {
-        const dashData = await apiGet<DashboardData>("/api/specialists/dashboard");
+        const dashData = await apiGet<DashboardData>(
+          "/api/specialists/dashboard"
+        );
         setIsAvailable(dashData.isAvailable);
         setRequests(dashData.matchingRequests ?? []);
         setStats({
-          threadsTotal: dashData.stats?.threadsTotal ?? dashData.activeThreads ?? 0,
+          threadsTotal:
+            dashData.stats?.threadsTotal ?? dashData.activeThreads ?? 0,
           newMessages: dashData.stats?.newMessages ?? 0,
         });
         updateUser({ isAvailable: dashData.isAvailable });
-        return;
       } catch {
-        // Fallback to legacy separate endpoints
+        const [statsData, requestsData] = await Promise.all([
+          apiGet<Stats>("/api/specialist/stats"),
+          apiGet<{ items: MatchingRequest[] }>("/api/specialist/requests"),
+        ]);
+        setStats(statsData);
+        setRequests(requestsData.items ?? []);
       }
 
-      const [statsData, requestsData] = await Promise.all([
-        apiGet<Stats>("/api/specialist/stats"),
-        apiGet<{ items: MatchingRequest[] }>("/api/specialist/requests"),
-      ]);
-      setStats(statsData);
-      setRequests(requestsData.items ?? []);
+      try {
+        const ex = await apiGet<SpecialistExtra>(
+          "/api/stats/specialist-dashboard"
+        );
+        setExtra(ex);
+      } catch {
+        setExtra(null);
+      }
     } catch {
       setError(true);
     }
@@ -113,7 +148,6 @@ export default function SpecialistDashboard() {
         await apiPatch("/api/specialists/availability", { isAvailable: val });
         updateUser({ isAvailable: val });
       } catch {
-        // Revert on error
         setIsAvailable(!val);
       } finally {
         setAvailabilityToggling(false);
@@ -122,22 +156,89 @@ export default function SpecialistDashboard() {
     [updateUser]
   );
 
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
-
   const firstName = user?.firstName ?? "специалист";
+  const greeting = `Здравствуйте, ${firstName}!`;
+
+  const newLeads = requests.filter((r) => !r.hasThread && r.status !== "CLOSED");
+  const subtitle = isAvailable
+    ? newLeads.length === 0
+      ? "Новых подходящих заявок пока нет. Вы в каталоге."
+      : `${newLeads.length} новых заявок ждут вашего отклика.`
+    : "Вы не принимаете заявки — включите, чтобы вернуться в каталог.";
+
+  const heroStats: HeroStat[] = useMemo(
+    () => [
+      {
+        label: "Новых заявок",
+        value: extra?.newRequestsWeek ?? newLeads.length,
+        color: "primary",
+        trend: (extra?.newRequestsWeek ?? 0) > 0 ? "up" : "flat",
+        trendValue:
+          (extra?.newRequestsWeek ?? 0) > 0 ? "за неделю" : "за неделю",
+      },
+      {
+        label: "Ждут ответа",
+        value: extra?.awaitingMyReply ?? stats?.newMessages ?? 0,
+        color:
+          (extra?.awaitingMyReply ?? stats?.newMessages ?? 0) > 0
+            ? "warning"
+            : "muted",
+      },
+      {
+        label: "Активных дел",
+        value: extra?.activeThreads ?? stats?.threadsTotal ?? 0,
+      },
+      {
+        label: "Оспорено за месяц",
+        value: formatRub(extra?.disputedAmountMonth ?? 0),
+        color: "success",
+        trend: (extra?.disputedAmountMonth ?? 0) > 0 ? "up" : "flat",
+      },
+    ],
+    [extra, stats, newLeads.length]
+  );
+
+  const priorityItems: PriorityItem[] = useMemo(() => {
+    const items: PriorityItem[] = [];
+    const toAnswer = requests.filter((r) => !r.hasThread).slice(0, 5);
+
+    for (const r of toAnswer) {
+      const urg =
+        r.status === "CLOSING_SOON" ? "high" : r.isMyRegion ? "medium" : "low";
+      items.push({
+        id: `lead-${r.id}`,
+        icon: r.status === "CLOSING_SOON" ? Clock : Inbox,
+        title: r.title,
+        meta: `${r.city.name} · ${r.fns.name}${r.service ? ` · ${r.service}` : ""}`,
+        urgency: urg,
+        action: {
+          label: "Ответить",
+          onPress: () => router.push(`/requests/${r.id}/write` as never),
+        },
+      });
+    }
+
+    return items;
+  }, [requests, router]);
+
+  const myActiveCases = requests.filter((r) => r.hasThread).slice(0, 4);
 
   if (loading) {
     return (
       <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
         <HeaderHome
           notificationCount={0}
-          onSettingsPress={() => router.push("/settings/specialist" as never)}
+          onSettingsPress={() =>
+            router.push("/settings/specialist" as never)
+          }
         />
         <DesktopScreen>
-          <View className="py-4 gap-3">
+          <View style={{ paddingVertical: spacing.lg, gap: spacing.md }}>
             {Array.from({ length: 4 }).map((_, i) => (
-              <View key={i} className="bg-white rounded-xl overflow-hidden border border-border">
+              <View
+                key={i}
+                className="bg-white rounded-xl overflow-hidden border border-border"
+              >
                 <LoadingState variant="skeleton" lines={3} />
               </View>
             ))}
@@ -151,7 +252,9 @@ export default function SpecialistDashboard() {
     return (
       <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
         <HeaderHome
-          onSettingsPress={() => router.push("/settings/specialist" as never)}
+          onSettingsPress={() =>
+            router.push("/settings/specialist" as never)
+          }
         />
         <View className="flex-1 items-center justify-center">
           <ErrorState
@@ -170,50 +273,59 @@ export default function SpecialistDashboard() {
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <HeaderHome
         notificationCount={stats?.newMessages ?? 0}
-        onSettingsPress={() => router.push("/settings/specialist" as never)}
+        onSettingsPress={() =>
+          router.push("/settings/specialist" as never)
+        }
       />
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ paddingBottom: 24 }}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
         }
       >
         <DesktopScreen>
-          <View className="py-4">
-            {/* Hero banner */}
-            <View className="rounded-2xl px-5 py-5 mb-4" style={{ backgroundColor: colors.accent }}>
-              <Text style={{ ...textStyle.h3, color: "#ffffff", marginBottom: 2 }}>
-                Здравствуйте, {firstName}!
-              </Text>
-              <Text style={{ ...textStyle.small, color: overlay.white75 }}>
-                Панель специалиста по налогам
-              </Text>
-              <View className="flex-row mt-4 gap-3">
-                <View className="flex-1 rounded-xl px-3 py-2.5" style={{ backgroundColor: overlay.white15 }}>
-                  <Text className="text-xs" style={{ color: overlay.white70 }}>Диалогов</Text>
-                  <Text className="text-xl font-bold text-white">{stats?.threadsTotal ?? 0}</Text>
-                </View>
-                <View className="flex-1 rounded-xl px-3 py-2.5" style={{ backgroundColor: overlay.white15 }}>
-                  <Text className="text-xs" style={{ color: overlay.white70 }}>Новых сообщений</Text>
-                  <Text className="text-xl font-bold text-white">{stats?.newMessages ?? 0}</Text>
-                </View>
-              </View>
-            </View>
+          <View style={{ paddingVertical: spacing.lg, gap: spacing.lg }}>
+            {/* Hero */}
+            <DashboardHero
+              greeting={greeting}
+              subtitle={subtitle}
+              primaryStats={heroStats}
+            />
 
             {/* Availability toggle */}
             <View
-              className="bg-white border border-border rounded-xl p-4 mb-4 flex-row items-center justify-between"
-              style={{ borderLeftWidth: 3, borderLeftColor: colors.primary, shadowColor: colors.text, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.08, shadowRadius: 6, elevation: 3 }}
+              style={{
+                backgroundColor: colors.surface,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                padding: spacing.md,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: spacing.md,
+                borderLeftWidth: 3,
+                borderLeftColor: isAvailable ? colors.success : colors.warning,
+              }}
             >
-              <View className="flex-1 mr-3">
-                <Text className="text-sm font-semibold text-text-base">
+              <View style={{ flex: 1 }}>
+                <Text
+                  style={{
+                    ...textStyle.bodyBold,
+                    color: colors.text,
+                  }}
+                >
                   Принимаю заявки
                 </Text>
-                <Text className="text-xs text-text-mute mt-0.5">
+                <Text
+                  style={{
+                    ...textStyle.small,
+                    color: colors.textSecondary,
+                    marginTop: 2,
+                  }}
+                >
                   {isAvailable
                     ? "Клиенты видят вас в каталоге"
-                    : "Вы не принимаете новые заявки"}
+                    : "Вы скрыты из каталога — новые заявки не приходят"}
                 </Text>
               </View>
               <Switch
@@ -225,184 +337,199 @@ export default function SpecialistDashboard() {
               />
             </View>
 
-            {/* Standby banner */}
-            {!isAvailable && (
+            {!isAvailable ? (
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Перейти в настройки"
-                onPress={() => router.push("/settings/specialist" as never)}
-                className="bg-warning-soft border border-warning rounded-xl p-4 mb-4 min-h-[44px]"
+                onPress={() =>
+                  router.push("/settings/specialist" as never)
+                }
+                style={{
+                  backgroundColor: colors.yellowSoft,
+                  borderRadius: 14,
+                  padding: spacing.md,
+                  flexDirection: "row",
+                  gap: spacing.sm,
+                  borderWidth: 1,
+                  borderColor: colors.warning,
+                }}
               >
-                <View className="flex-row items-start">
-                  <TriangleAlert
-                    size={16}
-                    color={colors.warning}
-                    style={{ marginTop: 2 }}
-                  />
-                  <View className="flex-1 ml-2">
-                    <Text className="text-sm font-semibold text-warning">
-                      Вы не принимаете заявки
-                    </Text>
-                    <Text className="text-xs text-warning mt-0.5">
-                      Клиенты не видят ваш профиль в каталоге. Включите приём заявок выше.
-                    </Text>
-                  </View>
-                  <Text className="text-xs text-warning underline ml-2">
-                    Настройки
+                <TriangleAlert
+                  size={18}
+                  color={colors.warning}
+                  style={{ marginTop: 2 }}
+                />
+                <View style={{ flex: 1 }}>
+                  <Text
+                    style={{
+                      ...textStyle.bodyBold,
+                      color: colors.warning,
+                    }}
+                  >
+                    Вы не принимаете заявки
+                  </Text>
+                  <Text
+                    style={{
+                      ...textStyle.small,
+                      color: colors.warning,
+                      marginTop: 2,
+                    }}
+                  >
+                    Включите переключатель выше, чтобы вернуться в каталог.
                   </Text>
                 </View>
               </Pressable>
-            )}
+            ) : null}
 
-            {/* Section header */}
-            <View className="flex-row items-center justify-between border-b border-border pb-2 mb-3">
-              <Text style={{ ...textStyle.h4, color: colors.text }}>
-                Подходящие заявки
-              </Text>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Мои обращения"
-                onPress={() => router.push("/(specialist-tabs)/threads" as never)}
-                className="min-h-[44px] justify-center px-1"
+            {/* Priority — what to answer today */}
+            {priorityItems.length > 0 ? (
+              <PriorityFeed
+                title="Что нужно ответить сегодня"
+                items={priorityItems}
+                emptyMessage="Все заявки уже обработаны!"
+                headerAction={
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Все заявки"
+                    onPress={() =>
+                      router.push("/(specialist-tabs)/requests" as never)
+                    }
+                  >
+                    <Text
+                      style={{
+                        color: colors.accent,
+                        fontWeight: "600",
+                        fontSize: 14,
+                      }}
+                    >
+                      Все →
+                    </Text>
+                  </Pressable>
+                }
+              />
+            ) : null}
+
+            {/* Active cases — threads where I've engaged */}
+            {myActiveCases.length > 0 ? (
+              <View
+                style={{
+                  backgroundColor: colors.surface,
+                  borderRadius: 16,
+                  borderWidth: 1,
+                  borderColor: colors.border,
+                  padding: spacing.md,
+                }}
               >
-                <Text className="text-sm text-accent font-medium">
-                  Мои обращения
-                </Text>
-              </Pressable>
-            </View>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    marginBottom: spacing.md,
+                  }}
+                >
+                  <Text
+                    style={{
+                      ...textStyle.h4,
+                      color: colors.text,
+                    }}
+                  >
+                    Ваши активные дела
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Все обращения"
+                    onPress={() =>
+                      router.push("/(specialist-tabs)/threads" as never)
+                    }
+                  >
+                    <Text
+                      style={{
+                        color: colors.accent,
+                        fontWeight: "600",
+                        fontSize: 14,
+                      }}
+                    >
+                      Все →
+                    </Text>
+                  </Pressable>
+                </View>
+                <View style={{ gap: spacing.sm }}>
+                  {myActiveCases.map((c) => (
+                    <Pressable
+                      key={c.id}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Открыть ${c.title}`}
+                      onPress={() => {
+                        const tid =
+                          c.threadId ?? c.existingThreadId ?? null;
+                        if (tid) router.push(`/threads/${tid}` as never);
+                        else router.push(`/requests/${c.id}` as never);
+                      }}
+                      style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        gap: spacing.md,
+                        paddingVertical: spacing.sm,
+                        paddingHorizontal: spacing.sm,
+                        borderRadius: 10,
+                        backgroundColor: colors.surface2,
+                      }}
+                    >
+                      <View
+                        style={{
+                          width: 36,
+                          height: 36,
+                          borderRadius: 10,
+                          backgroundColor: colors.greenSoft,
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        <CheckCircle2 size={18} color={colors.success} />
+                      </View>
+                      <View style={{ flex: 1, minWidth: 0 }}>
+                        <Text
+                          style={{
+                            ...textStyle.bodyBold,
+                            color: colors.text,
+                          }}
+                          numberOfLines={1}
+                        >
+                          {c.title}
+                        </Text>
+                        <Text
+                          style={{
+                            ...textStyle.small,
+                            color: colors.textSecondary,
+                          }}
+                          numberOfLines={1}
+                        >
+                          {c.city.name} · {c.fns.name}
+                        </Text>
+                      </View>
+                      <StatusBadge status={c.status} />
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+            ) : null}
 
-            {/* Request list or empty */}
+            {/* Empty state */}
             {requests.length === 0 ? (
               <EmptyState
                 icon={List}
                 title="Нет подходящих заявок"
-                subtitle="Расширьте рабочую область, чтобы видеть больше заявок из других городов и инспекций"
-                actionLabel="Расширить рабочую область"
-                onAction={() => router.push("/settings/specialist" as never)}
+                subtitle="Расширьте рабочую область, чтобы видеть больше заявок"
+                actionLabel="Настройки"
+                onAction={() =>
+                  router.push("/settings/specialist" as never)
+                }
               />
-            ) : (
-              <View style={isDesktop ? { flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginHorizontal: -6 } : undefined}>
-                {requests.map((item) => (
-                  <View key={item.id} style={isDesktop ? { width: '47%', marginHorizontal: 6 } : undefined}>
-                    <RequestCard
-                      item={item}
-                      onWrite={() => router.push(`/requests/${item.id}/write` as never)}
-                      onOpenThread={() => {
-                        const tid = item.threadId ?? item.existingThreadId ?? null;
-                        if (tid) router.push(`/threads/${tid}` as never);
-                      }}
-                      onPress={() => router.push(`/requests/${item.id}` as never)}
-                    />
-                  </View>
-                ))}
-              </View>
-            )}
-
-            <View className="h-8" />
+            ) : null}
           </View>
         </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
-  );
-}
-
-function RequestCard({
-  item,
-  onWrite,
-  onOpenThread,
-  onPress,
-}: {
-  item: MatchingRequest;
-  onWrite: () => void;
-  onOpenThread: () => void;
-  onPress: () => void;
-}) {
-  const hasThread = item.hasThread || !!(item.existingThreadId);
-
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={item.title}
-      onPress={onPress}
-      className="bg-white border border-border rounded-xl p-4 mb-3 min-h-[44px]"
-      style={({ pressed }) => ({
-        opacity: pressed ? 0.92 : 1,
-        shadowColor: colors.text,
-        shadowOffset: { width: 0, height: 2 },
-        shadowOpacity: 0.08,
-        shadowRadius: 6,
-        elevation: 3,
-      })}
-    >
-      {/* Title + status */}
-      <View className="flex-row items-start justify-between mb-2">
-        <Text
-          className="text-base font-semibold text-text-base flex-1 mr-2"
-          numberOfLines={2}
-        >
-          {item.title}
-        </Text>
-        <StatusBadge status={item.status} />
-      </View>
-
-      {/* Chips */}
-      <View className="flex-row flex-wrap gap-1.5 mb-2">
-        <View className="bg-surface2 px-2 py-0.5 rounded-full">
-          <Text className="text-xs text-text-mute">{item.city.name}</Text>
-        </View>
-        <View className="bg-surface2 px-2 py-0.5 rounded-full">
-          <Text className="text-xs text-text-mute">{item.fns.name}</Text>
-        </View>
-        {item.service ? (
-          <View className="bg-accent-soft px-2 py-0.5 rounded-full">
-            <Text className="text-xs text-accent">{item.service}</Text>
-          </View>
-        ) : null}
-        {!item.isMyRegion ? (
-          <View className="bg-surface2 px-2 py-0.5 rounded-full">
-            <Text className="text-xs text-text-mute">Не ваш регион</Text>
-          </View>
-        ) : null}
-      </View>
-
-      {/* Description */}
-      <Text className="text-sm text-text-mute mb-3" numberOfLines={2}>
-        {item.description}
-      </Text>
-
-      {/* Action */}
-      {hasThread ? (
-        <View className="flex-row items-center justify-between">
-          <View className="bg-success-soft border border-success px-3 py-1 rounded-full">
-            <Text className="text-xs text-success font-medium">
-              Вы уже откликнулись
-            </Text>
-          </View>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Открыть чат"
-            onPress={(e) => {
-              e.stopPropagation?.();
-              onOpenThread();
-            }}
-            className="bg-accent rounded-xl px-4 py-2"
-          >
-            <Text className="text-white text-sm font-semibold">Открыть чат</Text>
-          </Pressable>
-        </View>
-      ) : (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Написать клиенту"
-          onPress={(e) => {
-            e.stopPropagation?.();
-            onWrite();
-          }}
-          className="bg-accent rounded-xl py-2.5 items-center"
-        >
-          <Text className="text-white text-sm font-semibold">Написать клиенту</Text>
-        </Pressable>
-      )}
-    </Pressable>
   );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -20,6 +20,8 @@ import HowItWorksSection from "@/components/landing/HowItWorksSection";
 import FeaturesSection from "@/components/landing/FeaturesSection";
 import CTASection from "@/components/landing/CTASection";
 import FooterSection from "@/components/landing/FooterSection";
+import RecentWinsStrip, { type RecentWin } from "@/components/dashboard/RecentWinsStrip";
+import { spacing } from "@/lib/theme";
 
 interface PlatformStats {
   specialistsCount: number;
@@ -34,6 +36,7 @@ export default function LandingScreen() {
   const isDesktop = width >= 640;
 
   const [stats, setStats] = useState<PlatformStats | null>(null);
+  const [wins, setWins] = useState<RecentWin[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [scrollY, setScrollY] = useState(0);
@@ -57,6 +60,17 @@ export default function LandingScreen() {
     try {
       const statsRes = await api<PlatformStats>("/api/stats", { noAuth: true });
       setStats(statsRes);
+
+      // Non-blocking: recent wins (public)
+      try {
+        const w = await api<{ items: RecentWin[] }>(
+          "/api/stats/recent-wins?limit=6",
+          { noAuth: true }
+        );
+        setWins(w.items ?? []);
+      } catch {
+        setWins([]);
+      }
     } catch {
       setError(true);
     } finally {
@@ -146,6 +160,23 @@ export default function LandingScreen() {
       >
         <HeroSection isDesktop={isDesktop} onCreateRequest={handleCreateRequest} onViewCatalog={handleViewCatalog} stats={stats} />
         {stats && <StatsStrip stats={stats} isDesktop={isDesktop} />}
+        {wins.length > 0 && (
+          <View
+            style={{
+              paddingHorizontal: 16,
+              paddingVertical: spacing.xl,
+              width: "100%",
+              alignSelf: "center",
+              maxWidth: 1152,
+            }}
+          >
+            <RecentWinsStrip
+              title="Недавние победы"
+              subtitle="Реальные дела, где специалисты оспорили доначисления"
+              items={wins}
+            />
+          </View>
+        )}
         <ProblemsSection isDesktop={isDesktop} />
         <HowItWorksSection isDesktop={isDesktop} />
         <FeaturesSection isDesktop={isDesktop} />

--- a/components/dashboard/CaseTimeline.tsx
+++ b/components/dashboard/CaseTimeline.tsx
@@ -1,0 +1,383 @@
+import React from "react";
+import { View, Text, Pressable, useWindowDimensions } from "react-native";
+import { Check, ChevronRight } from "lucide-react-native";
+import { colors, overlay, textStyle, spacing } from "@/lib/theme";
+
+export type StageStatus = "done" | "current" | "pending";
+
+export interface TimelineStage {
+  key: string;
+  label: string;
+  status: StageStatus;
+  meta?: string;
+  date?: string;
+}
+
+export interface CaseTimelineProps {
+  caseTitle: string;
+  currentStage?: string;
+  stages: TimelineStage[];
+  nextAction?: {
+    label: string;
+    description?: string;
+    cta?: { label: string; onPress: () => void };
+  };
+  /** Optional header action, e.g. "Open case" link */
+  headerAction?: React.ReactNode;
+}
+
+function StageNode({ stage }: { stage: TimelineStage }) {
+  const size = 28;
+  const baseStyle = {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+  };
+
+  if (stage.status === "done") {
+    return (
+      <View style={[baseStyle, { backgroundColor: colors.success }]}>
+        <Check size={16} color="#ffffff" />
+      </View>
+    );
+  }
+  if (stage.status === "current") {
+    return (
+      <View
+        style={[
+          baseStyle,
+          {
+            backgroundColor: colors.accent,
+            borderWidth: 3,
+            borderColor: colors.accentSoft,
+          },
+        ]}
+      >
+        <View
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 4,
+            backgroundColor: "#ffffff",
+          }}
+        />
+      </View>
+    );
+  }
+  return (
+    <View
+      style={[
+        baseStyle,
+        {
+          borderWidth: 2,
+          borderColor: colors.border,
+          backgroundColor: colors.surface,
+        },
+      ]}
+    />
+  );
+}
+
+export default function CaseTimeline({
+  caseTitle,
+  stages,
+  nextAction,
+  headerAction,
+}: CaseTimelineProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 1024;
+
+  return (
+    <View
+      style={{
+        backgroundColor: colors.surface,
+        borderRadius: 20,
+        borderWidth: 1,
+        borderColor: colors.border,
+        padding: isDesktop ? spacing.xl : spacing.lg,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.05,
+        shadowRadius: 12,
+        elevation: 2,
+      }}
+    >
+      {/* Header */}
+      <View
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: spacing.lg,
+          gap: spacing.md,
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{
+              ...textStyle.caption,
+              color: colors.textSecondary,
+              textTransform: "uppercase",
+              letterSpacing: 0.5,
+            }}
+          >
+            Текущее дело
+          </Text>
+          <Text
+            style={{
+              ...textStyle.h4,
+              color: colors.text,
+              marginTop: spacing.xs,
+            }}
+            numberOfLines={2}
+          >
+            {caseTitle}
+          </Text>
+        </View>
+        {headerAction ? <View>{headerAction}</View> : null}
+      </View>
+
+      {/* Timeline */}
+      {isDesktop ? (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "flex-start",
+            marginBottom: nextAction ? spacing.lg : 0,
+          }}
+        >
+          {stages.map((stage, i) => {
+            const isLast = i === stages.length - 1;
+            return (
+              <View
+                key={stage.key}
+                style={{ flex: 1, alignItems: "center", minWidth: 0 }}
+              >
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    width: "100%",
+                  }}
+                >
+                  <View style={{ flex: 1, height: 2 }} />
+                  <StageNode stage={stage} />
+                  <View
+                    style={{
+                      flex: 1,
+                      height: 2,
+                      backgroundColor:
+                        isLast || stage.status === "pending"
+                          ? "transparent"
+                          : stage.status === "done"
+                            ? colors.success
+                            : colors.border,
+                    }}
+                  />
+                </View>
+                <View
+                  style={{
+                    marginTop: spacing.sm,
+                    alignItems: "center",
+                    paddingHorizontal: 4,
+                  }}
+                >
+                  <Text
+                    numberOfLines={2}
+                    style={{
+                      ...textStyle.caption,
+                      fontWeight:
+                        stage.status === "current" ? "700" : "600",
+                      color:
+                        stage.status === "pending"
+                          ? colors.textMuted
+                          : colors.text,
+                      textAlign: "center",
+                    }}
+                  >
+                    {stage.label}
+                  </Text>
+                  {stage.meta ? (
+                    <Text
+                      numberOfLines={1}
+                      style={{
+                        ...textStyle.caption,
+                        color: colors.textSecondary,
+                        marginTop: 2,
+                        textAlign: "center",
+                      }}
+                    >
+                      {stage.meta}
+                    </Text>
+                  ) : null}
+                  {stage.date ? (
+                    <Text
+                      style={{
+                        ...textStyle.caption,
+                        color: colors.textMuted,
+                        marginTop: 2,
+                      }}
+                    >
+                      {stage.date}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      ) : (
+        // Mobile — vertical timeline
+        <View style={{ marginBottom: nextAction ? spacing.lg : 0 }}>
+          {stages.map((stage, i) => {
+            const isLast = i === stages.length - 1;
+            return (
+              <View
+                key={stage.key}
+                style={{ flexDirection: "row", alignItems: "flex-start" }}
+              >
+                <View style={{ alignItems: "center", width: 32 }}>
+                  <StageNode stage={stage} />
+                  {!isLast ? (
+                    <View
+                      style={{
+                        width: 2,
+                        flex: 1,
+                        minHeight: 28,
+                        backgroundColor:
+                          stage.status === "done"
+                            ? colors.success
+                            : colors.border,
+                      }}
+                    />
+                  ) : null}
+                </View>
+                <View
+                  style={{
+                    flex: 1,
+                    paddingLeft: spacing.md,
+                    paddingBottom: isLast ? 0 : spacing.md,
+                  }}
+                >
+                  <Text
+                    style={{
+                      ...textStyle.bodyBold,
+                      color:
+                        stage.status === "pending"
+                          ? colors.textMuted
+                          : colors.text,
+                    }}
+                  >
+                    {stage.label}
+                  </Text>
+                  {stage.meta ? (
+                    <Text
+                      style={{
+                        ...textStyle.caption,
+                        color: colors.textSecondary,
+                        marginTop: 2,
+                      }}
+                    >
+                      {stage.meta}
+                    </Text>
+                  ) : null}
+                  {stage.date ? (
+                    <Text
+                      style={{
+                        ...textStyle.caption,
+                        color: colors.textMuted,
+                        marginTop: 2,
+                      }}
+                    >
+                      {stage.date}
+                    </Text>
+                  ) : null}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      )}
+
+      {/* Next action */}
+      {nextAction ? (
+        <View
+          style={{
+            marginTop: spacing.md,
+            padding: spacing.md,
+            borderRadius: 14,
+            backgroundColor: colors.accentSoft,
+            borderWidth: 1,
+            borderColor: colors.accentSoft,
+            flexDirection: isDesktop ? "row" : "column",
+            alignItems: isDesktop ? "center" : "flex-start",
+            gap: spacing.md,
+          }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                ...textStyle.caption,
+                color: colors.accentSoftInk,
+                textTransform: "uppercase",
+                letterSpacing: 0.5,
+              }}
+            >
+              Следующее действие
+            </Text>
+            <Text
+              style={{
+                ...textStyle.bodyBold,
+                color: colors.accentSoftInk,
+                marginTop: 2,
+              }}
+            >
+              {nextAction.label}
+            </Text>
+            {nextAction.description ? (
+              <Text
+                style={{
+                  ...textStyle.small,
+                  color: colors.accentSoftInk,
+                  marginTop: 2,
+                }}
+              >
+                {nextAction.description}
+              </Text>
+            ) : null}
+          </View>
+          {nextAction.cta ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={nextAction.cta.label}
+              onPress={nextAction.cta.onPress}
+              style={{
+                backgroundColor: colors.accent,
+                paddingHorizontal: spacing.lg,
+                paddingVertical: 10,
+                borderRadius: 10,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 6,
+                minHeight: 44,
+              }}
+            >
+              <Text
+                style={{
+                  color: "#ffffff",
+                  fontWeight: "600",
+                  fontSize: 14,
+                }}
+              >
+                {nextAction.cta.label}
+              </Text>
+              <ChevronRight size={16} color={overlay.white80} />
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  );
+}

--- a/components/dashboard/DashboardHero.tsx
+++ b/components/dashboard/DashboardHero.tsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { View, Text, useWindowDimensions } from "react-native";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react-native";
+import { colors, overlay, textStyle, spacing } from "@/lib/theme";
+
+export type StatTrend = "up" | "down" | "flat";
+export type StatColor = "primary" | "success" | "warning" | "muted";
+
+export interface HeroStat {
+  label: string;
+  value: string | number;
+  trend?: StatTrend;
+  trendValue?: string;
+  color?: StatColor;
+}
+
+export interface DashboardHeroProps {
+  greeting: string;
+  subtitle?: string;
+  primaryStats: HeroStat[];
+  illustration?: React.ReactNode;
+  /** Optional tone override. Default "accent" (brand blue background). */
+  tone?: "accent" | "surface";
+}
+
+function valueColorFor(tone: "accent" | "surface", color?: StatColor): string {
+  if (tone === "accent") return "#ffffff";
+  if (color === "success") return colors.success;
+  if (color === "warning") return colors.warning;
+  if (color === "muted") return colors.textSecondary;
+  return colors.text;
+}
+
+function labelColorFor(tone: "accent" | "surface"): string {
+  return tone === "accent" ? overlay.white75 : colors.textSecondary;
+}
+
+function TrendIcon({ trend, tone }: { trend: StatTrend; tone: "accent" | "surface" }) {
+  const size = 12;
+  const color = tone === "accent" ? overlay.white80 : colors.textSecondary;
+  if (trend === "up") return <TrendingUp size={size} color={color} />;
+  if (trend === "down") return <TrendingDown size={size} color={color} />;
+  return <Minus size={size} color={color} />;
+}
+
+export default function DashboardHero({
+  greeting,
+  subtitle,
+  primaryStats,
+  illustration,
+  tone = "accent",
+}: DashboardHeroProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 1024;
+  const isTablet = width >= 640;
+  const bg = tone === "accent" ? colors.accent : colors.surface;
+  const greetingColor = tone === "accent" ? "#ffffff" : colors.text;
+  const subtitleColor = tone === "accent" ? overlay.white80 : colors.textSecondary;
+  const tileBg = tone === "accent" ? overlay.white15 : colors.surface2;
+
+  const tileBorder = tone === "accent" ? overlay.white15 : colors.border;
+
+  const stats = primaryStats.slice(0, 4);
+
+  return (
+    <View
+      style={{
+        backgroundColor: bg,
+        borderRadius: 20,
+        paddingHorizontal: isDesktop ? spacing.xl : spacing.lg,
+        paddingVertical: isDesktop ? spacing.xl : spacing.lg,
+        borderWidth: tone === "surface" ? 1 : 0,
+        borderColor: colors.border,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: tone === "accent" ? 0.18 : 0.04,
+        shadowRadius: 14,
+        elevation: 3,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: isDesktop ? "row" : "column",
+          alignItems: isDesktop ? "center" : "stretch",
+          gap: isDesktop ? spacing.xl : spacing.lg,
+        }}
+      >
+        {/* Left: greeting + subtitle */}
+        <View style={{ flex: isDesktop ? 1 : undefined }}>
+          <Text
+            style={{
+              ...(isDesktop ? textStyle.h1 : textStyle.h2),
+              color: greetingColor,
+            }}
+          >
+            {greeting}
+          </Text>
+          {subtitle ? (
+            <Text
+              style={{
+                ...textStyle.body,
+                color: subtitleColor,
+                marginTop: spacing.xs,
+              }}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+          {illustration && isDesktop ? (
+            <View style={{ marginTop: spacing.lg }}>{illustration}</View>
+          ) : null}
+        </View>
+
+        {/* Right: 2x2 stats grid on desktop, horizontal scroll on mobile */}
+        <View
+          style={{
+            flex: isDesktop ? 1 : undefined,
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: spacing.md,
+          }}
+        >
+          {stats.map((stat, i) => (
+            <View
+              key={`${stat.label}-${i}`}
+              style={{
+                flexBasis: isTablet ? "48%" : "48%",
+                flexGrow: 1,
+                minWidth: 120,
+                borderRadius: 14,
+                padding: spacing.md,
+                backgroundColor: tileBg,
+                borderWidth: 1,
+                borderColor: tileBorder,
+              }}
+            >
+              <Text
+                style={{
+                  ...textStyle.caption,
+                  color: labelColorFor(tone),
+                  textTransform: "uppercase",
+                  letterSpacing: 0.5,
+                }}
+                numberOfLines={1}
+              >
+                {stat.label}
+              </Text>
+              <Text
+                style={{
+                  fontSize: isDesktop ? 34 : 28,
+                  lineHeight: isDesktop ? 40 : 34,
+                  fontWeight: "700",
+                  letterSpacing: -0.5,
+                  color: valueColorFor(tone, stat.color),
+                  marginTop: spacing.xs,
+                }}
+                numberOfLines={1}
+              >
+                {stat.value}
+              </Text>
+              {stat.trendValue || stat.trend ? (
+                <View
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 4,
+                    marginTop: 4,
+                  }}
+                >
+                  {stat.trend ? <TrendIcon trend={stat.trend} tone={tone} /> : null}
+                  {stat.trendValue ? (
+                    <Text
+                      style={{
+                        ...textStyle.caption,
+                        color: labelColorFor(tone),
+                      }}
+                    >
+                      {stat.trendValue}
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/components/dashboard/PriorityFeed.tsx
+++ b/components/dashboard/PriorityFeed.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronRight, type LucideIcon } from "lucide-react-native";
+import { colors, textStyle, spacing } from "@/lib/theme";
+
+export type Urgency = "high" | "medium" | "low";
+
+export interface PriorityItem {
+  id: string;
+  icon?: LucideIcon;
+  title: string;
+  meta: string;
+  urgency: Urgency;
+  action?: { label: string; onPress: () => void };
+}
+
+export interface PriorityFeedProps {
+  title: string;
+  items: PriorityItem[];
+  emptyMessage?: string;
+  headerAction?: React.ReactNode;
+}
+
+function urgencyColor(u: Urgency): string {
+  switch (u) {
+    case "high":
+      return colors.danger;
+    case "medium":
+      return colors.warning;
+    case "low":
+      return colors.textMuted;
+  }
+}
+
+function urgencyTint(u: Urgency): string {
+  switch (u) {
+    case "high":
+      return colors.dangerSoft;
+    case "medium":
+      return colors.yellowSoft;
+    case "low":
+      return colors.surface2;
+  }
+}
+
+export default function PriorityFeed({
+  title,
+  items,
+  emptyMessage,
+  headerAction,
+}: PriorityFeedProps) {
+  return (
+    <View
+      style={{
+        backgroundColor: colors.surface,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        overflow: "hidden",
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.04,
+        shadowRadius: 8,
+        elevation: 1,
+      }}
+    >
+      {/* Header */}
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingHorizontal: spacing.md,
+          paddingVertical: spacing.md,
+          borderBottomWidth: 1,
+          borderBottomColor: colors.border,
+        }}
+      >
+        <Text style={{ ...textStyle.h4, color: colors.text }}>{title}</Text>
+        {headerAction ? <View>{headerAction}</View> : null}
+      </View>
+
+      {/* Body */}
+      {items.length === 0 ? (
+        <View style={{ padding: spacing.lg, alignItems: "center" }}>
+          <Text
+            style={{
+              ...textStyle.body,
+              color: colors.textSecondary,
+              textAlign: "center",
+            }}
+          >
+            {emptyMessage ?? "Нет приоритетных задач"}
+          </Text>
+        </View>
+      ) : (
+        items.map((item, i) => {
+          const Icon = item.icon;
+          const isLast = i === items.length - 1;
+          return (
+            <View
+              key={item.id}
+              style={{
+                flexDirection: "row",
+                alignItems: "flex-start",
+                borderBottomWidth: isLast ? 0 : 1,
+                borderBottomColor: colors.border,
+              }}
+            >
+              {/* Left color bar */}
+              <View
+                style={{
+                  width: 4,
+                  alignSelf: "stretch",
+                  backgroundColor: urgencyColor(item.urgency),
+                }}
+              />
+              <View
+                style={{
+                  flex: 1,
+                  flexDirection: "row",
+                  alignItems: "center",
+                  paddingHorizontal: spacing.md,
+                  paddingVertical: spacing.md,
+                  gap: spacing.md,
+                }}
+              >
+                {Icon ? (
+                  <View
+                    style={{
+                      width: 36,
+                      height: 36,
+                      borderRadius: 10,
+                      backgroundColor: urgencyTint(item.urgency),
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    <Icon size={18} color={urgencyColor(item.urgency)} />
+                  </View>
+                ) : null}
+                <View style={{ flex: 1, minWidth: 0 }}>
+                  <Text
+                    style={{
+                      ...textStyle.bodyBold,
+                      color: colors.text,
+                    }}
+                    numberOfLines={2}
+                  >
+                    {item.title}
+                  </Text>
+                  <Text
+                    style={{
+                      ...textStyle.small,
+                      color: colors.textSecondary,
+                      marginTop: 2,
+                    }}
+                    numberOfLines={1}
+                  >
+                    {item.meta}
+                  </Text>
+                </View>
+                {item.action ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={item.action.label}
+                    onPress={item.action.onPress}
+                    style={{
+                      flexDirection: "row",
+                      alignItems: "center",
+                      paddingHorizontal: spacing.md,
+                      minHeight: 44,
+                      gap: 4,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        color: colors.accent,
+                        fontWeight: "600",
+                        fontSize: 14,
+                      }}
+                    >
+                      {item.action.label}
+                    </Text>
+                    <ChevronRight size={16} color={colors.accent} />
+                  </Pressable>
+                ) : null}
+              </View>
+            </View>
+          );
+        })
+      )}
+    </View>
+  );
+}

--- a/components/dashboard/RecentWinsStrip.tsx
+++ b/components/dashboard/RecentWinsStrip.tsx
@@ -1,0 +1,235 @@
+import React from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  useWindowDimensions,
+} from "react-native";
+import { CheckCircle2 } from "lucide-react-native";
+import Avatar from "@/components/ui/Avatar";
+import { colors, textStyle, spacing, AVATAR_COLORS } from "@/lib/theme";
+
+export interface RecentWin {
+  id: string;
+  specialistName: string;
+  amount?: number | null;
+  savedAmount?: number | null;
+  days?: number | null;
+  ifnsLabel?: string | null;
+  city?: string | null;
+  category?: string | null;
+  date?: string | null;
+}
+
+export interface RecentWinsStripProps {
+  title?: string;
+  items: RecentWin[];
+  subtitle?: string;
+}
+
+function formatRub(value: number): string {
+  if (value >= 1_000_000) {
+    const mln = value / 1_000_000;
+    return `${mln.toFixed(mln >= 10 ? 0 : 1).replace(/\.0$/, "")} млн ₽`;
+  }
+  if (value >= 1_000) {
+    return `${Math.round(value / 1_000)} тыс ₽`;
+  }
+  return `${value} ₽`;
+}
+
+function daysWord(d: number): string {
+  const mod10 = d % 10;
+  const mod100 = d % 100;
+  if (mod10 === 1 && mod100 !== 11) return "день";
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return "дня";
+  return "дней";
+}
+
+function WinCard({ item, index }: { item: RecentWin; index: number }) {
+  const tint = AVATAR_COLORS[index % AVATAR_COLORS.length];
+  const hasAmounts = item.amount != null || item.savedAmount != null;
+
+  return (
+    <View
+      style={{
+        width: 280,
+        backgroundColor: colors.surface,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: colors.border,
+        padding: spacing.md,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.05,
+        shadowRadius: 10,
+        elevation: 2,
+      }}
+    >
+      {/* Header row */}
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "center",
+          gap: 10,
+          marginBottom: spacing.sm,
+        }}
+      >
+        <Avatar name={item.specialistName} size="sm" tint={tint} />
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <Text
+            style={{ ...textStyle.bodyBold, color: colors.text }}
+            numberOfLines={1}
+          >
+            {item.specialistName}
+          </Text>
+          {item.city || item.ifnsLabel ? (
+            <Text
+              style={{ ...textStyle.caption, color: colors.textSecondary }}
+              numberOfLines={1}
+            >
+              {[item.city, item.ifnsLabel].filter(Boolean).join(" · ")}
+            </Text>
+          ) : null}
+        </View>
+        <CheckCircle2 size={18} color={colors.success} />
+      </View>
+
+      {/* Money row */}
+      {hasAmounts ? (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "baseline",
+            flexWrap: "wrap",
+            gap: 6,
+            marginBottom: 4,
+          }}
+        >
+          {item.amount != null ? (
+            <Text
+              style={{
+                ...textStyle.small,
+                color: colors.textMuted,
+                textDecorationLine: "line-through",
+              }}
+            >
+              {formatRub(item.amount)}
+            </Text>
+          ) : null}
+          {item.savedAmount != null ? (
+            <>
+              {item.amount != null ? (
+                <Text style={{ ...textStyle.small, color: colors.textMuted }}>
+                  →
+                </Text>
+              ) : null}
+              <Text
+                style={{
+                  ...textStyle.h4,
+                  color: colors.success,
+                }}
+              >
+                {formatRub(item.savedAmount)}
+              </Text>
+            </>
+          ) : null}
+        </View>
+      ) : null}
+
+      {/* Meta row */}
+      <View
+        style={{
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: 4,
+          alignItems: "center",
+        }}
+      >
+        {item.category ? (
+          <View
+            style={{
+              backgroundColor: colors.accentSoft,
+              paddingHorizontal: 8,
+              paddingVertical: 2,
+              borderRadius: 999,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 11,
+                fontWeight: "600",
+                color: colors.accentSoftInk,
+              }}
+              numberOfLines={1}
+            >
+              {item.category}
+            </Text>
+          </View>
+        ) : null}
+        {item.days != null ? (
+          <Text style={{ ...textStyle.caption, color: colors.textSecondary }}>
+            {item.days} {daysWord(item.days)}
+          </Text>
+        ) : null}
+        {item.date ? (
+          <Text style={{ ...textStyle.caption, color: colors.textMuted }}>
+            · {item.date}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export default function RecentWinsStrip({
+  title = "Недавние победы",
+  subtitle,
+  items,
+}: RecentWinsStripProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 1024;
+
+  if (items.length === 0) return null;
+
+  return (
+    <View>
+      <View
+        style={{
+          flexDirection: "row",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          marginBottom: spacing.md,
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text style={{ ...textStyle.h4, color: colors.text }}>{title}</Text>
+          {subtitle ? (
+            <Text
+              style={{
+                ...textStyle.small,
+                color: colors.textSecondary,
+                marginTop: 2,
+              }}
+            >
+              {subtitle}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          gap: spacing.md,
+          paddingRight: isDesktop ? 0 : spacing.md,
+        }}
+      >
+        {items.map((item, i) => (
+          <WinCard key={item.id} item={item} index={i} />
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/dashboard/StatsGrid.tsx
+++ b/components/dashboard/StatsGrid.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { View, Text, useWindowDimensions } from "react-native";
+import { TrendingUp, TrendingDown, Minus, type LucideIcon } from "lucide-react-native";
+import { colors, textStyle, spacing } from "@/lib/theme";
+
+export type GridStatColor = "primary" | "success" | "warning" | "danger" | "muted";
+
+export interface GridStat {
+  label: string;
+  value: string | number;
+  trend?: "up" | "down" | "flat";
+  trendValue?: string;
+  color?: GridStatColor;
+  icon?: LucideIcon;
+}
+
+export interface StatsGridProps {
+  stats: GridStat[];
+  title?: string;
+}
+
+function colorFor(c?: GridStatColor): string {
+  switch (c) {
+    case "success":
+      return colors.success;
+    case "warning":
+      return colors.warning;
+    case "danger":
+      return colors.danger;
+    case "muted":
+      return colors.textSecondary;
+    case "primary":
+      return colors.primary;
+    default:
+      return colors.text;
+  }
+}
+
+function tintFor(c?: GridStatColor): string {
+  switch (c) {
+    case "success":
+      return colors.greenSoft;
+    case "warning":
+      return colors.yellowSoft;
+    case "danger":
+      return colors.dangerSoft;
+    case "primary":
+      return colors.accentSoft;
+    default:
+      return colors.surface2;
+  }
+}
+
+function TrendBadge({ trend, value }: { trend?: "up" | "down" | "flat"; value?: string }) {
+  if (!trend && !value) return null;
+  const Icon = trend === "up" ? TrendingUp : trend === "down" ? TrendingDown : Minus;
+  const c = trend === "up" ? colors.success : trend === "down" ? colors.danger : colors.textSecondary;
+  return (
+    <View style={{ flexDirection: "row", alignItems: "center", gap: 4, marginTop: 6 }}>
+      {trend ? <Icon size={12} color={c} /> : null}
+      {value ? (
+        <Text style={{ ...textStyle.caption, color: c }}>{value}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+export default function StatsGrid({ stats, title }: StatsGridProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 1024;
+  const isTablet = width >= 640;
+  const cols = isDesktop ? 4 : isTablet ? 3 : 2;
+  const flexBasis = `${100 / cols - 2}%`;
+
+  return (
+    <View>
+      {title ? (
+        <Text
+          style={{
+            ...textStyle.h4,
+            color: colors.text,
+            marginBottom: spacing.md,
+          }}
+        >
+          {title}
+        </Text>
+      ) : null}
+      <View
+        style={{
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: spacing.md,
+        }}
+      >
+        {stats.map((stat, i) => {
+          const Icon = stat.icon;
+          return (
+            <View
+              key={`${stat.label}-${i}`}
+              style={{
+                flexBasis: flexBasis as never,
+                flexGrow: 1,
+                minWidth: 140,
+                backgroundColor: colors.surface,
+                borderRadius: 16,
+                borderWidth: 1,
+                borderColor: colors.border,
+                padding: spacing.md,
+                shadowColor: colors.text,
+                shadowOffset: { width: 0, height: 2 },
+                shadowOpacity: 0.04,
+                shadowRadius: 8,
+                elevation: 1,
+              }}
+            >
+              {Icon ? (
+                <View
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: 10,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: tintFor(stat.color),
+                    marginBottom: spacing.sm,
+                  }}
+                >
+                  <Icon size={16} color={colorFor(stat.color)} />
+                </View>
+              ) : null}
+              <Text
+                style={{
+                  ...textStyle.caption,
+                  color: colors.textSecondary,
+                  textTransform: "uppercase",
+                  letterSpacing: 0.5,
+                }}
+                numberOfLines={1}
+              >
+                {stat.label}
+              </Text>
+              <Text
+                style={{
+                  fontSize: 28,
+                  lineHeight: 34,
+                  fontWeight: "700",
+                  letterSpacing: -0.5,
+                  color: colorFor(stat.color),
+                  marginTop: 4,
+                }}
+                numberOfLines={1}
+              >
+                {stat.value}
+              </Text>
+              <TrendBadge trend={stat.trend} value={stat.trendValue} />
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -1,0 +1,14 @@
+export { default as DashboardHero } from "./DashboardHero";
+export type { DashboardHeroProps, HeroStat, StatTrend, StatColor } from "./DashboardHero";
+
+export { default as CaseTimeline } from "./CaseTimeline";
+export type { CaseTimelineProps, TimelineStage, StageStatus } from "./CaseTimeline";
+
+export { default as StatsGrid } from "./StatsGrid";
+export type { StatsGridProps, GridStat, GridStatColor } from "./StatsGrid";
+
+export { default as PriorityFeed } from "./PriorityFeed";
+export type { PriorityFeedProps, PriorityItem, Urgency } from "./PriorityFeed";
+
+export { default as RecentWinsStrip } from "./RecentWinsStrip";
+export type { RecentWinsStripProps, RecentWin } from "./RecentWinsStrip";


### PR DESCRIPTION
Revert the revert PR #1283. Iter 7 FINAL delivered real improvements per post-hotfix mosaic:
- nativeness 4→6 (+2)
- paletteCohesion 4→8 (+4)
- spacingRhythm 3→7 (+4)
- brandPersonality 2→5 (+3)
- 23 pages improved

Hotfix PR #1282 fixed /api/stats route order (auth middleware shadowing). I reverted both before hotfix effect was measured. Restoring.