### PR TITLE
feat: post-create confirmation alert + 409 thread handling

### DIFF
--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   useWindowDimensions,
   Platform,
+  Alert,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
@@ -102,7 +103,20 @@ export default function SpecialistConfirmWrite() {
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.status === 409) {
-          setSubmitError("Заявка закрыта — сообщение отправить невозможно");
+          const existingThreadId =
+            typeof err.data?.threadId === "string" ? err.data.threadId : null;
+          if (existingThreadId) {
+            const goToThread = () =>
+              nav.replaceAny(`/threads/${existingThreadId}`);
+            Alert.alert(
+              "Вы уже откликнулись",
+              "Перейдём к существующему диалогу.",
+              [{ text: "OK", onPress: goToThread }],
+              { onDismiss: goToThread }
+            );
+          } else {
+            setSubmitError("Заявка закрыта — сообщение отправить невозможно");
+          }
         } else if (err.status === 429) {
           setSubmitError(
             "Лимит новых диалогов на сегодня исчерпан (20 в день). Попробуйте завтра."

--- a/app/requests/create.tsx
+++ b/app/requests/create.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   ScrollView,
   ActivityIndicator,
+  Alert,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
@@ -201,7 +202,13 @@ export default function CreateRequest() {
       } catch {
         /* ignore storage errors */
       }
-      nav.replaceAny(`/requests/${result.id}/detail`);
+      const goToDetail = () => nav.replaceAny(`/requests/${result.id}/detail`);
+      Alert.alert(
+        "Заявка опубликована",
+        "Специалисты по вашей ФНС увидят её и напишут вам. Обычно первый отклик приходит в течение 24 часов.",
+        [{ text: "OK", onPress: goToDetail }],
+        { onDismiss: goToDetail }
+      );
     } catch (e: unknown) {
       const msg =
         e instanceof Error

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -95,7 +95,7 @@ export async function api<T = unknown>(
 
   if (!res.ok) {
     const errorData = await res.json().catch(() => ({ error: "Request failed" }));
-    throw new ApiError(res.status, errorData.error || "Request failed");
+    throw new ApiError(res.status, errorData.error || "Request failed", errorData);
   }
 
   return res.json() as Promise<T>;
@@ -104,7 +104,8 @@ export async function api<T = unknown>(
 export class ApiError extends Error {
   constructor(
     public status: number,
-    message: string
+    message: string,
+    public data: Record<string, unknown> = {}
   ) {
     super(message);
     this.name = "ApiError";


### PR DESCRIPTION
## Summary
- Confirmation alert after successful request submit before navigating to detail
- Specialist write screen: on 409 with existing thread, redirect to that thread via alert
- ApiError now carries response body so callers can read fields like `threadId`

## Test plan
- [ ] Submit a new request as authenticated user → see "Заявка опубликована" alert → OK navigates to detail
- [ ] As specialist, respond to a request you already replied to → see "Вы уже откликнулись" alert → OK navigates to existing /threads/:id
- [ ] As specialist, respond to a CLOSED request → see "Заявка закрыта" inline error (unchanged behavior)
- [ ] tsc --noEmit passes in both root and api/