### PR TITLE
feat: notifications bell + thread perspective badges (P1 polish)

### DIFF
--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -17,6 +17,7 @@ import { MessageSquare } from "lucide-react-native";
 import MessengerEmptyPane from "@/components/MessengerEmptyPane";
 import ErrorState from "@/components/ui/ErrorState";
 import Avatar from "@/components/ui/Avatar";
+import PerspectiveBadge from "@/components/ui/PerspectiveBadge";
 import InlineChatView from "@/components/InlineChatView";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
@@ -258,7 +259,7 @@ export default function UnifiedInbox() {
           <View className="flex-1 min-w-0 py-3.5">
             <View className="flex-row items-center justify-between gap-2">
               <Text
-                className={`text-base flex-1 flex-shrink ${
+                className={`text-base flex-shrink ${
                   hasUnread
                     ? "font-bold text-text-base"
                     : "font-semibold text-text-base"
@@ -267,6 +268,12 @@ export default function UnifiedInbox() {
               >
                 {name}
               </Text>
+              {item.perspective ? (
+                <View className="ml-2 flex-shrink-0">
+                  <PerspectiveBadge perspective={item.perspective} />
+                </View>
+              ) : null}
+              <View style={{ flex: 1 }} />
               {item.lastMessage && (
                 <Text
                   className={`text-xs flex-shrink-0 ${

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -18,6 +18,7 @@ import { FileText, ChevronRight } from "lucide-react-native";
 import MessageBubble from "@/components/MessageBubble";
 import { Avatar } from "@/components/ui";
 import Input from "@/components/ui/Input";
+import PerspectiveBadge from "@/components/ui/PerspectiveBadge";
 import { API_URL, api, apiPost, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -362,10 +363,17 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
             <FontAwesome name="user" size={16} color={colors.textSecondary} />
           </View>
         )}
-        <View className="ml-3 flex-1">
-          <Text className="text-base font-semibold" style={{ color: colors.text }} numberOfLines={1}>
+        <View className="ml-3 flex-1 flex-row items-center" style={{ gap: 8 }}>
+          <Text className="text-base font-semibold flex-shrink" style={{ color: colors.text }} numberOfLines={1}>
             {otherName}
           </Text>
+          {thread && myId ? (
+            thread.clientId === myId ? (
+              <PerspectiveBadge perspective="as_client" />
+            ) : thread.specialistId === myId ? (
+              <PerspectiveBadge perspective="as_specialist" />
+            ) : null
+          ) : null}
         </View>
       </View>
 

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -14,6 +14,7 @@ import { Menu, Search, Settings, LogOut, User } from "lucide-react-native";
 import { useAuth, type UserRole } from "@/contexts/AuthContext";
 import { colors, roleAccent, type RoleAccentKey, gray, spacing } from "@/lib/theme";
 import MobileMenu from "@/components/MobileMenu";
+import NotificationsBell from "./NotificationsBell";
 import RoleBadge from "./RoleBadge";
 
 /**
@@ -180,7 +181,7 @@ export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
             )}
           </View>
 
-          <View className="w-11 h-11" />
+          <NotificationsBell />
         </View>
 
         <MobileMenu visible={menuOpen} onClose={() => setMenuOpen(false)} />
@@ -271,6 +272,7 @@ export default function AppHeader({ title, onBurgerPress }: AppHeaderProps) {
 
       {/* Right cluster */}
       <View className="flex-row items-center" style={{ gap: spacing.sm, marginLeft: "auto" }}>
+        <NotificationsBell />
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Меню профиля"

--- a/components/layout/NotificationsBell.tsx
+++ b/components/layout/NotificationsBell.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { Bell } from "lucide-react-native";
+import { useTypedRouter } from "@/lib/navigation";
+import { apiGet } from "@/lib/api";
+import { colors } from "@/lib/theme";
+
+/**
+ * Notifications bell — header trigger that opens `/notifications` and
+ * surfaces an unread badge based on `GET /api/notifications`.
+ *
+ * The endpoint returns `{ unreadCount, total, ... }`; we use `unreadCount`
+ * as the source of truth. Polled every 30s while mounted so the badge
+ * stays roughly in sync without a websocket layer.
+ */
+interface NotificationsResponse {
+  unreadCount?: number;
+  total?: number;
+}
+
+const POLL_INTERVAL_MS = 30_000;
+
+export default function NotificationsBell() {
+  const nav = useTypedRouter();
+  const [unread, setUnread] = useState(0);
+
+  const fetchUnread = useCallback(async () => {
+    try {
+      const res = await apiGet<NotificationsResponse>(
+        "/api/notifications?unreadOnly=true&limit=1"
+      );
+      // Prefer explicit `unreadCount`; fall back to `total` for older shapes.
+      const next =
+        typeof res.unreadCount === "number"
+          ? res.unreadCount
+          : typeof res.total === "number"
+            ? res.total
+            : 0;
+      setUnread(Math.max(0, next));
+    } catch {
+      // Silent — header bell shouldn't error-block the UI.
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUnread();
+    const id = setInterval(fetchUnread, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [fetchUnread]);
+
+  const display = unread > 99 ? "99+" : String(unread);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={
+        unread > 0
+          ? `Уведомления, непрочитанных: ${display}`
+          : "Уведомления"
+      }
+      onPress={() => nav.any("/notifications")}
+      className="items-center justify-center"
+      style={{ width: 44, height: 44 }}
+    >
+      <View style={{ position: "relative" }}>
+        <Bell size={20} color={colors.text} />
+        {unread > 0 ? (
+          <View
+            className="rounded-full items-center justify-center"
+            style={{
+              position: "absolute",
+              top: -4,
+              right: -4,
+              minWidth: 16,
+              height: 16,
+              paddingHorizontal: 4,
+              backgroundColor: colors.danger,
+            }}
+          >
+            <Text
+              style={{
+                color: colors.white,
+                fontSize: 10,
+                fontWeight: "700",
+                fontVariant: ["tabular-nums"],
+                lineHeight: 12,
+              }}
+            >
+              {display}
+            </Text>
+          </View>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}

--- a/components/ui/PerspectiveBadge.tsx
+++ b/components/ui/PerspectiveBadge.tsx
@@ -1,0 +1,45 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+/**
+ * PerspectiveBadge — small uppercase chip indicating whether the current
+ * user is participating in a thread as the client or as the specialist.
+ *
+ * Used in:
+ *  - Inbox row (`app/(tabs)/messages.tsx`) — distinguish dual-role threads.
+ *  - Thread header (`components/InlineChatView.tsx`) — reinforce context.
+ */
+export interface PerspectiveBadgeProps {
+  perspective: "as_client" | "as_specialist";
+}
+
+export default function PerspectiveBadge({ perspective }: PerspectiveBadgeProps) {
+  const isClient = perspective === "as_client";
+  const label = isClient ? "Я КЛИЕНТ" : "Я СПЕЦИАЛИСТ";
+
+  const bg = isClient ? colors.surface2 : colors.accentSoft;
+  const fg = isClient ? colors.textSecondary : colors.accentSoftInk;
+
+  return (
+    <View
+      className="rounded-full"
+      style={{
+        backgroundColor: bg,
+        paddingHorizontal: 8,
+        paddingVertical: 2,
+        alignSelf: "flex-start",
+      }}
+    >
+      <Text
+        style={{
+          color: fg,
+          fontSize: 11,
+          fontWeight: "600",
+          letterSpacing: 0.6,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `NotificationsBell` to `AppHeader` (mobile + desktop): 20px lucide `Bell`, 44x44 hit area, opens `/notifications`. Unread badge fed by `GET /api/notifications` (`unreadCount`), 30s poll, `99+` cap, hidden at 0.
- New `PerspectiveBadge` (`Я КЛИЕНТ` / `Я СПЕЦИАЛИСТ`) used in inbox row (`(tabs)/messages.tsx`) and thread header (`InlineChatView.tsx`). Specialist variant uses `colors.accentSoft` + `accentSoftInk`; client variant uses `colors.surface2` + `textSecondary`.
- All colors via `lib/theme.ts`, no raw hex literals.

## Test plan
- [ ] Mobile (<640): burger + title + bell visible in header
- [ ] Desktop (>=640): bell sits between search and avatar
- [ ] Bell badge appears when `unreadCount > 0`, hidden at 0, shows `99+` for >99
- [ ] Tap bell -> navigates to `/notifications`
- [ ] Inbox row shows perspective badge after the name when `item.perspective` is set
- [ ] Thread header shows badge next to other-user name
- [ ] `npx tsc --noEmit` passes (frontend + api)