### PR TITLE
fix: circular avatar images in messages (#1419)

### DIFF
--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -57,18 +57,23 @@ export default function Avatar({
 
   if (imageUrl) {
     return (
-      <Image
-        source={{ uri: imageUrl }}
-        accessibilityLabel={name}
+      <View
         style={{
           width: wh,
           height: wh,
-          borderRadius: wh / 2,
+          borderRadius: 9999,
+          overflow: "hidden",
           borderWidth: 2,
           borderColor: colors.border,
           backgroundColor: colors.background,
         }}
-      />
+      >
+        <Image
+          source={{ uri: imageUrl }}
+          accessibilityLabel={name}
+          style={{ width: wh, height: wh }}
+        />
+      </View>
     );
   }
 


### PR DESCRIPTION
## Summary

- Fixes avatar images not being cropped to circles in message components
- Root cause: `Image` with `borderRadius` alone doesn't clip on web; needs `overflow: hidden` on a wrapping `View`
- Fix applied in `components/ui/Avatar.tsx` — all message views (ThreadsList, InlineChatView, client messages tab) use this shared component

## Change

In `Avatar.tsx`, when `imageUrl` is present: wrap `Image` in a `View` with `borderRadius: 9999` + `overflow: 'hidden'`, image takes `width: '100%' / height: '100%'`. Border styling moved to the wrapper View.

## Test plan

- [ ] Open messages tab as client — avatars in thread list rows are circular
- [ ] Open a chat — avatar in header is circular
- [ ] Verify on web (Expo web) where the bug was most visible

Closes #1419