### PR TITLE
fix: role-based access gates

### DIFF
--- a/app/(admin-tabs)/_layout.tsx
+++ b/app/(admin-tabs)/_layout.tsx
@@ -1,11 +1,32 @@
+import { useEffect } from "react";
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
 import { BarChart2, Users, Shield, Flag } from "lucide-react-native";
 import { colors, fontSizeValue, BREAKPOINT } from "@/lib/theme";
+import { useAuth } from "@/contexts/AuthContext";
+import { useTypedRouter } from "@/lib/navigation";
+import LoadingState from "@/components/ui/LoadingState";
 
 export default function AdminTabsLayout() {
   const { width } = useWindowDimensions();
   const isMobile = width < BREAKPOINT;
+  const { isAuthenticated, isLoading, isAdminUser } = useAuth();
+  const nav = useTypedRouter();
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (!isAuthenticated) {
+      nav.replaceRoutes.login();
+      return;
+    }
+    if (!isAdminUser) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [isLoading, isAuthenticated, isAdminUser]);
+
+  if (isLoading || !isAuthenticated || !isAdminUser) {
+    return <LoadingState />;
+  }
 
   return (
     <Tabs

--- a/app/(tabs)/public-requests.tsx
+++ b/app/(tabs)/public-requests.tsx
@@ -19,6 +19,8 @@ import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
 import { colors, overlay, BREAKPOINT } from "@/lib/theme";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRequireAuth } from "@/lib/useRequireAuth";
 
 interface CityOption {
   id: string;
@@ -55,6 +57,14 @@ export default function SpecialistPublicRequests() {
   const nav = useTypedRouter();
   const { width } = useWindowDimensions();
   const isDesktop = width >= BREAKPOINT;
+  const { ready, isLoading: authLoading, isAuthenticated } = useRequireAuth();
+  const { isSpecialistUser } = useAuth();
+
+  useEffect(() => {
+    if (!authLoading && isAuthenticated && !isSpecialistUser) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [authLoading, isAuthenticated, isSpecialistUser]);
 
   const [cities, setCities] = useState<CityOption[]>([]);
   const [services, setServices] = useState<ServiceOption[]>([]);
@@ -143,6 +153,14 @@ export default function SpecialistPublicRequests() {
   const handleServiceToggle = useCallback((id: string) => {
     setSelectedServiceId((prev) => (prev === id ? null : id));
   }, []);
+
+  if (!ready || !isSpecialistUser) {
+    return (
+      <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+        <LoadingState />
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>


### PR DESCRIPTION
## Summary

- **`app/(admin-tabs)/_layout.tsx`** — added admin gate. While `isLoading` show `<LoadingState />`. Unauthenticated → `nav.replaceRoutes.login()`. Non-admin authed → `nav.replaceRoutes.tabs()`. Tabs render only when `isAdminUser === true`.
- **`app/(tabs)/public-requests.tsx`** — specialist-only gate. `useRequireAuth()` for auth, `useAuth().isSpecialistUser` for role. Non-specialist authed users redirected to `/(tabs)`. Loading/non-specialist render `<LoadingState />`.
- **`app/settings/index.tsx`** — admin redirect already wrapped in `useEffect` (lines 163-172). Skipped per task instructions.

## Test plan

- [ ] Visit `/(admin-tabs)/dashboard` as unauthenticated → redirected to `/login`
- [ ] Visit `/(admin-tabs)/dashboard` as USER → redirected to `/(tabs)`
- [ ] Visit `/(admin-tabs)/dashboard` as ADMIN → tabs render
- [ ] Visit `/(tabs)/public-requests` as non-specialist USER → redirected to `/(tabs)`
- [ ] Visit `/(tabs)/public-requests` as specialist USER → feed renders
- [ ] `npx tsc --noEmit` (frontend + api) → 0 errors