### PR TITLE
feat(specialists): FNS-grouped services on SpecialistCard with +N overflow pill

### DIFF
--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -22,12 +22,6 @@ const specialistListSelect = Prisma.validator<Prisma.UserSelect>()({
   lastName: true,
   avatarUrl: true,
   createdAt: true,
-  specialistServices: {
-    select: {
-      service: { select: { id: true, name: true } },
-    },
-    distinct: ["serviceId"],
-  },
   specialistFns: {
     select: {
       fns: {
@@ -37,6 +31,11 @@ const specialistListSelect = Prisma.validator<Prisma.UserSelect>()({
           city: { select: { id: true, name: true } },
         },
       },
+      services: {
+        select: {
+          service: { select: { id: true, name: true } },
+        },
+      },
     },
   },
 });
@@ -44,19 +43,34 @@ const specialistListSelect = Prisma.validator<Prisma.UserSelect>()({
 type SpecialistListItem = Prisma.UserGetPayload<{ select: typeof specialistListSelect }>;
 
 function mapSpecialist(s: SpecialistListItem) {
-  const services = s.specialistServices.map((ss) => ss.service);
   const citiesMap = new Map<string, { id: string; name: string }>();
-  for (const sf of s.specialistFns) {
+  const specialistFns = s.specialistFns.map((sf) => {
     citiesMap.set(sf.fns.city.id, sf.fns.city);
+    return {
+      fnsId: sf.fns.id,
+      fnsName: sf.fns.name,
+      city: sf.fns.city,
+      services: sf.services.map((sv) => sv.service),
+    };
+  });
+
+  // Flat deduped services list (for backward compat with horizontal card variant)
+  const servicesMap = new Map<string, { id: string; name: string }>();
+  for (const sf of specialistFns) {
+    for (const svc of sf.services) {
+      servicesMap.set(svc.id, svc);
+    }
   }
+
   return {
     id: s.id,
     firstName: s.firstName,
     lastName: s.lastName,
     avatarUrl: s.avatarUrl,
     createdAt: s.createdAt,
-    services,
+    services: [...servicesMap.values()],
     cities: [...citiesMap.values()],
+    specialistFns,
   };
 }
 

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -35,6 +35,12 @@ interface SpecialistItem {
   createdAt: string;
   services: { id: string; name: string }[];
   cities: { id: string; name: string }[];
+  specialistFns?: {
+    fnsId: string;
+    fnsName: string;
+    city: { id: string; name: string };
+    services: { id: string; name: string }[];
+  }[];
   description?: string | null;
 }
 
@@ -418,6 +424,7 @@ export default function SpecialistsCatalog() {
                 createdAt={item.createdAt}
                 services={item.services}
                 cities={item.cities}
+                specialistFns={item.specialistFns}
                 description={item.description}
                 onPress={handleSpecialistPress}
                 onBookmark={handleBookmark}

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -3,6 +3,13 @@ import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { Bookmark } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
+interface FnsGroup {
+  fnsId: string;
+  fnsName: string;
+  city: { id: string; name: string };
+  services: { id: string; name: string }[];
+}
+
 interface SpecialistCardProps {
   id: string;
   firstName: string | null;
@@ -11,6 +18,8 @@ interface SpecialistCardProps {
   createdAt?: string;
   services: { id: string; name: string }[];
   cities: { id: string; name: string }[];
+  /** FNS-grouped services. When provided, used instead of flat services in vertical variant. */
+  specialistFns?: FnsGroup[];
   description?: string | null;
   onPress: (id: string) => void;
   variant?: "vertical" | "horizontal";
@@ -34,6 +43,7 @@ export default function SpecialistCard({
   createdAt,
   services,
   cities,
+  specialistFns,
   description,
   onPress,
   variant,
@@ -146,30 +156,77 @@ export default function SpecialistCard({
         </Text>
       ) : null}
 
-      {/* Service pills */}
-      {services.length > 0 && (
-        <View className="flex-row flex-wrap mt-2" style={{ gap: 8 }}>
-          {services.map((s) => (
-            <View
-              key={s.id}
-              className="px-2.5 py-1 rounded-full"
-              style={{ backgroundColor: colors.accentSoft }}
-            >
-              <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
-            </View>
-          ))}
-        </View>
-      )}
-
-      {/* City */}
-      {cities.length > 0 && (
-        <View className="flex-row items-center mt-2">
-          <FontAwesome name="map-marker" size={12} color={colors.textMuted} />
-          <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
-            {cities.map((c) => c.name).join(", ")}
-          </Text>
-        </View>
-      )}
+      {/* FNS-grouped services (vertical variant) */}
+      {specialistFns && specialistFns.length > 0
+        ? (() => {
+            // Show max 2 FNS groups, max 3 services each; rest as overflow pill
+            const visibleFns = specialistFns.slice(0, 2);
+            const totalServices = specialistFns.reduce((acc, g) => acc + g.services.length, 0);
+            const shownServices = visibleFns.reduce(
+              (acc, g) => acc + Math.min(g.services.length, 3),
+              0
+            );
+            const overflow = totalServices - shownServices;
+            return (
+              <View className="mt-2" style={{ gap: 8 }}>
+                {visibleFns.map((group) => (
+                  <View key={group.fnsId}>
+                    {/* FNS label */}
+                    <View className="flex-row items-center mb-1" style={{ gap: 4 }}>
+                      <FontAwesome name="map-marker" size={10} color={colors.textMuted} />
+                      <Text className="text-xs" style={{ color: colors.textMuted }} numberOfLines={1}>
+                        {group.city.name} — {group.fnsName}
+                      </Text>
+                    </View>
+                    {/* Service pills for this FNS */}
+                    <View className="flex-row flex-wrap" style={{ gap: 6 }}>
+                      {group.services.slice(0, 3).map((s) => (
+                        <View
+                          key={s.id}
+                          className="px-2.5 py-1 rounded-full"
+                          style={{ backgroundColor: colors.accentSoft }}
+                        >
+                          <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  </View>
+                ))}
+                {overflow > 0 && (
+                  <Text className="text-xs mt-1" style={{ color: colors.textMuted }}>
+                    +{overflow} ещё
+                  </Text>
+                )}
+              </View>
+            );
+          })()
+        : (
+          <>
+            {/* Fallback: flat service pills */}
+            {services.length > 0 && (
+              <View className="flex-row flex-wrap mt-2" style={{ gap: 8 }}>
+                {services.map((s) => (
+                  <View
+                    key={s.id}
+                    className="px-2.5 py-1 rounded-full"
+                    style={{ backgroundColor: colors.accentSoft }}
+                  >
+                    <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
+                  </View>
+                ))}
+              </View>
+            )}
+            {/* City */}
+            {cities.length > 0 && (
+              <View className="flex-row items-center mt-2">
+                <FontAwesome name="map-marker" size={12} color={colors.textMuted} />
+                <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
+                  {cities.map((c) => c.name).join(", ")}
+                </Text>
+              </View>
+            )}
+          </>
+        )}
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary
- **API**: `specialistListSelect` now fetches services grouped under each `specialistFns` row; `mapSpecialist` returns `specialistFns[]` alongside the existing flat `services`/`cities` (backward compat)
- **SpecialistCard** vertical variant: shows FNS office name as label + service pills per group; max 2 FNS groups × 3 services each; excess collapsed into `+N ещё` pill; horizontal variant unchanged
- **`app/specialists/index.tsx`**: added `SpecialistFnsGroup` type, passes `specialistFns` prop to card

## Test plan
- [ ] Catalog page shows FNS name above each service group
- [ ] Specialists with >2 FNS offices show `+N ещё` pill
- [ ] Specialists with >3 services in one FNS show overflow counted in pill
- [ ] Horizontal card (similar specialists on detail page) still shows flat service pills
- [ ] `npx tsc --noEmit` passes (frontend + api)

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)