### PR TITLE
iter8: Onboarding completeness + CityFnsCascade filter

### DIFF
--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -63,12 +63,47 @@ router.put("/name", authMiddleware, async (req: Request, res: Response) => {
 });
 
 // PUT /api/onboarding/work-area
+// Accepts two payload shapes for forward/back compat:
+//   A) { fnsServices: [{ fnsId, serviceIds: [...] }, ...] }  (legacy/client)
+//   B) { cities: [...], fns: [...], specialist_services: [{ fns_id, service_id }, ...] }
+//      — new shape used by the CityFnsCascade-based onboarding UI.
 router.put("/work-area", authMiddleware, async (req: Request, res: Response) => {
   try {
-    const { fnsServices } = req.body;
+    const { fnsServices, specialist_services: specialistServicesRaw } = req.body as {
+      fnsServices?: { fnsId?: string; serviceIds?: string[] }[];
+      cities?: string[];
+      fns?: string[];
+      specialist_services?: { fns_id?: string; service_id?: string }[];
+    };
 
-    if (!Array.isArray(fnsServices) || fnsServices.length === 0) {
-      res.status(400).json({ error: "At least one FNS office with services is required" });
+    // Normalise to the internal shape: Array<{ fnsId, serviceIds }>
+    let normalized: { fnsId: string; serviceIds: string[] }[] = [];
+
+    if (Array.isArray(fnsServices) && fnsServices.length > 0) {
+      normalized = fnsServices
+        .filter((x) => x && typeof x.fnsId === "string")
+        .map((x) => ({
+          fnsId: x.fnsId as string,
+          serviceIds: Array.isArray(x.serviceIds) ? x.serviceIds : [],
+        }));
+    } else if (Array.isArray(specialistServicesRaw) && specialistServicesRaw.length > 0) {
+      const grouped = new Map<string, string[]>();
+      for (const item of specialistServicesRaw) {
+        if (!item?.fns_id || !item?.service_id) continue;
+        const arr = grouped.get(item.fns_id) || [];
+        if (!arr.includes(item.service_id)) arr.push(item.service_id);
+        grouped.set(item.fns_id, arr);
+      }
+      normalized = [...grouped.entries()].map(([fnsId, serviceIds]) => ({
+        fnsId,
+        serviceIds,
+      }));
+    }
+
+    if (normalized.length === 0) {
+      res.status(400).json({
+        error: "At least one FNS office with services is required",
+      });
       return;
     }
 
@@ -85,10 +120,11 @@ router.put("/work-area", authMiddleware, async (req: Request, res: Response) => 
       return;
     }
 
-    // Validate all fnsIds and serviceIds exist
-    for (const item of fnsServices) {
-      if (!item.fnsId || !Array.isArray(item.serviceIds) || item.serviceIds.length === 0) {
-        res.status(400).json({ error: "Each FNS must have at least one service" });
+    for (const item of normalized) {
+      if (!item.fnsId || item.serviceIds.length === 0) {
+        res
+          .status(400)
+          .json({ error: "Each FNS must have at least one service" });
         return;
       }
     }
@@ -98,7 +134,7 @@ router.put("/work-area", authMiddleware, async (req: Request, res: Response) => 
       await tx.specialistService.deleteMany({ where: { specialistId: userId } });
       await tx.specialistFns.deleteMany({ where: { specialistId: userId } });
 
-      for (const item of fnsServices) {
+      for (const item of normalized) {
         const specialistFns = await tx.specialistFns.create({
           data: {
             specialistId: userId,

--- a/api/src/routes/reference.ts
+++ b/api/src/routes/reference.ts
@@ -130,21 +130,44 @@ router.get("/ifns/search", async (req: Request, res: Response) => {
   }
 });
 
-// GET /api/fns?city_id=X — legacy endpoint, kept for compatibility
+// GET /api/fns?city_id=X or ?city_ids=X,Y — offices for one or many cities
 router.get("/fns", async (req: Request, res: Response) => {
   try {
-    const cityId = req.query.city_id as string;
+    const cityId = (req.query.city_id as string) || "";
+    const cityIdsParam = (req.query.city_ids as string) || "";
 
-    if (!cityId) {
-      res.status(400).json({ error: "city_id is required" });
+    const ids = cityIdsParam
+      ? cityIdsParam.split(",").map((s) => s.trim()).filter(Boolean)
+      : cityId
+      ? [cityId]
+      : [];
+
+    if (ids.length === 0) {
+      res.status(400).json({ error: "city_id or city_ids is required" });
       return;
     }
 
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    for (const id of ids) {
+      if (!uuidRegex.test(id)) {
+        res.status(400).json({ error: "Invalid city id format: must be a valid UUID" });
+        return;
+      }
+    }
+
     const offices = await prisma.fnsOffice.findMany({
-      where: { cityId },
-      orderBy: { name: "asc" },
-      select: { id: true, name: true, code: true, cityId: true, address: true },
+      where: { cityId: { in: ids } },
+      orderBy: [{ city: { name: "asc" } }, { name: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        code: true,
+        cityId: true,
+        address: true,
+        city: { select: { id: true, name: true } },
+      },
     });
+
     res.json({ offices });
   } catch (error) {
     console.error("fns error:", error);

--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -19,14 +19,14 @@ router.get("/public", async (req: Request, res: Response) => {
     const skip = (page - 1) * limit;
 
     const cityId = (req.query.city_id as string) || undefined;
+    const fnsId = (req.query.fns_id as string) || undefined;
 
     const where: Prisma.RequestWhereInput = {
       status: { in: ["ACTIVE", "CLOSING_SOON"] },
     };
 
-    if (cityId) {
-      where.cityId = cityId;
-    }
+    if (cityId) where.cityId = cityId;
+    if (fnsId) where.fnsId = fnsId;
 
     const [items, total] = await Promise.all([
       prisma.request.findMany({

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -81,6 +81,18 @@ router.get("/", async (req: Request, res: Response) => {
     const q = ((req.query.q as string) || "").trim().slice(0, 100);
     const cityId = (req.query.city_id as string) || undefined;
     const fnsId = (req.query.fns_id as string) || undefined;
+    const cityIdsParam = (req.query.city_ids as string) || "";
+    const fnsIdsParam = (req.query.fns_ids as string) || "";
+    const cityIdsList = cityIdsParam
+      ? cityIdsParam.split(",").map((s) => s.trim()).filter(Boolean)
+      : cityId
+      ? [cityId]
+      : [];
+    const fnsIdsList = fnsIdsParam
+      ? fnsIdsParam.split(",").map((s) => s.trim()).filter(Boolean)
+      : fnsId
+      ? [fnsId]
+      : [];
     const servicesParam = (req.query.services as string) || undefined;
     const serviceIds = servicesParam
       ? servicesParam.split(",").filter(Boolean)
@@ -94,19 +106,23 @@ router.get("/", async (req: Request, res: Response) => {
       return;
     }
 
-    // Validate city_id and fns_id are UUID format to prevent DB crashes
+    // Validate every city/fns id is UUID to prevent DB crashes
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (cityId && !uuidRegex.test(cityId)) {
-      res.status(400).json({
-        error: "Invalid city_id format: must be a valid UUID",
-      });
-      return;
+    for (const id of cityIdsList) {
+      if (!uuidRegex.test(id)) {
+        res.status(400).json({
+          error: "Invalid city_id format: must be a valid UUID",
+        });
+        return;
+      }
     }
-    if (fnsId && !uuidRegex.test(fnsId)) {
-      res.status(400).json({
-        error: "Invalid fns_id format: must be a valid UUID",
-      });
-      return;
+    for (const id of fnsIdsList) {
+      if (!uuidRegex.test(id)) {
+        res.status(400).json({
+          error: "Invalid fns_id format: must be a valid UUID",
+        });
+        return;
+      }
     }
 
     const where: Prisma.UserWhereInput = {
@@ -123,11 +139,15 @@ router.get("/", async (req: Request, res: Response) => {
       ];
     }
 
-    if (cityId || fnsId) {
+    if (cityIdsList.length > 0 || fnsIdsList.length > 0) {
       where.specialistFns = {
         some: {
-          ...(cityId ? { fns: { cityId } } : {}),
-          ...(fnsId ? { fnsId } : {}),
+          ...(cityIdsList.length > 0
+            ? { fns: { cityId: { in: cityIdsList } } }
+            : {}),
+          ...(fnsIdsList.length > 0
+            ? { fnsId: { in: fnsIdsList } }
+            : {}),
         },
       };
     }

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -7,16 +7,17 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
-import { useState, useEffect, useCallback } from "react";
-import { X, Plus, MapPin } from "lucide-react-native";
+import { useState, useEffect, useMemo } from "react";
+import { MapPin } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
 import TwoColumnForm from "@/components/layout/TwoColumnForm";
 import OnboardingLeft from "@/components/onboarding/OnboardingLeft";
 import Button from "@/components/ui/Button";
 import { colors } from "@/lib/theme";
+import CityFnsCascade from "@/components/filters/CityFnsCascade";
 
-interface City {
+interface ServiceItem {
   id: string;
   name: string;
 }
@@ -26,18 +27,7 @@ interface FnsOffice {
   name: string;
   code: string;
   cityId: string;
-}
-
-interface ServiceItem {
-  id: string;
-  name: string;
-}
-
-interface SelectedFns {
-  fnsId: string;
-  fnsName: string;
-  cityName: string;
-  serviceIds: string[];
+  cityName?: string;
 }
 
 export default function OnboardingWorkAreaScreen() {
@@ -45,107 +35,135 @@ export default function OnboardingWorkAreaScreen() {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
 
-  const [cities, setCities] = useState<City[]>([]);
   const [services, setServices] = useState<ServiceItem[]>([]);
-  const [fnsOffices, setFnsOffices] = useState<FnsOffice[]>([]);
 
-  const [showCityPicker, setShowCityPicker] = useState(false);
-  const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
-  const [showFnsPicker, setShowFnsPicker] = useState(false);
+  // Cascade state — list of city ids + list of FNS ids, shared across this screen
+  const [cityIds, setCityIds] = useState<string[]>([]);
+  const [fnsIds, setFnsIds] = useState<string[]>([]);
 
-  const [selectedFns, setSelectedFns] = useState<SelectedFns[]>([]);
+  // Details of selected FNS offices (so we can show name + city per block)
+  const [fnsCatalog, setFnsCatalog] = useState<Map<string, FnsOffice>>(
+    new Map()
+  );
+
+  // Per-FNS services map: fnsId -> serviceIds[]
+  const [servicesByFns, setServicesByFns] = useState<Record<string, string[]>>(
+    {}
+  );
+
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
 
-  // Load cities and services on mount
+  // Load services (cities are fetched by the cascade component itself)
   useEffect(() => {
-    const loadData = async () => {
+    (async () => {
       try {
-        const [citiesRes, servicesRes] = await Promise.all([
-          api<{ items: City[] }>("/api/cities", { noAuth: true }),
-          api<{ items: ServiceItem[] }>("/api/services", { noAuth: true }),
-        ]);
-        setCities(citiesRes.items);
+        const servicesRes = await api<{ items: ServiceItem[] }>(
+          "/api/services",
+          { noAuth: true }
+        );
         setServices(servicesRes.items);
       } catch {
-        setError("Не удалось загрузить данные");
+        setError("Не удалось загрузить список услуг");
       }
-    };
-    loadData();
+    })();
   }, []);
 
-  // Load FNS offices when city selected
-  const loadFnsForCity = useCallback(async (cityId: string) => {
-    try {
-      const data = await api<{ offices: FnsOffice[] }>(
-        `/api/fns?city_id=${cityId}`,
-        { noAuth: true }
-      );
-      setFnsOffices(data.offices);
-    } catch {
-      setError("Не удалось загрузить отделения ФНС");
+  // Whenever selected city list changes, refresh FNS catalog for those cities
+  useEffect(() => {
+    if (cityIds.length === 0) {
+      setFnsCatalog(new Map());
+      return;
     }
-  }, []);
+    let cancelled = false;
+    (async () => {
+      try {
+        const path =
+          cityIds.length === 1
+            ? `/api/fns?city_id=${cityIds[0]}`
+            : `/api/fns?city_ids=${cityIds.join(",")}`;
+        const res = await api<{
+          offices: { id: string; name: string; code: string; cityId: string; city?: { name: string } }[];
+        }>(path, { noAuth: true });
+        if (cancelled) return;
+        const map = new Map<string, FnsOffice>();
+        for (const o of res.offices) {
+          map.set(o.id, {
+            id: o.id,
+            name: o.name,
+            code: o.code,
+            cityId: o.cityId,
+            cityName: o.city?.name,
+          });
+        }
+        setFnsCatalog(map);
+      } catch {
+        /* ignore */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [cityIds]);
 
-  const handleCitySelect = (city: City) => {
-    setSelectedCityId(city.id);
-    setShowCityPicker(false);
-    setShowFnsPicker(true);
-    loadFnsForCity(city.id);
-  };
+  // Drop services rows for FNS that have been deselected
+  useEffect(() => {
+    setServicesByFns((prev) => {
+      const next: Record<string, string[]> = {};
+      for (const id of fnsIds) {
+        next[id] = prev[id] ?? [];
+      }
+      return next;
+    });
+  }, [fnsIds]);
 
-  const handleFnsSelect = (fns: FnsOffice) => {
-    // Don't add if already selected
-    if (selectedFns.some((s) => s.fnsId === fns.id)) return;
-
-    const cityName = cities.find((c) => c.id === fns.cityId)?.name || "";
-    setSelectedFns((prev) => [
-      ...prev,
-      { fnsId: fns.id, fnsName: fns.name, cityName, serviceIds: [] },
-    ]);
-    setShowFnsPicker(false);
-    setSelectedCityId(null);
-  };
+  const selectedFnsList = useMemo(
+    () =>
+      fnsIds
+        .map((id) => fnsCatalog.get(id))
+        .filter((f): f is FnsOffice => Boolean(f)),
+    [fnsIds, fnsCatalog]
+  );
 
   const toggleService = (fnsId: string, serviceId: string) => {
-    setSelectedFns((prev) =>
-      prev.map((item) => {
-        if (item.fnsId !== fnsId) return item;
-        const has = item.serviceIds.includes(serviceId);
-        return {
-          ...item,
-          serviceIds: has
-            ? item.serviceIds.filter((id) => id !== serviceId)
-            : [...item.serviceIds, serviceId],
-        };
-      })
-    );
-  };
-
-  const removeFns = (fnsId: string) => {
-    setSelectedFns((prev) => prev.filter((item) => item.fnsId !== fnsId));
+    setServicesByFns((prev) => {
+      const current = prev[fnsId] || [];
+      const has = current.includes(serviceId);
+      return {
+        ...prev,
+        [fnsId]: has
+          ? current.filter((s) => s !== serviceId)
+          : [...current, serviceId],
+      };
+    });
   };
 
   const canProceed =
-    selectedFns.length > 0 &&
-    selectedFns.every((item) => item.serviceIds.length > 0);
+    cityIds.length > 0 &&
+    fnsIds.length > 0 &&
+    fnsIds.every((id) => (servicesByFns[id] || []).length > 0);
 
   const handleNext = async () => {
     if (!canProceed || isLoading) return;
     setError("");
     setIsLoading(true);
-
     try {
-      const fnsServices = selectedFns.map((item) => ({
-        fnsId: item.fnsId,
-        serviceIds: item.serviceIds,
+      const fnsServices = fnsIds.map((fnsId) => ({
+        fnsId,
+        serviceIds: servicesByFns[fnsId] || [],
       }));
-
+      // Also send full cascade payload for future endpoint evolution
       await api("/api/onboarding/work-area", {
         method: "PUT",
-        body: { fnsServices },
+        body: {
+          cities: cityIds,
+          fns: fnsIds,
+          fnsServices,
+          specialist_services: fnsServices.flatMap((f) =>
+            f.serviceIds.map((sid) => ({ fns_id: f.fnsId, service_id: sid }))
+          ),
+        },
       });
-
       router.push("/onboarding/profile" as never);
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Что-то пошло не так";
@@ -160,11 +178,11 @@ export default function OnboardingWorkAreaScreen() {
       step={2}
       icon={MapPin}
       title="Ваша рабочая зона"
-      description="Выберите города и ФНС-инспекции, которые обслуживаете. По этим данным клиенты найдут вас."
+      description="Выберите города, ФНС-инспекции и типы проверок, которыми вы занимаетесь."
       bullets={[
-        "Чем больше городов — тем больше заявок",
-        "Каждой ФНС можно привязать свой набор услуг",
-        `Выбрано сейчас: ${selectedFns.length}`,
+        "Города: где вы принимаете клиентов",
+        "ФНС: в каких инспекциях вы работаете",
+        `Выбрано ФНС: ${fnsIds.length}`,
       ]}
     />
   );
@@ -172,9 +190,12 @@ export default function OnboardingWorkAreaScreen() {
   const rightForm = (
     <SafeAreaView className="flex-1 bg-white">
       <HeaderBack title="" />
-      <View className="flex-1 px-4">
-        <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: isDesktop ? 64 : 40 }}>
-          <View className="pt-8">
+      <View className="flex-1">
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ paddingBottom: isDesktop ? 64 : 40 }}
+        >
+          <View className="pt-8 px-4">
             {/* Progress indicator */}
             <View className="mb-6">
               <View className="flex-row justify-center gap-2 mb-3">
@@ -191,196 +212,96 @@ export default function OnboardingWorkAreaScreen() {
               Рабочая зона
             </Text>
             <Text className="text-base text-text-mute text-center leading-6 mb-8">
-              Укажите отделения ФНС, в которых вы работаете
+              Укажите города, ФНС и услуги по каждой инспекции
             </Text>
+          </View>
 
-            {/* Selected FNS offices with services */}
-            {selectedFns.map((item) => (
-              <View
-                key={item.fnsId}
-                className="border border-border rounded-xl p-4 mb-3"
-                style={{ backgroundColor: colors.surface2 }}
-              >
-                <View className="flex-row items-start justify-between mb-3">
-                  <View className="flex-1 mr-3">
-                    <Text className="text-sm font-semibold text-text-base leading-5">
-                      {item.fnsName}
+          {/* Cascade lives outside px-4 because it has internal padding */}
+          <CityFnsCascade
+            mode="multi"
+            value={{ cities: cityIds, fns: fnsIds }}
+            onChange={(v) => {
+              setCityIds(v.cities);
+              setFnsIds(v.fns);
+            }}
+            labelCities="Города"
+            labelFns="Отделения ФНС"
+            showCounts
+          />
+
+          <View className="px-4 mt-4">
+            {/* Per-FNS service matrix */}
+            {selectedFnsList.length > 0 && (
+              <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-2">
+                Услуги по каждой инспекции
+              </Text>
+            )}
+
+            {selectedFnsList.map((fns) => {
+              const picked = servicesByFns[fns.id] || [];
+              return (
+                <View
+                  key={fns.id}
+                  className="border border-border rounded-xl p-4 mb-3"
+                  style={{ backgroundColor: colors.surface2 }}
+                >
+                  <Text className="text-sm font-semibold text-text-base leading-5">
+                    {fns.name}
+                  </Text>
+                  {fns.cityName ? (
+                    <Text className="text-sm text-text-mute mt-0.5">
+                      {fns.cityName}
                     </Text>
-                    <Text className="text-sm text-text-mute mt-0.5">{item.cityName}</Text>
-                  </View>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Удалить отделение"
-                    onPress={() => removeFns(item.fnsId)}
-                    className="w-7 h-7 rounded-full items-center justify-center"
-                    style={{ backgroundColor: colors.border }}
-                  >
-                    <X size={14} color={colors.textSecondary} />
-                  </Pressable>
-                </View>
+                  ) : null}
 
-                <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-2">
-                  Услуги
-                </Text>
-
-                {/* Service checkboxes */}
-                {services.map((svc) => {
-                  const isChecked = item.serviceIds.includes(svc.id);
-                  return (
-                    <Pressable
-                      accessibilityRole="button"
-                      key={svc.id}
-                      accessibilityLabel={svc.name}
-                      onPress={() => toggleService(item.fnsId, svc.id)}
-                      className={`flex-row items-center py-2 px-3 rounded-lg mb-1 ${isChecked ? "bg-accent-soft" : "bg-white"}`}
-                    >
-                      <View
-                        className={`w-5 h-5 rounded border-2 items-center justify-center ${
-                          isChecked
-                            ? "bg-accent border-accent"
-                            : "border-border bg-white"
-                        }`}
-                      >
-                        {isChecked && (
-                          <Text className="text-white text-xs font-bold">
-                            ✓
+                  <View className="flex-row flex-wrap gap-2 mt-3">
+                    {services.map((svc) => {
+                      const isChecked = picked.includes(svc.id);
+                      return (
+                        <Pressable
+                          accessibilityRole="button"
+                          accessibilityLabel={svc.name}
+                          key={svc.id}
+                          onPress={() => toggleService(fns.id, svc.id)}
+                          className={`px-3 h-10 rounded-full items-center justify-center border ${
+                            isChecked
+                              ? "bg-accent border-accent"
+                              : "bg-white border-border"
+                          }`}
+                        >
+                          <Text
+                            className={`text-sm ${
+                              isChecked
+                                ? "text-white font-medium"
+                                : "text-text-base"
+                            }`}
+                          >
+                            {svc.name}
                           </Text>
-                        )}
-                      </View>
-                      <Text className={`ml-2.5 text-sm leading-5 ${isChecked ? "text-accent font-medium" : "text-text-base"}`}>
-                        {svc.name}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-
-                {item.serviceIds.length === 0 && (
-                  <View className="mt-2 px-3 py-2 rounded-lg" style={{ backgroundColor: colors.errorBg }}>
-                    <Text className="text-sm text-danger">
-                      Выберите хотя бы одну услугу
-                    </Text>
+                        </Pressable>
+                      );
+                    })}
                   </View>
-                )}
-              </View>
-            ))}
 
-            {/* City picker dropdown */}
-            {showCityPicker && (
-              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden bg-white">
-                <View className="px-4 py-2.5 border-b border-border">
-                  <Text className="text-sm font-semibold text-text-base">Выберите город</Text>
-                </View>
-                <ScrollView nestedScrollEnabled>
-                  {cities.map((city) => (
-                    <Pressable
-                      accessibilityRole="button"
-                      key={city.id}
-                      accessibilityLabel={city.name}
-                      onPress={() => handleCitySelect(city)}
-                      className="px-4 py-3.5 border-b border-border active:bg-surface2"
+                  {picked.length === 0 && (
+                    <View
+                      className="mt-3 px-3 py-2 rounded-lg"
+                      style={{ backgroundColor: colors.errorBg }}
                     >
-                      <Text className="text-sm text-text-base">{city.name}</Text>
-                    </Pressable>
-                  ))}
-                  {cities.length === 0 && (
-                    <View className="px-4 py-3">
-                      <Text className="text-sm text-text-mute">
-                        Загрузка городов...
+                      <Text className="text-sm text-danger">
+                        Выберите хотя бы одну услугу
                       </Text>
                     </View>
                   )}
-                </ScrollView>
-              </View>
-            )}
-
-            {/* FNS picker dropdown */}
-            {showFnsPicker && selectedCityId && (
-              <View className="border border-border rounded-xl mb-3 max-h-60 overflow-hidden bg-white">
-                <View className="px-4 py-2.5 border-b border-border">
-                  <Text className="text-sm font-semibold text-text-base">Выберите отделение ФНС</Text>
                 </View>
-                <ScrollView nestedScrollEnabled>
-                  {fnsOffices
-                    .filter(
-                      (fns) =>
-                        !selectedFns.some((s) => s.fnsId === fns.id)
-                    )
-                    .map((fns) => (
-                      <Pressable
-                        accessibilityRole="button"
-                        key={fns.id}
-                        accessibilityLabel={fns.name}
-                        onPress={() => handleFnsSelect(fns)}
-                        className="px-4 py-3.5 border-b border-border active:bg-surface2"
-                      >
-                        <Text className="text-sm font-medium text-text-base">
-                          {fns.name}
-                        </Text>
-                        <Text className="text-xs text-text-mute mt-0.5">
-                          {fns.code}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  {fnsOffices.length === 0 && (
-                    <View className="px-4 py-3">
-                      <Text className="text-sm text-text-mute">
-                        Загрузка отделений...
-                      </Text>
-                    </View>
-                  )}
-                </ScrollView>
-              </View>
-            )}
-
-            {/* Add city button */}
-            {!showCityPicker && !showFnsPicker && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Добавить город"
-                onPress={() => {
-                  setShowCityPicker(true);
-                  setShowFnsPicker(false);
-                }}
-                className="flex-row items-center justify-center py-3.5 border-2 border-dashed border-border rounded-xl mb-6 active:bg-surface2"
-              >
-                <Plus size={16} color={colors.accent} />
-                <Text className="text-sm text-accent ml-2 font-semibold">
-                  Добавить город
-                </Text>
-              </Pressable>
-            )}
-
-            {showCityPicker && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Отмена"
-                onPress={() => setShowCityPicker(false)}
-                className="mb-4 py-2"
-              >
-                <Text className="text-sm text-text-mute text-center">
-                  Отмена
-                </Text>
-              </Pressable>
-            )}
-
-            {showFnsPicker && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Отмена"
-                onPress={() => {
-                  setShowFnsPicker(false);
-                  setSelectedCityId(null);
-                }}
-                className="mb-4 py-2"
-              >
-                <Text className="text-sm text-text-mute text-center">
-                  Отмена
-                </Text>
-              </Pressable>
-            )}
+              );
+            })}
 
             {error ? (
-              <View className="mb-4 px-4 py-3 rounded-xl" style={{ backgroundColor: colors.errorBg }}>
+              <View
+                className="mb-4 px-4 py-3 rounded-xl"
+                style={{ backgroundColor: colors.errorBg }}
+              >
                 <Text className="text-sm text-danger text-center leading-5">
                   {error}
                 </Text>

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -13,6 +13,7 @@ import { useRouter } from "expo-router";
 import HeaderBack from "@/components/HeaderBack";
 import DesktopScreen from "@/components/layout/DesktopScreen";
 import FilterBar from "@/components/FilterBar";
+import CityFnsCascade from "@/components/filters/CityFnsCascade";
 import { Inbox } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
@@ -73,6 +74,7 @@ export default function PublicRequestsFeed() {
   const [total, setTotal] = useState(0);
 
   const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
+  const [selectedFnsId, setSelectedFnsId] = useState<string | null>(null);
   const [selectedServiceIds, setSelectedServiceIds] = useState<string[]>([]);
 
   const loadingMoreRef = useRef(false);
@@ -83,6 +85,7 @@ export default function PublicRequestsFeed() {
       try {
         let path = `/api/requests/public?page=${pageNum}&limit=${LIMIT}`;
         if (selectedCityId) path += `&city_id=${selectedCityId}`;
+        if (selectedFnsId) path += `&fns_id=${selectedFnsId}`;
 
         const res = await api<RequestsResponse>(path, { noAuth: true });
 
@@ -99,7 +102,7 @@ export default function PublicRequestsFeed() {
         setError("Не удалось загрузить заявки");
       }
     },
-    [selectedCityId]
+    [selectedCityId, selectedFnsId]
   );
 
   // Initial load: fetch cities, services, and first page of requests
@@ -143,7 +146,7 @@ export default function PublicRequestsFeed() {
     setListLoading(true);
     setPage(1);
     fetchRequests(1).finally(() => setListLoading(false));
-  }, [selectedCityId, fetchRequests]);
+  }, [selectedCityId, selectedFnsId, fetchRequests]);
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -168,8 +171,17 @@ export default function PublicRequestsFeed() {
 
   const handleResetFilters = useCallback(() => {
     setSelectedCityId(null);
+    setSelectedFnsId(null);
     setSelectedServiceIds([]);
   }, []);
+
+  const handleCascadeChange = useCallback(
+    (v: { cities: string[]; fns: string[] }) => {
+      setSelectedCityId(v.cities[0] ?? null);
+      setSelectedFnsId(v.fns[0] ?? null);
+    },
+    []
+  );
 
   const handleRequestPress = useCallback(
     (id: string) => {
@@ -178,7 +190,10 @@ export default function PublicRequestsFeed() {
     [router]
   );
 
-  const hasFilters = selectedCityId !== null || selectedServiceIds.length > 0;
+  const hasFilters =
+    selectedCityId !== null ||
+    selectedFnsId !== null ||
+    selectedServiceIds.length > 0;
 
   // Skeleton on initial load
   if (initLoading) {
@@ -209,12 +224,21 @@ export default function PublicRequestsFeed() {
         )}
       </View>
 
-      {/* Filter bar */}
-      <View className="bg-white border-b border-border">
+      {/* Filter bar: city → FNS cascade + services chips */}
+      <View className="bg-white border-b border-border py-2">
+        <CityFnsCascade
+          mode="single"
+          value={{
+            cities: selectedCityId ? [selectedCityId] : [],
+            fns: selectedFnsId ? [selectedFnsId] : [],
+          }}
+          onChange={handleCascadeChange}
+          citiesSource={cities.map((c) => ({ id: c.id, name: c.name }))}
+        />
         <FilterBar
-          cities={cities}
-          selectedCityId={selectedCityId}
-          onCityChange={setSelectedCityId}
+          cities={[]}
+          selectedCityId={null}
+          onCityChange={() => {}}
           services={services}
           selectedServiceIds={selectedServiceIds}
           onServiceToggle={handleServiceToggle}

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -12,6 +12,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import SpecialistCard from "@/components/SpecialistCard";
 import FilterBar from "@/components/FilterBar";
+import CityFnsCascade from "@/components/filters/CityFnsCascade";
 import HeaderBack from "@/components/HeaderBack";
 import { AlertCircle, UserX, Search } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
@@ -67,23 +68,20 @@ export default function SpecialistsCatalog() {
 
   const [search, setSearch] = useState("");
   const [total, setTotal] = useState(0);
-  const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
-  const [selectedFnsId, setSelectedFnsId] = useState<string | null>(null);
+  const [selectedCityIds, setSelectedCityIds] = useState<string[]>([]);
+  const [selectedFnsIds, setSelectedFnsIds] = useState<string[]>([]);
   const [selectedServiceIds, setSelectedServiceIds] = useState<string[]>([]);
 
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hasFilters =
-    selectedCityId !== null ||
-    selectedFnsId !== null ||
+    selectedCityIds.length > 0 ||
+    selectedFnsIds.length > 0 ||
     selectedServiceIds.length > 0;
 
-  const selectedCity = cities.find((c) => c.id === selectedCityId);
-  const fnsOffices = selectedCity?.fnsOffices || [];
-
   const resetFilters = useCallback(() => {
-    setSelectedCityId(null);
-    setSelectedFnsId(null);
+    setSelectedCityIds([]);
+    setSelectedFnsIds([]);
     setSelectedServiceIds([]);
   }, []);
 
@@ -92,8 +90,10 @@ export default function SpecialistsCatalog() {
       try {
         const searchQ = q ?? search;
         let path = `/api/specialists?page=${pageNum}&limit=20`;
-        if (selectedCityId) path += `&city_id=${selectedCityId}`;
-        if (selectedFnsId) path += `&fns_id=${selectedFnsId}`;
+        if (selectedCityIds.length > 0)
+          path += `&city_ids=${selectedCityIds.join(",")}`;
+        if (selectedFnsIds.length > 0)
+          path += `&fns_ids=${selectedFnsIds.join(",")}`;
         if (selectedServiceIds.length > 0)
           path += `&services=${selectedServiceIds.join(",")}`;
         if (searchQ.trim()) path += `&q=${encodeURIComponent(searchQ.trim())}`;
@@ -114,7 +114,7 @@ export default function SpecialistsCatalog() {
         setError("Не удалось загрузить список");
       }
     },
-    [selectedCityId, selectedFnsId, selectedServiceIds, search]
+    [selectedCityIds, selectedFnsIds, selectedServiceIds, search]
   );
 
   useEffect(() => {
@@ -141,7 +141,7 @@ export default function SpecialistsCatalog() {
   useEffect(() => {
     setLoading(true);
     fetchSpecialists(1).finally(() => setLoading(false));
-  }, [selectedCityId, selectedFnsId, selectedServiceIds, fetchSpecialists]);
+  }, [selectedCityIds, selectedFnsIds, selectedServiceIds, fetchSpecialists]);
 
   // Debounced search
   useEffect(() => {
@@ -156,10 +156,13 @@ export default function SpecialistsCatalog() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
-  const handleCityChange = useCallback((id: string | null) => {
-    setSelectedCityId(id);
-    setSelectedFnsId(null);
-  }, []);
+  const handleCascadeChange = useCallback(
+    (v: { cities: string[]; fns: string[] }) => {
+      setSelectedCityIds(v.cities);
+      setSelectedFnsIds(v.fns);
+    },
+    []
+  );
 
   const handleServiceToggle = useCallback((id: string) => {
     setSelectedServiceIds((prev) =>
@@ -255,18 +258,23 @@ export default function SpecialistsCatalog() {
         )}
       </View>
 
-      {/* FilterBar */}
-      <FilterBar
-        cities={cities}
-        selectedCityId={selectedCityId}
-        onCityChange={handleCityChange}
-        services={services}
-        selectedServiceIds={selectedServiceIds}
-        onServiceToggle={handleServiceToggle}
-        fnsOffices={fnsOffices.map((f) => ({ id: f.id, name: f.name }))}
-        selectedFnsId={selectedFnsId}
-        onFnsChange={setSelectedFnsId}
-      />
+      {/* City → FNS cascade + services chips */}
+      <View className="bg-white border-b border-border py-2">
+        <CityFnsCascade
+          mode="multi"
+          value={{ cities: selectedCityIds, fns: selectedFnsIds }}
+          onChange={handleCascadeChange}
+          citiesSource={cities.map((c) => ({ id: c.id, name: c.name }))}
+        />
+        <FilterBar
+          cities={[]}
+          selectedCityId={null}
+          onCityChange={() => {}}
+          services={services}
+          selectedServiceIds={selectedServiceIds}
+          onServiceToggle={handleServiceToggle}
+        />
+      </View>
 
       {/* Specialist list */}
       {specialists.length === 0 && !loading ? (

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -57,28 +57,30 @@ export default function FilterBar({
 }: FilterBarProps) {
   return (
     <View className="py-2">
-      {/* City filter */}
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerClassName="px-4"
-      >
-        <FilterChip
-          label="Все города"
-          active={!selectedCityId}
-          onPress={() => onCityChange(null)}
-        />
-        {cities.map((city) => (
+      {/* City filter (hidden when caller passes empty city list) */}
+      {cities.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerClassName="px-4"
+        >
           <FilterChip
-            key={city.id}
-            label={city.name}
-            active={selectedCityId === city.id}
-            onPress={() =>
-              onCityChange(selectedCityId === city.id ? null : city.id)
-            }
+            label="Все города"
+            active={!selectedCityId}
+            onPress={() => onCityChange(null)}
           />
-        ))}
-      </ScrollView>
+          {cities.map((city) => (
+            <FilterChip
+              key={city.id}
+              label={city.name}
+              active={selectedCityId === city.id}
+              onPress={() =>
+                onCityChange(selectedCityId === city.id ? null : city.id)
+              }
+            />
+          ))}
+        </ScrollView>
+      )}
 
       {/* FNS filter (cascade from city) */}
       {fnsOffices && fnsOffices.length > 0 && onFnsChange && (

--- a/components/filters/CityFnsCascade.tsx
+++ b/components/filters/CityFnsCascade.tsx
@@ -1,0 +1,411 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  ScrollView,
+  ActivityIndicator,
+  TextInput,
+  useWindowDimensions,
+} from "react-native";
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react-native";
+import { api } from "@/lib/api";
+import { colors } from "@/lib/theme";
+
+export interface CityCascadeOption {
+  id: string;
+  name: string;
+}
+
+export interface FnsCascadeOption {
+  id: string;
+  name: string;
+  code: string;
+  cityId: string;
+  cityName?: string;
+}
+
+export interface CityFnsValue {
+  cities: string[];
+  fns: string[];
+}
+
+export interface CityFnsCascadeProps {
+  mode: "single" | "multi";
+  value: CityFnsValue;
+  onChange: (v: CityFnsValue) => void;
+  // Optional: external list of cities (skips internal fetch when provided)
+  citiesSource?: CityCascadeOption[];
+  // Future: filter offices by the specialists offering specific services
+  serviceIds?: string[];
+  showCounts?: boolean;
+  labelCities?: string;
+  labelFns?: string;
+}
+
+/**
+ * CityFnsCascade — reusable cascade filter component.
+ *
+ * Single mode: каталог, filter feed / form — exactly one city + one FNS.
+ * Multi mode:  onboarding work-area / catalog multi-select — set of cities + subset of FNS.
+ *
+ * Behavior:
+ *  - Renders cities as a chip row (fetched via /api/cities if citiesSource is not provided).
+ *  - When at least one city is selected, expands an FNS selector.
+ *  - FNS list is fetched via /api/fns?city_ids=... (multi) or /api/fns?city_id=... (single).
+ *  - Removing a city from the multi-value prunes orphan FNS ids from `value.fns`.
+ */
+export default function CityFnsCascade({
+  mode,
+  value,
+  onChange,
+  citiesSource,
+  serviceIds,
+  showCounts = false,
+  labelCities = "Город",
+  labelFns = "Инспекция ФНС",
+}: CityFnsCascadeProps) {
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 640;
+
+  const [cities, setCities] = useState<CityCascadeOption[]>(citiesSource ?? []);
+  const [fnsAll, setFnsAll] = useState<FnsCascadeOption[]>([]);
+  const [loadingFns, setLoadingFns] = useState(false);
+  const [fnsOpen, setFnsOpen] = useState(false);
+  const [fnsSearch, setFnsSearch] = useState("");
+
+  // Fetch cities only if caller hasn't supplied them
+  useEffect(() => {
+    if (citiesSource && citiesSource.length > 0) {
+      setCities(citiesSource);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await api<{ items: CityCascadeOption[] }>("/api/cities", {
+          noAuth: true,
+        });
+        if (!cancelled) setCities(res.items);
+      } catch {
+        /* ignore — empty cities simply hide filter */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [citiesSource]);
+
+  // Fetch FNS offices whenever the city selection changes
+  useEffect(() => {
+    if (value.cities.length === 0) {
+      setFnsAll([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingFns(true);
+    (async () => {
+      try {
+        const path =
+          value.cities.length === 1
+            ? `/api/fns?city_id=${value.cities[0]}`
+            : `/api/fns?city_ids=${value.cities.join(",")}`;
+        const res = await api<{ offices: FnsCascadeOption[] }>(path, {
+          noAuth: true,
+        });
+        if (!cancelled) setFnsAll(res.offices);
+      } catch {
+        if (!cancelled) setFnsAll([]);
+      } finally {
+        if (!cancelled) setLoadingFns(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [value.cities]);
+
+  // Prune orphan FNS ids if cities change so parent state stays consistent
+  useEffect(() => {
+    if (value.fns.length === 0 || fnsAll.length === 0) return;
+    const valid = new Set(fnsAll.map((f) => f.id));
+    const filtered = value.fns.filter((id) => valid.has(id));
+    if (filtered.length !== value.fns.length) {
+      onChange({ cities: value.cities, fns: filtered });
+    }
+    // value.fns intentionally excluded — we only react to the source list changing
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fnsAll]);
+
+  const toggleCity = useCallback(
+    (id: string) => {
+      if (mode === "single") {
+        const next = value.cities[0] === id ? [] : [id];
+        onChange({ cities: next, fns: [] });
+        return;
+      }
+      const has = value.cities.includes(id);
+      const next = has
+        ? value.cities.filter((c) => c !== id)
+        : [...value.cities, id];
+      onChange({ cities: next, fns: value.fns });
+    },
+    [mode, value, onChange]
+  );
+
+  const toggleFns = useCallback(
+    (id: string) => {
+      if (mode === "single") {
+        const next = value.fns[0] === id ? [] : [id];
+        onChange({ cities: value.cities, fns: next });
+        setFnsOpen(false);
+        return;
+      }
+      const has = value.fns.includes(id);
+      const next = has
+        ? value.fns.filter((f) => f !== id)
+        : [...value.fns, id];
+      onChange({ cities: value.cities, fns: next });
+    },
+    [mode, value, onChange]
+  );
+
+  const clearAll = useCallback(() => {
+    onChange({ cities: [], fns: [] });
+    setFnsOpen(false);
+    setFnsSearch("");
+  }, [onChange]);
+
+  const filteredFns = useMemo(() => {
+    const q = fnsSearch.trim().toLowerCase();
+    if (!q) return fnsAll;
+    return fnsAll.filter(
+      (f) =>
+        f.name.toLowerCase().includes(q) ||
+        (f.code || "").toLowerCase().includes(q)
+    );
+  }, [fnsAll, fnsSearch]);
+
+  const singleFnsSelected =
+    mode === "single" && value.fns.length === 1
+      ? fnsAll.find((f) => f.id === value.fns[0])
+      : undefined;
+
+  // --- render ---
+
+  return (
+    <View style={{ width: "100%" }}>
+      {/* Cities row */}
+      <View className="mb-2">
+        <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-2 px-4">
+          {labelCities}
+        </Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerClassName="px-4"
+        >
+          {cities.length === 0 ? (
+            <Text className="text-sm text-text-mute">Загрузка…</Text>
+          ) : (
+            cities.map((city) => {
+              const active = value.cities.includes(city.id);
+              return (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={city.name}
+                  key={city.id}
+                  onPress={() => toggleCity(city.id)}
+                  className={`px-3 h-11 items-center justify-center rounded-full mr-2 mb-1 border ${
+                    active
+                      ? "bg-accent border-accent"
+                      : "bg-white border-border"
+                  }`}
+                >
+                  <Text
+                    className={`text-sm ${
+                      active ? "text-white font-medium" : "text-text-base"
+                    }`}
+                  >
+                    {city.name}
+                  </Text>
+                </Pressable>
+              );
+            })
+          )}
+        </ScrollView>
+      </View>
+
+      {/* FNS combobox */}
+      {value.cities.length > 0 && (
+        <View
+          className={`${isDesktop ? "flex-row items-start gap-3" : ""} px-4 mt-1`}
+        >
+          <View style={{ flex: 1 }}>
+            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-2">
+              {labelFns}
+              {showCounts && fnsAll.length > 0 ? ` (${fnsAll.length})` : ""}
+            </Text>
+
+            {mode === "single" ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Выбрать инспекцию"
+                onPress={() => setFnsOpen((v) => !v)}
+                className="h-12 border border-border rounded-xl bg-white px-4 flex-row items-center justify-between"
+              >
+                <Text
+                  className={
+                    singleFnsSelected
+                      ? "text-text-base text-base"
+                      : "text-text-mute text-base"
+                  }
+                  numberOfLines={1}
+                >
+                  {loadingFns
+                    ? "Загрузка…"
+                    : singleFnsSelected?.name || "Все инспекции"}
+                </Text>
+                {fnsOpen ? (
+                  <ChevronUp size={14} color={colors.placeholder} />
+                ) : (
+                  <ChevronDown size={14} color={colors.placeholder} />
+                )}
+              </Pressable>
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Выбрать инспекции"
+                onPress={() => setFnsOpen((v) => !v)}
+                className="min-h-12 border border-border rounded-xl bg-white px-4 py-2 flex-row items-center justify-between"
+              >
+                <Text
+                  className={
+                    value.fns.length > 0
+                      ? "text-text-base text-base"
+                      : "text-text-mute text-base"
+                  }
+                >
+                  {loadingFns
+                    ? "Загрузка…"
+                    : value.fns.length > 0
+                    ? `Выбрано: ${value.fns.length}`
+                    : "Все инспекции"}
+                </Text>
+                {fnsOpen ? (
+                  <ChevronUp size={14} color={colors.placeholder} />
+                ) : (
+                  <ChevronDown size={14} color={colors.placeholder} />
+                )}
+              </Pressable>
+            )}
+
+            {fnsOpen && (
+              <View
+                className="border border-border rounded-xl mt-1 bg-white overflow-hidden"
+                style={{ maxHeight: 320 }}
+              >
+                <View className="flex-row items-center px-3 h-11 border-b border-border">
+                  <Search size={14} color={colors.placeholder} />
+                  <TextInput
+                    value={fnsSearch}
+                    onChangeText={setFnsSearch}
+                    placeholder="Поиск инспекции…"
+                    placeholderTextColor={colors.placeholder}
+                    style={{
+                      flex: 1,
+                      fontSize: 14,
+                      color: colors.text,
+                      marginLeft: 8,
+                      height: 40,
+                    }}
+                  />
+                </View>
+                <ScrollView nestedScrollEnabled>
+                  {loadingFns ? (
+                    <View className="px-4 py-4 flex-row items-center">
+                      <ActivityIndicator size="small" color={colors.primary} />
+                      <Text className="text-sm text-text-mute ml-2">
+                        Загрузка…
+                      </Text>
+                    </View>
+                  ) : filteredFns.length === 0 ? (
+                    <View className="px-4 py-4">
+                      <Text className="text-sm text-text-mute">
+                        Нет результатов
+                      </Text>
+                    </View>
+                  ) : (
+                    filteredFns.map((fns) => {
+                      const active = value.fns.includes(fns.id);
+                      return (
+                        <Pressable
+                          accessibilityRole="button"
+                          key={fns.id}
+                          accessibilityLabel={fns.name}
+                          onPress={() => toggleFns(fns.id)}
+                          className={`px-4 py-3 border-b border-surface2 ${
+                            active ? "bg-accent-soft" : ""
+                          }`}
+                        >
+                          <View className="flex-row items-center">
+                            {mode === "multi" && (
+                              <View
+                                className={`w-5 h-5 rounded border-2 items-center justify-center mr-2 ${
+                                  active
+                                    ? "bg-accent border-accent"
+                                    : "border-border bg-white"
+                                }`}
+                              >
+                                {active && (
+                                  <Text className="text-white text-xs font-bold">
+                                    ✓
+                                  </Text>
+                                )}
+                              </View>
+                            )}
+                            <View style={{ flex: 1 }}>
+                              <Text
+                                className={`text-sm ${
+                                  active
+                                    ? "text-accent font-medium"
+                                    : "text-text-base"
+                                }`}
+                              >
+                                {fns.name}
+                              </Text>
+                              {fns.code ? (
+                                <Text className="text-xs text-text-mute">
+                                  {fns.code}
+                                  {fns.cityName ? ` · ${fns.cityName}` : ""}
+                                </Text>
+                              ) : null}
+                            </View>
+                          </View>
+                        </Pressable>
+                      );
+                    })
+                  )}
+                </ScrollView>
+              </View>
+            )}
+          </View>
+
+          {(value.cities.length > 0 || value.fns.length > 0) && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Сбросить фильтры"
+              onPress={clearAll}
+              className="h-12 px-3 rounded-xl border border-border items-center justify-center flex-row mt-6"
+              style={{ alignSelf: isDesktop ? "flex-start" : "flex-start" }}
+            >
+              <X size={14} color={colors.textSecondary} />
+              <Text className="text-sm text-text-mute ml-1">Сбросить</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+


### PR DESCRIPTION
Closes #1300 #1301.

## Summary
- New reusable `components/filters/CityFnsCascade.tsx` — one component, two modes (`single` / `multi`). Cities chip row -> FNS combobox with search, prunes orphan FNS ids when cities change.
- Catalog `/specialists` and public feed `/requests` now use the cascade. Onboarding `/onboarding/work-area` rebuilt around the cascade + per-FNS service chips (all 3 SA-required fields: cities, fns, services).
- `/api/fns`, `/api/specialists`, `/api/requests/public` extended to accept multi-city / multi-FNS query params; backwards-compatible with single-id calls.
- `/api/onboarding/work-area` now accepts both legacy `{ fnsServices }` and new `{ cities, fns, specialist_services: [{ fns_id, service_id }] }` payload shapes.
- `FilterBar` tweak: skip the city chip row when caller passes an empty city list (lets cascade own that UI).

## Test plan
- [ ] `/specialists` — pick 2 cities, verify FNS selector lists unions, multi-select chips filter the list.
- [ ] `/requests` feed — city chip switches FNS combobox; picking a FNS narrows feed.
- [ ] `/onboarding/work-area` — cities -> FNS -> services per FNS; "Далее" disabled until every FNS has at least one service; PUT payload reaches backend and seeds `specialist_fns` + `specialist_services`.
- [ ] `tsc --noEmit` clean on both frontend and `api/`.