### PR TITLE
feat: notify-all-at-FNS when client picks 'Не знаю' service

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -14,8 +14,13 @@ function stripHtml(str: string): string {
 const router = Router();
 
 /**
- * Fan-out: notify every specialist whose FNS coverage matches this request's
- * FNS. Side-effect only — never crashes the request flow.
+ * Notifies all specialists who cover the request's FNS, regardless of
+ * which specific services they offer. This is intentional: when a client
+ * picks "Не знаю" for service, we still want their request visible to
+ * any qualified specialist at the FNS. Specialists can self-filter via
+ * the public-requests feed.
+ *
+ * Side-effect only — never crashes the request flow.
  */
 async function notifyMatchingSpecialists(args: {
   requestId: string;


### PR DESCRIPTION
## Summary
- The notify fan-out query in `api/src/routes/requests.ts::notifyMatchingSpecialists` already filters specialists only by FNS coverage (no `serviceId` filter), so it already supports "Не знаю" requests where no service is specified.
- Verified via `prisma/schema.prisma`: the `Request` model has no `serviceId` column at all — the schema simply does not associate a request with a service, which is why the query was always service-agnostic.
- Added a JSDoc comment on `notifyMatchingSpecialists` documenting that the FNS-only fan-out is intentional, so future contributors don't add a service filter and accidentally drop "Не знаю" requests.

## Test plan
- [x] `cd api && npx tsc --noEmit` passes (0 errors)
- [ ] Manual: client creates a request without picking a service; verify all FNS-covering specialists receive `new_request_in_city` notification