### PR TITLE
fix: resume incomplete onboarding + tap notification to navigate

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -155,6 +155,9 @@ router.post("/verify-otp", verifyOtpRateLimiter, async (req: Request, res: Respo
         isSpecialist: user.isSpecialist,
         firstName: user.firstName,
         lastName: user.lastName,
+        specialistProfileCompletedAt: user.specialistProfileCompletedAt
+          ? user.specialistProfileCompletedAt.toISOString()
+          : null,
       },
     });
   } catch (error) {
@@ -213,6 +216,9 @@ router.post("/refresh", refreshRateLimiter, async (req: Request, res: Response) 
         isSpecialist: storedToken.user.isSpecialist,
         firstName: storedToken.user.firstName,
         lastName: storedToken.user.lastName,
+        specialistProfileCompletedAt: storedToken.user.specialistProfileCompletedAt
+          ? storedToken.user.specialistProfileCompletedAt.toISOString()
+          : null,
       },
     });
   } catch (error) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import "../global.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useWindowDimensions, Platform, View, ActivityIndicator } from "react-native";
-import { Stack, usePathname } from "expo-router";
+import { Stack, usePathname, useRouter } from "expo-router";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import AppShell from "@/components/layout/AppShell";
 import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
@@ -11,6 +11,44 @@ import { colors } from "@/lib/theme";
 import MetroBridge from "@/components/MetroBridge";
 
 const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Runtime guard for stranded specialists.
