### PR TITLE
fix: remove border/bg from TextInput — no more double-input on web

### DIFF
--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -235,25 +235,37 @@ export default function AdminUsers() {
 
   const filterBar = (
     <View style={{ gap: 12 }}>
-      <TextInput
-        accessibilityLabel="Поиск по email или имени"
+      {/* Outer View owns all visual styling — prevents double-input on web (NativeWind wraps
+          TextInput in an extra div when className is used; keeping className off TextInput
+          and border/bg on the parent View avoids the double-box artifact). */}
+      <View
         style={{
           backgroundColor: colors.surface2,
           borderRadius: radiusValue.md,
           height: 44,
           paddingHorizontal: 14,
-          color: colors.text,
-          fontSize: fontSizeValue.md,
           borderWidth: 1,
           borderColor: colors.border,
-          outlineWidth: 0,
+          justifyContent: "center",
         }}
-        placeholder="Поиск по email или имени..."
-        placeholderTextColor={colors.placeholder}
-        value={search}
-        onChangeText={setSearch}
-        autoCapitalize="none"
-      />
+      >
+        <TextInput
+          accessibilityLabel="Поиск по email или имени"
+          style={{
+            flex: 1,
+            color: colors.text,
+            fontSize: fontSizeValue.md,
+            borderWidth: 0,
+            backgroundColor: "transparent",
+            outlineWidth: 0,
+          }}
+          placeholder="Поиск по email или имени..."
+          placeholderTextColor={colors.placeholder}
+          value={search}
+          onChangeText={setSearch}
+          autoCapitalize="none"
+        />
+      </View>
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -370,17 +370,15 @@ export default function AuthOtpScreen() {
 
             <View className="flex-row justify-center gap-2 mb-4">
               {digits.length === 0 ? null : digits.map((digit, i) => (
-                <TextInput
+                // Outer View owns border/bg — prevents double-input on web
+                // (NativeWind wraps TextInput in extra div when className is present;
+                // keeping className off TextInput and visual styling on parent View
+                // avoids the double-box artifact).
+                <View
                   key={i}
-                  accessibilityLabel={`Цифра ${i + 1} кода подтверждения`}
-                  ref={(ref) => {
-                    inputRefs.current[i] = ref;
-                  }}
-                  // @ts-expect-error — outlineStyle is web-only CSS; RN drops unknown style keys safely
                   style={{
                     width: 48,
                     height: 56,
-                    textAlign: "center",
                     borderRadius: radiusValue.md,
                     borderWidth: error ? 2 : digit ? 2 : 1.5,
                     borderColor: error
@@ -393,22 +391,39 @@ export default function AuthOtpScreen() {
                       : digit
                         ? colors.accentSoft
                         : colors.surface,
-                    fontSize: 24,
-                    fontWeight: "700",
-                    color: error ? colors.error : colors.text,
-                    outlineWidth: 0,
-                    outlineStyle: "none",
+                    alignItems: "center",
+                    justifyContent: "center",
                   }}
-                  value={digit}
-                  onChangeText={(v) => handleDigitChange(i, v)}
-                  onKeyPress={({ nativeEvent }) =>
-                    handleKeyPress(i, nativeEvent.key)
-                  }
-                  keyboardType="number-pad"
-                  maxLength={CODE_LENGTH}
-                  editable={!isLoading}
-                  selectTextOnFocus
-                />
+                >
+                  <TextInput
+                    accessibilityLabel={`Цифра ${i + 1} кода подтверждения`}
+                    ref={(ref) => {
+                      inputRefs.current[i] = ref;
+                    }}
+                    // @ts-expect-error — outlineStyle is web-only CSS; RN drops unknown style keys safely
+                    style={{
+                      width: 48,
+                      height: 56,
+                      textAlign: "center",
+                      fontSize: 24,
+                      fontWeight: "700",
+                      color: error ? colors.error : colors.text,
+                      outlineWidth: 0,
+                      outlineStyle: "none",
+                      borderWidth: 0,
+                      backgroundColor: "transparent",
+                    }}
+                    value={digit}
+                    onChangeText={(v) => handleDigitChange(i, v)}
+                    onKeyPress={({ nativeEvent }) =>
+                      handleKeyPress(i, nativeEvent.key)
+                    }
+                    keyboardType="number-pad"
+                    maxLength={CODE_LENGTH}
+                    editable={!isLoading}
+                    selectTextOnFocus
+                  />
+                </View>
               ))}
             </View>
 

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -201,32 +201,43 @@ export default function SpecialistConfirmWrite() {
           <Text className="text-sm font-semibold text-text-base mb-2">
             Ваше сообщение
           </Text>
-          <TextInput
-            accessibilityLabel="Ваше сообщение"
-            value={message}
-            maxLength={MAX_CHARS}
-            onChangeText={(t) => {
-              if (t.length <= MAX_CHARS) setMessage(t);
-            }}
-            placeholder="Здравствуйте! Я специалист по... Могу помочь с вашей ситуацией. Расскажите подробнее..."
-            placeholderTextColor={colors.placeholder}
-            multiline
-            editable={!isLimitReached}
+          {/* Outer View owns all visual styling — prevents double-input on web (NativeWind wraps
+              TextInput in an extra div when className is used; keeping className off TextInput
+              and border/bg on the parent View avoids the double-box artifact). */}
+          <View
             style={{
               minHeight: 140,
               borderWidth: 1,
               borderColor: isLimitReached ? colors.border : colors.borderLight,
               borderRadius: radiusValue.md,
-              paddingHorizontal: 14,
-              paddingVertical: 12,
-              fontSize: fontSizeValue.base,
-              color: colors.text,
               backgroundColor: isLimitReached ? colors.background : colors.surface,
-              textAlignVertical: "top",
               opacity: isLimitReached ? 0.5 : 1,
-              outlineWidth: 0,
             }}
-          />
+          >
+            <TextInput
+              accessibilityLabel="Ваше сообщение"
+              value={message}
+              maxLength={MAX_CHARS}
+              onChangeText={(t) => {
+                if (t.length <= MAX_CHARS) setMessage(t);
+              }}
+              placeholder="Здравствуйте! Я специалист по... Могу помочь с вашей ситуацией. Расскажите подробнее..."
+              placeholderTextColor={colors.placeholder}
+              multiline
+              editable={!isLimitReached}
+              style={{
+                flex: 1,
+                paddingHorizontal: 14,
+                paddingVertical: 12,
+                fontSize: fontSizeValue.base,
+                color: colors.text,
+                textAlignVertical: "top",
+                outlineWidth: 0,
+                borderWidth: 0,
+                backgroundColor: "transparent",
+              }}
+            />
+          </View>
 
           {/* Counter + min-length hint */}
           <View className="flex-row justify-between items-center mt-1 mb-1">


### PR DESCRIPTION
## Problem
NativeWind v4 wraps TextInput in an extra div when `className` is used, causing two visible input boxes on web. Additionally, TextInput elements with visual styling (border, backgroundColor, borderRadius) directly in their `style` prop — rather than on a parent View — produce the same double-box artifact.

## Audit results
Scanned all 8 files containing TextInput across `app/` and `components/`:

**Already correct (no change):**
- `components/ui/Input.tsx` — fixed in PR #1406, border owned by outer View
- `app/login.tsx` — parent View owns border, TextInput has `borderWidth: 0`
- `components/layout/AppHeader.tsx` — parent View owns border/bg
- `components/filters/CityFnsCascade.tsx` — parent View owns border
- `app/specialists/index.tsx` — parent View owns border

**Fixed (3 files):**
- `app/otp.tsx` — wrapped each OTP digit TextInput in a View that owns border/bg/borderRadius; TextInput gets `borderWidth:0 + backgroundColor:transparent`
- `app/(admin-tabs)/users.tsx` — wrapped search TextInput in a parent View for all visual styling
- `app/requests/[id]/write.tsx` — wrapped multiline textarea in a View; moved border/bg/opacity there

## No className on TextInput
Confirmed zero files had `className=` on any TextInput element.

🤖 Generated with Claude Code