### PR TITLE
feat: confirmation when toggling availability off (explains threads continue)

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -266,8 +266,7 @@ export default function UnifiedSettings() {
 
   const handleSave = isSpecialistUser ? handleSaveSpecialist : handleSaveClient;
 
-  const handleToggleAvailable = async (value: boolean) => {
-    if (availabilityLoading) return;
+  const applyAvailabilityChange = async (value: boolean) => {
     setIsAvailable(value);
     setAvailabilityLoading(true);
     try {
@@ -279,6 +278,28 @@ export default function UnifiedSettings() {
     } finally {
       setAvailabilityLoading(false);
     }
+  };
+
+  const handleToggleAvailable = (value: boolean) => {
+    if (availabilityLoading) return;
+    if (isAvailable && !value) {
+      Alert.alert(
+        "Скрыть профиль из каталога?",
+        "Новые клиенты не смогут вас найти. Существующие переписки сохранятся, и вы сможете отвечать как обычно. Включить обратно — в любой момент.",
+        [
+          { text: "Отмена", style: "cancel" },
+          {
+            text: "Скрыть",
+            style: "destructive",
+            onPress: () => {
+              void applyAvailabilityChange(value);
+            },
+          },
+        ],
+      );
+      return;
+    }
+    void applyAvailabilityChange(value);
   };
 
   const handleLogout = useCallback(() => {


### PR DESCRIPTION
## Summary
- When specialist toggles availability OFF, show Alert.alert confirmation explaining: hidden from search, but existing conversations continue.
- Toggle ON requires no confirmation.
- Preserves existing optimistic-update + rollback-on-error logic from PR #1473.

## Files
- `app/settings/index.tsx` — split handler into `applyAvailabilityChange` (API call + rollback) and `handleToggleAvailable` (confirmation gate for true→false).

## Alert text
- Title: "Скрыть профиль из каталога?"
- Body: "Новые клиенты не смогут вас найти. Существующие переписки сохранятся, и вы сможете отвечать как обычно. Включить обратно — в любой момент."
- Buttons: "Отмена" (cancel) / "Скрыть" (destructive)

## Test plan
- [ ] Toggle availability OFF → alert appears
- [ ] Cancel keeps toggle ON, no API call
- [ ] Confirm "Скрыть" disables and persists via PATCH /api/specialist/profile
- [ ] Toggle availability ON → no alert, immediate update
- [ ] API failure → rollback toggle, error alert shown