### PR TITLE
feat: catalog ranking — photos first, then by recency

### DIFF
--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -56,7 +56,12 @@ router.get("/featured", async (_req: Request, res: Response) => {
         isBanned: false,
       },
       take: 10,
-      orderBy: { createdAt: "desc" },
+      // Catalog ranking: specialists with avatar photos first, then newest.
+      // `avatarUrl` desc + nulls:last puts non-null URLs before null ones (Prisma 6.x).
+      orderBy: [
+        { avatarUrl: { sort: "desc", nulls: "last" } },
+        { createdAt: "desc" },
+      ],
       select: specialistListSelect,
     });
 
@@ -143,7 +148,12 @@ router.get("/", async (req: Request, res: Response) => {
         where,
         skip,
         take: limit,
-        orderBy: { createdAt: "desc" },
+        // Catalog ranking: specialists with avatar photos first, then newest.
+        // `avatarUrl` desc + nulls:last puts non-null URLs before null ones (Prisma 6.x).
+        orderBy: [
+          { avatarUrl: { sort: "desc", nulls: "last" } },
+          { createdAt: "desc" },
+        ],
         select: specialistListSelect,
       }),
       prisma.user.count({ where }),


### PR DESCRIPTION
## Summary
- Replace `orderBy: { createdAt: "desc" }` with multi-key sort in `api/src/routes/specialists.ts`.
- Specialists with `avatarUrl` (photos) rank first; nulls last; tiebreaker is `createdAt` desc.
- Applied to both `GET /api/specialists` (paginated catalog) and `GET /api/specialists/featured` (top 10).

## Implementation
```ts
orderBy: [
  { avatarUrl: { sort: "desc", nulls: "last" } },
  { createdAt: "desc" },
]
```
Prisma 6.19.3 supports `nulls` config — no fallback needed.

## Test plan
- [x] `cd api && npx tsc --noEmit` — 0 errors
- [ ] Verify catalog list returns avatar-first, then newest tiebreaker
- [ ] Verify featured top-10 reflects same ordering
- [ ] Verify `total` count and `hasMore` pagination unchanged