### PR TITLE
fix: landing header reflects auth state

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -201,6 +201,8 @@ export default function LandingScreen() {
           onLogin={goLogin}
           onCreateRequest={goCreateRequest}
           onFindSpecialist={goCatalog}
+          isAuthenticated={isAuthenticated}
+          onOpenDashboard={() => nav.routes.tabs()}
         />
 
         <HeroBlock

--- a/components/landing/LandingHeader.tsx
+++ b/components/landing/LandingHeader.tsx
@@ -9,6 +9,8 @@ interface LandingHeaderProps {
   onCreateRequest: () => void;
   transparent?: boolean;
   onFindSpecialist?: () => void;
+  isAuthenticated?: boolean;
+  onOpenDashboard?: () => void;
 }
 
 /**
@@ -24,6 +26,8 @@ export default function LandingHeader({
   onCreateRequest,
   transparent = true,
   onFindSpecialist,
+  isAuthenticated = false,
+  onOpenDashboard,
 }: LandingHeaderProps) {
   return (
     <View
@@ -96,16 +100,29 @@ export default function LandingHeader({
               </Text>
             </Pressable>
           ) : null)}
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Войти"
-            onPress={onLogin}
-            className="min-h-[44px] items-center justify-center px-3"
-          >
-            <Text className="font-medium" style={{ color: colors.textSecondary, fontSize: 14 }}>
-              Войти
-            </Text>
-          </Pressable>
+          {isAuthenticated ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Перейти в личный кабинет"
+              onPress={onOpenDashboard ?? onLogin}
+              className="min-h-[44px] items-center justify-center px-3"
+            >
+              <Text className="font-medium" style={{ color: colors.text, fontSize: 14 }}>
+                В кабинет
+              </Text>
+            </Pressable>
+          ) : (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Войти"
+              onPress={onLogin}
+              className="min-h-[44px] items-center justify-center px-3"
+            >
+              <Text className="font-medium" style={{ color: colors.textSecondary, fontSize: 14 }}>
+                Войти
+              </Text>
+            </Pressable>
+          )}
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Создать заявку"


### PR DESCRIPTION
Authed users no longer see login CTA on landing — show 'В кабинет' button routing to /(tabs).