### PR TITLE
fix: file upload audit — presigned URLs everywhere

### DIFF
--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -6,7 +6,7 @@ import { sendNotification } from "../notifications/notification.service";
 import { sendNewMessageEmail } from "../lib/email";
 import { firstNameInGenitive } from "../lib/ru";
 import type * as Minio from "minio";
-import { minioClient, MINIO_BUCKET } from "../lib/minio";
+import { minioClient, MINIO_BUCKET, presignStoredUrl } from "../lib/minio";
 
 const router = Router();
 
@@ -177,15 +177,17 @@ router.get("/threads", authMiddleware, async (req: Request, res: Response) => {
       }),
     ]);
 
-    const result = threads.map((t) => ({
-      id: t.id,
-      request: t.request,
-      client: t.client,
-      specialist: t.specialist,
-      lastMessage: t.messages[0] || null,
-      lastMessageAt: t.lastMessageAt,
-      createdAt: t.createdAt,
-    }));
+    const result = await Promise.all(
+      threads.map(async (t) => ({
+        id: t.id,
+        request: t.request,
+        client: { ...t.client, avatarUrl: await presignStoredUrl(t.client.avatarUrl) },
+        specialist: { ...t.specialist, avatarUrl: await presignStoredUrl(t.specialist.avatarUrl) },
+        lastMessage: t.messages[0] || null,
+        lastMessageAt: t.lastMessageAt,
+        createdAt: t.createdAt,
+      }))
+    );
 
     res.json({ threads: result, total, limit, offset, hasMore: offset + limit < total });
   } catch (error) {
@@ -298,10 +300,13 @@ router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => 
       filesByMessage[f.entityId].push(f);
     }
 
-    const result = messages.map((m) => ({
-      ...m,
-      files: filesByMessage[m.id] || [],
-    }));
+    const result = await Promise.all(
+      messages.map(async (m) => ({
+        ...m,
+        sender: { ...m.sender, avatarUrl: await presignStoredUrl(m.sender.avatarUrl) },
+        files: filesByMessage[m.id] || [],
+      }))
+    );
 
     if (!paginated) {
       res.json({ messages: result });
@@ -515,7 +520,13 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
       });
     }).catch((err: Error) => console.warn("[email] new_message email failed:", err.message));
 
-    res.json({ message: { ...message, files: savedFiles } });
+    res.json({
+      message: {
+        ...message,
+        sender: { ...message.sender, avatarUrl: await presignStoredUrl(message.sender.avatarUrl) },
+        files: savedFiles,
+      },
+    });
   } catch (error) {
     console.error("send message error:", error);
     res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## Summary

- **Root cause**: Hetzner S3 bucket is private (HTTP 403 on direct access). All stored file paths (`/p2ptax/avatars/xxx`, `/p2ptax/chat-files/xxx`, `/p2ptax/documents/xxx`) were inaccessible — the Express app has no proxy for these paths.
- **Secondary bug**: Frontend stored `${API_URL}/p2ptax/...` (e.g. `http://localhost:3000/p2ptax/...`) as the avatar URL in the DB, since the upload response returned a raw relative path and the frontend prepended the API base URL.

## Changes

| File | Fix |
|---|---|
| `api/src/lib/minio.ts` | Add `presignStoredUrl()` helper — handles all stored URL formats (http/relative/bucket-prefixed) |
| `api/src/routes/upload.ts` | Avatar upload now returns 1-year presigned URL instead of raw `/bucket/key` path |
| `api/src/routes/auth.ts` | `GET /api/auth/me` — presign avatarUrl before returning to client |
| `api/src/routes/user.ts` | `PATCH /api/user/profile` — presign avatarUrl in response |
| `api/src/routes/specialists.ts` | Presign avatarUrl in featured list, catalog list, and detail endpoints |
| `api/src/routes/messages.ts` | Presign sender + participant avatarUrls; presign chat file URLs in GET/POST responses |
| `api/src/routes/requests.ts` | Presign avatarUrl in public request detail + specialist recommendations |
| `components/InlineChatView.tsx` | Fix chat file open — call `GET /api/upload/signed-url/:key` instead of direct `${API_URL}/p2ptax/...` |

## Upload surfaces audit

| Surface | Endpoint | MinIO | URL returned | Accessible |
|---|---|---|---|---|
| Avatar upload | POST /api/upload/avatar | ✓ | presigned URL (1yr) | ✓ fixed |
| Document upload | POST /api/upload/documents | ✓ | `/p2ptax/documents/key` (stored in DB) | ✓ (detail.tsx uses signed-url) |
| Chat file upload | POST /api/upload/chat-file | ✓ | uploadToken → resolved by messages.ts | ✓ (InlineChatView fixed) |
| Signed URL | GET /api/upload/signed-url/:key | ✓ | 1-hour presigned URL | ✓ already correct |

## Test plan

- [ ] Upload avatar in settings — image loads after save
- [ ] Avatar visible in specialist catalog and chat threads
- [ ] Upload document on request creation — file opens via signed-url
- [ ] Send chat file attachment — file opens correctly
- [ ] `tsc --noEmit` passes on both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)