### PR TITLE
feat(iter12-phase-b): design-system sweep — hex tokens via theme.ts

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -388,7 +388,7 @@ export default function AdminDashboard() {
                           className="rounded-xl items-center justify-center bg-white/20"
                           style={{ width: 44, height: 44 }}
                         >
-                          <Shield size={22} color="#fff" />
+                          <Shield size={22} color={colors.white} />
                         </View>
                         <View className="flex-1 min-w-0">
                           <Text

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -541,7 +541,7 @@ export default function UserDashboard() {
                         >
                           <Plus
                             size={22}
-                            color={atLimit ? colors.textMuted : "#fff"}
+                            color={atLimit ? colors.textMuted : colors.white}
                           />
                         </View>
                         <View className="flex-1 min-w-0">
@@ -646,7 +646,7 @@ export default function UserDashboard() {
                             className="rounded-xl items-center justify-center bg-white/20"
                             style={{ width: 44, height: 44 }}
                           >
-                            <List size={22} color="#fff" />
+                            <List size={22} color={colors.white} />
                           </View>
                           <View className="flex-1 min-w-0">
                             <Text

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -193,7 +193,7 @@ export default function UnifiedInbox() {
               minHeight: 72,
               borderLeftWidth: hasUnread ? 3 : 0,
               borderLeftColor: hasUnread ? colors.primary : "transparent",
-              shadowColor: "#000",
+              shadowColor: colors.black,
               shadowOffset: { width: 0, height: 1 },
               shadowOpacity: 0.06,
               shadowRadius: 3,
@@ -205,7 +205,7 @@ export default function UnifiedInbox() {
           <View
             className="relative mr-3 my-3.5"
             style={{
-              shadowColor: "#000",
+              shadowColor: colors.black,
               shadowOffset: { width: 0, height: 2 },
               shadowOpacity: 0.1,
               shadowRadius: 4,
@@ -223,7 +223,7 @@ export default function UnifiedInbox() {
                 width: 12,
                 height: 12,
                 borderWidth: 2,
-                borderColor: "#fff",
+                borderColor: colors.white,
               }}
             />
             {hasUnread && (

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,7 +10,7 @@ import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
  * authenticated users and only on routes that don't have their own
  * chrome (landing, auth, onboarding, legal).
  *
- * Issue #1285 — persistent header on every authenticated route.
+ * Issue GH-1285 — persistent header on every authenticated route.
  */
 function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth();
@@ -67,7 +67,7 @@ export default function RootLayout() {
             <Stack.Screen name="notifications" />
             <Stack.Screen name="legal/privacy" />
             <Stack.Screen name="legal/terms" />
-            {/* Issue #1293: /brand is a dev-only design-system page. */}
+            {/* Issue GH-1293: /brand is a dev-only design-system page. */}
             {__DEV__ && <Stack.Screen name="brand" />}
 
             {/* Admin detail screens */}

--- a/app/brand.tsx
+++ b/app/brand.tsx
@@ -36,7 +36,7 @@ export default function BrandScreen() {
   const [inputError, setInputError] = useState("not-email");
   const [inputIcon, setInputIcon] = useState("");
 
-  // Issue #1293 (regression): /brand must never render in production.
+  // Issue GH-1293 (regression): /brand must never render in production.
   // The `{__DEV__ && <Stack.Screen />}` gate in `app/_layout.tsx` only hides
   // the route registration — Expo Router file-based routing still discovers
   // `app/brand.tsx` and serves the page. The only bulletproof guard is to

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -17,6 +17,7 @@ import FearTimeline from "@/components/landing/FearTimeline";
 import SpecialistCTASection from "@/components/landing/SpecialistCTASection";
 import FinalCTA from "@/components/landing/FinalCTA";
 import FooterSection from "@/components/landing/FooterSection";
+import { colors } from "@/lib/theme";
 
 interface LandingCounts {
   specialistsCount: number;
@@ -202,7 +203,7 @@ export default function LandingScreen() {
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       <ScrollView
         showsVerticalScrollIndicator={false}
-        contentContainerStyle={{ backgroundColor: "#ffffff" }}
+        contentContainerStyle={{ backgroundColor: colors.white }}
       >
         <LandingHeader
           isDesktop={isDesktop}

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -217,7 +217,7 @@ export default function PublicRequestsFeed() {
 
       {/* Accent hero */}
       <View style={{ backgroundColor: colors.accent, paddingHorizontal: 16, paddingTop: 16, paddingBottom: 16 }}>
-        <Text style={{ ...textStyle.h3, color: "#ffffff", marginBottom: 2 }}>Открытые заявки</Text>
+        <Text style={{ ...textStyle.h3, color: colors.white, marginBottom: 2 }}>Открытые заявки</Text>
         <Text style={{ ...textStyle.small, color: overlay.white75 }}>Задайте вопрос — получите предложения от специалистов</Text>
         {total > 0 && (
           <Text className="text-sm font-semibold text-white mt-2">{total} активных заявок</Text>

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -224,12 +224,12 @@ export default function SpecialistPublicProfile() {
         {isExFns && (
           <View
             className="flex-row items-center self-start mt-3 px-3 py-1.5 rounded-full"
-            style={{ backgroundColor: "#fef3c7", gap: 6 }}
+            style={{ backgroundColor: colors.yellowSoft, gap: 6 }}
           >
-            <ShieldCheck size={14} color="#b45309" />
+            <ShieldCheck size={14} color={colors.warningInk} />
             <Text
               className="text-xs font-semibold"
-              style={{ color: "#b45309" }}
+              style={{ color: colors.warningInk }}
             >
               Ex-ФНС {profile?.exFnsStartYear}–{profile?.exFnsEndYear}
             </Text>
@@ -543,7 +543,7 @@ export default function SpecialistPublicProfile() {
   );
 
   return (
-    <SafeAreaView className="flex-1" style={{ backgroundColor: "#fafbfc" }}>
+    <SafeAreaView className="flex-1" style={{ backgroundColor: colors.surface2 }}>
       <Head>
         <title>{name} — специалист по налогам | P2PTax</title>
         <meta

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -228,7 +228,7 @@ export default function SpecialistsCatalog() {
       <HeaderBack title="Специалисты" />
       <View style={{ backgroundColor: colors.accent, width: "100%", alignItems: "center" }}>
         <View style={{ width: "100%", maxWidth: isWide ? 1200 : isDesktop ? 900 : undefined, paddingHorizontal: isWide ? 32 : 16, paddingTop: 20, paddingBottom: 20 }}>
-        <Text style={{ ...(isWide ? textStyle.h1 : textStyle.h3), color: "#ffffff", marginBottom: 4 }}>Каталог специалистов</Text>
+        <Text style={{ ...(isWide ? textStyle.h1 : textStyle.h3), color: colors.white, marginBottom: 4 }}>Каталог специалистов</Text>
         <Text style={{ ...textStyle.small, color: overlay.white75 }}>Практики с опытом в вашей ИФНС. Выбирайте по инспекции, городу и типу проверки.</Text>
         <View className="flex-row mt-4 gap-3">
           <View className="flex-1 rounded-xl px-3 py-2.5" style={{ backgroundColor: overlay.white15 }}>

--- a/components/MessengerEmptyPane.tsx
+++ b/components/MessengerEmptyPane.tsx
@@ -135,9 +135,9 @@ export default function MessengerEmptyPane({
                 style={{ paddingHorizontal: 16, paddingVertical: 10 }}
               >
                 {primary.icon === "plus" ? (
-                  <Plus size={14} color="#fff" />
+                  <Plus size={14} color={colors.white} />
                 ) : (
-                  <Sparkles size={14} color="#fff" />
+                  <Sparkles size={14} color={colors.white} />
                 )}
                 <Text
                   className="text-white font-semibold"

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import StatusBadge from "./StatusBadge";
+import { colors } from "@/lib/theme";
 
 interface RequestCardProps {
   id: string;
@@ -29,7 +30,7 @@ export default function RequestCard({
       onPress={() => onPress(id)}
       className="bg-white border border-border rounded-xl p-4 mb-3"
       style={({ pressed }) => [
-        { shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
+        { shadowColor: colors.black, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
         pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
       ]}
     >

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -79,7 +79,7 @@ export default function SpecialistCard({
       onPress={() => onPress(id)}
       className="bg-white border border-border rounded-2xl p-4 mb-3"
       style={({ pressed }) => [
-        { shadowColor: "#000", shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
+        { shadowColor: colors.black, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
         pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
       ]}
     >

--- a/components/dashboard/CaseTimeline.tsx
+++ b/components/dashboard/CaseTimeline.tsx
@@ -39,7 +39,7 @@ function StageNode({ stage }: { stage: TimelineStage }) {
   if (stage.status === "done") {
     return (
       <View style={[baseStyle, { backgroundColor: colors.success }]}>
-        <Check size={16} color="#ffffff" />
+        <Check size={16} color={colors.white} />
       </View>
     );
   }
@@ -60,7 +60,7 @@ function StageNode({ stage }: { stage: TimelineStage }) {
             width: 8,
             height: 8,
             borderRadius: 4,
-            backgroundColor: "#ffffff",
+            backgroundColor: colors.white,
           }}
         />
       </View>
@@ -366,7 +366,7 @@ export default function CaseTimeline({
             >
               <Text
                 style={{
-                  color: "#ffffff",
+                  color: colors.white,
                   fontWeight: "600",
                   fontSize: 14,
                 }}

--- a/components/dashboard/DashboardHero.tsx
+++ b/components/dashboard/DashboardHero.tsx
@@ -24,7 +24,7 @@ export interface DashboardHeroProps {
 }
 
 function valueColorFor(tone: "accent" | "surface", color?: StatColor): string {
-  if (tone === "accent") return "#ffffff";
+  if (tone === "accent") return colors.white;
   if (color === "success") return colors.success;
   if (color === "warning") return colors.warning;
   if (color === "muted") return colors.textSecondary;
@@ -54,7 +54,7 @@ export default function DashboardHero({
   const isDesktop = width >= 1024;
   const isTablet = width >= 640;
   const bg = tone === "accent" ? colors.accent : colors.surface;
-  const greetingColor = tone === "accent" ? "#ffffff" : colors.text;
+  const greetingColor = tone === "accent" ? colors.white : colors.text;
   const subtitleColor = tone === "accent" ? overlay.white80 : colors.textSecondary;
   const tileBg = tone === "accent" ? overlay.white15 : colors.surface2;
 

--- a/components/landing/CaseCard.tsx
+++ b/components/landing/CaseCard.tsx
@@ -27,7 +27,7 @@ export default function CaseCard({ data, index }: CaseCardProps) {
       className="rounded-2xl"
       style={{
         flex: 1,
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
         borderWidth: 1,
         borderColor: colors.border,
         padding: 24,
@@ -50,7 +50,7 @@ export default function CaseCard({ data, index }: CaseCardProps) {
             {data.specialistName}
           </Text>
           <View className="flex-row items-center" style={{ gap: 4, marginTop: 2 }}>
-            <DuotoneIcon name="shield-check" size={14} color={colors.success} softColor="#d1fae5" />
+            <DuotoneIcon name="shield-check" size={14} color={colors.success} softColor={colors.successSoft} />
             <Text style={{ color: colors.success, fontSize: 11, fontWeight: "600" }}>
               Проверен платформой
             </Text>

--- a/components/landing/CasesSection.tsx
+++ b/components/landing/CasesSection.tsx
@@ -15,7 +15,7 @@ export default function CasesSection({ isDesktop, cases, onCreateRequest }: Case
       style={{
         paddingVertical: isDesktop ? 96 : 64,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
       }}
     >
       <View

--- a/components/landing/DuotoneIcon.tsx
+++ b/components/landing/DuotoneIcon.tsx
@@ -58,7 +58,7 @@ function renderIcon(name: IconName, stroke: string, soft: string) {
             strokeWidth={2}
             strokeLinecap="round"
           />
-          <Circle cx={32} cy={32} r={7} fill="#fff" stroke={stroke} strokeWidth={2.5} />
+          <Circle cx={32} cy={32} r={7} fill={colors.white} stroke={stroke} strokeWidth={2.5} />
           <Path
             d="M37 37l5 5"
             stroke={stroke}
@@ -77,7 +77,7 @@ function renderIcon(name: IconName, stroke: string, soft: string) {
             strokeWidth={2}
             strokeLinecap="round"
           />
-          <Circle cx={36} cy={34} r={6} fill="#fff" stroke={stroke} strokeWidth={2.5} />
+          <Circle cx={36} cy={34} r={6} fill={colors.white} stroke={stroke} strokeWidth={2.5} />
           <Path
             d="M33 34l2 2 4-4"
             stroke={stroke}
@@ -97,7 +97,7 @@ function renderIcon(name: IconName, stroke: string, soft: string) {
             strokeWidth={2}
             strokeLinejoin="round"
           />
-          <Circle cx={36} cy={14} r={7} fill="#fff" stroke={stroke} strokeWidth={2.5} />
+          <Circle cx={36} cy={14} r={7} fill={colors.white} stroke={stroke} strokeWidth={2.5} />
           <Path
             d="M36 11v3l2 2"
             stroke={stroke}
@@ -129,7 +129,7 @@ function renderIcon(name: IconName, stroke: string, soft: string) {
       return (
         <G>
           <Rect x={10} y={8} width={28} height={32} rx={3} fill={soft} />
-          <Rect x={18} y={6} width={12} height={6} rx={2} fill="#fff" stroke={stroke} strokeWidth={2} />
+          <Rect x={18} y={6} width={12} height={6} rx={2} fill={colors.white} stroke={stroke} strokeWidth={2} />
           <Path
             d="M16 20h16M16 26h16M16 32h10"
             stroke={stroke}

--- a/components/landing/FearTimeline.tsx
+++ b/components/landing/FearTimeline.tsx
@@ -35,8 +35,8 @@ const STEPS = [
 
 const TONE_COLORS = {
   slate: { bg: gray[100], text: gray[700] },
-  amber: { bg: "#fef3c7", text: "#92400e" },
-  red: { bg: "#fee2e2", text: "#b91c1c" },
+  amber: { bg: colors.yellowSoft, text: colors.warningInkStrong },
+  red: { bg: colors.dangerSoftAlt, text: colors.dangerInk },
 } as const;
 
 export default function FearTimeline({ isDesktop }: FearTimelineProps) {
@@ -45,7 +45,7 @@ export default function FearTimeline({ isDesktop }: FearTimelineProps) {
       style={{
         paddingVertical: isDesktop ? 96 : 64,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#fffbf2",
+        backgroundColor: colors.warningTintBg,
       }}
     >
       <View
@@ -56,7 +56,7 @@ export default function FearTimeline({ isDesktop }: FearTimelineProps) {
         }}
       >
         <View className="flex-row items-center" style={{ gap: 12, marginBottom: 16 }}>
-          <DuotoneIcon name="clock" size={28} color={colors.warning} softColor="#fef3c7" />
+          <DuotoneIcon name="clock" size={28} color={colors.warning} softColor={colors.yellowSoft} />
           <Text
             style={{
               color: colors.textMuted,
@@ -91,7 +91,7 @@ export default function FearTimeline({ isDesktop }: FearTimelineProps) {
                 className="rounded-2xl"
                 style={{
                   padding: 20,
-                  backgroundColor: "#ffffff",
+                  backgroundColor: colors.white,
                   borderWidth: 1,
                   borderColor: colors.border,
                   flexDirection: isDesktop ? "row" : "column",
@@ -147,7 +147,7 @@ export default function FearTimeline({ isDesktop }: FearTimelineProps) {
         >
           <Text
             style={{
-              color: "#ffffff",
+              color: colors.white,
               fontSize: 16,
               fontWeight: "600",
               textAlign: "center",

--- a/components/landing/FinalCTA.tsx
+++ b/components/landing/FinalCTA.tsx
@@ -13,7 +13,7 @@ export default function FinalCTA({ isDesktop, onCreateRequest, onViewCatalog }: 
       style={{
         paddingVertical: isDesktop ? 96 : 64,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
         alignItems: "center",
       }}
     >

--- a/components/landing/FooterSection.tsx
+++ b/components/landing/FooterSection.tsx
@@ -135,7 +135,7 @@ function FooterLink({ label, onPress }: { label: string; onPress: () => void }) 
       onPress={onPress}
       className="min-h-[36px] justify-center"
     >
-      <Text style={{ color: "#ffffff", fontSize: 14 }}>{label}</Text>
+      <Text style={{ color: colors.white, fontSize: 14 }}>{label}</Text>
     </Pressable>
   );
 }

--- a/components/landing/HeroBlock.tsx
+++ b/components/landing/HeroBlock.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { View, Text, Pressable } from "react-native";
-import { colors, gray, AVATAR_COLORS } from "@/lib/theme";
+import { colors, gray, AVATAR_COLORS, shadowColor } from "@/lib/theme";
 
 export interface HeroSpecialistPreview {
   id: string;
@@ -44,7 +44,7 @@ export default function HeroBlock({
         paddingTop: isDesktop ? 80 : 48,
         paddingBottom: isDesktop ? 64 : 48,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#f6f9ff",
+        backgroundColor: colors.accentTintBg,
       }}
     >
       {/* Soft gradient overlay via layered background pads. */}
@@ -69,7 +69,7 @@ export default function HeroBlock({
           width: 360,
           height: 360,
           borderRadius: 360,
-          backgroundColor: "#dce6fa",
+          backgroundColor: colors.accentTintShape,
           opacity: 0.55,
         }}
       />
@@ -91,7 +91,7 @@ export default function HeroBlock({
             style={{
               paddingHorizontal: 12,
               paddingVertical: 6,
-              backgroundColor: "#ffffff",
+              backgroundColor: colors.white,
               borderWidth: 1,
               borderColor: colors.border,
               marginBottom: 24,
@@ -179,7 +179,7 @@ export default function HeroBlock({
                 paddingHorizontal: 32,
                 borderWidth: 2,
                 borderColor: gray[300],
-                backgroundColor: "#ffffff",
+                backgroundColor: colors.white,
               }}
             >
               <Text className="font-semibold" style={{ fontSize: 16, color: colors.text }}>
@@ -234,7 +234,7 @@ function SpecialistCard({
     <View
       className="rounded-2xl"
       style={{
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
         borderWidth: 1,
         borderColor: colors.border,
         padding: 20,
@@ -242,7 +242,7 @@ function SpecialistCard({
         gap: 16,
         // eslint-disable-next-line react-native/no-inline-styles
         transform: [{ rotate: rotation }],
-        shadowColor: "#1a2b4a",
+        shadowColor: shadowColor.heroDeep,
         shadowOpacity: 0.06,
         shadowRadius: 16,
         shadowOffset: { width: 0, height: 8 },
@@ -277,7 +277,7 @@ function SpecialistCard({
               style={{
                 paddingHorizontal: 8,
                 paddingVertical: 3,
-                backgroundColor: "#ecfdf5",
+                backgroundColor: colors.successBgTint,
               }}
             >
               <View
@@ -317,7 +317,7 @@ function SpecialistSkeleton({ index, loading }: { index: number; loading: boolea
     <View
       className="rounded-2xl"
       style={{
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
         borderWidth: 1,
         borderColor: colors.border,
         padding: 20,

--- a/components/landing/HowItWorksFlow.tsx
+++ b/components/landing/HowItWorksFlow.tsx
@@ -29,7 +29,7 @@ export default function HowItWorksFlow({ isDesktop }: HowItWorksFlowProps) {
       style={{
         paddingVertical: isDesktop ? 96 : 64,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#f6f9ff",
+        backgroundColor: colors.accentTintBg,
       }}
     >
       <View
@@ -150,7 +150,7 @@ export default function HowItWorksFlow({ isDesktop }: HowItWorksFlowProps) {
             marginTop: 48,
             padding: 20,
             borderRadius: 16,
-            backgroundColor: "#ffffff",
+            backgroundColor: colors.white,
             borderWidth: 1,
             borderColor: colors.border,
             alignSelf: "center",

--- a/components/landing/LandingHeader.tsx
+++ b/components/landing/LandingHeader.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable } from "react-native";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 
 interface LandingHeaderProps {
   isDesktop: boolean;
@@ -27,7 +27,7 @@ export default function LandingHeader({
     <View
       className="w-full"
       style={{
-        backgroundColor: transparent ? "rgba(255,255,255,0.85)" : colors.background,
+        backgroundColor: transparent ? overlay.white85 : colors.background,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,
       }}

--- a/components/landing/ServiceCard.tsx
+++ b/components/landing/ServiceCard.tsx
@@ -30,7 +30,7 @@ export default function ServiceCard({
       className="rounded-2xl"
       style={{
         flex: 1,
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
         borderWidth: 1,
         borderColor: colors.border,
         padding: 28,

--- a/components/landing/ServicesSection.tsx
+++ b/components/landing/ServicesSection.tsx
@@ -16,7 +16,7 @@ export default function ServicesSection({ isDesktop }: ServicesSectionProps) {
       style={{
         paddingVertical: isDesktop ? 96 : 64,
         paddingHorizontal: isDesktop ? 32 : 20,
-        backgroundColor: "#ffffff",
+        backgroundColor: colors.white,
       }}
     >
       <View

--- a/components/landing/SpecialistCTASection.tsx
+++ b/components/landing/SpecialistCTASection.tsx
@@ -33,7 +33,7 @@ export default function SpecialistCTASection({
           maxWidth: 1152,
           marginHorizontal: "auto",
           padding: isDesktop ? 56 : 32,
-          backgroundColor: "#0b1424",
+          backgroundColor: colors.text,
           flexDirection: isDesktop ? "row" : "column",
           gap: isDesktop ? 48 : 32,
           alignItems: isDesktop ? "center" : "flex-start",
@@ -54,7 +54,7 @@ export default function SpecialistCTASection({
           </Text>
           <Text
             style={{
-              color: "#ffffff",
+              color: colors.white,
               fontSize: isDesktop ? 36 : 28,
               lineHeight: isDesktop ? 44 : 36,
               fontWeight: "800",
@@ -87,9 +87,9 @@ export default function SpecialistCTASection({
                     backgroundColor: overlay.white10,
                   }}
                 >
-                  <Text style={{ color: "#ffffff", fontSize: 12, fontWeight: "700" }}>✓</Text>
+                  <Text style={{ color: colors.white, fontSize: 12, fontWeight: "700" }}>✓</Text>
                 </View>
-                <Text style={{ color: "#ffffff", fontSize: 14, lineHeight: 20 }}>{b}</Text>
+                <Text style={{ color: colors.white, fontSize: 14, lineHeight: 20 }}>{b}</Text>
               </View>
             ))}
           </View>
@@ -105,7 +105,7 @@ export default function SpecialistCTASection({
             gap: 16,
           }}
         >
-          <Text style={{ color: "#ffffff", fontSize: 18, fontWeight: "700" }}>
+          <Text style={{ color: colors.white, fontSize: 18, fontWeight: "700" }}>
             Станьте специалистом
           </Text>
           <Text style={{ color: overlay.white70, fontSize: 14, lineHeight: 20 }}>
@@ -119,7 +119,7 @@ export default function SpecialistCTASection({
             className="rounded-xl items-center justify-center"
             style={{
               height: 52,
-              backgroundColor: "#ffffff",
+              backgroundColor: colors.white,
             }}
           >
             <Text style={{ color: colors.text, fontSize: 15, fontWeight: "700" }}>

--- a/components/landing/TrustStrip.tsx
+++ b/components/landing/TrustStrip.tsx
@@ -36,7 +36,7 @@ export default function TrustStrip({
   return (
     <View
       style={{
-        backgroundColor: "#0b1424",
+        backgroundColor: colors.text,
         paddingVertical: isDesktop ? 48 : 40,
         paddingHorizontal: isDesktop ? 32 : 20,
       }}
@@ -63,7 +63,7 @@ export default function TrustStrip({
           >
             <Text
               style={{
-                color: "#ffffff",
+                color: colors.white,
                 fontSize: isDesktop ? 56 : 44,
                 lineHeight: isDesktop ? 60 : 48,
                 fontWeight: "800",

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -27,7 +27,7 @@ import RoleBadge from "./RoleBadge";
  * Desktop (>= 640px): logo + breadcrumb + search input + role badge + bell + avatar dropdown.
  * Mobile  (<  640px): burger + centered title + bell, dropdown deferred to MobileMenu.
  *
- * Issue #1285 (persistent header), #1289 (role accent tint).
+ * Issue GH-1285 (persistent header), GH-1289 (role accent tint).
  *
  * The component deliberately keeps its own breadcrumb mapping small —
  * more sophisticated trails can be added later once the screen set
@@ -283,7 +283,7 @@ export default function AppHeader({ title }: AppHeaderProps) {
               borderWidth: 1,
               borderColor: colors.border,
               padding: spacing.sm,
-              shadowColor: "#000",
+              shadowColor: colors.black,
               shadowOffset: { width: 0, height: 6 },
               shadowOpacity: 0.08,
               shadowRadius: 16,

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { View, useWindowDimensions, Platform } from "react-native";
 import { usePathname, useSegments } from "expo-router";
-import { colors } from "@/lib/theme";
+import { colors, overlay } from "@/lib/theme";
 import SidebarNav, { detectSidebarGroup, SIDEBAR_WIDTH } from "./SidebarNav";
 
 /**
@@ -30,10 +30,11 @@ function installFocusRingCSS() {
   if (document.getElementById(FOCUS_RING_STYLE_ID)) return;
   const style = document.createElement("style");
   style.id = FOCUS_RING_STYLE_ID;
+  // overlay.accent20 expanded inline (browser CSS string, not RN style).
   style.textContent = `
     input:focus, textarea:focus {
       outline: none;
-      box-shadow: 0 0 0 3px rgba(34, 86, 194, 0.2);
+      box-shadow: 0 0 0 3px ${overlay.accent20};
       border-radius: 10px;
     }
   `;

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -32,7 +32,7 @@ import RoleBadge from "./RoleBadge";
  *   - Role-tinted background (blue client / emerald specialist / amber admin).
  *   - 3 zones: brand + role badge · primary nav · bottom identity/settings.
  *   - Active item: tint bg + left 2px accent border + bold label.
- *   - All nav items from issue #1285/#1289 spec + expanded to cover
+ *   - All nav items from issue GH-1285/GH-1289 spec + expanded to cover
  *     secondary destinations (Каталог специалистов, Публичные заявки,
  *     Уведомления) that were buried in AppHeader dropdown.
  *
@@ -482,7 +482,7 @@ export default function SidebarNav({ group }: SidebarNavProps) {
               borderWidth: 1,
               borderColor: colors.border,
               padding: spacing.xs,
-              shadowColor: "#000",
+              shadowColor: colors.black,
               shadowOffset: { width: 0, height: 6 },
               shadowOpacity: 0.08,
               shadowRadius: 16,

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -53,7 +53,7 @@ export default function Avatar({
   const wh = resolveSize(size);
   const textClass = textClassFor(wh);
   const bg = tint ?? colors.primary;
-  const ink = inkColor ?? "#ffffff";
+  const ink = inkColor ?? colors.white;
 
   if (imageUrl) {
     return (

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -32,7 +32,7 @@ export default function Button({
 
   const isInactive = disabled || loading;
 
-  // Issue #1290 — disabled must be a clearly different fill (gray[200] /
+  // Issue GH-1290 — disabled must be a clearly different fill (gray[200] /
   // gray[400]) so users don't tap a bleached-primary that looks active.
   // Loading keeps the variant fill and shows a spinner instead.
   const variantStyle = isInactive && disabled && !loading
@@ -55,14 +55,14 @@ export default function Button({
     disabled && !loading
       ? gray[400]
       : variant === "primary" || variant === "destructive"
-        ? "#ffffff"
+        ? colors.white
         : colors.text;
 
   const iconColor =
     disabled && !loading
       ? gray[400]
       : variant === "primary" || variant === "destructive"
-        ? "#ffffff"
+        ? colors.white
         : colors.primary;
 
   return (

--- a/components/ui/Text.tsx
+++ b/components/ui/Text.tsx
@@ -22,7 +22,7 @@ const TONE_COLOR: Record<NonNullable<TextProps["tone"]>, string> = {
   accent: colors.primary,
   danger: colors.danger,
   success: colors.success,
-  white: "#ffffff",
+  white: colors.white,
 };
 
 /**

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,7 +1,7 @@
 /**
  * Unified primary blue — #2256c2 (landing tone).
  *
- * Issue #1288: historically the app drifted between multiple shades of
+ * Issue GH-1288: historically the app drifted between multiple shades of
  * blue (#2e5bff, #2256c2, #3b5bdb, #1e40af). The landing marketing site
  * is already in market with #2256c2, so it's the single source of truth.
  * NEVER hardcode a different blue hex in app/ or components/ — always
@@ -15,8 +15,15 @@ export const colors = {
   accent: PRIMARY_BLUE,      // accent (same as primary)
   accentSoft: '#e8eefb',     // accent-soft
   accentSoftInk: '#1b3d8a',  // accent-soft-ink
-  background: '#ffffff',     // bg
-  surface: '#ffffff',        // pure white cards
+  // Landing hero tints (iter12 phase-b) — pale brand washes
+  accentTintBg: '#f6f9ff',     // hero section background (near-white blue tint)
+  accentTintShape: '#dce6fa',  // decorative shape on hero (slightly stronger blue tint)
+  // Raw neutrals (iter12 phase-b) — kept explicit so shared components stop
+  // minting fresh #fff / #000 literals; use these instead.
+  white: '#ffffff',
+  black: '#000000',
+  background: '#ffffff',     // bg (alias of white)
+  surface: '#ffffff',        // pure white cards (alias of white)
   surface2: '#fafbfc',       // surface-2
   text: '#0b1424',           // text
   textSecondary: '#525a6b',  // text-mute
@@ -34,6 +41,15 @@ export const colors = {
   success: '#1f8a5e',
   warning: '#d97706',
   dangerSoft: '#fef2f2',
+  // Semantic "ink" tones — saturated text on soft-tinted chips
+  warningInk: '#b45309',        // amber-700 on yellowSoft chip
+  warningInkStrong: '#92400e',  // amber-800 on yellowSoft (higher emphasis)
+  dangerInk: '#b91c1c',         // red-700 on dangerSoftAlt chip
+  // Extra soft backgrounds (iter12 phase-b consolidation)
+  dangerSoftAlt: '#fee2e2',   // red-100 (FearTimeline "red" step)
+  warningTintBg: '#fffbf2',   // warm amber section bg (FearTimeline wrapper)
+  successSoft: '#d1fae5',     // green-100 (same hue as roleAccent.specialist.soft)
+  successBgTint: '#ecfdf5',   // emerald-50 (inline "онлайн" chip bg)
   // Soft backgrounds for status/category chips
   indigoSoft: '#e0e7ff',
   pinkSoft: '#fce7f3',
@@ -48,7 +64,7 @@ export const colors = {
 
 /**
  * Gray scale — Tailwind-compatible neutrals used for disabled states,
- * muted chrome, separators. Issue #1290: disabled buttons must use
+ * muted chrome, separators. Issue GH-1290: disabled buttons must use
  * `gray.200` bg + `gray.400` text for sufficient contrast against the
  * active primary (so the eye can still tell "can press" vs "can't").
  */
@@ -66,7 +82,7 @@ export const gray = {
 } as const
 
 /**
- * Role-signalling accents (issue #1289). Every authenticated user belongs
+ * Role-signalling accents (issue GH-1289). Every authenticated user belongs
  * to exactly one role tier; the header + key chrome tinted accordingly so
  * three portals stop looking like a single template with swapped H1.
  *
@@ -214,6 +230,7 @@ export const fontSizeValue = {
 export const shadowColor = {
   dark: '#000000',   // standard card/modal shadow
   accent: 'rgba(34,86,194,0.1)', // accent glow
+  heroDeep: '#1a2b4a', // deep navy — landing hero card lift shadow
 } as const
 
 // Semantic overlay tokens — for rgba on colored backgrounds
@@ -225,7 +242,9 @@ export const overlay = {
   white70: 'rgba(255,255,255,0.7)',
   white75: 'rgba(255,255,255,0.75)',
   white80: 'rgba(255,255,255,0.8)',
+  white85: 'rgba(255,255,255,0.85)',
   white20: 'rgba(255,255,255,0.2)',
   accent10: 'rgba(34,86,194,0.1)',
+  accent20: 'rgba(34,86,194,0.2)',  // focus-ring tint (web)
   dark15: 'rgba(0,0,0,0.15)',  // image placeholder icon tint
 } as const


### PR DESCRIPTION
## Before
- unique hex colors: **21** (4 false positives from issue refs in comments).
- hardcoded hex references in app/ + components/: **~65**

## After
- unique hex colors: **0** outside `lib/theme.ts`.
- hardcoded hex references in app/ + components/: **0** (only in theme.ts).
- `metromap style` reports `colors: 0` (gate threshold was `<15`).

## Impact
- Single source of truth for brand colors (`lib/theme.ts`).
- Easier future theme changes (dark mode, re-branding).
- `sdlc-cycle` gate unblocked on `unique_hex_colors` threshold.

## Theme additions
- `colors.white` / `colors.black` — explicit raw neutrals so shared components
  stop minting fresh `#fff` / `#000` literals.
- `colors.accentTintBg` (`#f6f9ff`) / `colors.accentTintShape` (`#dce6fa`) — hero pale brand washes.
- `colors.warningInk` (`#b45309`) / `warningInkStrong` (`#92400e`) — amber text on yellowSoft chips.
- `colors.dangerInk` (`#b91c1c`) / `dangerSoftAlt` (`#fee2e2`) — red-700/100 pair.
- `colors.warningTintBg` (`#fffbf2`) — FearTimeline section bg.
- `colors.successSoft` (`#d1fae5`) / `successBgTint` (`#ecfdf5`) — emerald soft pair.
- `shadowColor.heroDeep` (`#1a2b4a`) — landing hero card lift.
- `overlay.white85`, `overlay.accent20` — ported from inline rgba() in LandingHeader and AppShell focus-ring CSS.

## Comment-ref hygiene
- `Issue #1285` → `Issue GH-1285` (11 occurrences across 6 files). Style audit was matching 4-digit issue numbers as `#RGBA` colors.

## Verification
- [x] `npx tsc --noEmit` (root) — 0 errors
- [x] `cd api && npx tsc --noEmit` — 0 errors
- [x] `metromap style` — `colors: 0` (was 21)
- [x] `metromap sa-check` — CLEAN
- [x] `vizor http://localhost:8081/ --problems` — 0 issues (mobile + desktop)
- [x] Visual screenshots (`/`, `/brand` at 1440×900) — zero regression

## Test plan
- [ ] Pull branch locally, run `npx expo start --web`, scroll landing — should look identical to development
- [ ] Open `/brand` page — full design-system swatches render with all named tokens
- [ ] Toggle role (client/specialist/admin) — role accents (blue/emerald/amber) intact
- [ ] Mobile viewport (390×844) — no broken text colors, FearTimeline tones preserved