### PR TITLE
fix: mobile bell visible + availability toggle shows errors

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -275,7 +275,7 @@ export default function UnifiedSettings() {
       updateUser({ isAvailable: value });
     } catch {
       setIsAvailable(!value);
-      Alert.alert("Ошибка", "Не удалось изменить статус");
+      Alert.alert("Ошибка", "Не удалось обновить статус доступности");
     } finally {
       setAvailabilityLoading(false);
     }


### PR DESCRIPTION
## Summary
- Mobile AppHeader already renders `<NotificationsBell />` (line 184) — verified docstring claim is true, no placeholder spacer to replace.
- Settings availability toggle: refined error Alert wording to be specific to the failure mode. Optimistic-UI rollback (`setIsAvailable(!value)`) was already in place.

## Changes
- `app/settings/index.tsx`: error alert text now reads "Не удалось обновить статус доступности" (was generic "Не удалось изменить статус").

## Test plan
- [ ] tsc --noEmit passes (frontend + api)
- [ ] Toggle availability with API offline → Alert shows new text + toggle reverts
- [ ] Mobile header (<640px) shows bell on right side