### PR TITLE
feat: messages UI + email notification on new message

### DIFF
--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1,0 +1,37 @@
+import nodemailer from "nodemailer";
+import { config } from "./config";
+
+const transporter = nodemailer.createTransport({
+  host: config.smtpHost || "smtp.gmail.com",
+  port: config.smtpPort,
+  secure: config.smtpSecure,
+  auth: {
+    user: config.smtpUser,
+    pass: config.smtpPass,
+  },
+});
+
+export async function sendNewMessageEmail(params: {
+  toEmail: string;
+  toName: string;
+  fromName: string;
+  threadId: string;
+  requestTitle: string;
+}): Promise<void> {
+  if (!config.smtpUser) {
+    // Dev mode: skip sending
+    console.log(`[email] Would send to ${params.toEmail}: New message from ${params.fromName} in thread ${params.threadId}`);
+    return;
+  }
+
+  const appUrl = process.env.APP_URL || "https://p2ptax.ru";
+  const link = `${appUrl}/threads/${params.threadId}`;
+
+  await transporter.sendMail({
+    from: `"P2PTax" <${config.smtpFrom}>`,
+    to: params.toEmail,
+    subject: `Вам написал ${params.fromName} — P2PTax`,
+    text: `Здравствуйте, ${params.toName}!\n\nВам написал ${params.fromName} по заявке «${params.requestTitle}».\n\nПрочитать сообщение: ${link}\n\nС уважением,\nP2PTax`,
+    html: `<p>Здравствуйте, ${params.toName}!</p><p>Вам написал <strong>${params.fromName}</strong> по заявке «${params.requestTitle}».</p><p><a href="${link}">Прочитать сообщение</a></p><p>С уважением,<br>P2PTax</p>`,
+  });
+}

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -3,6 +3,7 @@ import rateLimit from "express-rate-limit";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
 import { sendNotification } from "../notifications/notification.service";
+import { sendNewMessageEmail } from "../lib/email";
 import type * as Minio from "minio";
 import { minioClient, MINIO_BUCKET } from "../lib/minio";
 
@@ -207,7 +208,7 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
 
     const thread = await prisma.thread.findUnique({
       where: { id: threadId },
-      include: { request: { select: { status: true } } },
+      include: { request: { select: { status: true, title: true } } },
     });
 
     if (!thread) {
@@ -293,6 +294,22 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
       body: trimmedText ? trimmedText.slice(0, 200) : "Вложение",
       entityId: threadId,
     }).catch((err: Error) => console.warn("[notifications] new_message trigger failed:", err.message));
