### PR TITLE
feat(1369): navigation cleanup — rename tab, role-specific nav items

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -84,7 +84,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="profile"
         options={{
-          title: "Профиль",
+          title: "Настройки",
           tabBarIcon: ({ color, size }) => <User size={size} color={color} />,
         }}
       />

--- a/components/layout/MobileDrawer.tsx
+++ b/components/layout/MobileDrawer.tsx
@@ -23,8 +23,8 @@ import {
   Users,
   Shield,
   Flag,
-  Compass,
   Inbox,
+  Search,
 } from "lucide-react-native";
 import { colors, spacing, roleAccent, type RoleAccentKey } from "@/lib/theme";
 import { useAuth, type UserRole } from "@/contexts/AuthContext";
@@ -102,9 +102,19 @@ const USER_BASE_ITEMS: NavItem[] = [
   },
 ];
 
+// Client-only addition: injected after "Мои заявки" for non-specialist users.
+const USER_CLIENT_EXTRA: NavItem[] = [
+  {
+    label: "Найти специалиста",
+    href: "/specialists",
+    icon: Search,
+    match: (ctx) => topLevelMatch(ctx, "/specialists"),
+  },
+];
+
 const USER_SPECIALIST_EXTRA: NavItem[] = [
   {
-    label: "Публичные заявки",
+    label: "Заявки клиентов",
     href: "/(tabs)/public-requests",
     icon: Inbox,
     match: (ctx) =>
@@ -114,12 +124,6 @@ const USER_SPECIALIST_EXTRA: NavItem[] = [
 ];
 
 const USER_TAIL_ITEMS: NavItem[] = [
-  {
-    label: "Каталог специалистов",
-    href: "/specialists",
-    icon: Compass,
-    match: (ctx) => topLevelMatch(ctx, "/specialists"),
-  },
   {
     label: "Уведомления",
     href: "/notifications",
@@ -164,7 +168,7 @@ const ADMIN_ITEMS: NavItem[] = [
 function buildUserItems(isSpecialist: boolean): NavItem[] {
   return isSpecialist
     ? [...USER_BASE_ITEMS, ...USER_SPECIALIST_EXTRA, ...USER_TAIL_ITEMS]
-    : [...USER_BASE_ITEMS, ...USER_TAIL_ITEMS];
+    : [...USER_BASE_ITEMS, ...USER_CLIENT_EXTRA, ...USER_TAIL_ITEMS];
 }
 
 function itemsForGroup(

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -12,8 +12,8 @@ import {
   Bell,
   Settings,
   LogOut,
-  Compass,
   Inbox,
+  Search,
   type LucideIcon,
 } from "lucide-react-native";
 import { colors, spacing, roleAccent, type RoleAccentKey } from "@/lib/theme";
@@ -116,10 +116,20 @@ const USER_BASE_ITEMS: NavItem[] = [
   },
 ];
 
+// Client-only addition: injected after "Мои заявки" for non-specialist users.
+const USER_CLIENT_EXTRA: NavItem[] = [
+  {
+    label: "Найти специалиста",
+    href: "/specialists",
+    icon: Search,
+    match: (ctx) => topLevelMatch(ctx, "/specialists"),
+  },
+];
+
 // Specialist-only addition: appended to USER_BASE when isSpecialist=true.
 const USER_SPECIALIST_EXTRA: NavItem[] = [
   {
-    label: "Публичные заявки",
+    label: "Заявки клиентов",
     href: "/(tabs)/public-requests",
     icon: Inbox,
     match: (ctx) =>
@@ -129,12 +139,6 @@ const USER_SPECIALIST_EXTRA: NavItem[] = [
 ];
 
 const USER_TAIL_ITEMS: NavItem[] = [
-  {
-    label: "Каталог специалистов",
-    href: "/specialists",
-    icon: Compass,
-    match: (ctx) => topLevelMatch(ctx, "/specialists"),
-  },
   {
     label: "Уведомления",
     href: "/notifications",
@@ -249,7 +253,7 @@ export function detectSidebarGroup(
 function buildUserItems(isSpecialist: boolean): NavItem[] {
   return isSpecialist
     ? [...USER_BASE_ITEMS, ...USER_SPECIALIST_EXTRA, ...USER_TAIL_ITEMS]
-    : [...USER_BASE_ITEMS, ...USER_TAIL_ITEMS];
+    : [...USER_BASE_ITEMS, ...USER_CLIENT_EXTRA, ...USER_TAIL_ITEMS];
 }
 
 function itemsForGroup(


### PR DESCRIPTION
## Summary
- **Tab bar**: "Профиль" → "Настройки" (profile tab label)
- **Client sidebar + drawer**: add "Найти специалиста" (Search icon → /specialists) after "Мои заявки"; remove "Каталог специалистов" from tail (de-duplication)
- **Specialist sidebar + drawer**: rename "Публичные заявки" → "Заявки клиентов"

## Files changed
- `app/(tabs)/_layout.tsx` — tab title rename
- `components/layout/SidebarNav.tsx` — CLIENT_EXTRA array, specialist label, removed Compass import
- `components/layout/MobileDrawer.tsx` — same nav changes mirrored

Closes #1369