### PR TITLE
fix: kill remaining double-input artifacts on web (#1424)

### DIFF
--- a/app/(admin-tabs)/users.tsx
+++ b/app/(admin-tabs)/users.tsx
@@ -257,7 +257,12 @@ export default function AdminUsers() {
             fontSize: fontSizeValue.md,
             borderWidth: 0,
             backgroundColor: "transparent",
-            outlineWidth: 0,
+            ...(Platform.OS === "web" ? {
+              borderColor: "transparent",
+              outlineStyle: "none" as never,
+              outlineWidth: 0,
+              appearance: "none" as never,
+            } : {}),
           }}
           placeholder="Поиск по email или имени..."
           placeholderTextColor={colors.placeholder}

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -115,13 +115,19 @@ export default function AuthEmailScreen() {
                 marginLeft: 10,
                 fontSize: 15,
                 color: colors.text,
-                outlineWidth: 0,
                 borderWidth: 0,
                 // WCAG 2.5.5 — explicit 44px tap target on web; the
                 // <input> intrinsic height is ~18px otherwise.
+                // appearance:none + outlineStyle:none kill the default
+                // browser <input> chrome that creates the double-border
+                // artifact when the outer View owns the visible border.
                 ...(Platform.OS === "web" ? {
                   minHeight: 44,
                   alignSelf: "stretch" as never,
+                  borderColor: "transparent",
+                  outlineStyle: "none" as never,
+                  outlineWidth: 0,
+                  appearance: "none" as never,
                 } : {}),
               }}
             />

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -400,7 +400,7 @@ export default function AuthOtpScreen() {
                     ref={(ref) => {
                       inputRefs.current[i] = ref;
                     }}
-                    // @ts-expect-error — outlineStyle is web-only CSS; RN drops unknown style keys safely
+                    // @ts-expect-error — outlineStyle/appearance are web-only CSS; RN drops unknown style keys safely
                     style={{
                       width: 48,
                       height: 56,
@@ -408,10 +408,14 @@ export default function AuthOtpScreen() {
                       fontSize: 24,
                       fontWeight: "700",
                       color: error ? colors.error : colors.text,
-                      outlineWidth: 0,
-                      outlineStyle: "none",
                       borderWidth: 0,
                       backgroundColor: "transparent",
+                      ...(Platform.OS === "web" ? {
+                        borderColor: "transparent",
+                        outlineStyle: "none",
+                        outlineWidth: 0,
+                        appearance: "none",
+                      } : {}),
                     }}
                     value={digit}
                     onChangeText={(v) => handleDigitChange(i, v)}

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   ActivityIndicator,
   useWindowDimensions,
+  Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
@@ -232,9 +233,17 @@ export default function SpecialistConfirmWrite() {
                 fontSize: fontSizeValue.base,
                 color: colors.text,
                 textAlignVertical: "top",
-                outlineWidth: 0,
                 borderWidth: 0,
                 backgroundColor: "transparent",
+                // appearance:none + outlineStyle:none kill the default
+                // browser <textarea> chrome that creates the double-border
+                // artifact when the outer View owns the visible border.
+                ...(Platform.OS === "web" ? {
+                  borderColor: "transparent",
+                  outlineStyle: "none" as never,
+                  outlineWidth: 0,
+                  appearance: "none" as never,
+                } : {}),
               }}
             />
           </View>

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -126,13 +126,17 @@ export default function Input({
           onBlur={() => setFocused(false)}
           // @ts-expect-error — TextInput's `style` prop is typed as
           // `StyleProp<TextStyle>`, which doesn't include web-only CSS
-          // properties. We use two non-standard keys here:
+          // properties. We use several non-standard keys here:
           //   alignSelf: 'stretch' — forces the web <input> to fill its
           //     flex-row parent vertically (RN ignores on native).
           //   outlineStyle: 'none' — removes default browser outline on
           //     focus; the focus ring is rendered on the outer View via
           //     boxShadow instead.
-          // Both are safe: RN drops unknown style keys, and on web they
+          //   appearance: 'none' — strips UA-default chrome on
+          //     <input> AND <textarea> (multiline). Without this Safari
+          //     renders an inset border on textarea even when borderWidth
+          //     is 0, producing the double-border artifact.
+          // All are safe: RN drops unknown style keys, and on web they
           // produce the intended CSS.
           style={{
             flex: 1,
@@ -150,9 +154,12 @@ export default function Input({
             // This prevents the double-border artifact on web.
             borderWidth: 0,
             borderColor: 'transparent',
-            outlineWidth: 0,
-            outlineStyle: 'none',
             backgroundColor: 'transparent',
+            ...(Platform.OS === 'web' ? {
+              outlineWidth: 0,
+              outlineStyle: 'none',
+              appearance: 'none',
+            } : {}),
           }}
         />
       </View>


### PR DESCRIPTION
## Summary

Fixes the remaining double-border / double-input artifacts on web on `/login`, `/otp`, `/(admin-tabs)/users`, `/requests/[id]/write`, `/settings`, and `/onboarding/work-area`.

Closes #1424 (3rd round, after PR #1428).

## Root cause

A `TextInput` nested inside a `View` that owns the visible border still rendered the browser's default `<input>`/`<textarea>` chrome on top of the parent border. The fix is the canonical web-only reset:

\`\`\`ts
...(Platform.OS === 'web' ? {
  borderWidth: 0,
  borderColor: 'transparent',
  outlineStyle: 'none' as never,
  outlineWidth: 0,
  appearance: 'none' as never,
} : {})
\`\`\`

Several files had a partial reset (missing `appearance: 'none'` and/or `outlineStyle: 'none'`). Notably `appearance: 'none'` is what kills the inset UA chrome that Safari draws on `<textarea>` even when `borderWidth: 0`, which is what the `/settings` and `/onboarding/work-area` reports were seeing.

## Files

- \`app/login.tsx\` — email field
- \`app/otp.tsx\` — 6 OTP digit cells
- \`app/(admin-tabs)/users.tsx\` — admin search
- \`app/requests/[id]/write.tsx\` — multiline message textarea (also missing \`Platform\` import)
- \`components/ui/Input.tsx\` — shared component used by Settings + onboarding work-area; \`appearance: 'none'\` now applied for both single-line and multiline

## Test plan

- [ ] \`/login\` — email input renders with single soft border, focus ring is the React Native View boxShadow not the browser default outline
- [ ] \`/otp\` — 6 cells render without inset UA chrome under the per-cell borders
- [ ] \`/admin/users\` — search bar single border
- [ ] \`/requests/[id]/write\` — multiline textarea single border, no inner box (Safari + Chrome)
- [ ] \`/settings\` — name / phone / about (multiline) inputs single border
- [ ] \`/onboarding/work-area\` — same Input component, no double-border on multiline
- [ ] \`npx tsc --noEmit\` — 0 errors (verified locally)