### PR TITLE
fix: header missing on authenticated dashboard page

### DIFF
--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -410,7 +410,11 @@ export default function AppHeader({ title }: AppHeaderProps) {
 
 export function shouldShowAppHeader(pathname: string): boolean {
   if (!pathname) return false;
-  if (pathname === "/") return false;
+  // NOTE: "/" is NOT blocked here — Expo Router strips the "(tabs)" group prefix,
+  // so /(tabs)/index (the authenticated dashboard) resolves to pathname="/".
+  // The AuthenticatedHeaderGate already guards on isAuthenticated, so the
+  // landing page (which has its own LandingHeader) is never reached while
+  // the gate is active. Blocking "/" would hide the header on the dashboard tab.
   if (pathname.startsWith("/auth")) return false;
   if (pathname.startsWith("/legal")) return false;
   if (pathname.startsWith("/onboarding")) return false;


### PR DESCRIPTION
Task #1345.

**Root cause:** Expo Router strips route group prefixes when resolving `usePathname()`. The authenticated dashboard tab `/(tabs)/index` resolves to `pathname="/"` at the root layout level. `shouldShowAppHeader` had an unconditional `pathname === "/"` guard that blocked the header on the dashboard.

**Fix:** Removed the `"/"` block from `shouldShowAppHeader`. The `AuthenticatedHeaderGate` already guards on `isAuthenticated`, so the public landing page (which has its own `LandingHeader`) is unaffected.

**Not shown on:** `/auth/*`, `/legal/*`, `/onboarding/*` — unchanged.
**Now shown on:** `/` (dashboard), `/requests`, `/messages`, `/profile`, `/specialists`, `/settings`, `/notifications`, `/threads/*` — all authenticated routes.

Closes #1345.