+
+    // Email notification — fire-and-forget
+    prisma.user.findUnique({
+      where: { id: recipientId },
+      select: { email: true, firstName: true, lastName: true },
+    }).then((recipient) => {
+      if (!recipient) return;
+      const toName = [recipient.firstName, recipient.lastName].filter(Boolean).join(" ") || "Пользователь";
+      return sendNewMessageEmail({
+        toEmail: recipient.email,
+        toName,
+        fromName: senderName,
+        threadId,
+        requestTitle: thread.request.title,
+      });
+    }).catch((err: Error) => console.warn("[email] new_message email failed:", err.message));
 
     res.json({ message: { ...message, files: savedFiles } });
   } catch (error) {

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -484,23 +484,8 @@ export default function UnifiedInbox() {
           />
         }
         ListHeaderComponent={
-          <View style={{ paddingHorizontal: 16, paddingTop: 12 }}>
-            <View className="flex-row items-center gap-2 mb-3">
-              <Text className="text-2xl font-bold text-text-base flex-1">
-                Сообщения
-              </Text>
-              {unreadTotal > 0 && (
-                <View
-                  className="bg-accent rounded-full items-center justify-center"
-                  style={{ minWidth: 24, height: 24, paddingHorizontal: 6 }}
-                >
-                  <Text className="text-xs font-bold text-white">
-                    {unreadTotal > 99 ? "99+" : unreadTotal}
-                  </Text>
-                </View>
-              )}
-            </View>
-            <View className="flex-row gap-2 mb-3">
+          <View style={{ paddingHorizontal: 16, paddingTop: 6 }}>
+            <View className="flex-row gap-2 pb-2">
               <FilterChip
                 label="Все"
                 active={filter === "all"}
@@ -511,6 +496,16 @@ export default function UnifiedInbox() {
                 active={filter === "unread"}
                 onPress={() => setFilter("unread")}
               />
+              {unreadTotal > 0 && (
+                <View
+                  className="bg-accent rounded-full items-center justify-center self-center"
+                  style={{ minWidth: 20, height: 20, paddingHorizontal: 5 }}
+                >
+                  <Text className="text-xs font-bold text-white">
+                    {unreadTotal > 99 ? "99+" : unreadTotal}
+                  </Text>
+                </View>
+              )}
             </View>
           </View>
         }

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -163,7 +163,7 @@ export default function RequestMessages() {
   if (loading) {
     return (
       <SafeAreaView className="flex-1 bg-white">
-        <HeaderBack title="Сообщения" />
+        {!isDesktop && <HeaderBack title="Сообщения" />}
         <ResponsiveContainer>
           {[0, 1, 2, 3].map((i) => (
             <View key={i} className="flex-row items-center py-3 border-b border-border">
@@ -183,7 +183,7 @@ export default function RequestMessages() {
   if (error) {
     return (
       <SafeAreaView className="flex-1 bg-white">
-        <HeaderBack title="Сообщения" />
+        {!isDesktop && <HeaderBack title="Сообщения" />}
         <View className="flex-1 items-center justify-center">
           <ErrorState
             message={error}
@@ -199,7 +199,7 @@ export default function RequestMessages() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <HeaderBack title="Сообщения" />
+      {!isDesktop && <HeaderBack title="Сообщения" />}
       <ResponsiveContainer>
         <FlatList
           data={threads}

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -92,9 +92,6 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const { user } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
-  const desktopStyle = isDesktop
-    ? { maxWidth: 520, width: "100%" as const, alignSelf: "center" as const }
-    : undefined;
 
   const [messages, setMessages] = useState<MessageItem[]>([]);
   const [thread, setThread] = useState<ThreadInfo | null>(null);
@@ -282,9 +279,11 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     return (
       <View className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-border bg-white">
-          <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
-          </Pressable>
+          {!isDesktop && (
+            <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
+              <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+            </Pressable>
+          )}
           <Text className="text-base font-semibold" style={{ color: colors.text }}>Чат</Text>
         </View>
         <View className="flex-1 items-center justify-center">
@@ -298,9 +297,11 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     return (
       <View className="flex-1 bg-white">
         <View className="flex-row items-center px-4 py-3 border-b border-border bg-white">
-          <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
-            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
-          </Pressable>
+          {!isDesktop && (
+            <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center">
+              <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+            </Pressable>
+          )}
           <Text className="text-base font-semibold" style={{ color: colors.text }}>Чат</Text>
         </View>
         <View className="flex-1 items-center justify-center px-4">
@@ -321,12 +322,14 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   }
 
   return (
-    <View className="flex-1 bg-white" style={desktopStyle}>
+    <View className="flex-1 bg-white">
       {/* Header with avatar + other party name + request title */}
       <View className="flex-row items-center px-4 py-3 border-b border-border bg-white">
-        <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center" style={({ pressed }) => [pressed && { opacity: 0.7 }]}>
-          <FontAwesome name="chevron-left" size={18} color={colors.primary} />
-        </Pressable>
+        {!isDesktop && (
+          <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center" style={({ pressed }) => [pressed && { opacity: 0.7 }]}>
+            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+          </Pressable>
+        )}
         {otherUser ? (
           <Avatar
             name={displayName(otherUser)}


### PR DESCRIPTION
## Changes

### UI
- Messages list (mobile): removed big \"Сообщения\" heading, filter chips now at top with minimal 6px padding — content starts sooner
- Messages list: unread total badge moved inline next to filter chips (compact dot-style count)
- Chat (`InlineChatView`): back arrow hidden on desktop (≥640px) across loading, error, and main states; removed `maxWidth: 520` cap so chat fills the full right panel
- `requests/[id]/messages`: `HeaderBack` hidden on desktop

### File uploads in chat — audit result
- Frontend: `InlineChatView` already has paperclip button (`DocumentPicker`), upload to `/api/upload/chat-file`, `uploadToken` flow
- Backend: `POST /api/messages/:threadId` supports `uploadToken` + `files[]`, stores in `File` table, returns in response
- Display: `MessageBubble` renders file attachments with `Linking.openURL`
- Status: **fully working end-to-end**, no fixes needed

### Email notification
- New `api/src/lib/email.ts`: nodemailer transporter using `config.smtp*` vars; dev-safe (logs to console when `SMTP_USER` not set)
- `POST /api/messages/:threadId`: after push notification, fires `sendNewMessageEmail` to recipient (fire-and-forget, `Promise.catch` only)
- Thread query extended: `request.title` now included for email subject/body

🤖 Generated with Claude Code