### PR TITLE
iter8: AppHeader + role-signalling + theme unification

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,60 +1,86 @@
 import "../global.css";
-import { Stack } from "expo-router";
-import { AuthProvider } from "@/contexts/AuthContext";
+import { Stack, usePathname } from "expo-router";
+import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import AppShell from "@/components/layout/AppShell";
+import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
+
+/**
+ * Thin wrapper that decides whether the persistent {@link AppHeader}
+ * should render for the current route. Header is shown only for
+ * authenticated users and only on routes that don't have their own
+ * chrome (landing, auth, onboarding, legal).
+ *
+ * Issue #1285 — persistent header on every authenticated route.
+ */
+function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated } = useAuth();
+  const pathname = usePathname() ?? "";
+
+  const show = isAuthenticated && shouldShowAppHeader(pathname);
+
+  return (
+    <>
+      {show && <AppHeader />}
+      {children}
+    </>
+  );
+}
 
 export default function RootLayout() {
   return (
     <AuthProvider>
       <AppShell>
-      <Stack screenOptions={{ headerShown: false }}>
-        {/* Public */}
-        <Stack.Screen name="index" />
+        <AuthenticatedHeaderGate>
+          <Stack screenOptions={{ headerShown: false }}>
+            {/* Public */}
+            <Stack.Screen name="index" />
 
-        {/* Role-based tab groups */}
-        <Stack.Screen name="(client-tabs)" />
-        <Stack.Screen name="(specialist-tabs)" />
-        <Stack.Screen name="(admin-tabs)" />
+            {/* Role-based tab groups */}
+            <Stack.Screen name="(client-tabs)" />
+            <Stack.Screen name="(specialist-tabs)" />
+            <Stack.Screen name="(admin-tabs)" />
 
-        {/* Legacy tabs (kept for compatibility) */}
-        <Stack.Screen name="(tabs)" />
+            {/* Legacy tabs (kept for compatibility) */}
+            <Stack.Screen name="(tabs)" />
 
-        {/* Auth flow */}
-        <Stack.Screen name="auth/email" />
-        <Stack.Screen name="auth/otp" />
+            {/* Auth flow */}
+            <Stack.Screen name="auth/email" />
+            <Stack.Screen name="auth/otp" />
 
-        {/* Onboarding */}
-        <Stack.Screen name="onboarding/name" />
-        <Stack.Screen name="onboarding/work-area" />
-        <Stack.Screen name="onboarding/profile" />
+            {/* Onboarding */}
+            <Stack.Screen name="onboarding/name" />
+            <Stack.Screen name="onboarding/work-area" />
+            <Stack.Screen name="onboarding/profile" />
 
-        {/* Public screens */}
-        <Stack.Screen name="requests/index" />
-        <Stack.Screen name="requests/new" />
-        <Stack.Screen name="requests/[id]/index" />
-        <Stack.Screen name="requests/[id]/detail" />
-        <Stack.Screen name="requests/[id]/messages" />
-        <Stack.Screen name="specialists/index" />
-        <Stack.Screen name="specialists/[id]" />
+            {/* Public screens */}
+            <Stack.Screen name="requests/index" />
+            <Stack.Screen name="requests/new" />
+            <Stack.Screen name="requests/[id]/index" />
+            <Stack.Screen name="requests/[id]/detail" />
+            <Stack.Screen name="requests/[id]/messages" />
+            <Stack.Screen name="specialists/index" />
+            <Stack.Screen name="specialists/[id]" />
 
-        {/* Chat */}
-        <Stack.Screen name="threads/[id]" />
+            {/* Chat */}
+            <Stack.Screen name="threads/[id]" />
 
-        {/* Specialist flow */}
-        <Stack.Screen name="requests/[id]/write" />
-        <Stack.Screen name="settings" />
-        <Stack.Screen name="settings/client" />
-        <Stack.Screen name="notifications" />
-        <Stack.Screen name="legal/privacy" />
-        <Stack.Screen name="legal/terms" />
-        <Stack.Screen name="brand" />
+            {/* Specialist flow */}
+            <Stack.Screen name="requests/[id]/write" />
+            <Stack.Screen name="settings" />
+            <Stack.Screen name="settings/client" />
+            <Stack.Screen name="notifications" />
+            <Stack.Screen name="legal/privacy" />
+            <Stack.Screen name="legal/terms" />
+            {/* Issue #1293: /brand is a dev-only design-system page. */}
+            {__DEV__ && <Stack.Screen name="brand" />}
 
-        {/* Admin detail screens */}
-        <Stack.Screen name="admin/settings" />
+            {/* Admin detail screens */}
+            <Stack.Screen name="admin/settings" />
             <Stack.Screen name="requests/[id]" />
             <Stack.Screen name="requests" />
             <Stack.Screen name="specialists" />
-      </Stack>
+          </Stack>
+        </AuthenticatedHeaderGate>
       </AppShell>
     </AuthProvider>
   );

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -1,0 +1,428 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  TextInput,
+  useWindowDimensions,
+  Modal,
+  Platform,
+} from "react-native";
+import { useRouter, usePathname } from "expo-router";
+import { Bell, Menu, Search, Settings, LogOut, User } from "lucide-react-native";
+import { useAuth, type UserRole } from "@/contexts/AuthContext";
+import { colors, roleAccent, type RoleAccentKey, gray, spacing } from "@/lib/theme";
+import MobileMenu from "@/components/MobileMenu";
+import RoleBadge from "./RoleBadge";
+
+/**
+ * Persistent in-app header rendered on every authenticated route.
+ *
+ * Desktop (>= 640px): logo + breadcrumb + search input + role badge + bell + avatar dropdown.
+ * Mobile  (<  640px): burger + centered title + bell, dropdown deferred to MobileMenu.
+ *
+ * Issue #1285 (persistent header), #1289 (role accent tint).
+ *
+ * The component deliberately keeps its own breadcrumb mapping small —
+ * more sophisticated trails can be added later once the screen set
+ * stabilises. When there is no match the breadcrumb is hidden.
+ */
+
+export interface AppHeaderProps {
+  /** Optional override for the breadcrumb title. Falls back to route inference. */
+  title?: string;
+}
+
+function toAccentKey(role: UserRole): RoleAccentKey {
+  switch (role) {
+    case "SPECIALIST":
+      return "specialist";
+    case "ADMIN":
+      return "admin";
+    case "CLIENT":
+    default:
+      return "client";
+  }
+}
+
+// Shallow breadcrumb mapping — exact-prefix first, then longest-prefix wins.
+const BREADCRUMB_MAP: ReadonlyArray<{ prefix: string; label: string }> = [
+  { prefix: "/(client-tabs)/dashboard", label: "Обзор" },
+  { prefix: "/(client-tabs)/requests", label: "Мои заявки" },
+  { prefix: "/(client-tabs)/messages", label: "Сообщения" },
+  { prefix: "/(specialist-tabs)/dashboard", label: "Дашборд" },
+  { prefix: "/(specialist-tabs)/requests", label: "Заявки" },
+  { prefix: "/(specialist-tabs)/threads", label: "Переписки" },
+  { prefix: "/(specialist-tabs)/promotion", label: "Продвижение" },
+  { prefix: "/(admin-tabs)/dashboard", label: "Админ · Обзор" },
+  { prefix: "/(admin-tabs)/users", label: "Пользователи" },
+  { prefix: "/(admin-tabs)/moderation", label: "Модерация" },
+  { prefix: "/(admin-tabs)/complaints", label: "Жалобы" },
+  { prefix: "/admin/settings", label: "Админ · Настройки" },
+  { prefix: "/specialists", label: "Специалисты" },
+  { prefix: "/requests/new", label: "Новая заявка" },
+  { prefix: "/requests", label: "Заявки" },
+  { prefix: "/threads", label: "Переписки" },
+  { prefix: "/settings", label: "Настройки" },
+  { prefix: "/notifications", label: "Уведомления" },
+];
+
+function inferBreadcrumb(pathname: string): string | null {
+  if (!pathname) return null;
+  const sorted = [...BREADCRUMB_MAP].sort((a, b) => b.prefix.length - a.prefix.length);
+  for (const entry of sorted) {
+    // Normalise paren-group markers: Expo Router may emit either form.
+    const normalised = pathname.replace(/\((client|specialist|admin)-tabs\)/g, "/$1-tabs/");
+    if (pathname.startsWith(entry.prefix) || normalised.includes(entry.prefix.replace(/[()]/g, ""))) {
+      return entry.label;
+    }
+  }
+  return null;
+}
+
+export default function AppHeader({ title }: AppHeaderProps) {
+  const { width } = useWindowDimensions();
+  const isMobile = width < 640;
+  const { user, signOut } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const accentKey = toAccentKey(user?.role ?? "CLIENT");
+  const accent = roleAccent[accentKey];
+
+  const displayName = user?.firstName
+    ? `${user.firstName} ${user.lastName || ""}`.trim()
+    : user?.email || "Пользователь";
+  const initials =
+    user?.firstName?.[0]?.toUpperCase() ||
+    user?.email?.[0]?.toUpperCase() ||
+    "U";
+
+  const breadcrumb = title ?? inferBreadcrumb(pathname);
+
+  const handleSearchSubmit = () => {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      router.push("/specialists" as never);
+      return;
+    }
+    router.push(`/specialists?q=${encodeURIComponent(trimmed)}` as never);
+  };
+
+  const handleLogout = async () => {
+    setDropdownOpen(false);
+    await signOut();
+    router.replace("/auth/email" as never);
+  };
+
+  const handleSettings = () => {
+    setDropdownOpen(false);
+    const settingsPath =
+      user?.role === "SPECIALIST"
+        ? "/settings/specialist"
+        : user?.role === "ADMIN"
+        ? "/admin/settings"
+        : "/settings/client";
+    router.push(settingsPath as never);
+  };
+
+  // -------- Mobile --------
+  if (isMobile) {
+    return (
+      <>
+        <View
+          className="flex-row items-center justify-between px-4 h-14 bg-white border-b"
+          style={{ borderBottomColor: colors.border, borderTopWidth: 3, borderTopColor: accent.strong }}
+        >
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Открыть меню"
+            onPress={() => setMenuOpen(true)}
+            className="w-11 h-11 items-center justify-center"
+          >
+            <Menu size={20} color={colors.text} />
+          </Pressable>
+
+          <View className="flex-1 items-center">
+            {breadcrumb ? (
+              <Text
+                numberOfLines={1}
+                className="text-base font-semibold"
+                style={{ color: colors.text }}
+              >
+                {breadcrumb}
+              </Text>
+            ) : (
+              <Text className="text-lg font-bold" style={{ color: colors.primary }}>
+                P2PTax
+              </Text>
+            )}
+          </View>
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Уведомления"
+            onPress={() => router.push("/notifications" as never)}
+            className="w-11 h-11 items-center justify-center"
+          >
+            <Bell size={18} color={colors.text} />
+          </Pressable>
+        </View>
+
+        <MobileMenu visible={menuOpen} onClose={() => setMenuOpen(false)} />
+      </>
+    );
+  }
+
+  // -------- Desktop --------
+  return (
+    <View
+      className="flex-row items-center bg-white border-b"
+      style={{
+        borderBottomColor: colors.border,
+        borderTopWidth: 3,
+        borderTopColor: accent.strong,
+        height: 64,
+        paddingHorizontal: spacing.lg,
+        gap: spacing.lg,
+      }}
+    >
+      {/* Logo + breadcrumb */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="P2PTax — главная"
+        onPress={() => router.push("/" as never)}
+        className="flex-row items-center"
+        style={{ minHeight: 44, gap: spacing.sm }}
+      >
+        <View
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 6,
+            backgroundColor: colors.primary,
+          }}
+        />
+        <Text className="text-lg font-bold" style={{ color: colors.text }}>
+          P2P<Text style={{ color: colors.primary }}>Tax</Text>
+        </Text>
+      </Pressable>
+
+      {breadcrumb && (
+        <>
+          <Text style={{ color: colors.textMuted }}>/</Text>
+          <Text
+            numberOfLines={1}
+            className="text-sm font-semibold"
+            style={{ color: colors.text, maxWidth: 260 }}
+          >
+            {breadcrumb}
+          </Text>
+        </>
+      )}
+
+      {/* Search — fills available space */}
+      <View
+        className="flex-row items-center rounded-lg px-3"
+        style={{
+          flex: 1,
+          maxWidth: 520,
+          height: 40,
+          backgroundColor: gray[100],
+          borderWidth: 1,
+          borderColor: colors.border,
+          marginLeft: spacing.md,
+        }}
+      >
+        <Search size={16} color={colors.textMuted} />
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          onSubmitEditing={handleSearchSubmit}
+          placeholder="Найти специалиста, заявку…"
+          placeholderTextColor={colors.placeholder}
+          returnKeyType="search"
+          accessibilityLabel="Поиск"
+          style={{
+            flex: 1,
+            marginLeft: 8,
+            fontSize: 14,
+            color: colors.text,
+            ...(Platform.OS === "web" ? { outlineStyle: "none" as never } : {}),
+          }}
+        />
+      </View>
+
+      {/* Right cluster */}
+      <View className="flex-row items-center" style={{ gap: spacing.md, marginLeft: "auto" }}>
+        <RoleBadge role={user?.role ?? null} />
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Уведомления"
+          onPress={() => router.push("/notifications" as never)}
+          className="w-11 h-11 rounded-lg items-center justify-center"
+        >
+          <Bell size={18} color={colors.text} />
+          {/* Unread dot placeholder — wired to real count in future iteration */}
+        </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Меню профиля"
+          onPress={() => setDropdownOpen(true)}
+          className="w-10 h-10 rounded-full items-center justify-center"
+          style={{ backgroundColor: accent.soft, borderWidth: 1, borderColor: accent.strong }}
+        >
+          <Text className="text-sm font-bold" style={{ color: accent.strong }}>
+            {initials}
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Avatar dropdown (modal anchored to top-right) */}
+      <Modal
+        visible={dropdownOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDropdownOpen(false)}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрыть меню профиля"
+          onPress={() => setDropdownOpen(false)}
+          className="flex-1"
+          style={{ backgroundColor: "transparent" }}
+        >
+          <View
+            style={{
+              position: "absolute",
+              top: 64,
+              right: spacing.lg,
+              width: 260,
+              backgroundColor: colors.surface,
+              borderRadius: 12,
+              borderWidth: 1,
+              borderColor: colors.border,
+              padding: spacing.sm,
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 6 },
+              shadowOpacity: 0.08,
+              shadowRadius: 16,
+              elevation: 6,
+            }}
+          >
+            {/* Identity row */}
+            <View
+              className="flex-row items-center"
+              style={{ padding: spacing.sm, gap: spacing.sm }}
+            >
+              <View
+                className="w-9 h-9 rounded-full items-center justify-center"
+                style={{ backgroundColor: accent.soft }}
+              >
+                <Text className="text-sm font-bold" style={{ color: accent.strong }}>
+                  {initials}
+                </Text>
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text
+                  numberOfLines={1}
+                  className="text-sm font-semibold"
+                  style={{ color: colors.text }}
+                >
+                  {displayName}
+                </Text>
+                <Text
+                  numberOfLines={1}
+                  className="text-xs"
+                  style={{ color: colors.textSecondary }}
+                >
+                  {user?.email}
+                </Text>
+              </View>
+            </View>
+
+            <View
+              style={{
+                height: 1,
+                backgroundColor: colors.border,
+                marginVertical: spacing.xs,
+              }}
+            />
+
+            <View style={{ paddingHorizontal: spacing.xs }}>
+              <RoleBadge role={user?.role ?? null} size="md" />
+            </View>
+
+            <View
+              style={{
+                height: 1,
+                backgroundColor: colors.border,
+                marginVertical: spacing.xs,
+              }}
+            />
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Настройки"
+              onPress={handleSettings}
+              className="flex-row items-center rounded-md"
+              style={{ padding: spacing.sm, gap: spacing.sm }}
+            >
+              <Settings size={16} color={colors.textSecondary} />
+              <Text className="text-sm" style={{ color: colors.text }}>
+                Настройки
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Профиль"
+              onPress={() => {
+                setDropdownOpen(false);
+                router.push("/settings" as never);
+              }}
+              className="flex-row items-center rounded-md"
+              style={{ padding: spacing.sm, gap: spacing.sm }}
+            >
+              <User size={16} color={colors.textSecondary} />
+              <Text className="text-sm" style={{ color: colors.text }}>
+                Профиль
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Выйти"
+              onPress={handleLogout}
+              className="flex-row items-center rounded-md"
+              style={{ padding: spacing.sm, gap: spacing.sm }}
+            >
+              <LogOut size={16} color={colors.danger} />
+              <Text className="text-sm" style={{ color: colors.danger }}>
+                Выйти
+              </Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+/**
+ * Path-prefix gate: when the current route is public chrome (landing,
+ * auth, onboarding, legal) we suppress AppHeader entirely — those
+ * screens render their own hero/chrome.
+ */
+export function shouldShowAppHeader(pathname: string): boolean {
+  if (!pathname) return false;
+  if (pathname === "/") return false;
+  if (pathname.startsWith("/auth")) return false;
+  if (pathname.startsWith("/legal")) return false;
+  if (pathname.startsWith("/onboarding")) return false;
+  return true;
+}

