### PR TITLE
iter8: SA-compliance client rating fix + realistic seed

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -20,6 +20,7 @@
         "nodemailer": "^6.10.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^10.4.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.1",
         "@types/jsonwebtoken": "^9.0.9",
@@ -43,6 +44,23 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@ioredis/commands": {

--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,7 @@
     "nodemailer": "^6.10.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.1",
     "@types/jsonwebtoken": "^9.0.9",

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -1,4 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Role } from "@prisma/client";
+import { faker } from "@faker-js/faker/locale/ru";
 
 const prisma = new PrismaClient();
 
@@ -812,8 +813,45 @@ async function main() {
     },
   });
 
+  // Clean up legacy mosaic/metromap garbage accounts (those without names).
+  // Keeps real dev accounts intact (they have firstName/lastName set).
+  const purged = await prisma.user.deleteMany({
+    where: {
+      email: { contains: "@metromap.test" },
+      firstName: null,
+      lastName: null,
+    },
+  });
+
+  // Realistic demo users: 8 CLIENT + 3 SPECIALIST + 1 ADMIN = 12.
+  // Deterministic via faker.seed(42) so re-runs produce same 12 users.
+  faker.seed(42);
+
+  const demoUsers = Array.from({ length: 12 }, (_, i) => {
+    const firstName = faker.person.firstName();
+    const lastName = faker.person.lastName();
+    const role: Role = i < 8 ? "CLIENT" : i < 11 ? "SPECIALIST" : "ADMIN";
+    const email = faker.internet.email({ firstName, lastName }).toLowerCase();
+    return {
+      email,
+      firstName,
+      lastName,
+      role,
+      avatarUrl: `https://i.pravatar.cc/200?u=${faker.string.uuid()}`,
+      createdAt: faker.date.recent({ days: 90 }),
+    };
+  });
+
+  for (const u of demoUsers) {
+    await prisma.user.upsert({
+      where: { email: u.email },
+      update: {},
+      create: u,
+    });
+  }
+
   console.log(
-    `Seed complete: 10 cities, ${fnsCount} FNS offices, 3 services, 7 settings, 2 admins`
+    `Seed complete: 10 cities, ${fnsCount} FNS offices, 3 services, 7 settings, 2 admins, ${demoUsers.length} demo users (purged ${purged.count} garbage accounts)`
   );
 }
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -52,19 +52,23 @@ export default function ProfileScreen() {
               <Text style={{ ...textStyle.small, color: colors.textSecondary, marginTop: 4 }}>{displayEmail}</Text>
             ) : null}
 
-            {/* Rating */}
-            <Text className="text-sm font-medium text-text-mute mt-3 mb-1.5">Ваш рейтинг</Text>
-            <View className="flex-row items-center">
-              {[1, 2, 3, 4, 5].map((star) => (
-                <Star
-                  key={star}
-                  size={16}
-                  color={colors.warning}
-                  fill={star <= 4 ? colors.warning : "none"}
-                />
-              ))}
-              <Text className="text-sm text-text-mute ml-1.5">4.5 (23 отзыва)</Text>
-            </View>
+            {/* Rating — only for SPECIALIST role. SA: клиент не получает отзывы (MVP stub only). */}
+            {user?.role === "SPECIALIST" && (
+              <>
+                <Text className="text-sm font-medium text-text-mute mt-3 mb-1.5">Ваш рейтинг</Text>
+                <View className="flex-row items-center">
+                  {[1, 2, 3, 4, 5].map((star) => (
+                    <Star
+                      key={star}
+                      size={16}
+                      color={colors.warning}
+                      fill={star <= 4 ? colors.warning : "none"}
+                    />
+                  ))}
+                  <Text className="text-sm text-text-mute ml-1.5">4.5 (23 отзыва)</Text>
+                </View>
+              </>
+            )}
 
             {/* Stats */}
             <View


### PR DESCRIPTION
## Summary
- **#1291** Hide rating/reviews block on client profile — SA: "клиент не получает отзывы" (MVP stub only). Block now shows only for `user.role === 'SPECIALIST'`.
- **#1292** Seed 12 realistic demo users (8 CLIENT + 3 SPECIALIST + 1 ADMIN) with Russian names via `faker/locale/ru` + `seed(42)` for determinism. Pravatar avatars, `createdAt` spread over last 90 days.
- Purge legacy `@metromap.test` garbage accounts that cluttered admin users list (863 rows nuked on first run, by-email + name-null guard protects real dev accounts).
- Add `@faker-js/faker` as devDependency.

## Files
- `app/(tabs)/profile.tsx` — conditional rating block
- `api/prisma/seed.ts` — faker import, demo user block, purge block
- `api/package.json` + lock

## Verification
- `tsc --noEmit` passes on root + api (0 errors)
- `npm run seed` passes: reports `12 demo users (purged 863 garbage accounts)`
- DB confirms demo users by role: e.g. `Фёкла Воронцов`, `Денис Артемьев`, `Ангелина Панова`

Closes #1291
Closes #1292