### PR TITLE
fix(polish): batch 1 — tiny text 11→12px (12 components)

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -301,19 +301,19 @@ export default function AdminDashboard() {
                     >
                       <Text
                         className="text-text-dim uppercase"
-                        style={{ fontSize: 11, flex: 3, fontWeight: "700" }}
+                        style={{ fontSize: 12, flex: 3, fontWeight: "700" }}
                       >
                         Пользователь
                       </Text>
                       <Text
                         className="text-text-dim uppercase"
-                        style={{ fontSize: 11, flex: 1, fontWeight: "700" }}
+                        style={{ fontSize: 12, flex: 1, fontWeight: "700" }}
                       >
                         Роль
                       </Text>
                       <Text
                         className="text-text-dim uppercase"
-                        style={{ fontSize: 11, flex: 1, fontWeight: "700" }}
+                        style={{ fontSize: 12, flex: 1, fontWeight: "700" }}
                       >
                         Дата
                       </Text>

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -302,7 +302,7 @@ export default function SpecialistPublicProfile() {
           <Text
             className="uppercase mb-3"
             style={{
-              fontSize: 11,
+              fontSize: 12,
               letterSpacing: 3,
               color: colors.textSecondary,
               fontWeight: "600",
@@ -334,7 +334,7 @@ export default function SpecialistPublicProfile() {
           <Text
             className="uppercase mb-3"
             style={{
-              fontSize: 11,
+              fontSize: 12,
               letterSpacing: 3,
               color: colors.textSecondary,
               fontWeight: "600",
@@ -447,7 +447,7 @@ export default function SpecialistPublicProfile() {
       <Text
         className="uppercase mb-3"
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: 3,
           color: colors.textSecondary,
           fontWeight: "600",
@@ -523,7 +523,7 @@ export default function SpecialistPublicProfile() {
       <Text
         className="uppercase mb-3"
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: 3,
           color: colors.textSecondary,
           fontWeight: "600",

--- a/components/HeaderHome.tsx
+++ b/components/HeaderHome.tsx
@@ -36,8 +36,8 @@ export default function HeaderHome({ notificationCount = 0, onSettingsPress }: H
         >
           <Bell size={18} color={colors.surface} />
           {notificationCount > 0 && (
-            <View className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-warning items-center justify-center px-1">
-              <Text className="text-[10px] font-bold text-white">
+            <View className="absolute top-1 right-1 min-w-[18px] h-[18px] rounded-full bg-warning items-center justify-center px-1">
+              <Text className="text-xs font-bold text-white">
                 {notificationCount > 99 ? "99+" : notificationCount}
               </Text>
             </View>

--- a/components/dashboard/FeedList.tsx
+++ b/components/dashboard/FeedList.tsx
@@ -70,6 +70,7 @@ export default function FeedList({ items, emptyText, limit }: FeedListProps) {
             style={{
               paddingHorizontal: 16,
               paddingVertical: 12,
+              minHeight: 48,
               borderTopWidth: idx === 0 ? 0 : 1,
               borderTopColor: colors.border,
             }}

--- a/components/dashboard/KpiCard.tsx
+++ b/components/dashboard/KpiCard.tsx
@@ -93,7 +93,7 @@ export default function KpiCard({
             <TrendIcon trend={trend} />
             {trendLabel ? (
               <Text
-                style={{ fontSize: 11, fontWeight: "600" }}
+                style={{ fontSize: 12, fontWeight: "600" }}
                 className={
                   trend === "up"
                     ? "text-success"
@@ -131,7 +131,7 @@ export default function KpiCard({
         {hint ? (
           <Text
             className="text-text-dim mt-1"
-            style={{ fontSize: 11 }}
+            style={{ fontSize: 12 }}
             numberOfLines={1}
           >
             {hint}

--- a/components/dashboard/RecentWinsStrip.tsx
+++ b/components/dashboard/RecentWinsStrip.tsx
@@ -157,7 +157,7 @@ function WinCard({ item, index }: { item: RecentWin; index: number }) {
           >
             <Text
               style={{
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: "600",
                 color: colors.accentSoftInk,
               }}

--- a/components/layout/RoleBadge.tsx
+++ b/components/layout/RoleBadge.tsx
@@ -32,7 +32,7 @@ export default function RoleBadge({ role, isSpecialist = false, size = "sm" }: R
 
   const accent = roleAccent[toAccentKey(role, isSpecialist)];
   const paddingClass = size === "sm" ? "px-2 py-0.5" : "px-2.5 py-1";
-  const textSizeClass = size === "sm" ? "text-[11px]" : "text-xs";
+  const textSizeClass = size === "sm" ? "text-xs" : "text-sm";
 
   return (
     <View

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -450,7 +450,7 @@ export default function SidebarNav({ group }: SidebarNavProps) {
             </Text>
             <Text
               numberOfLines={1}
-              style={{ fontSize: 11, color: colors.textSecondary }}
+              style={{ fontSize: 12, color: colors.textSecondary }}
             >
               {user?.email ?? ""}
             </Text>

--- a/components/specialist/CaseCard.tsx
+++ b/components/specialist/CaseCard.tsx
@@ -90,7 +90,7 @@ export default function CaseCard({ case: c }: CaseCardProps) {
               <Text
                 className="uppercase"
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: 1.5,
                   color: colors.textMuted,
                   marginBottom: 2,
@@ -111,7 +111,7 @@ export default function CaseCard({ case: c }: CaseCardProps) {
               <Text
                 className="uppercase"
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: 1.5,
                   color: colors.textMuted,
                   marginBottom: 2,
@@ -142,7 +142,7 @@ export default function CaseCard({ case: c }: CaseCardProps) {
               <Text
                 className="uppercase"
                 style={{
-                  fontSize: 10,
+                  fontSize: 12,
                   letterSpacing: 1.5,
                   color: colors.textMuted,
                   marginBottom: 2,

--- a/components/specialist/ContactsSection.tsx
+++ b/components/specialist/ContactsSection.tsx
@@ -51,7 +51,7 @@ export default function ContactsSection({ contacts, officeAddress, workingHours,
       className="bg-white rounded-2xl border border-slate-100 p-4 mx-4 mt-4"
       style={cardShadow}
     >
-      <Text style={{ color: colors.textSecondary, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
+      <Text style={{ color: colors.textSecondary, fontSize: 12, letterSpacing: 3, marginBottom: 8 }}>
         КОНТАКТЫ
       </Text>
 

--- a/components/specialist/WorkAreaSection.tsx
+++ b/components/specialist/WorkAreaSection.tsx
@@ -15,7 +15,7 @@ export default function WorkAreaSection({ fnsServices, cardShadow }: WorkAreaSec
       className="bg-white rounded-2xl border border-border p-4 mx-4 mt-4"
       style={cardShadow}
     >
-      <Text style={{ color: colors.textSecondary, fontSize: 11, letterSpacing: 3, marginBottom: 8 }}>
+      <Text style={{ color: colors.textSecondary, fontSize: 12, letterSpacing: 3, marginBottom: 8 }}>
         РАБОЧИЕ ИНСПЕКЦИИ
       </Text>
       {fnsServices.map((group) => (

--- a/components/ui/MetricCard.tsx
+++ b/components/ui/MetricCard.tsx
@@ -49,7 +49,7 @@ export default function MetricCard({
       <Text
         className="uppercase mb-2"
         style={{
-          fontSize: 11,
+          fontSize: 12,
           letterSpacing: 2,
           color: colors.textSecondary,
           fontWeight: "600",


### PR DESCRIPTION
## Summary
- Bumps font-size from 11px to 12px across admin dashboard, specialist profile, sidebar nav, role badge, and 8 other components
- Resolves polish blockers in the `tiny-text` category

## Test plan
- [ ] Visual check on staging
- [ ] metromap rescore — fewer tiny-text blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)