### PR TITLE
fix(1378): fixed-layout scroll architecture (desktop + mobile web)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -44,6 +44,10 @@ function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
   const show = isAuthenticated && shouldShowAppHeader(pathname);
   // MobileDrawer only on web mobile (native has bottom tabs; sidebar handles desktop)
   const showDrawer = Platform.OS === "web" && width < MOBILE_BREAKPOINT;
+  // On desktop, AppShell's content pane already applies marginTop:56.
+  // On mobile web, the fixed header needs offsetting via paddingTop on the
+  // content container. Desktop web passes through here without extra padding.
+  const isMobileWeb = Platform.OS === "web" && width < MOBILE_BREAKPOINT;
 
   return (
     <>
@@ -52,7 +56,24 @@ function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
           onBurgerPress={showDrawer ? () => setDrawerOpen(true) : undefined}
         />
       )}
-      {children}
+      {isMobileWeb && show ? (
+        <View
+          style={
+            Platform.OS === "web"
+              ? ({
+                  paddingTop: 56,
+                  paddingBottom: 60,
+                  height: "100vh",
+                  overflowY: "auto",
+                } as object)
+              : { flex: 1 }
+          }
+        >
+          {children}
+        </View>
+      ) : (
+        children
+      )}
       {showDrawer && (
         <MobileDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
       )}

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -146,7 +146,14 @@ export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
       <>
         <View
           className="flex-row items-center justify-between px-4 h-14 bg-white border-b"
-          style={{ borderBottomColor: colors.border, borderTopWidth: 3, borderTopColor: accent.strong }}
+          style={{
+            borderBottomColor: colors.border,
+            borderTopWidth: 3,
+            borderTopColor: accent.strong,
+            ...(Platform.OS === "web"
+              ? ({ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 } as object)
+              : {}),
+          }}
         >
           <Pressable
             accessibilityRole="button"
@@ -198,6 +205,7 @@ export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
   // iter10 Phase 3a: role accent moved to SidebarNav; header is a neutral
   // slim bar with breadcrumb + search + bell + avatar.
   // feat-1350: logo + nav links added to left side on desktop.
+  // fix-1378: position:fixed so header stays at top while content scrolls.
   return (
     <View
       className="flex-row items-center bg-white border-b"
@@ -206,6 +214,9 @@ export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
         height: 56,
         paddingHorizontal: spacing.lg,
         gap: spacing.md,
+        ...(Platform.OS === "web"
+          ? ({ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 } as object)
+          : {}),
       }}
     >
       {/* Left: logo + nav links */}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -70,28 +70,31 @@ export default function AppShell({ children }: AppShellProps) {
     return <>{children}</>;
   }
 
+  // Desktop web with sidebar: fixed-position architecture.
+  // Sidebar is fixed (handled in SidebarNav). Header is fixed (handled in AppHeader).
+  // This root View is just a positioning context — the real scroll container
+  // is the content pane below.
   return (
     <View
       style={{
         flex: 1,
         width: "100%",
-        flexDirection: "row",
         backgroundColor: colors.surface2,
-        minHeight: "100%",
       }}
     >
+      {/* SidebarNav renders itself as position:fixed — no layout slot needed here */}
       <SidebarNav group={group} />
+      {/* Content area: offset by sidebar (left) and header (top), scrolls independently */}
       <View
         style={{
-          flex: 1,
-          minWidth: 0,
-          minHeight: "100%",
-          // The main pane is the scroll container — pages keep their own
-          // ScrollView for pull-to-refresh, but the shell provides the
-          // top-level overflow on desktop web.
           ...(Platform.OS === "web"
-            ? ({ overflowY: "auto", maxWidth: `calc(100% - ${SIDEBAR_WIDTH}px)` } as object)
-            : {}),
+            ? ({
+                marginLeft: SIDEBAR_WIDTH,
+                marginTop: 56,
+                height: "calc(100vh - 56px)",
+                overflowY: "auto",
+              } as object)
+            : { flex: 1, minWidth: 0 }),
         }}
       >
         {children}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -325,7 +325,13 @@ export default function SidebarNav({ group }: SidebarNavProps) {
         paddingTop: spacing.lg,
         paddingBottom: spacing.md,
         ...(Platform.OS === "web"
-          ? ({ position: "sticky", top: 0, height: "100vh" } as object)
+          ? ({
+              position: "fixed",
+              top: 56,
+              left: 0,
+              height: "calc(100vh - 56px)",
+              overflowY: "auto",
+            } as object)
           : {}),
       }}
     >


### PR DESCRIPTION
## Summary

- **AppHeader** (`AppHeader.tsx`): added `position:fixed, top:0, left:0, right:0, zIndex:50` on web for both mobile and desktop renderers
- **SidebarNav** (`SidebarNav.tsx`): changed `position:sticky, top:0, height:100vh` → `position:fixed, top:56px, left:0, height:calc(100vh-56px), overflowY:auto`
- **AppShell** (`AppShell.tsx`): content pane now uses `marginLeft:240, marginTop:56, height:calc(100vh-56px), overflowY:auto` instead of flex+minHeight passthrough
- **_layout.tsx**: mobile web content wrapper gets `paddingTop:56, paddingBottom:60, height:100vh, overflowY:auto` when header is shown

## Result

Header and sidebar are truly fixed; content scrolls independently. No more full-page scroll that carries the header along.

## Test plan
- [ ] Desktop: resize ≥768px → sidebar fixed left, header fixed top, content scrolls independently
- [ ] Desktop: sidebar does not scroll with content
- [ ] Mobile: resize <768px → header fixed top, content offset by 56px, bottom tab bar visible
- [ ] Public routes (/, /auth, /onboarding) → no layout regression (AppShell pass-through unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)