### PR TITLE
feat: onboarding route guards (auth + role + completion)

### DIFF
--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -1,22 +1,42 @@
 import { View, Text, Pressable, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import HeaderBack from "@/components/HeaderBack";
 import { useAuth } from "@/contexts/AuthContext";
+import { useRequireAuth } from "@/lib/useRequireAuth";
 import { api } from "@/lib/api";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import LoadingState from "@/components/ui/LoadingState";
 import { colors, textStyle } from "@/lib/theme";
 
 export default function OnboardingNameScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
-  const { updateUser } = useAuth();
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
+  const params = useLocalSearchParams<{ from?: string }>();
+  const fromSettings = params.from === "settings";
+  const { ready, user } = useRequireAuth();
+  const { updateUser, isSpecialistUser, isAdminUser } = useAuth();
+  const [firstName, setFirstName] = useState(user?.firstName ?? "");
+  const [lastName, setLastName] = useState(user?.lastName ?? "");
+
+  useEffect(() => {
+    if (!ready) return;
+    if (isAdminUser) {
+      nav.replaceRoutes.adminDashboard();
+      return;
+    }
+    if (!isSpecialistUser) {
+      nav.replaceRoutes.tabs();
+      return;
+    }
+    if (!fromSettings && user?.specialistProfileCompletedAt) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [ready, isAdminUser, isSpecialistUser, user, fromSettings]);
   const [agreed, setAgreed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
@@ -76,6 +96,10 @@ export default function OnboardingNameScreen() {
       setIsLoading(false);
     }
   };
+
+  if (!ready || isAdminUser || !isSpecialistUser) {
+    return <LoadingState />;
+  }
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -8,23 +8,43 @@ import {
   Platform,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
+import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Pencil, Camera } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { API_URL, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
+import LoadingState from "@/components/ui/LoadingState";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { colors, overlay, textStyle } from "@/lib/theme";
 
 export default function OnboardingProfileScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
-  const { updateUser } = useAuth();
+  const params = useLocalSearchParams<{ from?: string }>();
+  const fromSettings = params.from === "settings";
+  const { ready, user } = useRequireAuth();
+  const { updateUser, isSpecialistUser, isAdminUser } = useAuth();
+
+  useEffect(() => {
+    if (!ready) return;
+    if (isAdminUser) {
+      nav.replaceRoutes.adminDashboard();
+      return;
+    }
+    if (!isSpecialistUser) {
+      nav.replaceRoutes.tabs();
+      return;
+    }
+    if (!fromSettings && user?.specialistProfileCompletedAt) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [ready, isAdminUser, isSpecialistUser, user, fromSettings, nav]);
 
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
@@ -154,6 +174,10 @@ export default function OnboardingProfileScreen() {
       setIsLoading(false);
     }
   };
+
+  if (!ready || isAdminUser || !isSpecialistUser) {
+    return <LoadingState />;
+  }
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -7,8 +7,10 @@ import { Plus } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
+import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import Button from "@/components/ui/Button";
+import LoadingState from "@/components/ui/LoadingState";
 import { colors, textStyle } from "@/lib/theme";
 import SpecialistSearchBar, {
   CityOpt,
@@ -54,7 +56,23 @@ export default function OnboardingWorkAreaScreen() {
   const nav = useTypedRouter();
   const params = useLocalSearchParams<{ from?: string }>();
   const fromSettings = params.from === "settings";
-  const { isSpecialistUser, updateUser } = useAuth();
+  const { ready, user } = useRequireAuth();
+  const { isSpecialistUser, isAdminUser, updateUser } = useAuth();
+
+  useEffect(() => {
+    if (!ready) return;
+    if (isAdminUser) {
+      nav.replaceRoutes.adminDashboard();
+      return;
+    }
+    if (!isSpecialistUser) {
+      nav.replaceRoutes.tabs();
+      return;
+    }
+    if (!fromSettings && user?.specialistProfileCompletedAt) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [ready, isAdminUser, isSpecialistUser, user, fromSettings, nav]);
 
   // Catalogs (loaded once)
   const [cities, setCities] = useState<CityOpt[]>([]);
@@ -289,6 +307,10 @@ export default function OnboardingWorkAreaScreen() {
       setIsLoading(false);
     }
   };
+
+  if (!ready || isAdminUser || !isSpecialistUser) {
+    return <LoadingState />;
+  }
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>


### PR DESCRIPTION
## Summary
Adds proper guards to /onboarding/{name,work-area,profile} so users can't reach them out of context.

- Admins redirect to admin dashboard.
- Non-specialists redirect to (tabs).
- Already-onboarded specialists redirect to (tabs), unless ?from=settings is set.
- Pre-fills name fields if user.firstName/lastName already known (resume scenario).
- LoadingState shown during auth-context bootstrap.

Closes audit findings 4.2 and partial 4.3 (workflow guards).