### PR TITLE
fix(upload): presigned URL for avatars + TS errors

### DIFF
--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -71,7 +71,9 @@ router.post("/avatar", authMiddleware, uploadRateLimiter, avatarUpload.single("f
       "Content-Type": "image/jpeg",
     });
 
-    const url = `/${MINIO_BUCKET}/${key}`;
+    // Return 1-year presigned URL so the avatar is directly usable in <Image>.
+    // The raw key is also returned so callers can re-presign on future loads.
+    const url = await minioClient.presignedGetObject(MINIO_BUCKET, key, 365 * 24 * 60 * 60);
     res.json({ url, key });
   } catch (error) {
     console.error("avatar upload error:", error);

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -243,7 +243,7 @@ router.post("/become-specialist", authMiddleware, async (req: Request, res: Resp
 
 // POST /api/user/leave-specialist — disable specialist mode
 router.post("/leave-specialist", authMiddleware, async (req: Request, res: Response) => {
-  const userId = (req as AuthRequest).userId!;
+  const userId = req.user!.userId;
   try {
     const updated = await prisma.user.update({
       where: { id: userId },
@@ -259,7 +259,7 @@ router.post("/leave-specialist", authMiddleware, async (req: Request, res: Respo
 
 // POST /api/user/leave-specialist-toggle — re-enable specialist mode (user already has FNS data)
 router.post("/leave-specialist-toggle", authMiddleware, async (req: Request, res: Response) => {
-  const userId = (req as AuthRequest).userId!;
+  const userId = req.user!.userId;
   try {
     const updated = await prisma.user.update({
       where: { id: userId },


### PR DESCRIPTION
## Summary
- Avatar upload now returns a 1-year presigned URL (was raw `/p2ptax/...` path) — fixes broken avatar display after upload
- Fix \`leave-specialist\` and \`leave-specialist-toggle\` routes using undefined \`AuthRequest\` type; replaced with \`req.user!.userId\`

## Test plan
- [ ] Upload avatar in settings → avatar displays immediately after upload
- [ ] Avatar persists on reload (presigned URL works)
- [ ] Toggle specialist mode off/on works without errors