### PR TITLE
perf: cache landing counters (60s in-memory)

### DIFF
--- a/api/src/routes/reference.ts
+++ b/api/src/routes/reference.ts
@@ -209,9 +209,23 @@ router.get("/services", async (_req: Request, res: Response) => {
   }
 });
 
+// In-memory cache for public landing counts (60s TTL).
+// Avoids running 3 COUNT queries on every public landing hit.
+let cachedLandingCounts: {
+  data: { specialistsCount: number; citiesCount: number; consultationsCount: number };
+  expiresAt: number;
+} | null = null;
+const LANDING_TTL_MS = 60_000;
+
 // GET /api/stats — public platform statistics
 router.get("/stats", async (_req: Request, res: Response) => {
   try {
+    const now = Date.now();
+    if (cachedLandingCounts && cachedLandingCounts.expiresAt > now) {
+      res.json(cachedLandingCounts.data);
+      return;
+    }
+
     const [specialistsCount, citiesCount, consultationsCount] = await Promise.all([
       // Iter11: specialists counted by flag, not retired role value.
       prisma.user.count({ where: { isSpecialist: true, isBanned: false } }),
@@ -219,7 +233,9 @@ router.get("/stats", async (_req: Request, res: Response) => {
       prisma.thread.count(),
     ]);
 
-    res.json({ specialistsCount, citiesCount, consultationsCount });
+    const data = { specialistsCount, citiesCount, consultationsCount };
+    cachedLandingCounts = { data, expiresAt: now + LANDING_TTL_MS };
+    res.json(data);
   } catch (error) {
     console.error("stats error:", error);
     res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## Summary
- Adds 60s in-memory cache to `GET /api/stats` (public landing counts).
- Avoids 3 COUNT queries (specialists / cities / threads) on every public landing hit.
- TTL-only: no invalidation needed, freshness within 60s is acceptable for public stats.

## Implementation
- Module-level `cachedLandingCounts: { data, expiresAt }` in `api/src/routes/reference.ts`.
- On hit (within TTL): respond from cache, skip DB.
- On miss: run the 3 counts in parallel, store, respond.
- Single in-process variable; no Redis, no Map, no library.

## Test plan
- [ ] `npx tsc --noEmit` passes (frontend) — verified locally.
- [ ] `cd api && npx tsc --noEmit` passes (backend) — verified locally.
- [ ] First request after deploy hits DB, subsequent requests within 60s served from cache.
- [ ] After 60s elapses, next request refreshes cache from DB.