### PR TITLE
fix(iter8): 3 regressions — /brand gate, /requests/new + /(tabs) loading

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from "expo-router";
-import { useWindowDimensions, Platform } from "react-native";
+import { useWindowDimensions } from "react-native";
 import { Home, Search, PlusSquare, MessageCircle, User } from "lucide-react-native";
 import Header from "@/components/Header";
 import { colors, fontSizeValue } from "@/lib/theme";
@@ -7,13 +7,16 @@ import { colors, fontSizeValue } from "@/lib/theme";
 export default function TabLayout() {
   const { width } = useWindowDimensions();
   const isMobile = width < 640;
-  // Desktop web: AppShell sidebar carries primary navigation — hide the
-  // marketplace Header to kill the duplicate horizontal nav.
-  const isDesktopWeb = Platform.OS === "web" && width >= 1024;
+  // NOTE (iter8 regression fix): we previously suppressed `Header` on desktop
+  // web (>=1024px) assuming the AppShell sidebar would carry navigation — but
+  // `/(tabs)` reports pathname `/` to `usePathname()`, which is excluded from
+  // both the sidebar group detection (`detectSidebarGroup`) and the AppHeader
+  // gate (`shouldShowAppHeader`). Suppressing Header left authenticated users
+  // with zero chrome on the root marketplace tab. Render Header always.
 
   return (
     <>
-      {!isDesktopWeb && <Header />}
+      <Header />
       <Tabs
         screenOptions={{
           tabBarActiveTintColor: colors.primary,

--- a/app/brand.tsx
+++ b/app/brand.tsx
@@ -36,6 +36,15 @@ export default function BrandScreen() {
   const [inputError, setInputError] = useState("not-email");
   const [inputIcon, setInputIcon] = useState("");
 
+  // Issue #1293 (regression): /brand must never render in production.
+  // The `{__DEV__ && <Stack.Screen />}` gate in `app/_layout.tsx` only hides
+  // the route registration — Expo Router file-based routing still discovers
+  // `app/brand.tsx` and serves the page. The only bulletproof guard is to
+  // short-circuit the component itself when `__DEV__` is false (production
+  // builds, staging export, etc). Hooks above this guard so React hook
+  // ordering stays stable across renders.
+  if (!__DEV__) return null;
+
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <HeaderBack title="Design System" />

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -25,7 +25,7 @@ import FileUploadSection, { AttachedFile } from "@/components/requests/FileUploa
 
 export default function NewRequest() {
   const router = useRouter();
-  const { ready } = useRequireAuth();
+  const { ready, isLoading, isAuthenticated } = useRequireAuth();
 
   // Form fields
   const [title, setTitle] = useState("");
@@ -53,8 +53,12 @@ export default function NewRequest() {
   const [submitted, setSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState("");
 
-  // Load cities, services, and check limit on mount
+  // Load cities, services, and check limit on mount.
+  // Wait until auth is resolved — an unauthenticated call to /api/dashboard/stats
+  // would 401 and set `loadError=true`, trapping the user on the error screen
+  // instead of letting `useRequireAuth` redirect them to /auth/email.
   useEffect(() => {
+    if (isLoading || !isAuthenticated) return;
     async function init() {
       try {
         const [citiesRes, servicesRes, statsRes] = await Promise.all([
@@ -76,7 +80,7 @@ export default function NewRequest() {
       }
     }
     init();
-  }, []);
+  }, [isLoading, isAuthenticated]);
 
   // Load FNS offices when city changes
   const loadFnsForCity = useCallback(async (citySlug: string) => {
@@ -162,7 +166,11 @@ export default function NewRequest() {
   const selectedFns = fnsOffices.find((f) => f.id === selectedFnsId);
   const selectedService = services.find((s) => s.id === selectedServiceId);
 
-  if (!ready || loadingInit) {
+  // Auth resolution in progress OR initial data still loading — show spinner.
+  // Once auth is known to be `unauthenticated`, `useRequireAuth` will redirect;
+  // we render nothing in that window to avoid the infinite-spinner regression
+  // mosaic caught on /requests/new (iter8 baseline).
+  if (isLoading || (ready && loadingInit)) {
     return (
       <SafeAreaView className="flex-1 bg-surface2">
         <HeaderBack title="Новая заявка" />
@@ -171,6 +179,12 @@ export default function NewRequest() {
         </View>
       </SafeAreaView>
     );
+  }
+
+  if (!isAuthenticated) {
+    // `useRequireAuth` is redirecting to /auth/email — render nothing to avoid
+    // flashing a stale spinner while navigation completes.
+    return null;
   }
 
   if (loadError && cities.length === 0 && services.length === 0) {

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -417,12 +417,21 @@ export default function AppHeader({ title }: AppHeaderProps) {
  * Path-prefix gate: when the current route is public chrome (landing,
  * auth, onboarding, legal) we suppress AppHeader entirely — those
  * screens render their own hero/chrome.
+ *
+ * NOTE (iter8 regression fix): the legacy marketplace `(tabs)` group renders
+ * its own `Header` component (burger + nav links) from `(tabs)/_layout.tsx`.
+ * `usePathname()` strips the group segment, so routes like `/search`,
+ * `/create`, `/messages`, `/profile` belong to `(tabs)` but look like
+ * top-level paths. We must exclude them here to avoid double-chrome.
  */
+const TABS_ROUTES = new Set(["/search", "/create", "/messages", "/profile"]);
+
 export function shouldShowAppHeader(pathname: string): boolean {
   if (!pathname) return false;
   if (pathname === "/") return false;
   if (pathname.startsWith("/auth")) return false;
   if (pathname.startsWith("/legal")) return false;
   if (pathname.startsWith("/onboarding")) return false;
+  if (TABS_ROUTES.has(pathname)) return false;
   return true;
 }


### PR DESCRIPTION
## Summary

Three regressions surfaced after iter8 merge (mosaic baseline 094209 vs post-iter8):

- **/brand (#1293)** — the `{__DEV__ && <Stack.Screen />}` gate in `app/_layout.tsx` only hid the route registration; Expo Router file-based routing still served `app/brand.tsx` in staging/production. Added `if (!__DEV__) return null;` inside the component itself (after hooks to keep hook ordering stable).
- **/requests/new (#1287 TwoColumnForm)** — init `useEffect` fired before auth resolved and hit `/api/dashboard/stats` without a token → 401 flipped `loadError=true`, trapping unauthenticated visitors on an error screen instead of letting `useRequireAuth` redirect. The spinner sat forever. Gated the effect on `!isLoading && isAuthenticated`, split the loading guard into auth-loading / data-loading / unauthenticated-redirecting, and render `null` during the redirect window.
- **/(tabs) authenticated landing (#1285 AppHeader)** — `(tabs)/_layout.tsx` suppressed the marketplace `Header` on desktop web (>=1024px) assuming AppShell's SidebarNav would cover navigation. But `usePathname()` returns `/` for `/(tabs)`, which is excluded from both `detectSidebarGroup` (no sidebar) and `shouldShowAppHeader` (no AppHeader) — authenticated users ended up with zero chrome. Removed the `isDesktopWeb` suppression so Header always renders inside `(tabs)`. Bonus: `shouldShowAppHeader` now explicitly excludes `/search`, `/create`, `/messages`, `/profile` (children of `(tabs)` that appear top-level after group-segment stripping) to avoid double-chrome.

## Test plan

- [x] `tsc --noEmit` clean in root and `api/`
- [x] `/brand` still renders in dev (`__DEV__=true`); returns `null` in production builds
- [x] `/requests/new` renders full TwoColumnForm (left info pane + right form) after OTP auth bootstrap
- [x] `/(tabs)` renders marketplace Header + hero + categories + featured services on desktop
- [ ] Post-merge: rerun mosaic baseline and confirm /brand score drops to N/A, /requests/new + /(tabs) return to >=6/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)