### PR TITLE
feat(iter10-phase3a): App Shell — persistent SidebarNav + 3 dashboards refined

### DIFF
--- a/app/(admin-tabs)/complaints.tsx
+++ b/app/(admin-tabs)/complaints.tsx
@@ -6,7 +6,6 @@ import {
   ActivityIndicator,
   Alert,
   Platform,
-  useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -14,7 +13,7 @@ import { ChevronUp, ChevronDown, Flag } from "lucide-react-native";
 import DesktopScreen from "@/components/layout/DesktopScreen";
 import { Badge, EmptyState, ErrorState, LoadingState } from "@/components/ui";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, overlay } from "@/lib/theme";
+import { colors } from "@/lib/theme";
 import { API_URL } from "@/lib/api";
 
 
@@ -69,8 +68,6 @@ function formatDate(dateStr: string): string {
 
 export default function AdminComplaints() {
   const { token } = useAuth();
-  const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
   const [complaints, setComplaints] = useState<ComplaintItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -261,67 +258,65 @@ export default function AdminComplaints() {
     );
   };
 
+  const filterBar = (
+    <View style={{ flexDirection: "row", gap: 8, flexWrap: "wrap" }}>
+      {FILTER_OPTIONS.map((opt) => (
+        <Pressable
+          accessibilityRole="button"
+          key={opt.key}
+          accessibilityLabel={opt.label}
+          onPress={() => setFilter(opt.key)}
+          className={`px-3 py-1.5 rounded-full border min-h-[36px] justify-center ${
+            filter === opt.key
+              ? "bg-accent border-accent"
+              : "bg-surface2 border-border"
+          }`}
+        >
+          <Text
+            className={`text-sm ${
+              filter === opt.key ? "text-white font-medium" : "text-text-mute"
+            }`}
+          >
+            {opt.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      {/* Header with accent background */}
-      <View className="bg-accent px-4 pt-4 pb-4">
-        <Text className="text-2xl font-bold text-white">Жалобы</Text>
-        <Text className="text-sm mt-1" style={{ color: overlay.white75 }}>Управление жалобами пользователей</Text>
-      </View>
-
-      {/* Filter tabs */}
-      <View className="bg-white border-b border-border py-2.5">
-        <View style={{
-          maxWidth: isDesktop ? 680 : undefined,
-          alignSelf: 'center',
-          width: '100%',
-          paddingHorizontal: isDesktop ? 24 : 16,
-          flexDirection: 'row',
-          gap: 8,
-        }}>
-          {FILTER_OPTIONS.map((opt) => (
-            <Pressable
-              accessibilityRole="button"
-              key={opt.key}
-              accessibilityLabel={opt.label}
-              onPress={() => setFilter(opt.key)}
-              className={`px-3 py-1.5 rounded-full border min-h-[44px] justify-center ${
-                filter === opt.key
-                  ? "bg-accent border-accent"
-                  : "bg-surface2 border-border"
-              }`}
-            >
-              <Text
-                className={`text-sm ${
-                  filter === opt.key ? "text-white font-medium" : "text-text-mute"
-                }`}
-              >
-                {opt.label}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-      </View>
-
       {loading ? (
-        <DesktopScreen>
+        <DesktopScreen
+          title="Жалобы"
+          subtitle="Управление жалобами пользователей"
+          filters={filterBar}
+        >
           <LoadingState variant="skeleton" lines={5} />
           <LoadingState variant="skeleton" lines={5} />
         </DesktopScreen>
       ) : error ? (
-        <View className="flex-1 items-center justify-center">
+        <DesktopScreen
+          title="Жалобы"
+          subtitle="Управление жалобами пользователей"
+          filters={filterBar}
+        >
           <ErrorState
             message="Не удалось загрузить жалобы"
             onRetry={() => fetchComplaints(filter, 1)}
           />
-        </View>
+        </DesktopScreen>
       ) : (
-        <DesktopScreen>
+        <DesktopScreen
+          title="Жалобы"
+          subtitle="Управление жалобами пользователей"
+          filters={filterBar}
+        >
           <FlatList
             data={complaints}
             keyExtractor={(item) => item.id}
             renderItem={renderItem}
-            contentContainerStyle={{ flexGrow: 1, padding: 16, paddingTop: 12 }}
+            contentContainerStyle={{ flexGrow: 1, paddingVertical: 8 }}
             onEndReached={loadMore}
             onEndReachedThreshold={0.3}
             ListEmptyComponent={

--- a/app/(admin-tabs)/moderation.tsx
+++ b/app/(admin-tabs)/moderation.tsx
@@ -1,41 +1,16 @@
-import { View, Text } from "react-native";
+import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CheckCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import DesktopScreen from "@/components/layout/DesktopScreen";
-import { colors, overlay } from "@/lib/theme";
 
 export default function AdminModeration() {
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      {/* Accent hero header */}
-      <View className="bg-accent px-4 pt-4 pb-4">
-        <Text className="text-2xl font-bold text-white">Модерация</Text>
-        <Text
-          className="text-sm mt-1"
-          style={{ color: overlay.white75 }}
-        >
-          Управление контентом платформы
-        </Text>
-      </View>
-
-      {/* Section separator */}
-      <View
-        className="bg-white border-b border-border px-4 py-3"
-        style={{
-          shadowColor: "#000",
-          shadowOffset: { width: 0, height: 1 },
-          shadowOpacity: 0.05,
-          shadowRadius: 3,
-          elevation: 2,
-        }}
+      <DesktopScreen
+        title="Модерация"
+        subtitle="Контент, требующий проверки перед публикацией"
       >
-        <Text className="text-sm text-text-mute">
-          Контент, требующий проверки перед публикацией
-        </Text>
-      </View>
-
-      <DesktopScreen>
         <View className="flex-1">
           <EmptyState
             icon={CheckCircle}

--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -17,7 +17,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { API_URL } from "@/lib/api";
-import { colors, overlay, radiusValue, fontSizeValue } from "@/lib/theme";
+import { colors, radiusValue, fontSizeValue } from "@/lib/theme";
 
 
 type RoleFilter = "ALL" | "CLIENT" | "SPECIALIST" | "BANNED";
@@ -220,79 +220,84 @@ export default function AdminUsers() {
     return layoutMeasurement.height + contentOffset.y >= contentSize.height - 200;
   };
 
+  const filterBar = (
+    <View style={{ gap: 12 }}>
+      <TextInput
+        accessibilityLabel="Поиск по email или имени"
+        style={{
+          backgroundColor: colors.surface2,
+          borderRadius: radiusValue.md,
+          height: 44,
+          paddingHorizontal: 14,
+          color: colors.text,
+          fontSize: fontSizeValue.md,
+          borderWidth: 1,
+          borderColor: colors.border,
+          outlineWidth: 0,
+        }}
+        placeholder="Поиск по email или имени..."
+        placeholderTextColor={colors.placeholder}
+        value={search}
+        onChangeText={setSearch}
+        autoCapitalize="none"
+      />
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8 }}
+      >
+        {FILTER_OPTIONS.map((opt) => (
+          <Pressable
+            accessibilityRole="button"
+            key={opt.key}
+            accessibilityLabel={opt.label}
+            onPress={() => setFilter(opt.key)}
+            className={`px-3 rounded-full border active:opacity-70 ${
+              filter === opt.key
+                ? "bg-accent border-accent"
+                : "bg-surface2 border-border"
+            }`}
+            style={{ minHeight: 36, justifyContent: "center" }}
+          >
+            <Text
+              className={`text-sm ${
+                filter === opt.key
+                  ? "text-white font-medium"
+                  : "text-text-mute"
+              }`}
+            >
+              {opt.label}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+    </View>
+  );
+
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      {/* Search header — accent hero */}
-      <View className="bg-accent px-4 pt-4 pb-3">
-        <Text className="text-2xl font-bold text-white mb-1">Пользователи</Text>
-        <Text className="text-sm mb-3" style={{ color: overlay.white75 }}>Управление аккаунтами платформы</Text>
-        <TextInput
-          accessibilityLabel="Поиск по email или имени"
-          style={{
-            backgroundColor: overlay.white15,
-            borderRadius: radiusValue.md,
-            height: 44,
-            paddingHorizontal: 14,
-            color: colors.surface,
-            fontSize: fontSizeValue.md,
-            outlineWidth: 0,
-          }}
-          placeholder="Поиск по email или имени..."
-          placeholderTextColor={overlay.white50}
-          value={search}
-          onChangeText={setSearch}
-          autoCapitalize="none"
-        />
-      </View>
-
-      {/* Filter chips */}
-      <View className="bg-white border-b border-border px-4 py-2">
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={{ gap: 8 }}
-        >
-          {FILTER_OPTIONS.map((opt) => (
-            <Pressable
-              accessibilityRole="button"
-              key={opt.key}
-              accessibilityLabel={opt.label}
-              onPress={() => setFilter(opt.key)}
-              className={`px-3 rounded-full border active:opacity-70 ${
-                filter === opt.key
-                  ? "bg-accent border-accent"
-                  : "bg-surface2 border-border"
-              }`}
-              style={{ minHeight: 44, justifyContent: "center" }}
-            >
-              <Text
-                className={`text-sm ${
-                  filter === opt.key
-                    ? "text-white font-medium"
-                    : "text-text-mute"
-                }`}
-              >
-                {opt.label}
-              </Text>
-            </Pressable>
-          ))}
-        </ScrollView>
-      </View>
-
       {loading ? (
-        <DesktopScreen>
+        <DesktopScreen
+          title="Пользователи"
+          subtitle="Управление аккаунтами платформы"
+          filters={filterBar}
+        >
           <View className="py-2">
             {Array.from({ length: 5 }).map((_, i) => (
-              <View key={i} className="mx-4 mb-3 bg-white rounded-2xl overflow-hidden border border-border">
+              <View key={i} className="mb-3 bg-white rounded-2xl overflow-hidden border border-border">
                 <LoadingState variant="skeleton" lines={4} />
               </View>
             ))}
           </View>
         </DesktopScreen>
       ) : error ? (
-        <View className="flex-1 items-center justify-center">
+        <DesktopScreen
+          title="Пользователи"
+          subtitle="Управление аккаунтами платформы"
+          filters={filterBar}
+        >
           <ErrorState message="Не удалось загрузить пользователей" onRetry={() => fetchUsers(search, filter, 1)} />
-        </View>
+        </DesktopScreen>
       ) : (
         <ScrollView
           className="flex-1"
@@ -301,7 +306,11 @@ export default function AdminUsers() {
           }}
           scrollEventThrottle={400}
         >
-          <DesktopScreen>
+          <DesktopScreen
+            title="Пользователи"
+            subtitle="Управление аккаунтами платформы"
+            filters={filterBar}
+          >
             <View className="py-2">
               {users.length === 0 ? (
                 <EmptyState
@@ -311,7 +320,7 @@ export default function AdminUsers() {
                 />
               ) : (
                 users.map((user) => (
-                  <View key={user.id} className="mx-4 mb-2">
+                  <View key={user.id} className="mb-2">
                     <Pressable
                       accessibilityRole="button"
                       accessibilityLabel={`${[user.firstName, user.lastName].filter(Boolean).join(" ") || user.email}`}

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -11,52 +11,17 @@ interface HeaderHomeProps {
 /**
  * HeaderHome — top bar for tab-group screens.
  *
- * - Mobile (<1024px, including native): full-bleed blue bar (brand presence,
- *   constrained vertical space).
- * - Desktop web (>=1024px): subtle white bar with bottom border — the sidebar
- *   carries the brand, so a second full-bleed blue bar reads as a mobile
- *   stretched-to-wide mistake (Gemini critique #1).
+ * iter10 Phase 3a: on desktop web (>=768px) AppShell + AppHeader own the
+ * chrome — HeaderHome renders `null` to avoid double chrome. On mobile
+ * we keep the full-bleed blue brand bar because the sidebar isn't shown.
  */
 export default function HeaderHome({ notificationCount = 0, onSettingsPress }: HeaderHomeProps) {
   const router = useRouter();
   const { width } = useWindowDimensions();
-  const isDesktopWeb = Platform.OS === "web" && width >= 1024;
+  const isDesktopWeb = Platform.OS === "web" && width >= 768;
 
   if (isDesktopWeb) {
-    return (
-      <View
-        className="flex-row items-center justify-end h-14 px-6 border-b"
-        style={{ backgroundColor: colors.surface, borderBottomColor: colors.border }}
-      >
-        <View className="flex-row items-center gap-2">
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Уведомления"
-            onPress={() => router.push("/notifications" as never)}
-            className="w-11 h-11 rounded-lg items-center justify-center"
-          >
-            <Bell size={18} color={colors.textSecondary} />
-            {notificationCount > 0 && (
-              <View className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-warning items-center justify-center px-1">
-                <Text className="text-[10px] font-bold text-white">
-                  {notificationCount > 99 ? "99+" : notificationCount}
-                </Text>
-              </View>
-            )}
-          </Pressable>
-          {onSettingsPress && (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Настройки"
-              onPress={onSettingsPress}
-              className="w-11 h-11 rounded-lg items-center justify-center"
-            >
-              <Settings size={18} color={colors.textSecondary} />
-            </Pressable>
-          )}
-        </View>
-      </View>
-    );
+    return null;
   }
 
   return (

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -16,6 +16,12 @@ import MobileMenu from "@/components/MobileMenu";
 import RoleBadge from "./RoleBadge";
 
 /**
+ * iter10 Phase 3a: Desktop now renders SidebarNav which owns the role-accent
+ * brand/badge. AppHeader becomes a slim top-rail (search + right cluster) with
+ * NO role-accent border-top. Mobile keeps its compact burger/title/bell row.
+ */
+
+/**
  * Persistent in-app header rendered on every authenticated route.
  *
  * Desktop (>= 640px): logo + breadcrumb + search input + role badge + bell + avatar dropdown.
@@ -179,63 +185,39 @@ export default function AppHeader({ title }: AppHeaderProps) {
   }
 
   // -------- Desktop --------
+  // iter10 Phase 3a: role accent moved to SidebarNav; header is a neutral
+  // slim bar with breadcrumb + search + bell + avatar.
   return (
     <View
       className="flex-row items-center bg-white border-b"
       style={{
         borderBottomColor: colors.border,
-        borderTopWidth: 3,
-        borderTopColor: accent.strong,
-        height: 64,
+        height: 56,
         paddingHorizontal: spacing.lg,
-        gap: spacing.lg,
+        gap: spacing.md,
       }}
     >
-      {/* Logo + breadcrumb */}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="P2PTax — главная"
-        onPress={() => router.push("/" as never)}
-        className="flex-row items-center"
-        style={{ minHeight: 44, gap: spacing.sm }}
-      >
-        <View
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: 6,
-            backgroundColor: colors.primary,
-          }}
-        />
-        <Text className="text-lg font-bold" style={{ color: colors.text }}>
-          P2P<Text style={{ color: colors.primary }}>Tax</Text>
+      {breadcrumb ? (
+        <Text
+          numberOfLines={1}
+          className="text-sm font-semibold"
+          style={{ color: colors.text, maxWidth: 280 }}
+        >
+          {breadcrumb}
         </Text>
-      </Pressable>
-
-      {breadcrumb && (
-        <>
-          <Text style={{ color: colors.textMuted }}>/</Text>
-          <Text
-            numberOfLines={1}
-            className="text-sm font-semibold"
-            style={{ color: colors.text, maxWidth: 260 }}
-          >
-            {breadcrumb}
-          </Text>
-        </>
-      )}
+      ) : null}
 
       {/* Search — fills available space */}
       <View
         className="flex-row items-center rounded-lg px-3"
         style={{
           flex: 1,
-          maxWidth: 520,
-          height: 40,
+          maxWidth: 480,
+          height: 36,
           backgroundColor: gray[100],
           borderWidth: 1,
           borderColor: colors.border,
-          marginLeft: spacing.md,
+          marginLeft: breadcrumb ? spacing.md : 0,
         }}
       >
         <Search size={16} color={colors.textMuted} />
@@ -258,17 +240,14 @@ export default function AppHeader({ title }: AppHeaderProps) {
       </View>
 
       {/* Right cluster */}
-      <View className="flex-row items-center" style={{ gap: spacing.md, marginLeft: "auto" }}>
-        <RoleBadge role={user?.role ?? null} />
-
+      <View className="flex-row items-center" style={{ gap: spacing.sm, marginLeft: "auto" }}>
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Уведомления"
           onPress={() => router.push("/notifications" as never)}
-          className="w-11 h-11 rounded-lg items-center justify-center"
+          className="w-10 h-10 rounded-lg items-center justify-center"
         >
           <Bell size={18} color={colors.text} />
-          {/* Unread dot placeholder — wired to real count in future iteration */}
         </Pressable>
 
         <Pressable
@@ -301,7 +280,7 @@ export default function AppHeader({ title }: AppHeaderProps) {
           <View
             style={{
               position: "absolute",
-              top: 64,
+              top: 56,
               right: spacing.lg,
               width: 260,
               backgroundColor: colors.surface,

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,15 +1,29 @@
 import { useEffect } from "react";
 import { View, useWindowDimensions, Platform } from "react-native";
-import { usePathname } from "expo-router";
-import { colors, spacing } from "@/lib/theme";
-import SidebarNav, { detectSidebarGroup } from "./SidebarNav";
+import { usePathname, useSegments } from "expo-router";
+import { colors } from "@/lib/theme";
+import SidebarNav, { detectSidebarGroup, SIDEBAR_WIDTH } from "./SidebarNav";
 
 /**
- * Install a web-only <style> tag once — gives TextInput a visible focus ring
- * without touching every component. RN Web renders <input>/<textarea>; the
- * rule below adds a 3px accent-soft box-shadow on :focus. Style audits
- * (naked-input / no-focus-ring) rely on that diff.
+ * AppShell — desktop-first authenticated shell (iter10 Phase 3a).
+ *
+ * Triggered by multi-model critique (2026-04-24, 4/4 consensus P0):
+ *   "Implement a persistent left sidebar navigation (240px) for all
+ *    authenticated routes, push content to a max-width 960px container."
+ *
+ * Layout contract:
+ *   - Mobile  (<768px)  : pass-through. Existing bottom-tab + burger UX.
+ *   - Desktop (>=768px) : flex-row root with fixed {@link SidebarNav} on
+ *     the left (240px) and a scrollable main pane on the right. The main
+ *     pane hosts AppHeader + page content; page content is constrained
+ *     to 960px by {@link DesktopScreen} and its descendants.
+ *   - Native platforms  : pass-through (mobile UX preserved).
+ *
+ * Public-chrome routes (/, /auth/*, /onboarding/*, /legal/*, /brand) also
+ * bypass the sidebar because {@link detectSidebarGroup} returns `null`.
+ * Those screens keep their own marketing chrome.
  */
+
 const FOCUS_RING_STYLE_ID = "p2ptax-focus-ring";
 function installFocusRingCSS() {
   if (typeof document === "undefined") return;
@@ -26,84 +40,60 @@ function installFocusRingCSS() {
   document.head.appendChild(style);
 }
 
-/**
- * AppShell — desktop-first layout container.
- *
- * - Mobile (<768px): pass-through, no container, no sidebar.
- * - Tablet (768..1024px): centered column, max-width 1280px.
- * - Desktop (>=1024px): LEFT sidebar with role-aware navigation + content card.
- *
- * Sidebar visibility is route-aware (via usePathname): role-based links are
- * shown only when the user is inside a tab group. Outside those groups (auth,
- * onboarding, landing "/") the shell falls back to a plain centered column so
- * public pages don't grow a stray sidebar.
- */
-
 interface AppShellProps {
   children: React.ReactNode;
 }
 
-const MAX_WIDTH = 1280;
-const TABLET_BP = 768;
-const DESKTOP_BP = 1024;
+const SIDEBAR_BREAKPOINT = 768;
 
 export default function AppShell({ children }: AppShellProps) {
   const { width } = useWindowDimensions();
   const pathname = usePathname() ?? "";
+  const segments = useSegments();
 
   useEffect(() => {
     if (Platform.OS === "web") installFocusRingCSS();
   }, []);
 
-  // Native platforms: pass-through (mobile UX preserved).
+  // Native: preserve mobile UX.
   if (Platform.OS !== "web") {
     return <>{children}</>;
   }
 
-  const isTablet = width >= TABLET_BP;
-  const isDesktop = width >= DESKTOP_BP;
+  const isDesktop = width >= SIDEBAR_BREAKPOINT;
+  const group = detectSidebarGroup(pathname, segments as readonly string[]);
+  const showSidebar = isDesktop && group !== null;
 
-  // Mobile web: pass-through — preserve bottom-tab mobile UX.
-  if (!isTablet) {
+  // Mobile web or public-chrome routes: pass-through.
+  if (!showSidebar) {
     return <>{children}</>;
   }
-
-  const group = detectSidebarGroup(pathname);
-  const showSidebar = isDesktop && group !== null;
 
   return (
     <View
       style={{
         flex: 1,
         width: "100%",
-        alignItems: "center",
+        flexDirection: "row",
         backgroundColor: colors.surface2,
+        minHeight: "100%",
       }}
     >
+      <SidebarNav group={group} />
       <View
         style={{
-          flexDirection: "row",
-          width: "100%",
-          maxWidth: MAX_WIDTH,
           flex: 1,
-          paddingHorizontal: isDesktop ? spacing.xl : spacing.lg,
-          paddingVertical: spacing.lg,
+          minWidth: 0,
+          minHeight: "100%",
+          // The main pane is the scroll container — pages keep their own
+          // ScrollView for pull-to-refresh, but the shell provides the
+          // top-level overflow on desktop web.
+          ...(Platform.OS === "web"
+            ? ({ overflowY: "auto", maxWidth: `calc(100% - ${SIDEBAR_WIDTH}px)` } as object)
+            : {}),
         }}
       >
-        {showSidebar && <SidebarNav group={group} />}
-        <View
-          style={{
-            flex: 1,
-            minWidth: 0,
-            backgroundColor: colors.surface,
-            borderRadius: 12,
-            borderWidth: 1,
-            borderColor: colors.border,
-            overflow: "hidden",
-          }}
-        >
-          {children}
-        </View>
+        {children}
       </View>
     </View>
   );

--- a/components/layout/DesktopScreen.tsx
+++ b/components/layout/DesktopScreen.tsx
@@ -49,7 +49,10 @@ export default function DesktopScreen({
   headerActions,
   sidebar,
   filters,
-  maxWidth = 1200,
+  // iter10 Phase 3a: default content column is 960px (multi-model consensus).
+  // Sidebar is provided by AppShell at 240px — the 960 column sits to the
+  // right and centers within the remaining width.
+  maxWidth = 960,
   fullWidth = false,
   children,
 }: DesktopScreenProps) {

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -1,5 +1,6 @@
-import { View, Text, Pressable } from "react-native";
-import { useRouter, usePathname } from "expo-router";
+import { useState } from "react";
+import { View, Text, Pressable, Modal, Platform } from "react-native";
+import { useRouter, usePathname, useSegments } from "expo-router";
 import {
   LayoutGrid,
   FileText,
@@ -10,16 +11,37 @@ import {
   Users,
   Shield,
   Flag,
-  Home,
-  Search,
-  PlusSquare,
-  User,
-  Settings,
   Bell,
+  Settings,
+  LogOut,
+  UserRound,
+  Compass,
+  Inbox,
   type LucideIcon,
 } from "lucide-react-native";
-import { colors, spacing, typography } from "@/lib/theme";
-import { useAuth } from "@/contexts/AuthContext";
+import { colors, spacing, roleAccent, type RoleAccentKey } from "@/lib/theme";
+import { useAuth, type UserRole } from "@/contexts/AuthContext";
+import RoleBadge from "./RoleBadge";
+
+/**
+ * SidebarNav — persistent left-rail navigation for authenticated routes.
+ *
+ * Triggered by multi-model critique (2026-04-24, 4/4 consensus P0):
+ *   "Implement a persistent left sidebar navigation (240px) for all
+ *    authenticated routes, push content to max-width 960px container."
+ *
+ * Design:
+ *   - 240px wide, full-height, sticky to left edge.
+ *   - Role-tinted background (blue client / emerald specialist / amber admin).
+ *   - 3 zones: brand + role badge · primary nav · bottom identity/settings.
+ *   - Active item: tint bg + left 2px accent border + bold label.
+ *   - All nav items from issue #1285/#1289 spec + expanded to cover
+ *     secondary destinations (Каталог специалистов, Публичные заявки,
+ *     Уведомления) that were buried in AppHeader dropdown.
+ *
+ * Mobile (<768px): component is NOT rendered. AppShell bypasses on mobile
+ * and falls back to the existing bottom-tab + burger pattern.
+ */
 
 export type SidebarGroup =
   | "client"
@@ -28,31 +50,88 @@ export type SidebarGroup =
   | "main"
   | null;
 
+interface MatchContext {
+  /** Browser path (groups stripped), e.g. `/dashboard` for `/(client-tabs)/dashboard`. */
+  path: string;
+  /** Raw Expo-Router segments including groups, e.g. `["(client-tabs)", "dashboard"]`. */
+  segments: readonly string[];
+}
+
 interface NavItem {
   label: string;
   href: string;
   icon: LucideIcon;
-  match: (path: string) => boolean;
+  match: (ctx: MatchContext) => boolean;
 }
+
+// ─────────────────────────────────────────── per-role navigation maps
+
+/**
+ * Match helpers.
+ *
+ * usePathname() strips group-parens, so `/(client-tabs)/dashboard` reports
+ * as `/dashboard`. We use segments to know which group the user is in —
+ * that disambiguates colliding paths like `/requests` that exist both as
+ * `/(client-tabs)/requests.tsx` and `/requests/index.tsx`.
+ */
+const groupMatch = (
+  ctx: MatchContext,
+  group: "(client-tabs)" | "(specialist-tabs)" | "(admin-tabs)",
+  leaf: string
+): boolean => {
+  if (ctx.segments[0] === group && ctx.segments[1] === leaf) return true;
+  // Safety net when segments are empty (route transitions).
+  return (
+    ctx.path.includes(`${group}/${leaf}`) ||
+    ctx.path.includes(`${group.replace(/[()]/g, "")}/${leaf}`)
+  );
+};
+
+const topLevelMatch = (ctx: MatchContext, prefix: string): boolean => {
+  // Active for `/prefix` or `/prefix/*` only when NOT inside a role-tab group
+  // (e.g. client's `/requests` screen shares URL with public `/requests`).
+  const first = ctx.segments[0] ?? "";
+  const inGroup = first.startsWith("(") && first.endsWith(")") && first !== "(tabs)";
+  if (inGroup) return false;
+  return ctx.path === prefix || ctx.path.startsWith(`${prefix}/`);
+};
 
 const CLIENT_ITEMS: NavItem[] = [
   {
-    label: "Обзор",
+    label: "Дашборд",
     href: "/(client-tabs)/dashboard",
     icon: LayoutGrid,
-    match: (p) => p === "/dashboard" || p.endsWith("/client-tabs/dashboard") || p === "/(client-tabs)/dashboard",
+    match: (ctx) => groupMatch(ctx, "(client-tabs)", "dashboard"),
   },
   {
     label: "Мои заявки",
     href: "/(client-tabs)/requests",
     icon: FileText,
-    match: (p) => p.includes("/client-tabs/requests") || p === "/(client-tabs)/requests",
+    match: (ctx) => groupMatch(ctx, "(client-tabs)", "requests"),
   },
   {
     label: "Сообщения",
     href: "/(client-tabs)/messages",
     icon: MessageCircle,
-    match: (p) => p.includes("/client-tabs/messages") || p === "/(client-tabs)/messages",
+    match: (ctx) => groupMatch(ctx, "(client-tabs)", "messages"),
+  },
+  {
+    label: "Каталог специалистов",
+    href: "/specialists",
+    icon: Compass,
+    match: (ctx) => topLevelMatch(ctx, "/specialists"),
+  },
+  {
+    label: "Публичные заявки",
+    href: "/requests",
+    icon: Inbox,
+    match: (ctx) => topLevelMatch(ctx, "/requests"),
+  },
+  {
+    label: "Уведомления",
+    href: "/notifications",
+    icon: Bell,
+    match: (ctx) => topLevelMatch(ctx, "/notifications"),
   },
 ];
 
@@ -61,104 +140,192 @@ const SPECIALIST_ITEMS: NavItem[] = [
     label: "Дашборд",
     href: "/(specialist-tabs)/dashboard",
     icon: LayoutGrid,
-    match: (p) => p.includes("/specialist-tabs/dashboard"),
+    match: (ctx) => groupMatch(ctx, "(specialist-tabs)", "dashboard"),
   },
   {
-    label: "Заявки",
+    label: "Публичные заявки",
     href: "/(specialist-tabs)/requests",
     icon: List,
-    match: (p) => p.includes("/specialist-tabs/requests"),
+    match: (ctx) =>
+      groupMatch(ctx, "(specialist-tabs)", "requests") ||
+      topLevelMatch(ctx, "/requests"),
   },
   {
-    label: "Переписки",
+    label: "Диалоги",
     href: "/(specialist-tabs)/threads",
     icon: MessageCircle,
-    match: (p) => p.includes("/specialist-tabs/threads"),
+    match: (ctx) =>
+      groupMatch(ctx, "(specialist-tabs)", "threads") ||
+      topLevelMatch(ctx, "/threads"),
+  },
+  {
+    label: "Профиль",
+    href: "/settings/specialist",
+    icon: UserRound,
+    match: (ctx) => ctx.path.startsWith("/settings/specialist"),
   },
   {
     label: "Продвижение",
     href: "/(specialist-tabs)/promotion",
     icon: Rocket,
-    match: (p) => p.includes("/specialist-tabs/promotion"),
+    match: (ctx) => groupMatch(ctx, "(specialist-tabs)", "promotion"),
+  },
+  {
+    label: "Уведомления",
+    href: "/notifications",
+    icon: Bell,
+    match: (ctx) => topLevelMatch(ctx, "/notifications"),
   },
 ];
 
 const ADMIN_ITEMS: NavItem[] = [
   {
-    label: "Dashboard",
+    label: "Дашборд",
     href: "/(admin-tabs)/dashboard",
     icon: BarChart2,
-    match: (p) => p.includes("/admin-tabs/dashboard"),
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "dashboard"),
   },
   {
     label: "Пользователи",
     href: "/(admin-tabs)/users",
     icon: Users,
-    match: (p) => p.includes("/admin-tabs/users"),
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "users"),
   },
   {
     label: "Модерация",
     href: "/(admin-tabs)/moderation",
     icon: Shield,
-    match: (p) => p.includes("/admin-tabs/moderation"),
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "moderation"),
   },
   {
     label: "Жалобы",
     href: "/(admin-tabs)/complaints",
     icon: Flag,
-    match: (p) => p.includes("/admin-tabs/complaints"),
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "complaints"),
+  },
+  {
+    label: "Настройки системы",
+    href: "/admin/settings",
+    icon: Settings,
+    match: (ctx) => ctx.path.startsWith("/admin/settings"),
   },
 ];
 
+// "main" fallback — used for top-level authenticated screens (`/requests`,
+// `/specialists`, `/notifications`, `/threads`, `/settings`) that don't
+// live in a role-based tab group. When the user has a role we prefer that
+// role's full nav set; when role is unknown we surface the shared
+// public-ish destinations so the sidebar is never empty.
 const MAIN_ITEMS: NavItem[] = [
   {
-    label: "Главная",
-    href: "/(tabs)",
-    icon: Home,
-    match: (p) => p === "/" || p === "/(tabs)" || p.endsWith("/tabs/index") || p === "/(tabs)/index",
+    label: "Каталог специалистов",
+    href: "/specialists",
+    icon: Compass,
+    match: (ctx) => topLevelMatch(ctx, "/specialists"),
   },
   {
-    label: "Поиск",
-    href: "/(tabs)/search",
-    icon: Search,
-    match: (p) => p.includes("/tabs/search"),
+    label: "Публичные заявки",
+    href: "/requests",
+    icon: Inbox,
+    match: (ctx) => topLevelMatch(ctx, "/requests"),
   },
   {
-    label: "Создать",
-    href: "/(tabs)/create",
-    icon: PlusSquare,
-    match: (p) => p.includes("/tabs/create"),
-  },
-  {
-    label: "Сообщения",
-    href: "/(tabs)/messages",
-    icon: MessageCircle,
-    match: (p) => p.includes("/tabs/messages") && !p.includes("client-tabs") && !p.includes("specialist-tabs"),
-  },
-  {
-    label: "Профиль",
-    href: "/(tabs)/profile",
-    icon: User,
-    match: (p) => p.includes("/tabs/profile"),
+    label: "Уведомления",
+    href: "/notifications",
+    icon: Bell,
+    match: (ctx) => topLevelMatch(ctx, "/notifications"),
   },
 ];
 
+// ─────────────────────────────────────────── classification helpers
+
+function toAccentKey(role: UserRole): RoleAccentKey {
+  switch (role) {
+    case "SPECIALIST":
+      return "specialist";
+    case "ADMIN":
+      return "admin";
+    case "CLIENT":
+    default:
+      return "client";
+  }
+}
+
 /**
- * Classify current Expo-Router pathname to a tab group. Returns null when the
- * current screen is outside any role-based group (auth, onboarding, landing, ...).
+ * Classify current Expo-Router location to a tab group. Returns null for
+ * public chrome (auth, onboarding, landing, legal) so AppShell can fall
+ * back to its no-sidebar layout.
+ *
+ * Why both `pathname` AND `segments`?
+ *   - `usePathname()` strips group parens, so `/(client-tabs)/dashboard`
+ *     reports as `/dashboard` — we can't recover the group from it.
+ *   - `useSegments()` keeps raw segments including `(client-tabs)` —
+ *     that's the authoritative source of group membership.
+ *
+ * We use `segments` to detect the tab group and fall back to `pathname`
+ * for top-level screens (`/requests`, `/specialists`, `/notifications`,
+ * `/threads`, `/settings`) that don't live in any group.
  */
-export function detectSidebarGroup(pathname: string): SidebarGroup {
+export function detectSidebarGroup(
+  pathname: string,
+  segments: readonly string[] = []
+): SidebarGroup {
   if (!pathname) return null;
-  if (pathname.includes("(client-tabs)") || pathname.includes("/client-tabs/")) return "client";
-  if (pathname.includes("(specialist-tabs)") || pathname.includes("/specialist-tabs/")) return "specialist";
-  if (pathname.includes("(admin-tabs)") || pathname.includes("/admin-tabs/")) return "admin";
-  // Generic "tabs" group — but only when we're actually inside it. We rely on
-  // the path literal to disambiguate (landing "/" is NOT in the tabs group).
-  if (pathname.includes("(tabs)") || pathname.includes("/tabs/")) return "main";
+
+  // Public-chrome screens own their own layout.
+  if (pathname === "/") return null;
+  if (pathname.startsWith("/auth")) return null;
+  if (pathname.startsWith("/legal")) return null;
+  if (pathname.startsWith("/onboarding")) return null;
+  if (pathname === "/brand") return null;
+
+  // Group detection via segments (authoritative).
+  const first = segments[0] ?? "";
+  if (first === "(client-tabs)") return "client";
+  if (first === "(specialist-tabs)") return "specialist";
+  if (first === "(admin-tabs)") return "admin";
+  // Legacy (tabs) marketplace group keeps its own `<Header>` — out of
+  // Phase 3a scope, no sidebar there (to avoid double chrome).
+  if (first === "(tabs)") return null;
+
+  // Fallback: pathname-based match, for safety when segments are empty
+  // (happens during route transitions or in some preview environments).
+  if (pathname.includes("/client-tabs/") || pathname.includes("(client-tabs)")) return "client";
+  if (pathname.includes("/specialist-tabs/") || pathname.includes("(specialist-tabs)")) return "specialist";
+  if (pathname.includes("/admin-tabs/") || pathname.includes("(admin-tabs)")) return "admin";
+
+  const LEGACY_TABS_ROUTES = new Set([
+    "/",
+    "/search",
+    "/create",
+    "/messages",
+    "/profile",
+  ]);
+  if (LEGACY_TABS_ROUTES.has(pathname)) return null;
+
+  // Top-level authenticated screens reachable from sidebar (requests,
+  // specialists, notifications, threads, settings): show a generic "main"
+  // sidebar scoped to the user's role.
+  if (
+    pathname.startsWith("/specialists") ||
+    pathname.startsWith("/requests") ||
+    pathname.startsWith("/notifications") ||
+    pathname.startsWith("/threads") ||
+    pathname.startsWith("/settings")
+  ) {
+    return "main";
+  }
+
   return null;
 }
 
-function itemsForGroup(group: SidebarGroup): NavItem[] {
+function itemsForGroup(group: SidebarGroup, role: UserRole): NavItem[] {
+  // When the group is "main" but user has a known role, prefer that role's
+  // nav set so /specialists or /requests still shows Client/Specialist links.
+  if (group === "main" && role === "CLIENT") return CLIENT_ITEMS;
+  if (group === "main" && role === "SPECIALIST") return SPECIALIST_ITEMS;
+  if (group === "main" && role === "ADMIN") return ADMIN_ITEMS;
+
   switch (group) {
     case "client":
       return CLIENT_ITEMS;
@@ -173,7 +340,7 @@ function itemsForGroup(group: SidebarGroup): NavItem[] {
   }
 }
 
-const SIDEBAR_WIDTH = 240;
+export const SIDEBAR_WIDTH = 240;
 
 interface SidebarNavProps {
   group: SidebarGroup;
@@ -182,13 +349,36 @@ interface SidebarNavProps {
 export default function SidebarNav({ group }: SidebarNavProps) {
   const router = useRouter();
   const pathname = usePathname() ?? "";
-  const { user } = useAuth();
+  const segments = useSegments();
+  const { user, signOut } = useAuth();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  const items = itemsForGroup(group);
+  const matchCtx: MatchContext = {
+    path: pathname,
+    segments: segments as readonly string[],
+  };
+
+  const accentKey = toAccentKey(user?.role ?? "CLIENT");
+  const accent = roleAccent[accentKey];
+  const items = itemsForGroup(group, user?.role ?? "CLIENT");
   if (items.length === 0) return null;
 
+  const displayName = user?.firstName
+    ? `${user.firstName} ${user.lastName || ""}`.trim()
+    : user?.email || "Пользователь";
+  const initials =
+    user?.firstName?.[0]?.toUpperCase() ||
+    user?.email?.[0]?.toUpperCase() ||
+    "U";
+
+  const handleLogout = async () => {
+    setDropdownOpen(false);
+    await signOut();
+    router.replace("/auth/email" as never);
+  };
+
   const settingsPath =
-    group === "admin"
+    user?.role === "ADMIN"
       ? "/admin/settings"
       : user?.role === "SPECIALIST"
       ? "/settings/specialist"
@@ -196,22 +386,32 @@ export default function SidebarNav({ group }: SidebarNavProps) {
 
   return (
     <View
+      accessibilityRole="menubar"
       style={{
         width: SIDEBAR_WIDTH,
-        paddingRight: spacing.lg,
+        flexShrink: 0,
+        backgroundColor: accent.soft,
+        borderRightWidth: 1,
+        borderRightColor: colors.border,
+        paddingHorizontal: spacing.md,
+        paddingTop: spacing.lg,
+        paddingBottom: spacing.md,
+        ...(Platform.OS === "web"
+          ? ({ position: "sticky", top: 0, height: "100vh" } as object)
+          : {}),
       }}
     >
-      {/* Brand mark */}
+      {/* Brand + role badge */}
       <Pressable
-        accessibilityRole="button"
+        accessibilityRole="link"
         accessibilityLabel="P2PTax — главная"
         onPress={() => router.push("/" as never)}
         style={{
-          height: 44,
-          paddingHorizontal: spacing.base,
+          height: 48,
+          paddingHorizontal: spacing.sm,
           flexDirection: "row",
           alignItems: "center",
-          marginBottom: spacing.lg,
+          marginBottom: spacing.sm,
         }}
       >
         <View
@@ -219,20 +419,31 @@ export default function SidebarNav({ group }: SidebarNavProps) {
             width: 28,
             height: 28,
             borderRadius: 6,
-            backgroundColor: colors.primary,
+            backgroundColor: accent.strong,
             marginRight: spacing.sm,
           }}
         />
-        <Text className={typography.h3} style={{ color: colors.text }}>
-          P2P<Text style={{ color: colors.primary }}>Tax</Text>
+        <Text
+          style={{
+            fontSize: 18,
+            fontWeight: "800",
+            color: colors.text,
+          }}
+        >
+          P2P
+          <Text style={{ color: accent.strong }}>Tax</Text>
         </Text>
       </Pressable>
 
+      <View style={{ paddingHorizontal: spacing.sm, marginBottom: spacing.md }}>
+        <RoleBadge role={user?.role ?? null} size="sm" />
+      </View>
+
       {/* Primary nav */}
-      <View style={{ gap: 4 }}>
+      <View style={{ gap: 2, flex: 1 }}>
         {items.map((item) => {
           const Icon = item.icon;
-          const active = item.match(pathname);
+          const active = item.match(matchCtx);
           return (
             <Pressable
               key={item.href}
@@ -242,23 +453,26 @@ export default function SidebarNav({ group }: SidebarNavProps) {
               style={{
                 flexDirection: "row",
                 alignItems: "center",
-                paddingVertical: spacing.sm,
-                paddingHorizontal: spacing.md,
+                height: 40,
+                paddingLeft: spacing.md,
+                paddingRight: spacing.sm,
                 borderRadius: 8,
-                backgroundColor: active ? colors.accentSoft : "transparent",
-                minHeight: 40,
+                backgroundColor: active ? accent.strong : "transparent",
+                borderLeftWidth: 2,
+                borderLeftColor: active ? accent.strong : "transparent",
               }}
             >
               <Icon
                 size={18}
-                color={active ? colors.primary : colors.textSecondary}
+                color={active ? accent.ink : colors.textSecondary}
               />
               <Text
+                numberOfLines={1}
                 style={{
-                  marginLeft: spacing.md,
-                  color: active ? colors.primary : colors.text,
+                  marginLeft: spacing.sm + 4,
                   fontSize: 14,
-                  fontWeight: active ? "600" : "500",
+                  fontWeight: active ? "700" : "500",
+                  color: active ? accent.ink : colors.text,
                 }}
               >
                 {item.label}
@@ -268,69 +482,167 @@ export default function SidebarNav({ group }: SidebarNavProps) {
         })}
       </View>
 
-      {/* Divider + utility links */}
+      {/* Bottom identity cluster */}
       <View
         style={{
-          height: 1,
-          backgroundColor: colors.border,
-          marginVertical: spacing.lg,
+          borderTopWidth: 1,
+          borderTopColor: colors.border,
+          paddingTop: spacing.sm,
+          marginTop: spacing.sm,
         }}
-      />
-
-      <View style={{ gap: 4 }}>
+      >
         <Pressable
-          accessibilityRole="link"
-          accessibilityLabel="Уведомления"
-          onPress={() => router.push("/notifications" as never)}
+          accessibilityRole="button"
+          accessibilityLabel="Открыть меню профиля"
+          onPress={() => setDropdownOpen(true)}
           style={{
             flexDirection: "row",
             alignItems: "center",
-            paddingVertical: spacing.sm,
-            paddingHorizontal: spacing.md,
-            borderRadius: 8,
-            minHeight: 40,
+            padding: spacing.sm,
+            borderRadius: 10,
           }}
         >
-          <Bell size={18} color={colors.textSecondary} />
-          <Text
+          <View
             style={{
-              marginLeft: spacing.md,
-              color: colors.text,
-              fontSize: 14,
-              fontWeight: "500",
+              width: 32,
+              height: 32,
+              borderRadius: 16,
+              backgroundColor: accent.strong,
+              alignItems: "center",
+              justifyContent: "center",
+              marginRight: spacing.sm,
             }}
           >
-            Уведомления
-          </Text>
-        </Pressable>
-        <Pressable
-          accessibilityRole="link"
-          accessibilityLabel="Настройки"
-          onPress={() => router.push(settingsPath as never)}
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            paddingVertical: spacing.sm,
-            paddingHorizontal: spacing.md,
-            borderRadius: 8,
-            minHeight: 40,
-          }}
-        >
-          <Settings size={18} color={colors.textSecondary} />
-          <Text
-            style={{
-              marginLeft: spacing.md,
-              color: colors.text,
-              fontSize: 14,
-              fontWeight: "500",
-            }}
-          >
-            Настройки
-          </Text>
+            <Text style={{ color: accent.ink, fontSize: 13, fontWeight: "700" }}>
+              {initials}
+            </Text>
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text
+              numberOfLines={1}
+              style={{ fontSize: 13, fontWeight: "600", color: colors.text }}
+            >
+              {displayName}
+            </Text>
+            <Text
+              numberOfLines={1}
+              style={{ fontSize: 11, color: colors.textSecondary }}
+            >
+              {user?.email ?? ""}
+            </Text>
+          </View>
         </Pressable>
       </View>
+
+      {/* Dropdown modal */}
+      <Modal
+        visible={dropdownOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setDropdownOpen(false)}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрыть меню"
+          onPress={() => setDropdownOpen(false)}
+          style={{ flex: 1 }}
+        >
+          <View
+            style={{
+              position: "absolute",
+              bottom: 72,
+              left: spacing.md,
+              width: SIDEBAR_WIDTH - spacing.md * 2,
+              backgroundColor: colors.surface,
+              borderRadius: 12,
+              borderWidth: 1,
+              borderColor: colors.border,
+              padding: spacing.xs,
+              shadowColor: "#000",
+              shadowOffset: { width: 0, height: 6 },
+              shadowOpacity: 0.08,
+              shadowRadius: 16,
+              elevation: 6,
+            }}
+          >
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Настройки"
+              onPress={() => {
+                setDropdownOpen(false);
+                router.push(settingsPath as never);
+              }}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingVertical: spacing.sm,
+                paddingHorizontal: spacing.sm,
+                borderRadius: 8,
+              }}
+            >
+              <Settings size={16} color={colors.textSecondary} />
+              <Text
+                style={{
+                  marginLeft: spacing.sm,
+                  fontSize: 14,
+                  color: colors.text,
+                }}
+              >
+                Настройки
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Уведомления"
+              onPress={() => {
+                setDropdownOpen(false);
+                router.push("/notifications" as never);
+              }}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingVertical: spacing.sm,
+                paddingHorizontal: spacing.sm,
+                borderRadius: 8,
+              }}
+            >
+              <Bell size={16} color={colors.textSecondary} />
+              <Text
+                style={{
+                  marginLeft: spacing.sm,
+                  fontSize: 14,
+                  color: colors.text,
+                }}
+              >
+                Уведомления
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Выйти"
+              onPress={handleLogout}
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                paddingVertical: spacing.sm,
+                paddingHorizontal: spacing.sm,
+                borderRadius: 8,
+              }}
+            >
+              <LogOut size={16} color={colors.danger} />
+              <Text
+                style={{
+                  marginLeft: spacing.sm,
+                  fontSize: 14,
+                  color: colors.danger,
+                }}
+              >
+                Выйти
+              </Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Modal>
     </View>
   );
 }
-
-export { SIDEBAR_WIDTH };


### PR DESCRIPTION
## Summary

Phase 3a of iter10: **persistent left sidebar navigation (240px)** for all authenticated routes. Triggered by multi-model critique 2026-04-24 where all 4 models flagged **P0**:

> "All authenticated screens are single-column mobile layouts on 1440px desktop canvas. Implement persistent left sidebar navigation (240px) for all authenticated routes, push content to max-width 960px container."

## Changes

- **`components/layout/SidebarNav.tsx`** — rewritten. 240px full-height rail, role-tinted (client=blue, specialist=emerald, admin=amber), brand + role badge + primary nav (per role) + bottom identity/settings/logout. Uses `useSegments()` for group detection so colliding paths like `/requests` (client-tabs vs top-level) resolve correctly.
- **`components/layout/AppShell.tsx`** — flex-row shell with fixed sidebar + scrollable main pane. Mobile and public-chrome routes bypass.
- **`components/layout/AppHeader.tsx`** — slimmed to 56px neutral top rail on desktop: breadcrumb + search + bell + avatar. Role-accent border-top removed (now on SidebarNav).
- **`components/layout/DesktopScreen.tsx`** — default `maxWidth` 1200 → 960 per consensus.
- **`components/HeaderHome.tsx`** — `null` on desktop web; mobile unchanged.
- **`app/(admin-tabs)/users.tsx · moderation.tsx · complaints.tsx`** — replaced blue hero banners with `DesktopScreen` title/subtitle + filter bar (Gemini "Unify Application Chrome" P0).

## Out of Phase 3a scope (future iterations)

- List pages → data tables (Phase 3b)
- Settings dedupe (Phase 3c)
- Specialist dashboard real empty states (separate task)

## Test plan

- [x] `tsc --noEmit` clean (root + api)
- [x] `metromap grade` B (88/100), structure 25/25
- [x] Live test 1440×900: client + specialist + admin dashboards show 240px role-tinted sidebar, 56px neutral header, 960px content column
- [x] Live test 1440×900: `/(admin-tabs)/users` — no blue hero, DesktopScreen with filter bar; sidebar "Пользователи" active (amber)
- [x] Mobile 430×932: dashboard shows existing blue HeaderHome + bottom tabs (shell bypass preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)