### PR TITLE
fix: remove double border on search TextInputs on web

### DIFF
--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -259,8 +259,6 @@ export default function SpecialistsCatalog() {
             height: 48,
             backgroundColor: "transparent",
             ...(Platform.OS === "web" ? {
-              borderWidth: 1,
-              borderColor: colors.border,
               borderRadius: 8,
               paddingHorizontal: 8,
               outlineStyle: "none" as never,

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -234,8 +234,6 @@ export default function AppHeader({ title }: AppHeaderProps) {
               minHeight: 44,
               alignSelf: "stretch" as never,
               outlineStyle: "none" as never,
-              borderWidth: 1,
-              borderColor: colors.border,
               borderRadius: 6,
               paddingHorizontal: 8,
             } : {}),


### PR DESCRIPTION
## Summary
- Removed redundant `borderWidth: 1` + `borderColor` from TextInput web platform styles where the parent wrapper View already provides the border
- Fixes double-border visual bug on web for search inputs

## Files changed
- `app/specialists/index.tsx` (line 261–265): TextInput inside `<View className="border border-border ...">` — removed `borderWidth` and `borderColor` from web style
- `components/layout/AppHeader.tsx` (line 233–241): TextInput inside `<View style={{borderWidth:1,...}}>` — removed `borderWidth` and `borderColor` from web style

## Pattern applied
Correct pattern (per `components/ui/Input.tsx`):
- When wrapper has border → TextInput web style has only `outlineStyle: "none"` + layout props, no `borderWidth`

## Test plan
- [ ] Open /specialists on web — search bar shows single border
- [ ] Open any page with AppHeader search on web — search bar shows single border

🤖 Generated with [Claude Code](https://claude.com/claude-code)