### PR TITLE
fix: keep tab bar visible on settings/profile tab

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,10 +1,10 @@
-import { Redirect } from "expo-router";
+import UnifiedSettings from "@/app/settings/index";
 
 /**
- * Iter11 PR 2 — profile tab is now a thin redirect to the unified settings
- * page. The settings screen carries personal-data, notification, specialist
- * toggle, and account sections in a single progressive form.
+ * Profile tab — renders the unified settings screen inline so the tab bar
+ * remains visible. Previously used <Redirect href="/settings" /> which
+ * pushed a Stack screen outside (tabs), causing the tab bar to disappear.
  */
 export default function ProfileTab() {
-  return <Redirect href={"/settings" as never} />;
+  return <UnifiedSettings />;
 }


### PR DESCRIPTION
## Summary
- `app/(tabs)/profile.tsx` previously used `<Redirect href="/settings" />` which pushed a Stack screen **outside** the `(tabs)` group, causing the tab bar to disappear
- Fix: render `UnifiedSettings` component directly inside `profile.tsx` — tab bar stays visible since we stay within the tabs navigator
- `UnifiedSettings` already has `SafeAreaView` as its root wrapper, so no double-wrapping needed
- Redirect-only screens (`create.tsx`, `search.tsx`) and the `<Tabs>` navigator layout don't require `SafeAreaView`

## Test plan
- [ ] Open app → tap "Настройки" tab → settings screen renders with tab bar still visible at bottom
- [ ] Settings content (personal data, specialist section, notifications, legal, account) all render correctly
- [ ] tsc --noEmit passes: 0 errors (frontend + backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)