### PR TITLE
feat(1353): mobile drawer navigation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,28 +1,49 @@
 import "../global.css";
+import { useState } from "react";
+import { useWindowDimensions, Platform } from "react-native";
 import { Stack, usePathname } from "expo-router";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import AppShell from "@/components/layout/AppShell";
 import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
+import MobileDrawer from "@/components/layout/MobileDrawer";
 
 import MetroBridge from "@/components/MetroBridge";
+
+const MOBILE_BREAKPOINT = 768;
+
 /**
  * Thin wrapper that decides whether the persistent {@link AppHeader}
  * should render for the current route. Header is shown only for
  * authenticated users and only on routes that don't have their own
  * chrome (landing, auth, onboarding, legal).
  *
+ * On mobile (<768px) the burger opens {@link MobileDrawer} — a slide-in
+ * left rail that mirrors SidebarNav navigation items exactly.
+ *
  * Issue GH-1285 — persistent header on every authenticated route.
+ * Issue GH-1353 — mobile drawer navigation.
  */
 function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
   const { isAuthenticated } = useAuth();
   const pathname = usePathname() ?? "";
+  const { width } = useWindowDimensions();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const show = isAuthenticated && shouldShowAppHeader(pathname);
+  // MobileDrawer only on web mobile (native has bottom tabs; sidebar handles desktop)
+  const showDrawer = Platform.OS === "web" && width < MOBILE_BREAKPOINT;
 
   return (
     <>
-      {show && <AppHeader />}
+      {show && (
+        <AppHeader
+          onBurgerPress={showDrawer ? () => setDrawerOpen(true) : undefined}
+        />
+      )}
       {children}
+      {showDrawer && (
+        <MobileDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      )}
     </>
   );
 }

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -44,6 +44,8 @@ const NAV_LINKS = [
 export interface AppHeaderProps {
   /** Optional override for the breadcrumb title. Falls back to route inference. */
   title?: string;
+  /** Called when the burger button is pressed on mobile. */
+  onBurgerPress?: () => void;
 }
 
 function toAccentKey(
@@ -90,7 +92,7 @@ function inferBreadcrumb(pathname: string): string | null {
   return null;
 }
 
-export default function AppHeader({ title }: AppHeaderProps) {
+export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
   const { width } = useWindowDimensions();
   const isMobile = width < 640;
   const { user, isSpecialistUser, signOut } = useAuth();
@@ -149,7 +151,13 @@ export default function AppHeader({ title }: AppHeaderProps) {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Открыть меню"
-            onPress={() => setMenuOpen(true)}
+            onPress={() => {
+              if (onBurgerPress) {
+                onBurgerPress();
+              } else {
+                setMenuOpen(true);
+              }
+            }}
             className="w-11 h-11 items-center justify-center"
           >
             <Menu size={20} color={colors.text} />

--- a/components/layout/MobileDrawer.tsx
+++ b/components/layout/MobileDrawer.tsx
@@ -1,0 +1,492 @@
+import { useEffect, useRef } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  Modal,
+  Animated,
+  Platform,
+} from "react-native";
+import { useRouter, usePathname, useSegments } from "expo-router";
+import {
+  X,
+  LogOut,
+  Settings,
+  Bell,
+  type LucideIcon,
+} from "lucide-react-native";
+import {
+  LayoutGrid,
+  FileText,
+  MessageCircle,
+  BarChart2,
+  Users,
+  Shield,
+  Flag,
+  Compass,
+  Inbox,
+} from "lucide-react-native";
+import { colors, spacing, roleAccent, type RoleAccentKey } from "@/lib/theme";
+import { useAuth, type UserRole } from "@/contexts/AuthContext";
+import RoleBadge from "./RoleBadge";
+import {
+  detectSidebarGroup,
+  type SidebarGroup,
+} from "./SidebarNav";
+
+/**
+ * MobileDrawer — slide-in left rail for mobile (<768px).
+ *
+ * Mirrors SidebarNav nav items exactly. Opened by the burger button in
+ * AppHeader; closed by: overlay tap, X button, or a nav tap.
+ *
+ * Implementation: React Native Animated (no 3rd-party libs), Modal for
+ * overlay. Slide animation: translateX -280 → 0.
+ */
+
+const DRAWER_WIDTH = 280;
+
+// ─────────────────────────────────────────── nav item types (mirrors SidebarNav)
+
+interface MatchContext {
+  path: string;
+  segments: readonly string[];
+}
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  match: (ctx: MatchContext) => boolean;
+}
+
+const groupMatch = (
+  ctx: MatchContext,
+  group: "(tabs)" | "(admin-tabs)",
+  leaf: string
+): boolean => {
+  if (ctx.segments[0] === group && ctx.segments[1] === leaf) return true;
+  return (
+    ctx.path.includes(`${group}/${leaf}`) ||
+    ctx.path.includes(`${group.replace(/[()]/g, "")}/${leaf}`)
+  );
+};
+
+const topLevelMatch = (ctx: MatchContext, prefix: string): boolean => {
+  const first = ctx.segments[0] ?? "";
+  const inGroup = first.startsWith("(") && first.endsWith(")") && first !== "(tabs)";
+  if (inGroup) return false;
+  return ctx.path === prefix || ctx.path.startsWith(`${prefix}/`);
+};
+
+const USER_BASE_ITEMS: NavItem[] = [
+  {
+    label: "Дашборд",
+    href: "/(tabs)",
+    icon: LayoutGrid,
+    match: (ctx) =>
+      groupMatch(ctx, "(tabs)", "index") ||
+      (ctx.segments[0] === "(tabs)" && !ctx.segments[1]),
+  },
+  {
+    label: "Мои заявки",
+    href: "/(tabs)/requests",
+    icon: FileText,
+    match: (ctx) => groupMatch(ctx, "(tabs)", "requests"),
+  },
+  {
+    label: "Сообщения",
+    href: "/(tabs)/messages",
+    icon: MessageCircle,
+    match: (ctx) => groupMatch(ctx, "(tabs)", "messages"),
+  },
+];
+
+const USER_SPECIALIST_EXTRA: NavItem[] = [
+  {
+    label: "Публичные заявки",
+    href: "/(tabs)/public-requests",
+    icon: Inbox,
+    match: (ctx) =>
+      groupMatch(ctx, "(tabs)", "public-requests") ||
+      topLevelMatch(ctx, "/requests"),
+  },
+];
+
+const USER_TAIL_ITEMS: NavItem[] = [
+  {
+    label: "Каталог специалистов",
+    href: "/specialists",
+    icon: Compass,
+    match: (ctx) => topLevelMatch(ctx, "/specialists"),
+  },
+  {
+    label: "Уведомления",
+    href: "/notifications",
+    icon: Bell,
+    match: (ctx) => topLevelMatch(ctx, "/notifications"),
+  },
+];
+
+const ADMIN_ITEMS: NavItem[] = [
+  {
+    label: "Дашборд",
+    href: "/(admin-tabs)/dashboard",
+    icon: BarChart2,
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "dashboard"),
+  },
+  {
+    label: "Пользователи",
+    href: "/(admin-tabs)/users",
+    icon: Users,
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "users"),
+  },
+  {
+    label: "Модерация",
+    href: "/(admin-tabs)/moderation",
+    icon: Shield,
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "moderation"),
+  },
+  {
+    label: "Жалобы",
+    href: "/(admin-tabs)/complaints",
+    icon: Flag,
+    match: (ctx) => groupMatch(ctx, "(admin-tabs)", "complaints"),
+  },
+  {
+    label: "Настройки системы",
+    href: "/admin/settings",
+    icon: Settings,
+    match: (ctx) => ctx.path.startsWith("/admin/settings"),
+  },
+];
+
+function buildUserItems(isSpecialist: boolean): NavItem[] {
+  return isSpecialist
+    ? [...USER_BASE_ITEMS, ...USER_SPECIALIST_EXTRA, ...USER_TAIL_ITEMS]
+    : [...USER_BASE_ITEMS, ...USER_TAIL_ITEMS];
+}
+
+function itemsForGroup(
+  group: SidebarGroup,
+  role: UserRole,
+  isSpecialist: boolean
+): NavItem[] {
+  if (group === "admin" || role === "ADMIN") return ADMIN_ITEMS;
+  switch (group) {
+    case "user":
+    case "main":
+      return buildUserItems(isSpecialist);
+    default:
+      return [];
+  }
+}
+
+function toAccentKey(role: UserRole, isSpecialist: boolean): RoleAccentKey {
+  if (role === "ADMIN") return "admin";
+  if (isSpecialist) return "specialist";
+  return "client";
+}
+
+// ─────────────────────────────────────────── component
+
+export interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
+  const segments = useSegments();
+  const { user, isSpecialistUser, signOut } = useAuth();
+
+  // Slide animation — translateX: -DRAWER_WIDTH (hidden) → 0 (visible)
+  const translateX = useRef(new Animated.Value(-DRAWER_WIDTH)).current;
+
+  useEffect(() => {
+    Animated.timing(translateX, {
+      toValue: open ? 0 : -DRAWER_WIDTH,
+      duration: 260,
+      useNativeDriver: Platform.OS !== "web",
+    }).start();
+  }, [open, translateX]);
+
+  const matchCtx: MatchContext = {
+    path: pathname,
+    segments: segments as readonly string[],
+  };
+
+  const group = detectSidebarGroup(pathname, segments as readonly string[]);
+  const accentKey = toAccentKey(user?.role ?? null, isSpecialistUser);
+  const accent = roleAccent[accentKey];
+  const items = itemsForGroup(group, user?.role ?? null, isSpecialistUser);
+
+  const displayName = user?.firstName
+    ? `${user.firstName} ${user.lastName || ""}`.trim()
+    : user?.email || "Пользователь";
+  const initials =
+    user?.firstName?.[0]?.toUpperCase() ||
+    user?.email?.[0]?.toUpperCase() ||
+    "U";
+
+  const handleNav = (href: string) => {
+    onClose();
+    router.push(href as never);
+  };
+
+  const handleLogout = async () => {
+    onClose();
+    await signOut();
+    router.replace("/login" as never);
+  };
+
+  const settingsPath = user?.role === "ADMIN" ? "/admin/settings" : "/settings";
+
+  return (
+    <Modal
+      visible={open}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      {/* Overlay */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Закрыть меню"
+        onPress={onClose}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "rgba(0,0,0,0.45)",
+        }}
+      />
+
+      {/* Drawer panel */}
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: DRAWER_WIDTH,
+          backgroundColor: accent.soft,
+          borderRightWidth: 1,
+          borderRightColor: colors.border,
+          paddingHorizontal: spacing.md,
+          paddingTop: spacing.xl,
+          paddingBottom: spacing.md,
+          transform: [{ translateX }],
+          // Ensure drawer sits above overlay
+          zIndex: 10,
+        }}
+      >
+        {/* Close button */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрыть меню"
+          onPress={onClose}
+          style={{
+            position: "absolute",
+            top: spacing.md,
+            right: spacing.md,
+            width: 36,
+            height: 36,
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 8,
+          }}
+        >
+          <X size={20} color={colors.textSecondary} />
+        </Pressable>
+
+        {/* Brand */}
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel="P2PTax — главная"
+          onPress={() => handleNav("/")}
+          style={{
+            height: 48,
+            paddingHorizontal: spacing.sm,
+            flexDirection: "row",
+            alignItems: "center",
+            marginBottom: spacing.sm,
+          }}
+        >
+          <View
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 6,
+              backgroundColor: accent.strong,
+              marginRight: spacing.sm,
+            }}
+          />
+          <Text style={{ fontSize: 18, fontWeight: "800", color: colors.text }}>
+            P2P<Text style={{ color: accent.strong }}>Tax</Text>
+          </Text>
+        </Pressable>
+
+        {/* Role badge */}
+        <View style={{ paddingHorizontal: spacing.sm, marginBottom: spacing.md }}>
+          <RoleBadge role={user?.role ?? null} isSpecialist={isSpecialistUser} size="sm" />
+        </View>
+
+        {/* Nav items */}
+        <View style={{ gap: 2, flex: 1 }}>
+          {items.map((item) => {
+            const Icon = item.icon;
+            const active = item.match(matchCtx);
+            return (
+              <Pressable
+                key={item.href}
+                accessibilityRole="link"
+                accessibilityLabel={item.label}
+                onPress={() => handleNav(item.href)}
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  minHeight: 44,
+                  paddingLeft: spacing.md,
+                  paddingRight: spacing.sm,
+                  borderRadius: 8,
+                  backgroundColor: active ? accent.strong : "transparent",
+                  borderLeftWidth: 2,
+                  borderLeftColor: active ? accent.strong : "transparent",
+                }}
+              >
+                <Icon
+                  size={18}
+                  color={active ? accent.ink : colors.textSecondary}
+                />
+                <Text
+                  style={{
+                    marginLeft: spacing.sm + 4,
+                    fontSize: 14,
+                    fontWeight: active ? "700" : "500",
+                    color: active ? accent.ink : colors.text,
+                    flexShrink: 1,
+                    flex: 1,
+                  }}
+                >
+                  {item.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        {/* Bottom identity cluster */}
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderTopColor: colors.border,
+            paddingTop: spacing.sm,
+            marginTop: spacing.sm,
+            gap: 2,
+          }}
+        >
+          {/* Settings row */}
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel="Настройки"
+            onPress={() => handleNav(settingsPath)}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              minHeight: 44,
+              paddingLeft: spacing.md,
+              paddingRight: spacing.sm,
+              borderRadius: 8,
+            }}
+          >
+            <Settings size={16} color={colors.textSecondary} />
+            <Text
+              style={{
+                marginLeft: spacing.sm + 4,
+                fontSize: 14,
+                fontWeight: "500",
+                color: colors.text,
+              }}
+            >
+              Настройки
+            </Text>
+          </Pressable>
+
+          {/* Identity row */}
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              paddingHorizontal: spacing.sm,
+              paddingVertical: spacing.sm,
+              borderRadius: 10,
+              marginTop: 2,
+            }}
+          >
+            <View
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 16,
+                backgroundColor: accent.strong,
+                alignItems: "center",
+                justifyContent: "center",
+                marginRight: spacing.sm,
+              }}
+            >
+              <Text style={{ color: accent.ink, fontSize: 13, fontWeight: "700" }}>
+                {initials}
+              </Text>
+            </View>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text
+                numberOfLines={1}
+                style={{ fontSize: 13, fontWeight: "600", color: colors.text }}
+              >
+                {displayName}
+              </Text>
+              <Text
+                numberOfLines={1}
+                style={{ fontSize: 12, color: colors.textSecondary }}
+              >
+                {user?.email ?? ""}
+              </Text>
+            </View>
+          </View>
+
+          {/* Logout */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Выйти"
+            onPress={handleLogout}
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              minHeight: 44,
+              paddingLeft: spacing.md,
+              paddingRight: spacing.sm,
+              borderRadius: 8,
+            }}
+          >
+            <LogOut size={16} color={colors.danger} />
+            <Text
+              style={{
+                marginLeft: spacing.sm + 4,
+                fontSize: 14,
+                fontWeight: "500",
+                color: colors.danger,
+              }}
+            >
+              Выйти
+            </Text>
+          </Pressable>
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- New `MobileDrawer` component: 280px slide-in from left, `Animated.Value` translateX, Modal overlay, close on overlay tap / X button / nav tap
- Nav items mirror `SidebarNav` exactly — same icons, labels, routes, active-route highlight, role-aware (user/specialist/admin)
- `AppHeader` gets optional `onBurgerPress` prop; burger calls it when provided, falls back to old `MobileMenu` otherwise
- `_layout.tsx` wires everything: `drawerOpen` state, passes `onBurgerPress` to `AppHeader`, renders `<MobileDrawer>` only on web mobile (<768px)
- Desktop sidebar and native bottom-tabs unchanged

## Test plan
- [ ] Mobile web (<768px): tap burger → drawer slides in from left
- [ ] Tap overlay → drawer closes
- [ ] Tap X button → drawer closes
- [ ] Tap nav item → navigate + drawer closes
- [ ] Active route highlighted (role-tinted bg + left border)
- [ ] Desktop (>=768px): no drawer, sidebar visible as before
- [ ] Native: pass-through, no drawer rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)