### PR TITLE
fix: remove duplicate isSpecialist in schema, fix landing-counts 500

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -36,7 +36,6 @@ model User {
   firstName   String?  @map("first_name")
   lastName    String?  @map("last_name")
   avatarUrl   String?  @map("avatar_url")
-  isSpecialist Boolean  @default(false) @map("is_specialist")
   isAvailable Boolean  @default(false) @map("is_available")
   isBanned    Boolean  @default(false) @map("is_banned")
   createdAt   DateTime @default(now()) @map("created_at")


### PR DESCRIPTION
## Summary
- `api/prisma/schema.prisma` had `isSpecialist` field defined twice on the `User` model (lines 32 and 39)
- This caused `npx prisma generate` to fail with P1012 validation error (duplicate field)
- The stale Prisma client made `GET /api/stats/landing-counts` return 500, breaking the landing page

## Fix
- Removed the duplicate `isSpecialist Boolean @default(false) @map("is_specialist")` line (line 39)
- Regenerated Prisma client — confirmed `✔ Generated Prisma Client` with no errors
- Endpoint now returns: `{"specialistsCount":22,"citiesCount":10,"consultationsCount":33,"resolvedCases":58,"priceFrom":0}`

## Test plan
- [x] `curl http://localhost:3812/api/stats/landing-counts` returns valid JSON (verified)
- [ ] Landing page renders without error state on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)