### PR TITLE
fix(1367): eliminate auth loading flash on app open

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,12 @@
 import "../global.css";
 import { useState } from "react";
-import { useWindowDimensions, Platform } from "react-native";
+import { useWindowDimensions, Platform, View, ActivityIndicator } from "react-native";
 import { Stack, usePathname } from "expo-router";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import AppShell from "@/components/layout/AppShell";
 import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
 import MobileDrawer from "@/components/layout/MobileDrawer";
+import { colors } from "@/lib/theme";
 
 import MetroBridge from "@/components/MetroBridge";
 
@@ -22,12 +23,23 @@ const MOBILE_BREAKPOINT = 768;
  *
  * Issue GH-1285 — persistent header on every authenticated route.
  * Issue GH-1353 — mobile drawer navigation.
+ * Issue GH-1367 — auth loading flash: show spinner while auth restores from storage.
  */
 function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
   const pathname = usePathname() ?? "";
   const { width } = useWindowDimensions();
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Block rendering until AsyncStorage token restoration is complete.
+  // Without this, authenticated users briefly see the public landing page.
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: "#fff" }}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
 
   const show = isAuthenticated && shouldShowAppHeader(pathname);
   // MobileDrawer only on web mobile (native has bottom tabs; sidebar handles desktop)

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -70,7 +70,7 @@ interface RecentWinsResponse {
  */
 export default function LandingScreen() {
   const router = useRouter();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
 
@@ -84,14 +84,14 @@ export default function LandingScreen() {
   // Iter11 — unified (tabs) carries both USER sub-modes (isSpecialist on/off);
   // admin still has its own group.
   useEffect(() => {
-    if (isAuthenticated && user?.role) {
+    if (!authLoading && isAuthenticated && user?.role) {
       if (user.role === "ADMIN") {
         router.replace("/(admin-tabs)/dashboard" as never);
       } else {
         router.replace("/(tabs)" as never);
       }
     }
-  }, [isAuthenticated, user, router]);
+  }, [authLoading, isAuthenticated, user, router]);
 
   const loadData = useCallback(async () => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- `app/_layout.tsx`: `AuthenticatedHeaderGate` now reads `isLoading` from `useAuth()` and returns a full-screen `ActivityIndicator` spinner while `AuthContext` is restoring the token from AsyncStorage. Children (including the landing page) are not rendered until auth state is settled.
- `app/index.tsx`: the redirect `useEffect` is guarded with `!authLoading` so `router.replace` only fires after token restoration is complete — preventing a race where `isAuthenticated` was still `false` mid-restore.

## Root cause
`AuthContext` initialises `isLoading = true` and flips it to `false` in the `finally` block of the AsyncStorage restore effect. But `_layout.tsx` rendered children immediately, so `index.tsx` rendered the full landing page for ~300ms before the redirect useEffect could fire.

## Test plan
- [ ] Open app while logged in → spinner briefly, then `/(tabs)` directly — no landing flash
- [ ] Open app while logged out → spinner, then landing page renders normally
- [ ] Admin user → spinner, then `/(admin-tabs)/dashboard`
- [ ] `npx tsc --noEmit` passes (frontend + backend, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)