### PR TITLE
fix: settings — iOS toggles, no duplicate heading, legal hub

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -121,6 +121,7 @@ export default function RootLayout() {
             <Stack.Screen name="requests/[id]/write" />
             <Stack.Screen name="settings" />
             <Stack.Screen name="notifications" />
+            <Stack.Screen name="legal/index" options={{ headerShown: false }} />
             <Stack.Screen name="legal/privacy" />
             <Stack.Screen name="legal/terms" />
             {/* Issue GH-1293: /brand is a dev-only design-system page. */}

--- a/app/legal/index.tsx
+++ b/app/legal/index.tsx
@@ -1,0 +1,69 @@
+import { View, Text, Pressable, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useTypedRouter } from "@/lib/navigation";
+import { FileText, Shield, ChevronRight } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+import DesktopScreen from "@/components/layout/DesktopScreen";
+
+const LEGAL_DOCS = [
+  {
+    icon: FileText,
+    title: "Условия использования",
+    subtitle: "Правила использования сервиса",
+    route: "legalTerms" as const,
+  },
+  {
+    icon: Shield,
+    title: "Политика конфиденциальности",
+    subtitle: "Как мы обрабатываем ваши данные",
+    route: "legalPrivacy" as const,
+  },
+];
+
+export default function LegalIndexPage() {
+  const nav = useTypedRouter();
+
+  return (
+    <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <DesktopScreen>
+          <View className="mb-6">
+            <Text className="text-2xl font-bold text-text-base mb-1">Правовая информация</Text>
+            <Text className="text-sm text-text-mute">Документы и соглашения P2PTax</Text>
+          </View>
+
+          <View className="bg-white border border-border rounded-2xl overflow-hidden">
+            {LEGAL_DOCS.map((doc, idx) => {
+              const Icon = doc.icon;
+              return (
+                <Pressable
+                  key={doc.route}
+                  accessibilityRole="link"
+                  accessibilityLabel={doc.title}
+                  onPress={() => nav.routes[doc.route]()}
+                  className={`flex-row items-center px-4 min-h-[60px] ${idx > 0 ? "border-t border-border" : ""}`}
+                >
+                  <View
+                    className="w-9 h-9 rounded-xl items-center justify-center mr-3"
+                    style={{ backgroundColor: colors.accentSoft }}
+                  >
+                    <Icon size={18} color={colors.primary} />
+                  </View>
+                  <View className="flex-1">
+                    <Text className="text-base text-text-base font-medium">{doc.title}</Text>
+                    <Text className="text-xs text-text-mute mt-0.5">{doc.subtitle}</Text>
+                  </View>
+                  <ChevronRight size={14} color={colors.borderLight} />
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text className="text-xs text-text-mute text-center mt-8 px-4">
+            © {new Date().getFullYear()} P2PTax. Все права защищены.
+          </Text>
+        </DesktopScreen>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -609,7 +609,7 @@ export default function UnifiedSettings() {
               accessibilityRole="link"
               accessibilityLabel="Все уведомления"
               onPress={() => nav.routes.notifications()}
-              className="flex-row items-center py-3 mt-2 border-t border-border"
+              className="flex-row items-center py-3 border-t border-border"
             >
               <Bell size={16} color={colors.textSecondary} />
               <Text className="flex-1 ml-3 text-sm text-text-base">
@@ -626,26 +626,12 @@ export default function UnifiedSettings() {
             </Text>
             <Pressable
               accessibilityRole="link"
-              accessibilityLabel="Условия использования"
-              onPress={() => nav.routes.legalTerms()}
+              accessibilityLabel="Правовые документы"
+              onPress={() => nav.routes.legalIndex()}
               className="flex-row items-center min-h-[44px]"
             >
               <FileText size={16} color={colors.placeholder} />
-              <Text className="text-base text-text-base ml-3 flex-1">
-                Условия использования
-              </Text>
-              <ChevronRight size={14} color={colors.borderLight} />
-            </Pressable>
-            <Pressable
-              accessibilityRole="link"
-              accessibilityLabel="Политика конфиденциальности"
-              onPress={() => nav.routes.legalPrivacy()}
-              className="flex-row items-center min-h-[44px] border-t border-border"
-            >
-              <FileText size={16} color={colors.placeholder} />
-              <Text className="text-base text-text-base ml-3 flex-1">
-                Политика конфиденциальности
-              </Text>
+              <Text className="text-base text-text-base ml-3 flex-1">Правовые документы</Text>
               <ChevronRight size={14} color={colors.borderLight} />
             </Pressable>
           </View>

--- a/components/settings/NotificationPreferences.tsx
+++ b/components/settings/NotificationPreferences.tsx
@@ -1,20 +1,68 @@
-import { View, Text, Switch, Pressable, Platform } from "react-native";
+import { View, Text, Pressable, Animated } from "react-native";
+import { useRef, useEffect } from "react";
 import { colors } from "@/lib/theme";
-
-// On web RN's <Switch> renders as ~40x20 native HTML <input type="checkbox">.
-// Vizor / a11y audits measure that inner DOM element, not the Pressable
-// wrapper. Forcing height: 44 + width: 52 directly on the Switch makes the
-// rendered element clear the 44x44 minimum tap-target threshold (WCAG 2.5.5).
-const switchWebStyle =
-  Platform.OS === "web"
-    ? ({ height: 44, width: 52 } as const)
-    : undefined;
 
 interface NotificationPreferencesProps {
   pushEnabled: boolean;
   emailEnabled: boolean;
   onPushChange: (val: boolean) => void;
   onEmailChange: (val: boolean) => void;
+}
+
+function IosToggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+  const anim = useRef(new Animated.Value(value ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: value ? 1 : 0,
+      duration: 150,
+      useNativeDriver: false,
+    }).start();
+  }, [value]);
+
+  const trackColor = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ["#E5E5EA", colors.primary],
+  });
+  const thumbPos = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [2, 22],
+  });
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value }}
+      onPress={() => onChange(!value)}
+      style={{ width: 51, height: 31 }}
+    >
+      <Animated.View
+        style={{
+          width: 51,
+          height: 31,
+          borderRadius: 15.5,
+          backgroundColor: trackColor,
+          justifyContent: "center",
+        }}
+      >
+        <Animated.View
+          style={{
+            width: 27,
+            height: 27,
+            borderRadius: 13.5,
+            backgroundColor: "white",
+            position: "absolute",
+            left: thumbPos,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.15,
+            shadowRadius: 2,
+            elevation: 2,
+          }}
+        />
+      </Animated.View>
+    </Pressable>
+  );
 }
 
 export default function NotificationPreferences({
@@ -24,62 +72,25 @@ export default function NotificationPreferences({
   onEmailChange,
 }: NotificationPreferencesProps) {
   return (
-    <View>
-      <Text className="text-xs font-semibold text-text-mute uppercase tracking-wide mb-3">
-        Уведомления
-      </Text>
-      <View className="bg-white border border-border rounded-xl mb-6 overflow-hidden">
-        <View className="flex-row items-center px-4 py-3 border-b border-border">
-          <View className="flex-1 mr-3">
-            <Text className="text-base text-text-base">Push-уведомления</Text>
-            <Text className="text-xs text-text-mute mt-0.5">
-              Новые заявки и сообщения
-            </Text>
-          </View>
-          <Pressable
-            accessibilityRole="switch"
-            accessibilityLabel="Push-уведомления"
-            accessibilityState={{ checked: pushEnabled }}
-            onPress={() => onPushChange(!pushEnabled)}
-            style={{ width: 56, height: 44, alignItems: "center", justifyContent: "center" }}
-          >
-            <Switch
-              accessibilityLabel="Push-уведомления"
-              value={pushEnabled}
-              onValueChange={onPushChange}
-              trackColor={{ false: colors.border, true: colors.primary }}
-              thumbColor={colors.surface}
-              pointerEvents="none"
-              style={switchWebStyle}
-            />
-          </Pressable>
+    <>
+      <View className="flex-row items-center py-3 border-b border-border">
+        <View className="flex-1 mr-3">
+          <Text className="text-base text-text-base">Push-уведомления</Text>
+          <Text className="text-xs text-text-mute mt-0.5">
+            Новые заявки и сообщения
+          </Text>
         </View>
-        <View className="flex-row items-center px-4 py-3">
-          <View className="flex-1 mr-3">
-            <Text className="text-base text-text-base">Email-уведомления</Text>
-            <Text className="text-xs text-text-mute mt-0.5">
-              Дублировать уведомления на почту
-            </Text>
-          </View>
-          <Pressable
-            accessibilityRole="switch"
-            accessibilityLabel="Email-уведомления"
-            accessibilityState={{ checked: emailEnabled }}
-            onPress={() => onEmailChange(!emailEnabled)}
-            style={{ width: 56, height: 44, alignItems: "center", justifyContent: "center" }}
-          >
-            <Switch
-              accessibilityLabel="Email-уведомления"
-              value={emailEnabled}
-              onValueChange={onEmailChange}
-              trackColor={{ false: colors.border, true: colors.primary }}
-              thumbColor={colors.surface}
-              pointerEvents="none"
-              style={switchWebStyle}
-            />
-          </Pressable>
-        </View>
+        <IosToggle value={pushEnabled} onChange={onPushChange} />
       </View>
-    </View>
+      <View className="flex-row items-center py-3 border-b border-border">
+        <View className="flex-1 mr-3">
+          <Text className="text-base text-text-base">Email-уведомления</Text>
+          <Text className="text-xs text-text-mute mt-0.5">
+            Дублировать уведомления на почту
+          </Text>
+        </View>
+        <IosToggle value={emailEnabled} onChange={onEmailChange} />
+      </View>
+    </>
   );
 }

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -64,6 +64,7 @@ export const ROUTES = {
   specialists: "/specialists",
 
   // Legal
+  legalIndex: "/legal",
   legalTerms: "/legal/terms",
   legalPrivacy: "/legal/privacy",
 } as const;


### PR DESCRIPTION
## Changes
- NotificationPreferences: custom iOS-style Animated toggle replaces RN Switch
- Removed duplicate "Уведомления" heading inside NotificationPreferences component
- New page: app/legal/index.tsx — legal document hub
- Settings: single "Правовые документы" row → /legal instead of two separate links
- Added legalIndex route to lib/navigation.ts

🤖 Generated with Claude Code