--- a/components/layout/RoleBadge.tsx
+++ b/components/layout/RoleBadge.tsx
@@ -1,0 +1,60 @@
+import { View, Text } from "react-native";
+import { roleAccent, type RoleAccentKey } from "@/lib/theme";
+import type { UserRole } from "@/contexts/AuthContext";
+
+export interface RoleBadgeProps {
+  role: UserRole;
+  size?: "sm" | "md";
+}
+
+/**
+ * Maps {@link UserRole} (uppercase DB enum) to the role-accent key used
+ * by the theme. Falls back to `client` so the badge always has a colour
+ * to render instead of disappearing silently.
+ */
+function toAccentKey(role: UserRole): RoleAccentKey {
+  switch (role) {
+    case "SPECIALIST":
+      return "specialist";
+    case "ADMIN":
+      return "admin";
+    case "CLIENT":
+    default:
+      return "client";
+  }
+}
+
+/**
+ * Small pill shown inside {@link AppHeader} to signal which portal the
+ * current user is in. Colour map lives in `lib/theme.ts`.
+ */
+export default function RoleBadge({ role, size = "sm" }: RoleBadgeProps) {
+  if (!role) return null;
+
+  const accent = roleAccent[toAccentKey(role)];
+  const paddingClass = size === "sm" ? "px-2 py-0.5" : "px-2.5 py-1";
+  const textSizeClass = size === "sm" ? "text-[11px]" : "text-xs";
+
+  return (
+    <View
+      className={`${paddingClass} rounded-full flex-row items-center`}
+      style={{ backgroundColor: accent.soft }}
+    >
+      <View
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 3,
+          backgroundColor: accent.strong,
+          marginRight: 6,
+        }}
+      />
+      <Text
+        className={`${textSizeClass} font-semibold`}
+        style={{ color: accent.strong }}
+      >
+        {accent.label}
+      </Text>
+    </View>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,7 +1,7 @@
 import { Pressable, Text, ActivityIndicator } from "react-native";
 import { useState } from "react";
 import { type LucideIcon } from "lucide-react-native";
