### PR TITLE
fix: role-aware mobile nav + dashboard/settings/profile audit

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import Constants from "expo-constants";
 import {
   View,
   Text,
@@ -670,7 +671,7 @@ export default function UnifiedSettings() {
           </View>
 
           <Text className="text-xs text-text-dim text-center mb-4">
-            Версия 1.0.0
+            Версия {Constants.expoConfig?.version ?? "1.0.0"}
           </Text>
         </View>
       </ScrollView>

--- a/components/MobileMenu.tsx
+++ b/components/MobileMenu.tsx
@@ -1,16 +1,9 @@
 import { View, Text, Pressable, Modal } from "react-native";
-import { useRouter } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
-import { User, X, Home, FileText, Users, Settings, LogOut, type LucideIcon } from "lucide-react-native";
+import { User, X, Settings, LogOut } from "lucide-react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors } from "@/lib/theme";
-
-const MENU_ITEMS: { label: string; route: string; Icon: LucideIcon }[] = [
-  { label: "Главная", route: "/", Icon: Home },
-  { label: "Заявки", route: "/requests", Icon: FileText },
-  { label: "Специалисты", route: "/specialists", Icon: Users },
-  { label: "Настройки", route: "/settings", Icon: Settings },
-];
+import { buildUserItems } from "@/lib/nav-items";
 
 interface MobileMenuProps {
   visible: boolean;
@@ -18,14 +11,17 @@ interface MobileMenuProps {
 }
 
 export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
-  const { isAuthenticated, user, signOut } = useAuth();
-  const router = useRouter()
+  const { isAuthenticated, user, isSpecialistUser, signOut } = useAuth();
   const nav = useTypedRouter();
 
   const displayName = user?.firstName
     ? `${user.firstName} ${user.lastName || ""}`.trim()
     : "Профиль";
   const initials = user?.firstName?.[0]?.toUpperCase() || user?.email?.[0]?.toUpperCase() || "U";
+
+  // Role-aware nav: authenticated users get items per their role.
+  // Unauthenticated users see only Settings and no role-specific items.
+  const navItems = isAuthenticated ? buildUserItems(isSpecialistUser) : [];
 
   const handleNavigate = (route: string) => {
     onClose();
@@ -68,22 +64,37 @@ export default function MobileMenu({ visible, onClose }: MobileMenuProps) {
             <X size={20} color={colors.surface} />
           </Pressable>
 
-          {/* Menu items */}
+          {/* Menu items — role-aware via buildUserItems */}
           <View className="flex-1 pt-2">
-            {MENU_ITEMS.map((item) => (
-              <Pressable
-                accessibilityRole="button"
-                key={item.label}
-                accessibilityLabel={item.label}
-                onPress={() => handleNavigate(item.route)}
-                className="flex-row items-center px-5 py-3.5 active:bg-surface2"
-              >
-                <View className="w-8 items-center">
-                  <item.Icon size={18} color={colors.textSecondary} />
-                </View>
-                <Text className="text-base text-text-base ml-3">{item.label}</Text>
-              </Pressable>
-            ))}
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <Pressable
+                  accessibilityRole="button"
+                  key={item.href}
+                  accessibilityLabel={item.label}
+                  onPress={() => handleNavigate(item.href)}
+                  className="flex-row items-center px-5 py-3.5 active:bg-surface2"
+                >
+                  <View className="w-8 items-center">
+                    <Icon size={18} color={colors.textSecondary} />
+                  </View>
+                  <Text className="text-base text-text-base ml-3">{item.label}</Text>
+                </Pressable>
+              );
+            })}
+            {/* Settings always present */}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Настройки"
+              onPress={() => handleNavigate("/settings")}
+              className="flex-row items-center px-5 py-3.5 active:bg-surface2"
+            >
+              <View className="w-8 items-center">
+                <Settings size={18} color={colors.textSecondary} />
+              </View>
+              <Text className="text-base text-text-base ml-3">Настройки</Text>
+            </Pressable>
           </View>
 
           {/* Bottom actions */}

--- a/lib/nav-items.ts
+++ b/lib/nav-items.ts
@@ -115,9 +115,10 @@ export const USER_SPECIALIST_EXTRA: NavItem[] = [
     label: "Заявки клиентов",
     href: "/(tabs)/public-requests",
     icon: Inbox,
-    match: (ctx) =>
-      groupMatch(ctx, "(tabs)", "public-requests") ||
-      topLevelMatch(ctx, "/requests"),
+    // Only match the public-requests tab — do NOT match "/requests" which is
+    // "Мои заявки" (the client-side tab). Previously this had an erroneous
+    // topLevelMatch("/requests") that highlighted the wrong item.
+    match: (ctx) => groupMatch(ctx, "(tabs)", "public-requests"),
   },
 ];
 


### PR DESCRIPTION
## Summary

- **MobileMenu**: replaced hardcoded nav items with `buildUserItems(isSpecialist)` — specialists now see "Заявки клиентов" instead of the client-only "Специалисты" link
- **nav-items**: removed erroneous `topLevelMatch("/requests")` from `USER_SPECIALIST_EXTRA` that caused "Заявки клиентов" tab to falsely highlight when navigating to own requests
- **AuthContext**: removed duplicate `isSpecialist` field in `UserData` interface (TS2300 compile error)
- **my-requests.tsx**: fixed stale re-export pointing to deleted `(client-tabs)/requests` (TS2307 compile error)
- **settings/index**: version badge now reads from `Constants.expoConfig?.version` instead of hardcoded "1.0.0"

## Pages audited (no structural bugs found)

- `app/(tabs)/index.tsx` — dashboard correctly shows client and specialist sections, empty states with CTAs present
- `app/settings/index.tsx` — IosToggle, "Принимаю заявки" toggle, AvatarUploader, name/email edit all correct
- `app/specialists/[id].tsx` — own-profile banner, "Написать" CTA for clients, edit button for own profile all present

## Test plan

- [ ] Specialist user opens mobile menu → sees Дашборд, Мои заявки, Сообщения, Заявки клиентов, Настройки
- [ ] Client user opens mobile menu → sees Дашборд, Мои заявки, Сообщения, Найти специалиста, Мои специалисты, Настройки
- [ ] Specialist on /(tabs)/requests → "Заявки клиентов" in sidebar is NOT highlighted, "Мои заявки" IS highlighted
- [ ] Settings version badge shows correct version from app.json
- [ ] Frontend `tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)