### PR TITLE
fix: specialist toggle rehydrates profile data correctly

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -166,10 +166,13 @@ export default function UnifiedSettings() {
       nav.replaceRoutes.adminSettings();
       return;
     }
-    if (ready && isSpecialistUser) {
+    // Load specialist profile for any non-admin user. Returning specialists
+    // who toggled off keep their FNS data — we need it to skip onboarding
+    // when they re-enable from client mode.
+    if (ready && !isAdminUser) {
       loadSpecialistData();
     }
-  }, [ready, isSpecialistUser, isAdminUser, loadSpecialistData, router]);
+  }, [ready, isAdminUser, loadSpecialistData, router]);
 
   const initials = [firstName, lastName]
     .map((n) => n?.charAt(0)?.toUpperCase())
@@ -324,9 +327,13 @@ export default function UnifiedSettings() {
           nav.any("/onboarding/work-area?from=settings");
           return;
         }
-        // Already has data — just re-enable.
+        // Already has data — just re-enable, then refresh profile so the
+        // settings panel reflects current FNS/services/contacts immediately.
         apiPost("/api/user/leave-specialist-toggle", { enable: true })
-          .then(() => updateUser({ isSpecialist: true }))
+          .then(async () => {
+            updateUser({ isSpecialist: true });
+            await loadSpecialistData();
+          })
           .catch(() => Alert.alert("Ошибка", "Не удалось включить режим специалиста"));
       } else {
         Alert.alert(
@@ -350,7 +357,7 @@ export default function UnifiedSettings() {
         );
       }
     },
-    [specData, updateUser, router]
+    [specData, updateUser, loadSpecialistData, router]
   );
 
   if (!ready) {


### PR DESCRIPTION
## Summary
- Fix returning specialists being forced through onboarding when re-enabling specialist mode from client view (Bug 6 from audit).
- Reload specialist profile after successful toggle-on so the FNS panel reflects current data immediately (Bug 2 from audit).

## Why
Previously specialist data was only loaded when `isSpecialistUser=true`. So when a user had toggled specialist mode OFF and was viewing settings as a client, `specData` was always null. The toggle handler's `hasData` check used `specData?.fnsServices.length`, which always evaluated to false → routed to onboarding even for users with prior FNS configuration.

## Fix
1. Load specialist profile for any non-admin user on settings mount.
2. After successful `apiPost("/api/user/leave-specialist-toggle", { enable: true })`, call `loadSpecialistData()` to refresh.

## Test plan
- [x] tsc --noEmit passes (frontend + api)
- [ ] Toggle ON from client mode with prior FNS → skips onboarding, shows FNS panel populated
- [ ] Toggle OFF → ON without page reload → FNS panel shows correct state immediately