### PR TITLE
feat: avatar upload UX hardening (size pre-check + error mapping)

### DIFF
--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -13,14 +13,20 @@ import { useTypedRouter } from "@/lib/navigation";
 import { useState, useRef, useEffect } from "react";
 import { Pencil, Camera } from "lucide-react-native";
 import HeaderBack from "@/components/HeaderBack";
-import { API_URL, api } from "@/lib/api";
+import {
+  api,
+  ApiError,
+  AVATAR_MAX_BYTES,
+  AVATAR_TOO_LARGE_MESSAGE,
+  avatarUploadErrorMessage,
+  uploadAvatarFile,
+} from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import LoadingState from "@/components/ui/LoadingState";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { colors, overlay, textStyle } from "@/lib/theme";
 
 export default function OnboardingProfileScreen() {
@@ -81,31 +87,20 @@ export default function OnboardingProfileScreen() {
   };
 
   const uploadAvatar = async (file: File) => {
+    // Pre-check size before any network call
+    if (file.size > AVATAR_MAX_BYTES) {
+      setError(AVATAR_TOO_LARGE_MESSAGE);
+      return;
+    }
+
     setAvatarUploading(true);
     setError("");
     try {
-      const token = await AsyncStorage.getItem("p2ptax_access_token");
-      const formData = new FormData();
-      formData.append("file", file);
-
-      const res = await fetch(`${API_URL}/api/upload/avatar`, {
-        method: "POST",
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-        body: formData,
-      });
-
-      if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(data.error || "Не удалось загрузить фото");
-      }
-
-      const data = (await res.json()) as { url: string; key: string };
-      const fullUrl = data.url.startsWith("http")
-        ? data.url
-        : `${API_URL}${data.url}`;
+      const fullUrl = await uploadAvatarFile(file);
       setAvatarUrl(fullUrl);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Ошибка загрузки фото";
+      const msg =
+        e instanceof ApiError ? e.message : avatarUploadErrorMessage(-1);
       setError(msg);
     } finally {
       setAvatarUploading(false);

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import {
   View,
   Text,
@@ -9,8 +9,14 @@ import {
   Platform,
 } from "react-native";
 import { Pencil } from "lucide-react-native";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { API_URL } from "@/lib/api";
+import {
+  ApiError,
+  AVATAR_MAX_BYTES,
+  AVATAR_TOO_LARGE_TITLE,
+  AVATAR_TOO_LARGE_MESSAGE,
+  avatarUploadErrorMessage,
+  uploadAvatarFile,
+} from "@/lib/api";
 import { colors } from "@/lib/theme";
 
 interface AvatarUploaderProps {
@@ -31,33 +37,34 @@ export default function AvatarUploader({
   onUploadEnd,
 }: AvatarUploaderProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [lastFile, setLastFile] = useState<File | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const uploadAvatar = async (file: File) => {
+    // Pre-check size before any network call
+    if (file.size > AVATAR_MAX_BYTES) {
+      Alert.alert(AVATAR_TOO_LARGE_TITLE, AVATAR_TOO_LARGE_MESSAGE);
+      return;
+    }
+
+    setErrorMessage(null);
     onUploadStart();
     try {
-      const token = await AsyncStorage.getItem("p2ptax_access_token");
-      const formData = new FormData();
-      formData.append("file", file);
-
-      const res = await fetch(`${API_URL}/api/upload/avatar`, {
-        method: "POST",
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-        body: formData,
-      });
-
-      if (!res.ok) {
-        const errData = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(errData.error || "Не удалось загрузить фото");
-      }
-
-      const resData = (await res.json()) as { url: string };
-      const fullUrl = resData.url.startsWith("http")
-        ? resData.url
-        : `${API_URL}${resData.url}`;
+      const fullUrl = await uploadAvatarFile(file);
       onAvatarChange(fullUrl);
+      setLastFile(null);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Ошибка загрузки фото";
-      Alert.alert("Ошибка", msg);
+      const status = e instanceof ApiError ? e.status : -1;
+      const msg =
+        e instanceof ApiError ? e.message : avatarUploadErrorMessage(-1);
+      // Keep file for retry, but for 413 the file itself is the problem — don't offer retry.
+      if (status === 413) {
+        Alert.alert(AVATAR_TOO_LARGE_TITLE, AVATAR_TOO_LARGE_MESSAGE);
+        setLastFile(null);
+      } else {
+        setLastFile(file);
+        setErrorMessage(msg);
+      }
     } finally {
       onUploadEnd();
     }
@@ -74,6 +81,12 @@ export default function AvatarUploader({
     if (file) {
       void uploadAvatar(file);
       e.target.value = "";
+    }
+  };
+
+  const handleRetry = () => {
+    if (lastFile) {
+      void uploadAvatar(lastFile);
     }
   };
 
@@ -126,6 +139,26 @@ export default function AvatarUploader({
           {avatarUrl ? "Изменить фото" : "Нажмите, чтобы добавить фото"}
         </Text>
       </Pressable>
+
+      {errorMessage ? (
+        <View className="mt-3 items-center">
+          <Text className="text-xs text-red-600 mb-2 text-center">
+            {errorMessage}
+          </Text>
+          {lastFile ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Повторить загрузку аватара"
+              onPress={handleRetry}
+              disabled={avatarUploading}
+              className="px-4 py-2 rounded-full bg-blue-900"
+              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+            >
+              <Text className="text-xs font-medium text-white">Повторить</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      ) : null}
 
       {Platform.OS === "web" && (
         <input

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -120,3 +120,52 @@ export const apiPatch = <T>(path: string, body: unknown) =>
   api<T>(path, { method: "PATCH", body });
 export const apiDelete = <T>(path: string) =>
   api<T>(path, { method: "DELETE" });
+
+// Avatar upload constants & helpers (shared between settings + onboarding)
+export const AVATAR_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — must match api/src/routes/upload.ts
+export const AVATAR_TOO_LARGE_TITLE = "Файл слишком большой";
+export const AVATAR_TOO_LARGE_MESSAGE = "Максимальный размер аватара — 5 МБ.";
+
+/**
+ * Map an avatar upload failure (HTTP status / network) to a user-facing message in Russian.
+ * status 0 = network error / no response.
+ */
+export function avatarUploadErrorMessage(status: number): string {
+  if (status === 413) return "Файл слишком большой. Максимум 5 МБ.";
+  if (status === 429) return "Слишком много загрузок. Попробуйте через минуту.";
+  if (status === 0) return "Нет связи с сервером.";
+  return "Не удалось загрузить аватар. Попробуйте ещё раз.";
+}
+
+/**
+ * Upload an avatar file. Performs client-side size pre-check, throws ApiError on
+ * server error (with mapped Russian message), or a network ApiError(0, ...) on fetch failure.
+ * Returns the absolute URL of the uploaded avatar.
+ */
+export async function uploadAvatarFile(file: File): Promise<string> {
+  if (file.size > AVATAR_MAX_BYTES) {
+    throw new ApiError(413, avatarUploadErrorMessage(413));
+  }
+
+  const token = await AsyncStorage.getItem(TOKEN_KEY);
+  const formData = new FormData();
+  formData.append("file", file);
+
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/api/upload/avatar`, {
+      method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      body: formData,
+    });
+  } catch {
+    throw new ApiError(0, avatarUploadErrorMessage(0));
+  }
+
+  if (!res.ok) {
+    throw new ApiError(res.status, avatarUploadErrorMessage(res.status));
+  }
+
+  const data = (await res.json()) as { url: string };
+  return data.url.startsWith("http") ? data.url : `${API_URL}${data.url}`;
+}


### PR DESCRIPTION
## Summary
- Adds shared `uploadAvatarFile()` helper in `lib/api.ts` with client-side 5 MB pre-check (matches backend multer limit) and HTTP-status-to-Russian message mapping (413 / 429 / network / default).
- `components/settings/AvatarUploader.tsx`: shows `Alert` on oversized file before any network call; on transient errors shows inline error text plus a "Повторить" retry button that re-uploads the same `File` (no re-pick required). 413 path skips retry since the file itself is the problem.
- `app/onboarding/profile.tsx` + `app/settings/client.tsx`: use the same helper so the size pre-check and error mapping carry over to the onboarding step and client settings.

## Error texts shown to user
- Pre-check (>5 MB): "Файл слишком большой" / "Максимальный размер аватара — 5 МБ."
- 413: "Файл слишком большой. Максимум 5 МБ."
- 429: "Слишком много загрузок. Попробуйте через минуту."
- Network failure: "Нет связи с сервером."
- Other: "Не удалось загрузить аватар. Попробуйте ещё раз."

## Test plan
- [ ] Pick a >5 MB image in settings — Alert appears, no POST sent (verify in devtools Network tab).
- [ ] Pick a >5 MB image in onboarding — inline error appears, no POST sent.
- [ ] Stop the API server, try uploading — "Нет связи с сервером." appears, "Повторить" button visible in `AvatarUploader`.
- [ ] Restart API, click "Повторить" — same file is re-sent, succeeds.
- [ ] Trigger 11 uploads in 60s (rate-limit) — 429 message appears.
- [ ] `npx tsc --noEmit` from `/` and `api/` both pass.