### PR TITLE
fix: unify responsive breakpoint to 768px

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -1,11 +1,11 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import { BarChart2, Users, Shield, Flag } from "lucide-react-native";
-import { colors, fontSizeValue } from "@/lib/theme";
+import { colors, fontSizeValue, BREAKPOINT } from "@/lib/theme";
 
 export default function AdminTabsLayout() {
   const { width } = useWindowDimensions();
-  const isMobile = width < 640;
+  const isMobile = width < BREAKPOINT;
 
   return (
     <Tabs

--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -31,7 +31,7 @@ import {
   type FeedItem,
 } from "@/components/dashboard";
 import { api } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, BREAKPOINT } from "@/lib/theme";
 
 interface Stats {
   activeRequests: number;
@@ -110,7 +110,7 @@ export default function AdminDashboard() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
   const [stats, setStats] = useState<Stats | null>(null);
   const [extra, setExtra] = useState<AdminExtra | null>(null);
   const [recentUsers, setRecentUsers] = useState<AdminUser[]>([]);

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,7 +6,7 @@ import {
   MessageCircle,
   User,
 } from "lucide-react-native";
-import { colors, fontSizeValue } from "@/lib/theme";
+import { colors, fontSizeValue, BREAKPOINT } from "@/lib/theme";
 
 /**
  * Unified (tabs) navigator — task #1379 cleanup.
@@ -15,11 +15,11 @@ import { colors, fontSizeValue } from "@/lib/theme";
  * "Публичные заявки" is hidden from the tab bar (href: null) — accessible
  * via the mobile drawer / sidebar only.
  *
- * Tab bar is hidden on desktop (≥640px) — SidebarNav carries navigation there.
+ * Tab bar is hidden on desktop (≥768px) — SidebarNav carries navigation there.
  */
 export default function TabLayout() {
   const { width } = useWindowDimensions();
-  const isMobile = width < 640;
+  const isMobile = width < BREAKPOINT;
 
   return (
     <Tabs

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -40,7 +40,7 @@ import {
 import { api, apiGet, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
-import { colors, spacing } from "@/lib/theme";
+import { colors, spacing, BREAKPOINT } from "@/lib/theme";
 
 /**
  * Unified User Dashboard — iter11 UI layer (PR 2/3).
@@ -131,7 +131,7 @@ export default function UserDashboard() {
   const { ready } = useRequireAuth();
   const { user, isSpecialistUser, updateUser } = useAuth();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   // Shared (client side of dashboard) state
   const [stats, setStats] = useState<DashboardStats | null>(null);

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -21,7 +21,7 @@ import InlineChatView from "@/components/InlineChatView";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { apiGet } from "@/lib/api";
-import { colors, overlay } from "@/lib/theme";
+import { colors, overlay, BREAKPOINT } from "@/lib/theme";
 
 /**
  * Unified Inbox — iter11 UI layer (PR 2/3).
@@ -114,7 +114,7 @@ export default function UnifiedInbox() {
   const { ready } = useRequireAuth();
   const { isSpecialistUser } = useAuth();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const otherPartyFallback = isSpecialistUser ? "Клиент" : "Специалист";
 

--- a/app/(tabs)/public-requests.tsx
+++ b/app/(tabs)/public-requests.tsx
@@ -18,7 +18,7 @@ import { TriangleAlert, FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
-import { colors, overlay } from "@/lib/theme";
+import { colors, overlay, BREAKPOINT } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -54,7 +54,7 @@ export default function SpecialistPublicRequests() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [cities, setCities] = useState<CityOption[]>([]);
   const [services, setServices] = useState<ServiceOption[]>([]);

--- a/app/brand.tsx
+++ b/app/brand.tsx
@@ -15,7 +15,7 @@ import {
 import HeaderBack from "../components/HeaderBack";
 import HeaderHome from "../components/HeaderHome";
 import ResponsiveContainer from "../components/ResponsiveContainer";
-import { colors, tw, typography, spacing, radius } from "../lib/theme";
+import { colors, tw, typography, spacing, radius, BREAKPOINT } from "../lib/theme";
 
 // Spacing rhythm is unified on `gap-4` (16px) for all section content. Old
 // design had a mix of mb-4 (16), mb-2 (8) and gap-5 (20) on the same level —
@@ -35,7 +35,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 export default function BrandScreen() {
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
   const [inputDefault, setInputDefault] = useState("");
   const [inputFocused, setInputFocused] = useState("ivan@mail.ru");
   const [inputError, setInputError] = useState("not-email");

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -9,7 +9,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import EmptyState from "@/components/ui/EmptyState";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { api, apiPatch } from "@/lib/api";
-import { colors, overlay } from "@/lib/theme";
+import { colors, overlay, BREAKPOINT } from "@/lib/theme";
 
 interface NotificationItem {
   id: string;
@@ -110,7 +110,7 @@ function NotificationRow({
 
 export default function NotificationsScreen() {
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
   const router = useRouter();
   const { ready } = useRequireAuth();
 

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -17,7 +17,7 @@ import HeaderBack from "@/components/HeaderBack";
 import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
 import { api, apiPost, apiDelete } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, BREAKPOINT } from "@/lib/theme";
 import ThreadsList, { ThreadSummary } from "@/components/requests/ThreadsList";
 import SpecialistRecommendations, { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
 import EmptyState from "@/components/ui/EmptyState";
@@ -51,7 +51,7 @@ export default function MyRequestDetail() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [request, setRequest] = useState<RequestDetailData | null>(null);
   const [threads, setThreads] = useState<ThreadSummary[]>([]);

--- a/app/requests/[id]/index.tsx
+++ b/app/requests/[id]/index.tsx
@@ -12,6 +12,7 @@ import LoadingState from "@/components/ui/LoadingState";
 import { useAuth } from "@/contexts/AuthContext";
 import { MessageCircle, Send } from "lucide-react-native";
 import { api, ApiError } from "@/lib/api";
+import { BREAKPOINT } from "@/lib/theme";
 
 interface RequestDetail {
   id: string;
@@ -62,7 +63,7 @@ export default function PublicRequestDetail() {
   const nav = useTypedRouter();
   const { isAuthenticated, user, isLoading: authLoading } = useAuth();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [request, setRequest] = useState<RequestDetail | null>(null);
   const [loading, setLoading] = useState(true);

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -16,7 +16,7 @@ import { MessageCircle } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import { api, ApiError } from "@/lib/api";
-import { colors } from "@/lib/theme";
+import { colors, BREAKPOINT } from "@/lib/theme";
 
 interface ThreadItem {
   id: string;
@@ -66,7 +66,7 @@ export default function RequestMessages() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [threads, setThreads] = useState<ThreadItem[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -16,7 +16,7 @@ import Button from "@/components/ui/Button";
 import { Send } from "lucide-react-native";
 import { api, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, radiusValue, fontSizeValue } from "@/lib/theme";
+import { colors, radiusValue, fontSizeValue, BREAKPOINT } from "@/lib/theme";
 
 interface RequestSummary {
   id: string;
@@ -43,7 +43,7 @@ export default function SpecialistConfirmWrite() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { isAuthenticated, user, isSpecialistUser, isLoading: authLoading } = useAuth();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [request, setRequest] = useState<RequestSummary | null>(null);
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null);

--- a/app/requests/index.tsx
+++ b/app/requests/index.tsx
@@ -21,7 +21,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import RequestCard from "@/components/RequestCard";
 import { api } from "@/lib/api";
-import { colors, overlay, textStyle } from "@/lib/theme";
+import { colors, overlay, textStyle, BREAKPOINT } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -59,7 +59,7 @@ export default function PublicRequestsFeed() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
 
   const [cities, setCities] = useState<CityOption[]>([]);
   const [services, setServices] = useState<ServiceOption[]>([]);

--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -33,7 +33,7 @@ import type {
 } from "@/components/specialist/types";
 import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
-import { colors, gray, textStyle, spacing } from "@/lib/theme";
+import { colors, gray, textStyle, spacing, BREAKPOINT } from "@/lib/theme";
 
 function getInitials(
   firstName: string | null,
@@ -51,7 +51,7 @@ export default function SpecialistPublicProfile() {
   const { user, isAuthenticated } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 1024;
-  const isTablet = width >= 640;
+  const isTablet = width >= BREAKPOINT;
 
   const [specialist, setSpecialist] = useState<SpecialistDetail | null>(null);
   const [contacts, setContacts] = useState<ContactMethodItem[]>([]);

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -20,7 +20,7 @@ import { AlertCircle, UserX, Search } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
-import { colors, overlay, textStyle } from "@/lib/theme";
+import { colors, overlay, textStyle, BREAKPOINT } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -55,7 +55,7 @@ export default function SpecialistsCatalog() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
-  const isDesktop = width >= 640;
+  const isDesktop = width >= BREAKPOINT;
   const isWide = width >= 1024;
   const gridCols = isWide ? 3 : isDesktop ? 2 : 1;
 

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -236,6 +236,10 @@ export const shadowColor = {
 // Semantic overlay tokens — for rgba on colored backgrounds.
 // NOTE: white-on-#2256c2 hits WCAG AA only at >=92% opacity. Hero subcopy
 // uses white90 (passes) instead of the older white75 (4.48:1, fails).
+// Unified responsive breakpoint — desktop ≥ 768px, mobile < 768px.
+// Use this constant everywhere; do NOT hardcode 640 or other values.
+export const BREAKPOINT = 768;
+
 export const overlay = {
   white10: 'rgba(255,255,255,0.1)',
   white15: 'rgba(255,255,255,0.15)',


### PR DESCRIPTION
## Summary
- Added `BREAKPOINT = 768` constant to `lib/theme.ts`
- Replaced all `width >= 640` / `width < 640` layout comparisons (15 occurrences across 15 files) with `BREAKPOINT` import from `@/lib/theme`
- Preserved `maxWidth: 640` style values (onboarding screens) — those are sizing, not breakpoints

## Fixes
On widths 640-767px some screens were rendering as desktop while others rendered as mobile → broken layout. Now all screens switch at the same 768px threshold.

## Files changed
16 files: `lib/theme.ts` + 15 app screens

## Test plan
- [ ] tsc --noEmit: 0 errors (verified)
- [ ] Check width ~700px: all screens should show mobile layout (tabs, no sidebar)
- [ ] Check width ~800px: all screens should show desktop layout (sidebar, no tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)