### PR TITLE
feat: cursor-based pagination for thread messages (load 50, then 'load older' button)

### DIFF
--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -151,6 +151,17 @@ router.get("/threads", authMiddleware, async (req: Request, res: Response) => {
 });
 
 // GET /api/messages/:threadId — get messages in thread (with file attachments)
+//
+// Pagination (cursor-based, opt-in):
+//   ?limit=50          → return latest 50 messages (ASC for display)
+//   ?limit=50&before=X → return 50 messages older than message id X (ASC for display)
+//
+// Backward compatibility: if `limit` is NOT provided, returns ALL messages
+// (legacy behavior) so older clients continue to work.
+//
+// Response shape (paginated): { messages, hasMore, nextCursor }
+//   nextCursor = id of the OLDEST message in the returned page (use as `before` for next page)
+//   hasMore    = whether more older messages likely exist (page filled exactly to limit)
 router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
@@ -170,15 +181,63 @@ router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => 
       return;
     }
 
-    const messages = await prisma.message.findMany({
-      where: { threadId },
-      include: {
-        sender: {
-          select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+    // Parse pagination params. `limit` presence = paginated mode.
+    const limitRaw = param(req.query.limit as string | string[] | undefined);
+    const beforeRaw = param(req.query.before as string | string[] | undefined);
+    const paginated = limitRaw !== "";
+    let limit = 50;
+    if (paginated) {
+      const parsed = parseInt(limitRaw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        limit = Math.min(parsed, 100);
+      }
+    }
+
+    type MessageRow = Awaited<ReturnType<typeof prisma.message.findMany>>[number];
+    let messages: MessageRow[];
+
+    if (!paginated) {
+      // Legacy: return ALL messages, ASC order.
+      messages = await prisma.message.findMany({
+        where: { threadId },
+        include: {
+          sender: {
+            select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+          },
         },
-      },
-      orderBy: { createdAt: "asc" },
-    });
+        orderBy: { createdAt: "asc" },
+      });
+    } else if (beforeRaw) {
+      // Older page: messages older than `before` cursor.
+      // Strategy: order DESC by createdAt, use cursor on the `before` id, skip 1, take limit.
+      // Then reverse client-side response so frontend gets ASC.
+      const olderDesc = await prisma.message.findMany({
+        where: { threadId },
+        include: {
+          sender: {
+            select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        cursor: { id: beforeRaw },
+        skip: 1,
+        take: limit,
+      });
+      messages = olderDesc.reverse();
+    } else {
+      // First page: latest `limit` messages, returned ASC for display.
+      const latestDesc = await prisma.message.findMany({
+        where: { threadId },
+        include: {
+          sender: {
+            select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        take: limit,
+      });
+      messages = latestDesc.reverse();
+    }
 
     // Attach files for each message
     const messageIds = messages.map((m) => m.id);
@@ -200,7 +259,16 @@ router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => 
       files: filesByMessage[m.id] || [],
     }));
 
-    res.json({ messages: result });
+    if (!paginated) {
+      res.json({ messages: result });
+      return;
+    }
+
+    res.json({
+      messages: result,
+      hasMore: result.length === limit,
+      nextCursor: result.length > 0 ? result[0].id : null,
+    });
   } catch (error) {
     console.error("get messages error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -95,6 +95,8 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
 
+  const PAGE_SIZE = 50;
+
   const [messages, setMessages] = useState<MessageItem[]>([]);
   const [thread, setThread] = useState<ThreadInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -104,6 +106,9 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [hasMoreOlder, setHasMoreOlder] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const [oldestMessageId, setOldestMessageId] = useState<string | null>(null);
 
   const flatListRef = useRef<FlatList>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -114,15 +119,46 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const otherUser = thread?.otherUser ?? null;
   const otherName = otherUser ? displayName(otherUser) : "Чат";
 
+  // Initial fetch / refresh: pulls the latest PAGE_SIZE messages.
+  // Polling reuses this; older pages stay in `messages` only on the first poll
+  // (refresh resets the paged window — acceptable trade-off for poll simplicity).
   const fetchMessages = useCallback(async () => {
     if (!threadId) return;
     try {
-      const res = await api<{ messages: MessageItem[] }>(`/api/messages/${threadId}`);
+      const res = await api<{
+        messages: MessageItem[];
+        hasMore?: boolean;
+        nextCursor?: string | null;
+      }>(`/api/messages/${threadId}?limit=${PAGE_SIZE}`);
       setMessages(res.messages);
+      setHasMoreOlder(Boolean(res.hasMore));
+      setOldestMessageId(res.nextCursor ?? (res.messages[0]?.id ?? null));
     } catch (e) {
       // ignore
     }
   }, [threadId]);
+
+  // Load one page of older messages, prepending to `messages`.
+  const loadOlder = useCallback(async () => {
+    if (!threadId || !oldestMessageId || loadingOlder || !hasMoreOlder) return;
+    setLoadingOlder(true);
+    try {
+      const res = await api<{
+        messages: MessageItem[];
+        hasMore?: boolean;
+        nextCursor?: string | null;
+      }>(`/api/messages/${threadId}?limit=${PAGE_SIZE}&before=${encodeURIComponent(oldestMessageId)}`);
+      if (res.messages.length > 0) {
+        setMessages((prev) => [...res.messages, ...prev]);
+      }
+      setHasMoreOlder(Boolean(res.hasMore));
+      setOldestMessageId(res.nextCursor ?? (res.messages[0]?.id ?? oldestMessageId));
+    } catch (e) {
+      console.error("load older messages error:", e);
+    } finally {
+      setLoadingOlder(false);
+    }
+  }, [threadId, oldestMessageId, loadingOlder, hasMoreOlder]);
 
   const fetchThread = useCallback(async () => {
     if (!threadId) return;
@@ -417,8 +453,39 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
           renderItem={renderMessage}
           contentContainerStyle={{ padding: 16, flexGrow: 1, justifyContent: "flex-end" }}
           onContentSizeChange={() => {
-            flatListRef.current?.scrollToEnd({ animated: false });
+            // Scroll to bottom only on initial load / new messages.
+            // When loading older messages, prepended items would otherwise
+            // jerk the list to the bottom. `loadingOlder` short-circuits that.
+            if (!loadingOlder) {
+              flatListRef.current?.scrollToEnd({ animated: false });
+            }
           }}
+          ListHeaderComponent={
+            hasMoreOlder ? (
+              <View className="items-center py-3">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Загрузить старые сообщения"
+                  onPress={loadOlder}
+                  disabled={loadingOlder}
+                  className="px-4 py-2 rounded-xl border border-slate-200"
+                  style={({ pressed }) => [
+                    { backgroundColor: "#f8fafc" },
+                    pressed && { opacity: 0.7 },
+                    loadingOlder && { opacity: 0.6 },
+                  ]}
+                >
+                  {loadingOlder ? (
+                    <ActivityIndicator size="small" color="#1e3a8a" />
+                  ) : (
+                    <Text className="text-sm font-medium" style={{ color: "#1e3a8a" }}>
+                      Загрузить старые сообщения
+                    </Text>
+                  )}
+                </Pressable>
+              </View>
+            ) : null
+          }
           ListEmptyComponent={
             <View className="flex-1 items-center justify-center py-16">
               <FontAwesome name="comments-o" size={48} color={colors.textSecondary} />


### PR DESCRIPTION
## Summary

- **Backend** (`api/src/routes/messages.ts`): `GET /api/messages/:threadId` now supports cursor-based pagination via `?limit=50&before=<messageId>`. Without params, returns ALL messages (legacy behavior preserved for backward compatibility).
- **Frontend** (`components/InlineChatView.tsx`): initial load fetches latest 50 messages; "Загрузить старые сообщения" button at top of FlatList loads next page of 50 older messages on demand.
- Long threads (>500 msgs) no longer block on initial render.

## API contract

Request:
```
GET /api/messages/:threadId?limit=50&before=<oldestMessageId>
```

- `limit` — 1-100 (default 50). **Presence of `limit` enables paged response shape.**
- `before` — id of the FIRST visible (oldest) message; returns messages older than this cursor.
- No params → legacy: returns all messages, response `{ messages }` only.

Response (paged):
```json
{ "messages": [...], "hasMore": boolean, "nextCursor": "<id> | null" }
```
Messages always returned ASC by `createdAt`. `nextCursor` = id of oldest message in the page, used as the next `before`.

## Files changed

- `api/src/routes/messages.ts` — pagination logic
- `components/InlineChatView.tsx` — paging state (`hasMoreOlder`, `loadingOlder`, `oldestMessageId`), `loadOlder` callback, `ListHeaderComponent` button, suppressed auto-scroll-to-bottom while loading older

## Test plan

- [ ] Open existing thread — sees latest 50 messages, scroll auto-snaps to bottom
- [ ] Thread with 50+ messages — "Загрузить старые сообщения" button shown at top
- [ ] Click button — older 50 prepend, list does NOT jump to bottom
- [ ] Reach the start of the thread — button disappears (`hasMore=false`)
- [ ] Send new message — appends at bottom, scrolls to bottom
- [ ] Mark-as-read still triggers on initial load
- [ ] Legacy clients (no `?limit`) still receive ALL messages

## TS verification

- `messages.ts`: 0 errors
- `InlineChatView.tsx`: 0 errors  
- (api/ has pre-existing 'SPECIALIST' role-enum errors on `development` unrelated to this PR.)