### PR TITLE
fix: enable specialist mode for existing CLIENT users

### DIFF
--- a/api/prisma/migrations/20250428000000_add_is_specialist/migration.sql
+++ b/api/prisma/migrations/20250428000000_add_is_specialist/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: add is_specialist flag to users
+ALTER TABLE "users" ADD COLUMN "is_specialist" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   firstName   String?  @map("first_name")
   lastName    String?  @map("last_name")
   avatarUrl   String?  @map("avatar_url")
+  isSpecialist Boolean  @default(false) @map("is_specialist")
   isAvailable Boolean  @default(false) @map("is_available")
   isBanned    Boolean  @default(false) @map("is_banned")
   createdAt   DateTime @default(now()) @map("created_at")

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -62,7 +62,7 @@ export function roleGuard(...roles: Role[]) {
     const { prisma } = await import("../lib/prisma");
     const user = await prisma.user.findUnique({
       where: { id: req.user.userId },
-      select: { role: true, isBanned: true },
+      select: { role: true, isSpecialist: true, isBanned: true },
     });
 
     if (!user) {
@@ -75,7 +75,14 @@ export function roleGuard(...roles: Role[]) {
       return;
     }
 
-    if (!user.role || !roles.includes(user.role)) {
+    // A user with isSpecialist=true is treated as having SPECIALIST role
+    // even if their base role is CLIENT (dual-role scenario)
+    const effectiveRoles: Role[] = user.role ? [user.role] : [];
+    if (user.isSpecialist && !effectiveRoles.includes("SPECIALIST")) {
+      effectiveRoles.push("SPECIALIST");
+    }
+
+    if (!roles.some((r) => effectiveRoles.includes(r))) {
       res.status(403).json({ error: "Insufficient permissions" });
       return;
     }

--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -29,15 +29,29 @@ router.put("/name", authMiddleware, async (req: Request, res: Response) => {
       return;
     }
 
-    // Guard: role can only be set once (during onboarding)
     const existing = await prisma.user.findUnique({
       where: { id: req.user!.userId },
-      select: { role: true },
+      select: { role: true, isSpecialist: true },
     });
-    if (existing?.role !== null && existing?.role !== undefined) {
-      res.status(400).json({ error: "Role already set" });
-      return;
+
+    // Determine update: new users get role=SPECIALIST, existing CLIENTs get isSpecialist=true
+    const isExistingClient = existing?.role === "CLIENT";
+    const updateData: {
+      firstName: string;
+      lastName: string;
+      role?: "SPECIALIST";
+      isSpecialist?: boolean;
+    } = {
+      firstName: firstName.trim(),
+      lastName: lastName.trim(),
+    };
+    if (isExistingClient) {
+      updateData.isSpecialist = true;
+    } else if (!existing?.role) {
+      // New user — set role to SPECIALIST
+      updateData.role = "SPECIALIST";
     }
+    // If already SPECIALIST or ADMIN, just update name fields
 
     // Iter11 — /onboarding/name is part of the specialist signup flow.
     // After unification everyone is role=USER; specialist identity is opt-in

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -35,6 +35,37 @@ router.patch("/profile", authMiddleware, async (req: Request, res: Response) => 
   }
 });
 
+// PATCH /api/user/specialist-mode — enable or disable specialist mode
+router.patch("/specialist-mode", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { isSpecialist } = req.body;
+
+    if (typeof isSpecialist !== "boolean") {
+      res.status(400).json({ error: "isSpecialist must be a boolean" });
+      return;
+    }
+
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { isSpecialist },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        isSpecialist: true,
+        firstName: true,
+        lastName: true,
+      },
+    });
+
+    res.json({ user });
+  } catch (error) {
+    console.error("user/specialist-mode error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // PATCH /api/user/notification-settings — update notification settings
 router.patch("/notification-settings", authMiddleware, async (req: Request, res: Response) => {
   try {

--- a/app/(tabs)/my-requests.tsx
+++ b/app/(tabs)/my-requests.tsx
@@ -1,0 +1,4 @@
+// Re-exports the client "My Requests" screen so specialist-mode users
+// (isSpecialist=true, role=CLIENT) can access their own requests from the
+// specialist tab group without duplicating code.
+export { default } from "@/app/(client-tabs)/requests";

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -142,9 +142,9 @@ export default function OnboardingProfileScreen() {
         },
       });
 
-      if (avatarUrl) {
-        updateUser({ avatarUrl });
-      }
+      // Mark user as specialist in local context (covers both new specialists
+      // and existing CLIENTs who enabled specialist mode)
+      updateUser({ isSpecialist: true, ...(avatarUrl ? { avatarUrl } : {}) });
 
       nav.replaceRoutes.tabs();
     } catch (e: unknown) {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -37,6 +37,7 @@ export interface UserData {
   lastName: string | null;
   avatarUrl?: string | null;
   isAvailable?: boolean;
+  isSpecialist?: boolean;
 }
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- `isSpecialist` boolean field added to `User` model (schema + migration) — this is the single source of truth for specialist mode
- `roleGuard` middleware updated to treat `isSpecialist=true` as having SPECIALIST permissions
- Onboarding endpoints (`/name`, `/work-area`, `/profile`) now allow existing CLIENTs through — instead of blocking with "role already set", they set `isSpecialist=true`
- New `PATCH /api/user/specialist-mode` endpoint to toggle mode off
- General settings screen now has "Режим специалиста" toggle: OFF → starts onboarding, ON → confirm to disable + routes back to client dashboard
- `(specialist-tabs)/_layout.tsx` gets a "Мои заявки" tab (hidden unless `isSpecialist=true` + `role=CLIENT`) so dual-mode users keep client features
- Routing fixed: `isSpecialist=true` users land on specialist dashboard regardless of base role

## Test plan
- [ ] New user signs up as client (`role=CLIENT`) → goes to client dashboard
- [ ] Client opens Settings → sees "Режим специалиста" toggle → enables it → goes through onboarding (name/work-area/profile) → lands on specialist dashboard
- [ ] Specialist dashboard shows "Мои заявки" tab for isSpecialist+CLIENT users
- [ ] Disabling specialist mode from settings routes back to client dashboard cleanly
- [ ] `role=SPECIALIST` users (old accounts) still work normally
- [ ] `tsc --noEmit` passes on both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)