### PR TITLE
fix: remove console.* calls and add accessibilityLabel to images

### DIFF
--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -235,7 +235,6 @@ export default function MyRequests() {
       const res = await api<{ items: RequestItem[] }>("/api/requests/my");
       setRequests(res.items);
     } catch (e) {
-      console.error("Fetch my requests error:", e);
       setError("Не удалось загрузить заявки");
     }
   }, []);
@@ -271,7 +270,6 @@ export default function MyRequests() {
                 );
                 showToast();
               } catch (e) {
-                console.error("Close request error:", e);
                 Alert.alert("Ошибка", "Не удалось закрыть заявку");
               }
             },

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -75,7 +75,6 @@ export default function MyRequestDetail() {
         .catch(() => {/* silent — not critical */});
     } catch (e) {
       setError("Не удалось загрузить заявку");
-      console.error("Request detail error:", e);
     } finally {
       setLoading(false);
     }
@@ -99,7 +98,6 @@ export default function MyRequestDetail() {
               await apiDelete(`/api/requests/${id}`);
               router.back();
             } catch (e) {
-              console.error("Delete error:", e);
               Alert.alert("Ошибка", "Не удалось удалить заявку");
             }
           },
@@ -140,7 +138,7 @@ export default function MyRequestDetail() {
       );
       await Linking.openURL(res.url);
     } catch (e) {
-      console.error("File open error:", e);
+      // ignore
     }
   }, []);
 

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -85,7 +85,6 @@ export default function RequestMessages() {
       } else {
         setError("Проверьте соединение с интернетом и попробуйте снова");
       }
-      console.error("fetch request threads error:", e);
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -113,7 +113,6 @@ export default function SpecialistsCatalog() {
         setPage(pageNum);
         setError(null);
       } catch (e) {
-        console.error("Fetch specialists error:", e);
         setError("Не удалось загрузить список");
       }
     },
@@ -134,7 +133,6 @@ export default function SpecialistsCatalog() {
         setCities(citiesRes.items);
         setServices(servicesRes.items);
       } catch (e) {
-        console.error("Init error:", e);
       }
       await fetchSpecialistsRef.current(1);
       setLoading(false);

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -120,7 +120,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
       const res = await api<{ messages: MessageItem[] }>(`/api/messages/${threadId}`);
       setMessages(res.messages);
     } catch (e) {
-      console.error("fetch messages error:", e);
+      // ignore
     }
   }, [threadId]);
 
@@ -130,7 +130,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
       const res = await api<ThreadInfo>(`/api/threads/${threadId}`);
       setThread(res);
     } catch (e) {
-      console.error("fetch thread error:", e);
+      // ignore
     }
   }, [threadId]);
 
@@ -139,7 +139,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     try {
       await apiPatch(`/api/messages/${threadId}/read`, {});
     } catch (e) {
-      console.error("mark read error:", e);
+      // ignore
     }
   }, [threadId]);
 
@@ -198,7 +198,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
         },
       ]);
     } catch (e) {
-      console.error("document picker error:", e);
+      // ignore
     }
   }, [pendingFiles.length]);
 

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -96,6 +96,7 @@ export default function AvatarUploader({
           <View>
             <Image
               source={{ uri: avatarUrl }}
+              accessibilityLabel="Profile photo"
               style={{
                 width: 80,
                 height: 80,

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -59,6 +59,7 @@ export default function Avatar({
     return (
       <Image
         source={{ uri: imageUrl }}
+        accessibilityLabel={name}
         style={{
           width: wh,
           height: wh,


### PR DESCRIPTION
## Summary
- Remove console.error/log from 5 production files (requests, specialists, messages, detail, InlineChatView)
- Add accessibilityLabel to Image components in Avatar.tsx and AvatarUploader.tsx
- lib/api.ts and AuthContext.tsx already used EXPO_PUBLIC_API_URL pattern — no change needed

## Files changed
- app/(tabs)/requests.tsx — removed 2 console.error calls
- app/specialists/index.tsx — removed 2 console.error calls
- app/requests/[id]/messages.tsx — removed 1 console.error call
- app/requests/[id]/detail.tsx — removed 3 console.error calls
- components/InlineChatView.tsx — removed 4 console.error calls
- components/ui/Avatar.tsx — added accessibilityLabel={name} to Image
- components/settings/AvatarUploader.tsx — added accessibilityLabel="Profile photo" to Image

## Verification
- tsc --noEmit: 0 errors (frontend + api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)