### PR TITLE
feat: file attachment in specialist's first response (closes #1469)

### DIFF
--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -1,9 +1,53 @@
 import { Router, Request, Response } from "express";
+import * as Minio from "minio";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
 import { sendNotification } from "../notifications/notification.service";
 
 const router = Router();
+
+const BUCKET = process.env.MINIO_BUCKET || "p2ptax";
+
+function getMinioClient(): Minio.Client {
+  return new Minio.Client({
+    endPoint: process.env.MINIO_ENDPOINT || "localhost",
+    port: parseInt(process.env.MINIO_PORT || "9000", 10),
+    useSSL: process.env.MINIO_USE_SSL === "true",
+    accessKey: process.env.MINIO_ACCESS_KEY || "minioadmin",
+    secretKey: process.env.MINIO_SECRET_KEY || "minioadmin",
+  });
+}
+
+// Resolve a pending uploadToken (uploaded before the thread existed) to its MinIO object key.
+// Returns null if not found.
+async function resolvePendingUpload(
+  uploadToken: string
+): Promise<{ key: string; filename: string } | null> {
+  const client = getMinioClient();
+  const prefix = `chat-files/_pending/${uploadToken}_`;
+  try {
+    return await new Promise((resolve, reject) => {
+      const stream = client.listObjects(BUCKET, prefix, false);
+      let found: Minio.BucketItem | null = null;
+      stream.on("data", (obj: Minio.BucketItem) => {
+        if (!found) found = obj;
+      });
+      stream.on("end", () => {
+        if (found && found.name) {
+          const rawName = found.name.split("/").pop() ?? "file";
+          const underscoreIdx = rawName.indexOf("_");
+          const filename = underscoreIdx >= 0 ? rawName.slice(underscoreIdx + 1) : rawName;
+          resolve({ key: found.name, filename });
+        } else {
+          resolve(null);
+        }
+      });
+      stream.on("error", reject);
+    });
+  } catch {
+    return null;
+  }
+}
 
 // GET /api/threads/sample — dev helper: first thread ID for metromap URL resolver
 router.get("/sample", async (_req: Request, res: Response) => {
@@ -391,7 +435,11 @@ router.get("/:id", async (req: Request, res: Response) => {
 router.post("/", async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
-    const { requestId, firstMessage } = req.body;
+    const { requestId, firstMessage, uploadToken } = req.body as {
+      requestId?: string;
+      firstMessage?: string;
+      uploadToken?: string;
+    };
 
     if (!requestId || !firstMessage) {
       res.status(400).json({ error: "requestId and firstMessage are required" });
@@ -486,6 +534,7 @@ router.post("/", async (req: Request, res: Response) => {
         },
         include: {
           request: { select: { id: true, title: true, status: true } },
+          messages: { select: { id: true }, take: 1 },
         },
       });
 
@@ -498,6 +547,30 @@ router.post("/", async (req: Request, res: Response) => {
     });
 
     const thread = result;
+
+    // If specialist attached a pending file (uploaded before the thread existed),
+    // link it to the first message. Failures are silent — the thread+message must succeed
+    // even if the upload step has trouble.
+    if (uploadToken && typeof uploadToken === "string" && uploadToken.length >= 8) {
+      try {
+        const resolved = await resolvePendingUpload(uploadToken);
+        const firstMessageId = thread.messages[0]?.id;
+        if (resolved && firstMessageId) {
+          await prisma.file.create({
+            data: {
+              entityType: "message",
+              entityId: firstMessageId,
+              url: `/${BUCKET}/${resolved.key}`,
+              filename: resolved.filename,
+              size: 0,
+              mimeType: "application/octet-stream",
+            },
+          });
+        }
+      } catch (linkErr) {
+        console.warn("[threads] failed to link uploadToken file:", linkErr);
+      }
+    }
 
     // Notify client: specialist started a new thread on their request
     // SA: «Специалист X написал по вашей заявке 'TITLE'»

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -157,16 +157,17 @@ router.post("/chat-file", authMiddleware, uploadRateLimiter, chatFileUpload.sing
       return;
     }
 
-    if (!threadId || typeof threadId !== "string") {
-      res.status(400).json({ error: "threadId is required" });
-      return;
-    }
+    // threadId is OPTIONAL — when omitted, the upload goes to a "_pending" namespace
+    // so the file can be linked later when the thread is created (specialist's first response).
+    const hasThread = typeof threadId === "string" && threadId.length > 0;
 
     await ensureMinioBucket();
 
     // Sanitize filename: replace unsafe chars, preserve extension
     const safeName = req.file.originalname.replace(/[^a-zA-Z0-9._-]/g, "_");
-    const key = `chat-files/${threadId}/${uploadToken}_${safeName}`;
+    const key = hasThread
+      ? `chat-files/${threadId}/${uploadToken}_${safeName}`
+      : `chat-files/_pending/${uploadToken}_${safeName}`;
 
     await minioClient.putObject(MINIO_BUCKET, key, req.file.buffer, req.file.size, {
       "Content-Type": req.file.mimetype,

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -6,20 +6,47 @@ import {
   ScrollView,
   useWindowDimensions,
   Platform,
+  Pressable,
   Alert,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
+import * as DocumentPicker from "expo-document-picker";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useTypedRouter } from "@/lib/navigation";
 import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { Send } from "lucide-react-native";
-import { api, ApiError } from "@/lib/api";
+import { Send, Paperclip, X } from "lucide-react-native";
+import { api, ApiError, API_URL } from "@/lib/api";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, radiusValue, fontSizeValue, BREAKPOINT } from "@/lib/theme";
+
+interface PendingFile {
+  uri: string;
+  name: string;
+  size: number;
+  mimeType: string;
+}
+
+const CHAT_FILE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB — must match api/src/routes/upload.ts (chatFileUpload)
+const TOKEN_KEY = "p2ptax_access_token";
+
+function chatUploadErrorMessage(status: number): string {
+  if (status === 413) return "Файл слишком большой. Максимум 10 МБ.";
+  if (status === 429) return "Слишком много загрузок. Попробуйте через минуту.";
+  if (status === 0) return "Нет связи с сервером.";
+  return "Не удалось загрузить файл. Попробуйте ещё раз.";
+}
+
+function generateUploadToken(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
 
 interface RequestSummary {
   id: string;
@@ -55,6 +82,8 @@ export default function SpecialistConfirmWrite() {
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [pendingFile, setPendingFile] = useState<PendingFile | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -87,17 +116,107 @@ export default function SpecialistConfirmWrite() {
     }
   }, [ready, isSpecialistUser, load]);
 
+  const handleAttachFile = useCallback(async () => {
+    if (pendingFile) {
+      Alert.alert("Лимит файлов", "Можно прикрепить только один файл к первому сообщению");
+      return;
+    }
+    setUploadError(null);
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ["application/pdf", "image/jpeg", "image/png"],
+        copyToCacheDirectory: true,
+        multiple: false,
+      });
+      if (result.canceled || !result.assets?.[0]) return;
+      const asset = result.assets[0];
+      const fileSize = asset.size ?? 0;
+      if (fileSize > CHAT_FILE_MAX_BYTES) {
+        Alert.alert("Файл слишком большой", "Максимальный размер файла — 10 МБ");
+        return;
+      }
+      setPendingFile({
+        uri: asset.uri,
+        name: asset.name,
+        size: fileSize,
+        mimeType: asset.mimeType ?? "application/octet-stream",
+      });
+    } catch (e) {
+      console.error("document picker error:", e);
+    }
+  }, [pendingFile]);
+
+  const handleRemoveFile = useCallback(() => {
+    setPendingFile(null);
+    setUploadError(null);
+  }, []);
+
+  const uploadPendingFile = useCallback(
+    async (file: PendingFile): Promise<string> => {
+      const uploadToken = generateUploadToken();
+      const formData = new FormData();
+      formData.append("file", {
+        uri: file.uri,
+        name: file.name,
+        type: file.mimeType,
+      } as unknown as Blob);
+      formData.append("uploadToken", uploadToken);
+      // NOTE: no threadId — the upload endpoint stores under chat-files/_pending/
+      // and threads.ts links it to the first message when the thread is created.
+
+      const token = await AsyncStorage.getItem(TOKEN_KEY);
+      let res: Response;
+      try {
+        res = await fetch(`${API_URL}/api/upload/chat-file`, {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          body: formData,
+        });
+      } catch {
+        throw new ApiError(0, chatUploadErrorMessage(0));
+      }
+
+      if (!res.ok) {
+        throw new ApiError(res.status, chatUploadErrorMessage(res.status));
+      }
+
+      const data = (await res.json()) as { uploadToken: string };
+      return data.uploadToken;
+    },
+    []
+  );
+
   const handleSend = async () => {
     if (message.length < MIN_CHARS || sending) return;
     if (rateLimit && rateLimit.writesToday >= DAILY_LIMIT) return;
 
     setSending(true);
     setSubmitError(null);
+    setUploadError(null);
 
     try {
+      let uploadToken: string | undefined;
+      if (pendingFile) {
+        try {
+          uploadToken = await uploadPendingFile(pendingFile);
+        } catch (uploadErr) {
+          if (uploadErr instanceof ApiError) {
+            setUploadError(uploadErr.message);
+          } else {
+            setUploadError(chatUploadErrorMessage(0));
+          }
+          setSending(false);
+          return;
+        }
+      }
+
       const result = await api<{ id: string }>("/api/threads", {
         method: "POST",
-        body: { requestId: id, firstMessage: message },
+        body: {
+          requestId: id,
+          firstMessage: message,
+          ...(uploadToken ? { uploadToken } : {}),
+        },
       });
       nav.replaceAny(`/threads/${result.id}`);
     } catch (err) {
@@ -279,6 +398,44 @@ export default function SpecialistConfirmWrite() {
             >
               {message.length}/{MAX_CHARS}
             </Text>
+          </View>
+
+          {/* File attachment row */}
+          <View className="mt-3">
+            {pendingFile ? (
+              <View className="flex-row items-center justify-between bg-slate-100 border border-slate-200 rounded-xl px-3 py-2">
+                <View className="flex-1 mr-2">
+                  <Text className="text-sm text-slate-900" numberOfLines={1}>
+                    {pendingFile.name}
+                  </Text>
+                  <Text className="text-xs text-slate-500">
+                    {(pendingFile.size / 1024).toFixed(0)} КБ
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityLabel="Удалить файл"
+                  onPress={handleRemoveFile}
+                  hitSlop={8}
+                  className="p-1"
+                >
+                  <X size={18} color={colors.text} />
+                </Pressable>
+              </View>
+            ) : (
+              <Pressable
+                accessibilityLabel="Прикрепить файл"
+                onPress={handleAttachFile}
+                disabled={isLimitReached || sending}
+                className="flex-row items-center self-start px-3 py-2 rounded-xl border border-slate-200 bg-white"
+                style={{ opacity: isLimitReached || sending ? 0.5 : 1 }}
+              >
+                <Paperclip size={16} color={colors.text} />
+                <Text className="text-sm text-slate-700 ml-2">Прикрепить файл</Text>
+              </Pressable>
+            )}
+            {uploadError && (
+              <Text className="text-xs text-red-500 mt-2">{uploadError}</Text>
+            )}
           </View>
 
           {/* Submit error */}


### PR DESCRIPTION
Closes #1469.

## Summary
- POST /api/upload/chat-file: threadId is now optional. Pre-thread uploads (used by the specialist's first response) go to `chat-files/_pending/{token}_{filename}`.
- POST /api/threads accepts optional `uploadToken`. After the thread + first message is created, the pending file is linked as a File row (`entityType="message"`, `entityId=firstMessage.id`). Linking errors are silent — the thread/message creation must succeed even if the upload step has trouble.
- app/requests/[id]/write.tsx: DocumentPicker file picker with chip UI (filename + size + remove ×). Uploads the file before POST /api/threads, sends uploadToken in the body. Maps 413/429/network errors to Russian messages, matching the avatar upload pattern from PR #1476.

## Test plan
- [ ] Specialist opens a request, attaches a PDF, sends first response. File appears in the new thread's first message.
- [ ] Specialist sends first response with no attachment. Works as before.
- [ ] File over 10 MB → "Файл слишком большой" message, no upload, no thread created.
- [ ] Backend returns 429 → "Слишком много загрузок" message.
- [ ] Network failure during upload → "Нет связи с сервером" message.
- [ ] Upload succeeds but pending object is missing/expired (edge) → thread + message still created, just without attachment.