### PR TITLE
fix: messages UX — 9 improvements

### DIFF
--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -52,6 +52,48 @@ interface FileInput {
   mimeType: string;
 }
 
+// GET /api/messages/unread-count — count of threads with unread messages
+router.get("/unread-count", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+
+    const threads = await prisma.thread.findMany({
+      where: {
+        OR: [{ clientId: userId }, { specialistId: userId }],
+      },
+      select: {
+        id: true,
+        clientId: true,
+        specialistId: true,
+        clientLastReadAt: true,
+        specialistLastReadAt: true,
+        messages: {
+          orderBy: { createdAt: "desc" },
+          take: 1,
+          select: { senderId: true, createdAt: true },
+        },
+      },
+    });
+
+    let count = 0;
+    for (const t of threads) {
+      const isClient = t.clientId === userId;
+      const lastReadAt = isClient ? t.clientLastReadAt : t.specialistLastReadAt;
+      const lastMsg = t.messages[0];
+      if (!lastMsg) continue;
+      if (lastMsg.senderId === userId) continue;
+      if (!lastReadAt || lastMsg.createdAt > lastReadAt) {
+        count++;
+      }
+    }
+
+    res.json({ count });
+  } catch (error) {
+    console.error("unread-count error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // GET /api/messages/threads — list threads for current user
 router.get("/threads", authMiddleware, async (req: Request, res: Response) => {
   try {

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -118,11 +118,25 @@ const chatFileUpload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 10 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
-    const allowed = ["application/pdf", "image/jpeg", "image/png"];
+    const allowed = [
+      // Images
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "image/gif",
+      // Documents
+      "application/pdf",
+      "application/msword",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.ms-excel",
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      // Text
+      "text/plain",
+    ];
     if (allowed.includes(file.mimetype)) {
       cb(null, true);
     } else {
-      cb(new Error("Only pdf, jpg, png allowed for chat files"));
+      cb(new Error("Недопустимый тип файла. Разрешены: изображения, PDF, Word, Excel, TXT"));
     }
   },
 });

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -96,14 +96,12 @@ function formatTime(dateStr: string): string {
 
 function sortThreads(threads: ThreadItem[]): ThreadItem[] {
   return [...threads].sort((a, b) => {
-    if (a.unreadCount > 0 && b.unreadCount === 0) return -1;
-    if (a.unreadCount === 0 && b.unreadCount > 0) return 1;
     const aTime = a.lastMessage
       ? new Date(a.lastMessage.createdAt).getTime()
-      : new Date(a.createdAt).getTime();
+      : a.createdAt ? new Date(a.createdAt).getTime() : 0;
     const bTime = b.lastMessage
       ? new Date(b.lastMessage.createdAt).getTime()
-      : new Date(b.createdAt).getTime();
+      : b.createdAt ? new Date(b.createdAt).getTime() : 0;
     return bTime - aTime;
   });
 }
@@ -178,6 +176,14 @@ export default function UnifiedInbox() {
         }
       };
 
+      // If we're viewing as_client, the other party is a specialist — navigate to their profile
+      const handleUserPress = (e: { stopPropagation?: () => void }) => {
+        if (e.stopPropagation) e.stopPropagation();
+        if (item.perspective === "as_client") {
+          nav.any(`/specialists/${item.otherUser.id}`);
+        }
+      };
+
       return (
         <Pressable
           accessibilityRole="button"
@@ -203,7 +209,10 @@ export default function UnifiedInbox() {
             pressed && { opacity: 0.75 },
           ]}
         >
-          <View
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel={item.perspective === "as_client" ? `Профиль специалиста ${name}` : name}
+            onPress={handleUserPress}
             className="relative mr-3 my-3.5"
             style={{
               shadowColor: colors.black,
@@ -229,15 +238,11 @@ export default function UnifiedInbox() {
             />
             {hasUnread && (
               <View
-                className="absolute -top-1 -right-1 rounded-full bg-accent items-center justify-center px-1"
-                style={{ minWidth: 18, height: 18 }}
-              >
-                <Text className="text-xs font-bold text-white">
-                  {item.unreadCount > 99 ? "99+" : item.unreadCount}
-                </Text>
-              </View>
+                className="absolute -top-0.5 -right-0.5 rounded-full"
+                style={{ width: 10, height: 10, backgroundColor: colors.primary }}
+              />
             )}
-          </View>
+          </Pressable>
 
           <View className="flex-1 min-w-0 py-3.5">
             <View className="flex-row items-center justify-between gap-2">
@@ -290,7 +295,7 @@ export default function UnifiedInbox() {
 
   if (!ready || loading) {
     return (
-      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      <SafeAreaView className="flex-1 bg-white" edges={isDesktop ? [] : ["top"]}>
         <HeaderHome />
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
@@ -301,7 +306,7 @@ export default function UnifiedInbox() {
 
   if (error) {
     return (
-      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      <SafeAreaView className="flex-1 bg-white" edges={isDesktop ? [] : ["top"]}>
         <HeaderHome />
         <View className="flex-1 items-center justify-center">
           <ErrorState message={error} onRetry={fetchThreads} />
@@ -334,7 +339,7 @@ export default function UnifiedInbox() {
   if (isDesktop) {
     const isWide = width >= 1024;
     return (
-      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      <SafeAreaView className="flex-1 bg-white" edges={[]}>
         <HeaderHome />
         <View className="flex-1 items-center" style={{ width: "100%", overflow: "hidden" }}>
           <View
@@ -435,7 +440,6 @@ export default function UnifiedInbox() {
                         ? "Напишите по публичной заявке, чтобы начать переписку с клиентом."
                         : "Когда специалисты напишут по заявкам, переписки появятся слева."
                   }
-                  leftHint="Список диалогов"
                   primary={
                     isSpecialistUser
                       ? {
@@ -456,7 +460,7 @@ export default function UnifiedInbox() {
                       : {
                           label: "Найти специалиста",
                           onPress: () => nav.routes.specialists(),
-                          icon: "sparkles",
+                          icon: "search",
                         }
                   }
                 />
@@ -470,7 +474,7 @@ export default function UnifiedInbox() {
 
   // Mobile: full-screen list
   return (
-    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+    <SafeAreaView className="flex-1 bg-white" edges={isDesktop ? [] : ["top"]}>
       <HeaderHome />
       <FlatList
         data={filtered}
@@ -530,13 +534,13 @@ function FilterChip({
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
-      className={`px-4 rounded-full border ${
+      className={`px-3 rounded-full border ${
         active ? "bg-accent border-accent" : "bg-white border-border"
       }`}
-      style={{ minHeight: 44, justifyContent: "center" }}
+      style={{ height: 28, justifyContent: "center" }}
     >
       <Text
-        className={`text-sm font-medium ${active ? "text-white" : "text-text-base"}`}
+        className={`text-xs font-medium ${active ? "text-white" : "text-text-base"}`}
       >
         {label}
       </Text>

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -101,6 +101,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const [text, setText] = useState("");
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
 
   const flatListRef = useRef<FlatList>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -202,6 +203,25 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const handleRemovePendingFile = useCallback((index: number) => {
     setPendingFiles((prev) => prev.filter((_, i) => i !== index));
   }, []);
+
+  const handleWebFileDrop = useCallback(async (file: File) => {
+    const MAX_SIZE = 10 * 1024 * 1024;
+    if (file.size > MAX_SIZE) {
+      Alert.alert("Файл слишком большой", "Максимум 10 МБ");
+      return;
+    }
+    if (pendingFiles.length >= 3) {
+      Alert.alert("Лимит файлов", "Можно прикрепить не более 3 файлов");
+      return;
+    }
+    const pending: PendingFile = {
+      uri: URL.createObjectURL(file),
+      name: file.name,
+      mimeType: file.type || "application/octet-stream",
+      size: file.size,
+    };
+    setPendingFiles((prev) => [...prev, pending]);
+  }, [pendingFiles.length]);
 
   const uploadChatFile = useCallback(async (file: PendingFile, tid: string): Promise<string> => {
     const uploadToken = crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -415,7 +435,29 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
 
         {/* Input bar */}
         {!isClosed && (
-          <View className="flex-row items-end border-t border-border px-3 py-2 bg-white">
+          <View
+            className="flex-row items-end border-t border-border px-3 py-2 bg-white"
+            style={dragOver ? { backgroundColor: colors.accentSoft } as object : undefined}
+            {...(Platform.OS === "web" ? {
+              onDragOver: (e: React.DragEvent) => { e.preventDefault(); setDragOver(true); },
+              onDragLeave: () => setDragOver(false),
+              onDrop: (e: React.DragEvent) => {
+                e.preventDefault();
+                setDragOver(false);
+                const file = e.dataTransfer.files[0];
+                if (file) handleWebFileDrop(file);
+              },
+            } as object : {})}
+          >
+            {dragOver && Platform.OS === "web" && (
+              <View
+                className="absolute inset-0 items-center justify-center rounded-lg"
+                style={{ backgroundColor: "rgba(0,0,0,0.05)", zIndex: 10 }}
+                pointerEvents="none"
+              >
+                <Text className="text-sm font-medium text-text-dim">Перетащите файл сюда</Text>
+              </View>
+            )}
             {/* Attach button */}
             <Pressable
               accessibilityRole="button"

--- a/components/MessengerEmptyPane.tsx
+++ b/components/MessengerEmptyPane.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { View, Text, Pressable } from "react-native";
-import { MessagesSquare, Sparkles, ArrowLeft, Plus } from "lucide-react-native";
+import { MessagesSquare, Sparkles, ArrowLeft, Plus, Search } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 /**
@@ -16,7 +16,7 @@ import { colors } from "@/lib/theme";
 interface CTAProps {
   label: string;
   onPress: () => void;
-  icon?: "plus" | "sparkles";
+  icon?: "plus" | "sparkles" | "search";
 }
 
 interface Props {
@@ -30,7 +30,7 @@ interface Props {
 export default function MessengerEmptyPane({
   title = "Выберите диалог",
   hint = "Нажмите на переписку слева, чтобы открыть её",
-  leftHint = "Выберите диалог слева",
+  leftHint,
   primary,
   secondary,
 }: Props) {
@@ -113,16 +113,18 @@ export default function MessengerEmptyPane({
           </Text>
         </View>
 
-        {/* Left-arrow hint strip */}
-        <View
-          className="flex-row items-center gap-2 bg-white rounded-full border border-border"
-          style={{ paddingHorizontal: 12, paddingVertical: 6 }}
-        >
-          <ArrowLeft size={14} color={colors.accent} />
-          <Text className="text-accent font-semibold" style={{ fontSize: 12 }}>
-            {leftHint}
-          </Text>
-        </View>
+        {/* Left-arrow hint strip — only shown when leftHint is provided */}
+        {leftHint ? (
+          <View
+            className="flex-row items-center gap-2 bg-white rounded-full border border-border"
+            style={{ paddingHorizontal: 12, paddingVertical: 6 }}
+          >
+            <ArrowLeft size={14} color={colors.accent} />
+            <Text className="text-accent font-semibold" style={{ fontSize: 12 }}>
+              {leftHint}
+            </Text>
+          </View>
+        ) : null}
 
         {(primary || secondary) && (
           <View className="flex-row flex-wrap items-center justify-center gap-2 mt-2">
@@ -157,6 +159,8 @@ export default function MessengerEmptyPane({
               >
                 {secondary.icon === "plus" ? (
                   <Plus size={14} color={colors.accent} />
+                ) : secondary.icon === "search" ? (
+                  <Search size={14} color={colors.accent} />
                 ) : (
                   <Sparkles size={14} color={colors.accent} />
                 )}

--- a/components/layout/SidebarNav.tsx
+++ b/components/layout/SidebarNav.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { View, Text, Pressable, Modal, Platform } from "react-native";
 import { useRouter, usePathname, useSegments } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import { Settings, LogOut } from "lucide-react-native";
 import { colors, spacing, roleAccent, type RoleAccentKey } from "@/lib/theme";
 import { useAuth, type UserRole } from "@/contexts/AuthContext";
+import { apiGet } from "@/lib/api";
 import RoleBadge from "./RoleBadge";
 import {
   type MatchContext,
@@ -120,6 +121,20 @@ export default function SidebarNav({ group }: SidebarNavProps) {
   const segments = useSegments();
   const { user, isSpecialistUser, signOut } = useAuth();
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    if (!user) return;
+    apiGet<{ count: number }>("/api/messages/unread-count")
+      .then((r) => setUnreadCount(r.count))
+      .catch(() => {});
+    const interval = setInterval(() => {
+      apiGet<{ count: number }>("/api/messages/unread-count")
+        .then((r) => setUnreadCount(r.count))
+        .catch(() => {});
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [user]);
 
   const matchCtx: MatchContext = {
     path: pathname,
@@ -248,6 +263,23 @@ export default function SidebarNav({ group }: SidebarNavProps) {
               >
                 {item.label}
               </Text>
+              {unreadCount > 0 && item.href === "/(tabs)/messages" && (
+                <View
+                  style={{
+                    width: 18,
+                    height: 18,
+                    borderRadius: 9,
+                    backgroundColor: colors.danger,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    marginLeft: 4,
+                  }}
+                >
+                  <Text style={{ color: "white", fontSize: 10, fontWeight: "700" }}>
+                    {unreadCount > 99 ? "99+" : unreadCount}
+                  </Text>
+                </View>
+              )}
             </Pressable>
           );
         })}


### PR DESCRIPTION
## Changes
1. Thread list sorted newest-first (by lastMessage.createdAt desc, no unread-pinning)
2. Removed excess top padding on messages page (SafeAreaView edges=[] on desktop)
3. Unread indicator: small 10px dot instead of large numbered badge
4. Thread card: tap avatar → specialist profile (when perspective=as_client)
5. Sidebar: unread message count badge on Сообщения nav item (polls every 30s)
6. Web chat: drag-and-drop file upload with visual overlay on input area
7. Upload: expanded MIME type whitelist (images + PDF + Word + Excel + TXT)
8. Compact filter buttons (h-7 / 28px height, text-xs, px-3)
9. Open thread → mark all messages as read (already implemented via PATCH /read on mount)
10. MessengerEmptyPane: leftHint strip is now conditional (only shown when provided)
11. "Найти специалиста" secondary CTA uses Search icon instead of Sparkles

🤖 Generated with Claude Code