### PR TITLE
fix: landing page no longer auto-redirects authenticated users

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -53,8 +53,8 @@ interface RecentWinsResponse {
 }
 
 /**
- * Public landing (/). The only route any unauthenticated user sees by
- * default. Authenticated users are redirected to their role dashboard.
+ * Public landing (/). Accessible by both authenticated and unauthenticated
+ * users — no automatic redirect. Authenticated users can navigate manually.
  *
  * Layout (top → bottom):
  *   Header → Hero (copy + 3 specialist cards) → Trust strip (3 counters)
@@ -72,7 +72,7 @@ interface RecentWinsResponse {
 export default function LandingScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
-  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
+  const { isAuthenticated } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 768;
 
@@ -81,19 +81,6 @@ export default function LandingScreen() {
   const [cases, setCases] = useState<CaseCardData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-
-  // Redirect authenticated users to their role-specific dashboard.
-  // Iter11 — unified (tabs) carries both USER sub-modes (isSpecialist on/off);
-  // admin still has its own group.
-  useEffect(() => {
-    if (!authLoading && isAuthenticated && user?.role) {
-      if (user.role === "ADMIN") {
-        nav.replaceRoutes.adminDashboard();
-      } else {
-        nav.replaceRoutes.tabs();
-      }
-    }
-  }, [authLoading, isAuthenticated, user, router]);
 
   const loadData = useCallback(async () => {
     setLoading(true);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -102,6 +102,14 @@ export default function Header() {
         <View className="flex-row items-center gap-3">
           <Pressable
             accessibilityRole="button"
+            accessibilityLabel="Личный кабинет"
+            onPress={() => router.push("/(tabs)" as never)}
+            className="px-4 h-11 rounded-lg items-center justify-center active:bg-slate-100"
+          >
+            <Text className="text-sm font-semibold text-blue-900">Личный кабинет</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Уведомления"
             onPress={() => nav.routes.notifications()}
             className="w-11 h-11 rounded-lg items-center justify-center active:bg-surface2"


### PR DESCRIPTION
## Summary
- Removed the `useEffect` in `app/index.tsx` that redirected authenticated users to their role-based dashboard — landing is now always visible
- Landing header now shows "Личный кабинет" button (→ `/(tabs)`) for authenticated users on desktop instead of "Создать заявку"
- Added "Личный кабинет" link in `components/Header.tsx` desktop authenticated nav so users can reach the dashboard from the landing page

## Test plan
- [ ] Visit `/` as a guest — landing renders normally
- [ ] Visit `/` while logged in — landing renders, no redirect occurs
- [ ] On desktop as authenticated user — header shows "Личный кабинет" button
- [ ] Click "Личный кабинет" → navigates to `/(tabs)`
- [ ] After OTP login, redirect goes to role-based dashboard (not broken)

Closes #1446

🤖 Generated with [Claude Code](https://claude.com/claude-code)