### PR TITLE
fix(struct): dedupe duplicate screen routes via Redirect

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -83,6 +83,9 @@ export default function TabLayout() {
           tabBarIcon: ({ color, size }) => <User size={size} color={color} />,
         }}
       />
+      {/* STRUCT-1 — redirect-only tabs, hidden from tab bar. */}
+      <Tabs.Screen name="create" options={{ href: null }} />
+      <Tabs.Screen name="search" options={{ href: null }} />
     </Tabs>
   );
 }

--- a/app/(tabs)/create.tsx
+++ b/app/(tabs)/create.tsx
@@ -1,0 +1,10 @@
+import { Redirect } from "expo-router";
+
+/**
+ * STRUCT-1 — legacy /(tabs)/create route redirects to the actual
+ * request-creation form. Kept as a file so any deep-linked or bookmarked
+ * URL continues to work without a 404.
+ */
+export default function CreateRedirect() {
+  return <Redirect href={"/requests/new" as never} />;
+}

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -1,0 +1,10 @@
+import { Redirect } from "expo-router";
+
+/**
+ * STRUCT-1 — legacy /(tabs)/search route redirects to the specialists
+ * catalog. Kept as a file so any deep-linked or bookmarked URL continues
+ * to work without a 404.
+ */
+export default function SearchRedirect() {
+  return <Redirect href={"/specialists" as never} />;
+}


### PR DESCRIPTION
## Summary
- Add `app/(tabs)/create.tsx` → `<Redirect href="/requests/new" />`
- Add `app/(tabs)/search.tsx` → `<Redirect href="/specialists" />`
- Hide both from tab bar via `href: null` in `(tabs)/_layout.tsx`
- `/messages` already unified as `/(tabs)/messages` (iter11) — no file needed
- `/settings` already unified in `settings/index.tsx` with internal role redirect

## Notes
`/(tabs)/create` and `/(tabs)/search` were the only two routes that didn't have source files. The other two pairs (`/messages` → `/(tabs)/messages`, `/settings` → role-specific) were already resolved in iter11.

## Test plan
- [ ] Navigate to `/(tabs)/create` → redirects to `/requests/new`
- [ ] Navigate to `/(tabs)/search` → redirects to `/specialists`
- [ ] Tab bar shows no extra tabs (create/search hidden)
- [ ] `tsc --noEmit` passes (frontend + api)

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)