-import { colors } from "../../lib/theme";
+import { colors, gray } from "../../lib/theme";
 
 export interface ButtonProps {
   variant?: "primary" | "secondary" | "destructive";
@@ -27,18 +27,23 @@ export default function Button({
   const [pressed, setPressed] = useState(false);
 
   const widthClass = fullWidth ? "w-full" : "px-6";
-  const opacityClass = disabled || loading ? "opacity-40" : "";
 
-  const baseContainerClass = `rounded-xl h-12 flex-row items-center justify-center ${widthClass} ${opacityClass}`;
+  const baseContainerClass = `rounded-xl h-12 flex-row items-center justify-center ${widthClass}`;
 
-  const variantStyle =
-    variant === "primary"
+  const isInactive = disabled || loading;
+
+  // Issue #1290 — disabled must be a clearly different fill (gray[200] /
+  // gray[400]) so users don't tap a bleached-primary that looks active.
+  // Loading keeps the variant fill and shows a spinner instead.
+  const variantStyle = isInactive && disabled && !loading
+    ? { backgroundColor: gray[200], borderWidth: 0 }
+    : variant === "primary"
       ? { backgroundColor: colors.primary }
       : variant === "secondary"
         ? { backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.border }
         : { backgroundColor: colors.danger };
 
-  const shadowStyle = variant === "primary" && !pressed
+  const shadowStyle = variant === "primary" && !pressed && !isInactive
     ? { shadowColor: colors.primary, shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.2, shadowRadius: 4, elevation: 3 }
     : undefined;
 
@@ -47,20 +52,29 @@ export default function Button({
     : undefined;
 
   const textColorValue =
-    variant === "primary" || variant === "destructive" ? "#ffffff" : colors.text;
+    disabled && !loading
+      ? gray[400]
+      : variant === "primary" || variant === "destructive"
+        ? "#ffffff"
+        : colors.text;
 
   const iconColor =
-    variant === "primary" || variant === "destructive" ? "#ffffff" : colors.primary;
+    disabled && !loading
+      ? gray[400]
+      : variant === "primary" || variant === "destructive"
+        ? "#ffffff"
+        : colors.primary;
 
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityState={{ disabled: isInactive, busy: loading }}
       testID={testID}
       onPress={onPress}
       onPressIn={() => setPressed(true)}
       onPressOut={() => setPressed(false)}
-      disabled={disabled || loading}
+      disabled={isInactive}
       className={baseContainerClass}
       style={[variantStyle, shadowStyle, pressStyle]}
     >

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,7 +1,18 @@
+/**
+ * Unified primary blue — #2256c2 (landing tone).
+ *
+ * Issue #1288: historically the app drifted between multiple shades of
+ * blue (#2e5bff, #2256c2, #3b5bdb, #1e40af). The landing marketing site
+ * is already in market with #2256c2, so it's the single source of truth.
+ * NEVER hardcode a different blue hex in app/ or components/ — always
+ * import `colors.primary` (or the Tailwind `accent` token) from here.
+ */
+const PRIMARY_BLUE = '#2256c2' as const
+
 export const colors = {
   // Brand — staging palette
-  primary: '#2256c2',        // accent/primary
-  accent: '#2256c2',         // accent (same as primary)
+  primary: PRIMARY_BLUE,     // accent/primary (single source of truth)
+  accent: PRIMARY_BLUE,      // accent (same as primary)
   accentSoft: '#e8eefb',     // accent-soft
   accentSoftInk: '#1b3d8a',  // accent-soft-ink
   background: '#ffffff',     // bg
@@ -34,6 +45,42 @@ export const colors = {
   blue300: '#93c5fd',
   blue500: '#3b82f6',
 } as const
+
+/**
+ * Gray scale — Tailwind-compatible neutrals used for disabled states,
+ * muted chrome, separators. Issue #1290: disabled buttons must use
+ * `gray.200` bg + `gray.400` text for sufficient contrast against the
+ * active primary (so the eye can still tell "can press" vs "can't").
+ */
+export const gray = {
+  50:  '#f9fafb',
+  100: '#f3f4f6',
+  200: '#e5e7eb',
+  300: '#d1d5db',
+  400: '#9ca3af',
+  500: '#6b7280',
+  600: '#4b5563',
+  700: '#374151',
+  800: '#1f2937',
+  900: '#111827',
+} as const
+
+/**
+ * Role-signalling accents (issue #1289). Every authenticated user belongs
+ * to exactly one role tier; the header + key chrome tinted accordingly so
+ * three portals stop looking like a single template with swapped H1.
+ *
+ *   client      blue (inherits primary) — default, safest choice
+ *   specialist  emerald — "active professional" signal
+ *   admin       amber — "internal ops, handle with care"
+ */
+export const roleAccent = {
+  client:     { strong: PRIMARY_BLUE, soft: '#e8eefb', ink: '#ffffff', label: 'Клиент' },
+  specialist: { strong: '#059669',    soft: '#d1fae5', ink: '#ffffff', label: 'Специалист' },
+  admin:      { strong: '#d97706',    soft: '#fef3c7', ink: '#ffffff', label: 'Админ' },
+} as const
+
+export type RoleAccentKey = keyof typeof roleAccent
 
 export const tw = {
   primary: 'bg-accent',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,24 @@ module.exports = {
         'success-soft': '#ecfdf5',
         warning: '#d97706',
         'warning-soft': '#fef3c7',
+        // Gray scale — disabled states, muted chrome (issue #1290)
+        gray: {
+          50:  '#f9fafb',
+          100: '#f3f4f6',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#9ca3af',
+          500: '#6b7280',
+          600: '#4b5563',
+          700: '#374151',
+          800: '#1f2937',
+          900: '#111827',
+        },
+        // Role accents (issue #1289)
+        'role-specialist': '#059669',
+        'role-specialist-soft': '#d1fae5',
+        'role-admin': '#d97706',
+        'role-admin-soft': '#fef3c7',
       },
       borderRadius: {
         sm: '6px',


### PR DESCRIPTION
Closes #1285 #1288 #1289 #1290 #1293.

## Summary
- **AppHeader** (#1285): persistent chrome on every authenticated route — desktop (logo + breadcrumb + search + role badge + bell + avatar dropdown), mobile (burger + route title + bell). Excluded from `/`, `/auth/*`, `/legal/*`, `/onboarding/*`.
- **Role-signalling** (#1289): `roleAccent` theme token map — client=blue, specialist=emerald, admin=amber. 3 px coloured top border on header + `RoleBadge` pill in header and profile dropdown.
- **Theme unification** (#1288): `PRIMARY_BLUE = #2256c2` extracted as single source of truth (landing tone). No alt blue hex remains in app/components.
- **Disabled contrast** (#1290): Button `disabled` state now uses `gray[200]` bg + `gray[400]` text (≥3:1 against active primary) instead of faded-primary.
- **Brand dev-gate** (#1293): `<Stack.Screen name="brand" />` wrapped in `__DEV__`.

## Test plan
- [ ] `npx tsc --noEmit` passes in root and `api/` (verified locally, 0 errors).
- [ ] Login as CLIENT → desktop header shows blue accent, "Клиент" badge, search input.
- [ ] Login as SPECIALIST → header flips to emerald accent + "Специалист" badge.
- [ ] Login as ADMIN → amber accent + "Админ" badge.
- [ ] Landing `/`, `/auth/email`, `/legal/privacy`, `/onboarding/name` — no AppHeader.
- [ ] `/brand` returns 404 in prod build (dev only).
- [ ] Disabled submit button on `/auth/email` visibly gray, not tinted primary.
- [ ] Mobile <640px: header collapses to burger + title + bell; MobileMenu opens via burger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)