### PR TITLE
fix: Role enum mismatch — align schema with DB (CLIENT/SPECIALIST/ADMIN)

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -7,14 +7,9 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// Iter11 — role unification. CLIENT + SPECIALIST merged into USER.
-// - `role = USER` is the default for any authenticated human user.
-// - Specialist features opt-in via `User.isSpecialist` + `specialistProfileCompletedAt`.
-// - GUEST retained for unauthenticated visitors, ADMIN for platform moderators.
-// Legacy CLIENT/SPECIALIST values are migrated to USER in data migration.
 enum Role {
-  GUEST
-  USER
+  CLIENT
+  SPECIALIST
   ADMIN
 }
 

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -155,7 +155,7 @@ export function canWriteThreads(user: UserPermissionShape | null): boolean {
  */
 export function canCreateRequests(user: UserPermissionShape | null): boolean {
   if (!user) return false;
-  return user.role === "USER";
+  return user.role === "CLIENT";
 }
 
 /**

--- a/api/src/routes/admin/users.ts
+++ b/api/src/routes/admin/users.ts
@@ -31,23 +31,22 @@ router.get("/", async (req: Request, res: Response) => {
       ];
     }
 
-    // Iter11 PR 3 — admin UI filter tokens map onto the unified schema.
-    // Tokens are just filter identifiers, NOT DB role enum values.
-    //   "CLIENT"     -> role=USER, isSpecialist=false
+    // Filter tokens map onto DB enum values (CLIENT | SPECIALIST | ADMIN).
+    //   "CLIENT"     -> role=CLIENT, isSpecialist=false
     //   "SPECIALIST" -> isSpecialist=true
-    //   "USER"       -> role=USER (any)
+    //   "USER"       -> role=CLIENT (legacy alias)
     //   "ADMIN"      -> role=ADMIN
     //   "BANNED"     -> isBanned=true
     const roleFilter: string | undefined = role;
     switch (roleFilter) {
       case "CLIENT":
-        where.role = "USER";
+      case "USER":
+        where.role = "CLIENT";
         where.isSpecialist = false;
         break;
       case "SPECIALIST":
         where.isSpecialist = true;
         break;
-      case "USER":
       case "ADMIN":
         where.role = roleFilter;
         break;
@@ -123,20 +122,18 @@ router.patch("/:id", async (req: Request, res: Response) => {
     if (typeof isBanned === "boolean") data.isBanned = isBanned;
     if (typeof firstName === "string") data.firstName = firstName;
     if (typeof lastName === "string") data.lastName = lastName;
-    // Iter11 PR 3 — admin PATCH accepts legacy UI labels and remaps onto
-    // the unified schema. The legacy tokens are UI-only; the DB always
-    // stores role=USER|ADMIN with isSpecialist toggled.
+    // Admin PATCH accepts role tokens and maps onto DB enum values.
     const roleInput: string | undefined = role;
     switch (roleInput) {
       case "CLIENT":
-        data.role = "USER";
+      case "USER":
+        data.role = "CLIENT";
         data.isSpecialist = false;
         break;
       case "SPECIALIST":
-        data.role = "USER";
+        data.role = "CLIENT";
         data.isSpecialist = true;
         break;
-      case "USER":
       case "ADMIN":
         data.role = roleInput;
         break;

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -272,14 +272,9 @@ router.get("/me", authMiddleware, async (req: Request, res: Response) => {
 
 // POST /api/auth/set-role — set role for new users (auth required, one-time only)
 //
-// Iter11 — role unification. After merge of CLIENT + SPECIALIST -> USER, this
-// endpoint continues to accept legacy role strings from existing UI clients
-// for backwards compatibility during the 3-PR rollout:
-//   - "CLIENT"      -> role=USER, isSpecialist=false
-//   - "SPECIALIST"  -> role=USER, isSpecialist=true  (profile still needs completion)
-//   - "USER"        -> role=USER, isSpecialist=false (new clients)
-// UI merge in PR 2 will replace this with a cleaner `/set-user-type` that only
-// accepts `{ isSpecialist: boolean }`.
+// Accepts role tokens:
+//   - "CLIENT" / "USER" -> role=CLIENT, isSpecialist=false
+//   - "SPECIALIST"      -> role=CLIENT, isSpecialist=true
 router.post("/set-role", authMiddleware, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
@@ -288,7 +283,7 @@ router.post("/set-role", authMiddleware, async (req: Request, res: Response) => 
     const ALLOWED_TOKENS = new Set(["CLIENT", "SPECIALIST", "USER"]);
     const roleToken: string | undefined = role;
     if (!roleToken || !ALLOWED_TOKENS.has(roleToken)) {
-      res.status(400).json({ error: "Role must be USER, CLIENT, or SPECIALIST" });
+      res.status(400).json({ error: "Role must be CLIENT or SPECIALIST" });
       return;
     }
 
@@ -313,7 +308,7 @@ router.post("/set-role", authMiddleware, async (req: Request, res: Response) => 
     const updated = await prisma.user.update({
       where: { id: userId },
       data: {
-        role: "USER",
+        role: "CLIENT",
         isSpecialist: wantsSpecialist,
       },
       select: {

--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -38,7 +38,7 @@ router.put("/name", authMiddleware, async (req: Request, res: Response) => {
       data: {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
-        role: "USER",
+        role: "CLIENT",
         isSpecialist: true,
       },
       select: {

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -323,7 +323,7 @@ router.get(
         prisma.user.count({
           where: { isSpecialist: true, isAvailable: true, isBanned: false },
         }),
-        prisma.user.count({ where: { role: "USER", isSpecialist: false } }),
+        prisma.user.count({ where: { role: "CLIENT", isSpecialist: false } }),
         prisma.user.count({ where: { isSpecialist: true } }),
         prisma.user.count({
           where: { createdAt: { gte: weekAgo } },


### PR DESCRIPTION
## Problem
API was crashing with `PrismaClientUnknownRequestError: Value 'USER' not found in enum 'Role'` because `schema.prisma` had `GUEST|USER|ADMIN` but the PostgreSQL DB still has `CLIENT|SPECIALIST|ADMIN` (Iter11 migration was never run).

## Changes
- **`api/prisma/schema.prisma`**: Role enum reverted to `CLIENT | SPECIALIST | ADMIN`
- **`api/src/middleware/auth.ts`**: `canCreateRequests` — `role === "USER"` → `role === "CLIENT"`
- **`api/src/routes/onboarding.ts`**: `role: "USER"` → `role: "CLIENT"`
- **`api/src/routes/stats.ts`**: count filter `role: "USER"` → `role: "CLIENT"`
- **`api/src/routes/auth.ts`**: `set-role` endpoint assignment → `role: "CLIENT"`
- **`api/src/routes/admin/users.ts`**: filter + PATCH role mappings updated to `"CLIENT"`

## Verification
- `npx tsc --noEmit` — 0 errors
- `curl http://localhost:3812/api/stats/landing-counts` returns `{"specialistsCount":22,"citiesCount":10,...}`