### PR TITLE
fix: rename auth routes /login + /otp, fix input border

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,8 +43,8 @@ export default function RootLayout() {
             <Stack.Screen name="(admin-tabs)" />
 
             {/* Auth flow */}
-            <Stack.Screen name="auth/email" />
-            <Stack.Screen name="auth/otp" />
+            <Stack.Screen name="login" />
+            <Stack.Screen name="otp" />
 
             {/* Onboarding */}
             <Stack.Screen name="onboarding/name" />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -154,7 +154,7 @@ export default function LandingScreen() {
   }, [loadData]);
 
   const goCreateRequest = useCallback(() => {
-    router.push("/auth/email" as never);
+    router.push("/login" as never);
   }, [router]);
 
   const goCatalog = useCallback(() => {
@@ -166,11 +166,11 @@ export default function LandingScreen() {
   }, [router]);
 
   const goLogin = useCallback(() => {
-    router.push("/auth/email" as never);
+    router.push("/login" as never);
   }, [router]);
 
   const goBecomeSpecialist = useCallback(() => {
-    router.push("/auth/email" as never);
+    router.push("/login" as never);
   }, [router]);
 
   const goLegal = useCallback(

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -43,7 +43,7 @@ export default function AuthEmailScreen() {
         noAuth: true,
       });
       router.push({
-        pathname: "/auth/otp" as never,
+        pathname: "/otp" as never,
         params: { email: email.trim().toLowerCase() },
       } as never);
     } catch (e: unknown) {
@@ -114,6 +114,7 @@ export default function AuthEmailScreen() {
                 fontSize: 15,
                 color: colors.text,
                 outlineWidth: 0,
+                borderWidth: 0,
                 // WCAG 2.5.5 — explicit 44px tap target on web; the
                 // <input> intrinsic height is ~18px otherwise.
                 ...(Platform.OS === "web" ? {

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -290,8 +290,8 @@ export default function AuthOtpScreen() {
 
   // Iter11-b — if the user landed here without an email query param (direct
   // URL / session lost), show a distinct notice state with a CTA back to
-  // /auth/email instead of silently redirecting. The silent redirect made
-  // /auth/otp render identical to /auth/email in audits, which hides the
+  // /login instead of silently redirecting. The silent redirect made
+  // /otp render identical to /login in audits, which hides the
   // screen and caused the "identical render" critique finding.
   if (!email) {
     return (
@@ -319,7 +319,7 @@ export default function AuthOtpScreen() {
             </Text>
             <Button
               label="Ввести email"
-              onPress={() => router.replace("/auth/email" as never)}
+              onPress={() => router.replace("/login" as never)}
             />
           </View>
         </View>
@@ -359,7 +359,7 @@ export default function AuthOtpScreen() {
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Изменить email"
-              onPress={() => router.replace("/auth/email" as never)}
+              onPress={() => router.replace("/login" as never)}
               className="mb-7"
             >
               <Text className="text-accent text-center font-medium" style={{ fontSize: 13 }}>

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -206,7 +206,7 @@ export default function PublicRequestDetail() {
         <ResponsiveContainer>
           <Button
             label="Войдите, чтобы написать"
-            onPress={() => router.push("/auth/email" as never)}
+            onPress={() => router.push("/login" as never)}
           />
         </ResponsiveContainer>
       </View>

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -71,7 +71,7 @@ export default function SpecialistConfirmWrite() {
   useEffect(() => {
     if (!authLoading) {
       if (!isAuthenticated || !isSpecialistUser) {
-        router.replace("/auth/email" as never);
+        router.replace("/login" as never);
         return;
       }
       load();

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -85,7 +85,7 @@ export default function SpecialistPublicProfile() {
   const handleWritePress = useCallback(() => {
     if (!isAuthenticated) {
       router.push(
-        `/auth/email?returnTo=/specialists/${id}` as never,
+        `/login?returnTo=/specialists/${id}` as never,
       );
     } else {
       router.push("/requests/new" as never);
@@ -95,7 +95,7 @@ export default function SpecialistPublicProfile() {
   const handleSavePress = useCallback(() => {
     if (!isAuthenticated) {
       router.push(
-        `/auth/email?returnTo=/specialists/${id}` as never,
+        `/login?returnTo=/specialists/${id}` as never,
       );
     }
     // Future: POST /api/bookmarks
@@ -509,7 +509,7 @@ export default function SpecialistPublicProfile() {
           <Button
             label="Войти"
             onPress={() =>
-              router.push(`/auth/email?returnTo=/specialists/${id}` as never)
+              router.push(`/login?returnTo=/specialists/${id}` as never)
             }
             fullWidth={false}
           />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Войти"
-              onPress={() => router.push("/auth/email" as never)}
+              onPress={() => router.push("/login" as never)}
               className="px-4 h-11 rounded-lg items-center justify-center"
               style={{ borderWidth: 1, borderColor: colors.border }}
             >
@@ -124,7 +124,7 @@ export default function Header() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Войти"
-            onPress={() => router.push("/auth/email" as never)}
+            onPress={() => router.push("/login" as never)}
             className="px-5 h-11 rounded-lg items-center justify-center"
             style={{ borderWidth: 1, borderColor: colors.border }}
           >

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -33,7 +33,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
   const handleLogout = async () => {
     onClose();
     await signOut();
-    router.replace("/auth/email" as never);
+    router.replace("/login" as never);
   };
 
   return (
@@ -95,7 +95,7 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Войти"
-                onPress={() => handleNavigate("/auth/email")}
+                onPress={() => handleNavigate("/login")}
                 className="h-12 rounded-xl bg-accent items-center justify-center"
               >
                 <Text className="text-base font-semibold text-white">Войти</Text>

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -119,7 +119,7 @@ export default function AppHeader({ title }: AppHeaderProps) {
   const handleLogout = async () => {
     setDropdownOpen(false);
     await signOut();
-    router.replace("/auth/email" as never);
+    router.replace("/login" as never);
   };
 
   const handleSettings = () => {

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -302,7 +302,7 @@ export default function SidebarNav({ group }: SidebarNavProps) {
   const handleLogout = async () => {
     setDropdownOpen(false);
     await signOut();
-    router.replace("/auth/email" as never);
+    router.replace("/login" as never);
   };
 
   const settingsPath =


### PR DESCRIPTION
Task #1344. Closes #1344.

- `app/auth/email.tsx` → `app/login.tsx` (route `/auth/email` → `/login`)
- `app/auth/otp.tsx` → `app/otp.tsx` (route `/auth/otp` → `/otp`)
- All navigation references updated across 11 files
- `borderWidth: 0` added to TextInput in login.tsx to fix double border on web
- Frontend tsc: 0 errors