### PR TITLE
fix(polish): batch 2 — top 3 routes (overflow, tiny text, tap targets)

### DIFF
--- a/app/auth/email.tsx
+++ b/app/auth/email.tsx
@@ -146,9 +146,9 @@ export default function AuthEmailScreen() {
             accessibilityRole="button"
             accessibilityLabel="Условия использования"
             onPress={() => router.push("/legal/terms" as never)}
-            className="mt-6 py-2"
+            className="mt-4 min-h-[44px] items-center justify-center"
           >
-            <Text className="text-xs text-text-mute text-center underline">
+            <Text className="text-text-mute text-center underline" style={{ fontSize: 13 }}>
               Условия использования
             </Text>
           </Pressable>

--- a/components/landing/CaseCard.tsx
+++ b/components/landing/CaseCard.tsx
@@ -32,7 +32,7 @@ export default function CaseCard({ data, index }: CaseCardProps) {
         borderColor: colors.border,
         padding: 24,
         gap: 18,
-        minWidth: 280,
+        minWidth: 240,
       }}
     >
       {/* Top — specialist + verification badge. */}
@@ -51,7 +51,7 @@ export default function CaseCard({ data, index }: CaseCardProps) {
           </Text>
           <View className="flex-row items-center" style={{ gap: 4, marginTop: 2 }}>
             <DuotoneIcon name="shield-check" size={14} color={colors.success} softColor={colors.successSoft} />
-            <Text style={{ color: colors.success, fontSize: 11, fontWeight: "600" }}>
+            <Text style={{ color: colors.success, fontSize: 12, fontWeight: "600" }}>
               Проверен платформой
             </Text>
           </View>
@@ -87,7 +87,7 @@ export default function CaseCard({ data, index }: CaseCardProps) {
           borderTopColor: colors.border,
         }}
       >
-        <Text style={{ color: colors.textMuted, fontSize: 11, fontWeight: "600", textTransform: "uppercase", letterSpacing: 1 }}>
+        <Text style={{ color: colors.textMuted, fontSize: 12, fontWeight: "600", textTransform: "uppercase", letterSpacing: 1 }}>
           Оспорено
         </Text>
         <Text
@@ -116,7 +116,7 @@ function Chip({ label }: { label: string }) {
         backgroundColor: colors.accentSoft,
       }}
     >
-      <Text style={{ color: colors.accentSoftInk, fontSize: 11, fontWeight: "500" }}>
+      <Text style={{ color: colors.accentSoftInk, fontSize: 12, fontWeight: "500" }}>
         {label}
       </Text>
     </View>

--- a/components/landing/FooterSection.tsx
+++ b/components/landing/FooterSection.tsx
@@ -114,7 +114,7 @@ function FooterColumn({ title, children }: { title: string; children: React.Reac
       <Text
         style={{
           color: overlay.white70,
-          fontSize: 11,
+          fontSize: 12,
           fontWeight: "700",
           textTransform: "uppercase",
           letterSpacing: 1.2,
@@ -133,7 +133,7 @@ function FooterLink({ label, onPress }: { label: string; onPress: () => void }) 
       accessibilityRole="link"
       accessibilityLabel={label}
       onPress={onPress}
-      className="min-h-[36px] justify-center"
+      className="min-h-[44px] justify-center"
     >
       <Text style={{ color: colors.white, fontSize: 14 }}>{label}</Text>
     </Pressable>

--- a/components/landing/HeroBlock.tsx
+++ b/components/landing/HeroBlock.tsx
@@ -109,7 +109,7 @@ export default function HeroBlock({
             <Text
               style={{
                 color: colors.textSecondary,
-                fontSize: 11,
+                fontSize: 12,
                 fontWeight: "600",
                 letterSpacing: 1.2,
                 textTransform: "uppercase",
@@ -289,7 +289,7 @@ function SpecialistCard({
                   marginRight: 5,
                 }}
               />
-              <Text style={{ color: colors.success, fontSize: 10, fontWeight: "600" }}>
+              <Text style={{ color: colors.success, fontSize: 12, fontWeight: "600" }}>
                 онлайн
               </Text>
             </View>
@@ -357,7 +357,7 @@ function Chip({ label, tone }: { label: string; tone: "default" | "accent" }) {
         backgroundColor: bg,
       }}
     >
-      <Text style={{ color, fontSize: 11, fontWeight: "500" }}>{label}</Text>
+      <Text style={{ color, fontSize: 12, fontWeight: "500" }}>{label}</Text>
     </View>
   );
 }

--- a/components/landing/LandingHeader.tsx
+++ b/components/landing/LandingHeader.tsx
@@ -99,7 +99,7 @@ export default function LandingHeader({
             onPress={onCreateRequest}
             className="rounded-xl items-center justify-center"
             style={{
-              height: 40,
+              height: 44,
               paddingHorizontal: isDesktop ? 18 : 14,
               backgroundColor: colors.primary,
             }}

--- a/components/landing/ServiceCard.tsx
+++ b/components/landing/ServiceCard.tsx
@@ -35,7 +35,7 @@ export default function ServiceCard({
         borderColor: colors.border,
         padding: 28,
         gap: 18,
-        minWidth: 260,
+        minWidth: 240,
       }}
     >
       <View
@@ -76,7 +76,7 @@ export default function ServiceCard({
           marginTop: "auto",
         }}
       >
-        <Text style={{ color: colors.textSecondary, fontSize: 11, fontWeight: "600" }}>
+        <Text style={{ color: colors.textSecondary, fontSize: 12, fontWeight: "600" }}>
           {statChip}
         </Text>
       </View>


### PR DESCRIPTION
## Summary
Polish batch 2 — addresses top 3 worst-scoring routes from polish-plan (gap 1.9):

- **/** (home): HeroBlock + CaseCard + ServiceCard + FooterSection + LandingHeader
- **/(tabs)**: shares all landing components via composition + HeaderHome
- **/auth/email**: terms-link tap target

## Fixes by route

### / (home) and /(tabs)
- **HeroBlock**: fontSize 11→12 (badge, chip), 10→12 (online indicator)
- **CaseCard**: 3x fontSize 11→12, reduce minWidth 280→240 (prevents mobile overflow at 320px viewport)
- **ServiceCard**: fontSize 11→12 (statChip), minWidth 260→240
- **FooterSection**: fontSize 11→12 (column titles), FooterLink min-h 36→44px (tap target)
- **LandingHeader**: "Создать заявку" button height 40→44px (tap target)

### /auth/email
- Terms-link Pressable: `py-2` → `min-h-[44px] items-center justify-center`, fontSize 12→13

## Test plan
- [x] `npx tsc --noEmit` (frontend) — 0 errors
- [x] `cd api && npx tsc --noEmit` — 0 errors
- [ ] Next /minime cycle reruns metromap polish + rescore