### PR TITLE
feat: char-count hints in request form + file upload in specialist response

### DIFF
--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -272,7 +272,11 @@ export default function SpecialistConfirmWrite() {
             ) : (
               <View />
             )}
-            <Text className="text-xs text-text-mute ml-auto">
+            <Text
+              className={`text-xs ml-auto ${
+                message.length >= MAX_CHARS ? "text-danger" : "text-text-mute"
+              }`}
+            >
               {message.length}/{MAX_CHARS}
             </Text>
           </View>

--- a/app/requests/create.tsx
+++ b/app/requests/create.tsx
@@ -324,7 +324,11 @@ export default function CreateRequest() {
                 maxLength={100}
                 editable={!atLimit && !submitting}
               />
-              <Text className="text-xs text-text-dim text-right mt-1">
+              <Text
+                className={`text-xs text-right mt-1 ${
+                  title.length >= 100 ? "text-danger" : "text-text-dim"
+                }`}
+              >
                 {title.length}/100
               </Text>
             </View>
@@ -374,7 +378,11 @@ export default function CreateRequest() {
                 editable={!atLimit && !submitting}
                 containerStyle={{ minHeight: 120 }}
               />
-              <Text className="text-xs text-text-dim text-right mt-1">
+              <Text
+                className={`text-xs text-right mt-1 ${
+                  description.length >= 2000 ? "text-danger" : "text-text-dim"
+                }`}
+              >
                 {description.length}/2000
               </Text>
             </View>


### PR DESCRIPTION
## Summary

- Add red-color treatment to char-count hints when at limit (title 100, description 2000 in `app/requests/create.tsx`; specialist message 2000 in `app/requests/[id]/write.tsx`). Uses `text-danger` token from `lib/theme.ts`.
- File upload in specialist response form: **DEFERRED** — backend `POST /api/threads` accepts only `{ requestId, firstMessage }`; `Message` Prisma model has no attachments relation. Adding the UI would write data the backend silently drops. Tracked in #1469.

## Notes

- Audit said description max is 5000; backend reality is 2000 (`api/src/routes/requests.ts:323`). Kept frontend at 2000 to match server-side validation.
- Title/description counters already existed (`X/100`, `X/2000`) — only added the at-limit color flip.
- `npx tsc --noEmit` passes.

## Test plan

- [ ] Open `/requests/create` — type 100 chars in title — counter turns red
- [ ] Type 2000 chars in description — counter turns red
- [ ] As specialist, open `/requests/<id>/write` — type 2000 chars — counter turns red
- [ ] Submit form normally — no regression in validation