+ *
+ * A user who picks "Я специалист" and abandons after step 1 has
+ * `isSpecialist=true` but `specialistProfileCompletedAt=null`. They
+ * cannot appear in the catalog or write threads — so they must finish
+ * onboarding before doing anything else. This effect catches every
+ * authenticated entry point (deep links, token-only restore, browser
+ * back nav) and bounces them to /onboarding/name. Allowed pass-through:
+ * onboarding screens themselves, auth flow, legal pages, and the public
+ * landing page (which redirects on its own).
+ */
+function useStrandedSpecialistGuard() {
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const pathname = usePathname() ?? "";
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || !user) return;
+    if (!user.isSpecialist) return;
+    if (user.specialistProfileCompletedAt) return;
+
+    if (
+      pathname.startsWith("/onboarding") ||
+      pathname.startsWith("/auth") ||
+      pathname.startsWith("/legal") ||
+      pathname === "/login" ||
+      pathname === "/otp" ||
+      pathname === "/" ||
+      pathname === ""
+    ) {
+      return;
+    }
+
+    router.replace("/onboarding/name" as never);
+  }, [isLoading, isAuthenticated, user, pathname, router]);
+}
 
 /**
  * Thin wrapper that decides whether the persistent {@link AppHeader}
@@ -30,6 +68,10 @@ function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "";
   const { width } = useWindowDimensions();
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Bounce stranded specialists (incomplete onboarding) to /onboarding/name
+  // regardless of how they reached the current route.
+  useStrandedSpecialistGuard();
 
   // Block rendering until AsyncStorage token restoration is complete.
   // Without this, authenticated users briefly see the public landing page.

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -143,22 +143,58 @@ export default function NotificationsScreen() {
     setRefreshing(false);
   }, [fetchNotifications]);
 
+  /**
+   * Resolve the in-app route a notification should navigate to.
+   * Backend payload: notifications carry a single `entityId` (no `data` JSON).
+   * Type -> entityId semantics:
+   *   - new_message / new_message_from_specialist : entityId = thread.id  -> /threads/{id}
+   *   - new_response                              : entityId = thread.id  -> /threads/{id}
+   *   - new_request_in_city                       : entityId = request.id -> /requests/{id}/detail
+   *   - promo_expiring                            : no navigation
+   */
+  const routeForNotification = useCallback((item: NotificationItem): string | null => {
+    if (!item.entityId) return null;
+    switch (item.type) {
+      case "new_message":
+      case "new_message_from_specialist":
+      case "new_response":
+        return `/threads/${item.entityId}`;
+      case "new_request_in_city":
+        return `/requests/${item.entityId}/detail`;
+      case "promo_expiring":
+      default:
+        return null;
+    }
+  }, []);
+
   const handleMarkRead = useCallback(async (id: string) => {
     const item = notifications.find((n) => n.id === id);
-    if (!item || item.isRead) return;
+    if (!item) return;
+    const target = routeForNotification(item);
+
+    if (item.isRead) {
+      // Already read - just navigate (tap-again behaviour).
+      if (target) router.push(target as never);
+      return;
+    }
+
+    // Optimistic update
     setNotifications((prev) =>
       prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
     );
     setUnreadCount((prev) => Math.max(0, prev - 1));
-    try {
-      await apiPatch(`/api/notifications/${id}/read`, {});
-    } catch {
+
+    // Fire-and-forget mark-read; navigate immediately for snappy UX.
+    apiPatch(`/api/notifications/${id}/read`, {}).catch(() => {
+      // Revert on failure
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? { ...n, isRead: false } : n))
       );
       setUnreadCount((prev) => prev + 1);
-    }
-  }, [notifications]);
+    });
+
+    if (target) router.push(target as never);
+  }, [notifications, routeForNotification, router]);
 
   const handleMarkAllRead = useCallback(async () => {
     const prevNotifications = notifications;

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -149,22 +149,30 @@ export default function OnboardingProfileScreen() {
     setIsLoading(true);
 
     try {
-      await api("/api/onboarding/profile", {
-        method: "PUT",
-        body: {
-          description: description.trim() || null,
-          phone: phone.trim() || null,
-          telegram: telegram.trim() || null,
-          whatsapp: whatsapp.trim() || null,
-          officeAddress: officeAddress.trim() || null,
-          workingHours: workingHours.trim() || null,
-          avatarUrl: avatarUrl || null,
-        },
-      });
+      const result = await api<{ success: boolean; specialistProfileCompletedAt?: string }>(
+        "/api/onboarding/profile",
+        {
+          method: "PUT",
+          body: {
+            description: description.trim() || null,
+            phone: phone.trim() || null,
+            telegram: telegram.trim() || null,
+            whatsapp: whatsapp.trim() || null,
+            officeAddress: officeAddress.trim() || null,
+            workingHours: workingHours.trim() || null,
+            avatarUrl: avatarUrl || null,
+          },
+        }
+      );
 
-      // Mark user as specialist in local context (covers both new specialists
-      // and existing CLIENTs who enabled specialist mode)
-      updateUser({ isSpecialist: true, ...(avatarUrl ? { avatarUrl } : {}) });
+      // Mark user as specialist locally + record onboarding completion so
+      // useStrandedSpecialistGuard stops bouncing back to /onboarding/name.
+      const completedAt = result.specialistProfileCompletedAt ?? new Date().toISOString();
+      updateUser({
+        isSpecialist: true,
+        specialistProfileCompletedAt: completedAt,
+        ...(avatarUrl ? { avatarUrl } : {}),
+      });
 
       nav.replaceRoutes.tabs();
     } catch (e: unknown) {

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -93,9 +93,14 @@ export default function AuthOtpScreen() {
         nav.replaceRoutes.adminDashboard();
         return;
       }
-      // Specialist opt-in still requires a name/profile finish before the
-      // dashboard can render the specialist widgets meaningfully.
-      if (user.isSpecialist && !user.firstName) {
+      // Resume incomplete specialist onboarding. The previous check used
+      // `!user.firstName`, which only catches users who quit before step 1.
+      // Specialists who finish step 1 (firstName set) but abandon before
+      // step 3 are stranded — they have no profile, are invisible in the
+      // catalog, and cannot write threads. `specialistProfileCompletedAt`
+      // is the authoritative gate: it's set only after `/api/onboarding/profile`
+      // succeeds, so any falsy value means onboarding is incomplete.
+      if (user.isSpecialist && !user.specialistProfileCompletedAt) {
         nav.replaceRoutes.onboardingName();
         return;
       }


### PR DESCRIPTION
## Summary

**Fix 1 — Stranded specialists resume onboarding**
- Adds `users.specialist_profile_completed_at` (nullable timestamp). Set when `/api/onboarding/profile` (step 3) succeeds. Backfilled for existing specialists with a profile row.
- Exposed in `verify-otp`, `refresh`, `me` payloads + `UserData` type.
- `app/auth/otp.tsx` `routeByRole` now checks `specialistProfileCompletedAt` (was: `firstName`) — so a user who finished only step 1 keeps resuming at `/onboarding/name`.
- `app/_layout.tsx` adds `OnboardingGate` runtime guard for deep-link / token-restore paths. Skips redirect on `/auth/*`, `/onboarding/*`, and `/` to avoid loops.
- `app/onboarding/profile.tsx` updates the local auth context with the new field after submit so the gate immediately stops redirecting.

**Fix 2 — Notification tap navigates**
- `app/notifications.tsx`: tapping a notification marks-read AND navigates by type.
- Mapping (uses existing `entityId` column — backend has no `data` JSON):
  - `new_message`, `new_response` → `/threads/{entityId}`
  - `new_request_in_city` → `/requests/{entityId}/detail`
  - `promo_expiring` → no navigation
- Mark-read is fire-and-forget for snappy UX; reverts on failure. Tapping an already-read item re-navigates.

## Files changed

- `api/prisma/schema.prisma` — `User.specialistProfileCompletedAt`
- `api/prisma/migrations/20260428000000_add_specialist_profile_completed_at/migration.sql`
- `api/src/routes/onboarding.ts` — set timestamp on `/profile`
- `api/src/routes/auth.ts` — expose field in 3 endpoints
- `contexts/AuthContext.tsx` — `UserData.specialistProfileCompletedAt`
- `app/auth/otp.tsx` — `routeByRole` uses new field
- `app/_layout.tsx` — `OnboardingGate` runtime guard
- `app/onboarding/profile.tsx` — `updateUser` with completedAt
- `app/notifications.tsx` — tap navigation by type

## Test plan

- [ ] `npx tsc --noEmit` (root + api) passes — verified locally, both 0 errors
- [ ] Specialist quits after step 1 → log in again → lands on `/onboarding/name`
- [ ] Specialist quits after step 1 → opens `/threads/X` deep link → redirected to `/onboarding/name`
- [ ] Specialist completes step 3 → no longer redirected; lands on dashboard
- [ ] Existing specialists (have `specialistProfile` row) backfilled to completed → no surprise redirect
- [ ] Tap unread `new_message` notification → marked read + opens `/threads/{id}`
- [ ] Tap unread `new_response` → marked read + opens `/threads/{id}`
- [ ] Tap `promo_expiring` → marked read, no navigation
- [ ] Tap a notification with null `entityId` → marked read, no navigation