### PR TITLE
fix: revert Role enum to GUEST/USER/ADMIN to match PostgreSQL DB

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -8,8 +8,8 @@ datasource db {
 }
 
 enum Role {
-  CLIENT
-  SPECIALIST
+  GUEST
+  USER
   ADMIN
 }
 

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -155,7 +155,7 @@ export function canWriteThreads(user: UserPermissionShape | null): boolean {
  */
 export function canCreateRequests(user: UserPermissionShape | null): boolean {
   if (!user) return false;
-  return user.role === "CLIENT";
+  return user.role === "USER";
 }
 
 /**

--- a/api/src/routes/admin/users.ts
+++ b/api/src/routes/admin/users.ts
@@ -41,7 +41,7 @@ router.get("/", async (req: Request, res: Response) => {
     switch (roleFilter) {
       case "CLIENT":
       case "USER":
-        where.role = "CLIENT";
+        where.role = "USER";
         where.isSpecialist = false;
         break;
       case "SPECIALIST":
@@ -127,11 +127,11 @@ router.patch("/:id", async (req: Request, res: Response) => {
     switch (roleInput) {
       case "CLIENT":
       case "USER":
-        data.role = "CLIENT";
+        data.role = "USER";
         data.isSpecialist = false;
         break;
       case "SPECIALIST":
-        data.role = "CLIENT";
+        data.role = "USER";
         data.isSpecialist = true;
         break;
       case "ADMIN":

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -308,7 +308,7 @@ router.post("/set-role", authMiddleware, async (req: Request, res: Response) => 
     const updated = await prisma.user.update({
       where: { id: userId },
       data: {
-        role: "CLIENT",
+        role: "USER",
         isSpecialist: wantsSpecialist,
       },
       select: {

--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -38,7 +38,7 @@ router.put("/name", authMiddleware, async (req: Request, res: Response) => {
       data: {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
-        role: "CLIENT",
+        role: "USER",
         isSpecialist: true,
       },
       select: {

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -2,7 +2,7 @@ import { Router, Request, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { Prisma } from "@prisma/client";
 import { verifyAccessToken } from "../lib/jwt";
-import { authMiddleware, roleGuard } from "../middleware/auth";
+import { authMiddleware, requireSpecialistFeatures } from "../middleware/auth";
 
 const router = Router();
 
@@ -224,7 +224,7 @@ router.get("/", async (req: Request, res: Response) => {
 
 // GET /api/specialists/dashboard — specialist's own dashboard data (auth required)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-router.get("/dashboard", authMiddleware, roleGuard("SPECIALIST" as any), async (req: Request, res: Response) => {
+router.get("/dashboard", authMiddleware, requireSpecialistFeatures, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
 
@@ -331,7 +331,7 @@ router.get("/dashboard", authMiddleware, roleGuard("SPECIALIST" as any), async (
 
 // PATCH /api/specialists/availability — toggle specialist availability (auth required)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-router.patch("/availability", authMiddleware, roleGuard("SPECIALIST" as any), async (req: Request, res: Response) => {
+router.patch("/availability", authMiddleware, requireSpecialistFeatures, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
     const { isAvailable } = req.body as { isAvailable?: unknown };

--- a/api/src/routes/stats.ts
+++ b/api/src/routes/stats.ts
@@ -323,7 +323,7 @@ router.get(
         prisma.user.count({
           where: { isSpecialist: true, isAvailable: true, isBanned: false },
         }),
-        prisma.user.count({ where: { role: "CLIENT", isSpecialist: false } }),
+        prisma.user.count({ where: { role: "USER", isSpecialist: false } }),
         prisma.user.count({ where: { isSpecialist: true } }),
         prisma.user.count({
           where: { createdAt: { gte: weekAgo } },


### PR DESCRIPTION
## Summary
- Reverts `Role` enum in `schema.prisma` from `CLIENT/SPECIALIST/ADMIN` back to `GUEST/USER/ADMIN` to match actual PostgreSQL database
- Updates all 5 route/middleware files that referenced `CLIENT` role → `USER`
- Replaces `roleGuard("SPECIALIST" as any)` with `requireSpecialistFeatures` in `specialists.ts`

## Files changed
- `api/prisma/schema.prisma` — enum Role: CLIENT/SPECIALIST/ADMIN → GUEST/USER/ADMIN
- `api/src/middleware/auth.ts` — canCreateRequests check
- `api/src/routes/admin/users.ts` — where.role / data.role filters
- `api/src/routes/auth.ts` — set-role handler
- `api/src/routes/onboarding.ts` — default role assignment
- `api/src/routes/specialists.ts` — roleGuard → requireSpecialistFeatures
- `api/src/routes/stats.ts` — role count query

## Test plan
- [ ] `npx prisma generate` completes without errors
- [ ] `npx tsc --noEmit` passes in root and api/
- [ ] Login/role assignment works end-to-end on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)