### PR TITLE
feat: soft-delete account flow (no hard delete, anonymize on delete)

### DIFF
--- a/api/prisma/migrations/20260428120000_add_user_soft_delete/migration.sql
+++ b/api/prisma/migrations/20260428120000_add_user_soft_delete/migration.sql
@@ -1,0 +1,5 @@
+-- Soft-delete column for User model.
+-- When non-null, the user is considered deleted: PII anonymized in-place,
+-- hidden from public catalog/queries, but the row is preserved so threads
+-- and messages keep a valid foreign-key target.
+ALTER TABLE "users" ADD COLUMN "deleted_at" TIMESTAMP(3);

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -33,6 +33,10 @@ model User {
   avatarUrl   String?  @map("avatar_url")
   isAvailable Boolean  @default(false) @map("is_available")
   isBanned    Boolean  @default(false) @map("is_banned")
+  // Soft-delete timestamp. When non-null the user is considered deleted —
+  // PII is anonymized in-place and they're hidden from public catalog/queries
+  // but the row is preserved so threads/messages keep a valid FK target.
+  deletedAt   DateTime? @map("deleted_at")
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -23,6 +23,7 @@ import notificationsRoutes from "./routes/notifications";
 import contactsRoutes from "./routes/contacts";
 import statsRoutes from "./routes/stats";
 import savedSpecialistsRoutes from "./routes/saved-specialists";
+import accountRoutes from "./routes/account";
 import { startNotificationWorker } from "./notifications/notification.processor";
 import { runRequestLifecycleCron } from "./cron/requestLifecycle";
 
@@ -56,6 +57,7 @@ app.use("/api/threads", threadsRoutes);
 app.use("/api/admin", adminRoutes);
 app.use("/api/notifications", notificationsRoutes);
 app.use("/api/saved-specialists", savedSpecialistsRoutes);
+app.use("/api/account", accountRoutes);
 app.use("/api", contactsRoutes);
 
 // 404 handler — no matching route

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -30,17 +30,27 @@ export async function authMiddleware(req: Request, res: Response, next: NextFunc
 
   req.user = payload;
 
-  // Check isBanned on every authenticated request — security fix #175
-  // Banned users must be rejected regardless of which endpoint they call.
+  // Check isBanned + deletedAt on every authenticated request.
+  // Banned users must be rejected regardless of which endpoint they call (#175).
+  // Soft-deleted users must be force-signed-out (deletedAt sets isBanned=true,
+  // but we explicitly check deletedAt so the error message is more honest).
   // Using lazy import to avoid circular dependency (same pattern as roleGuard).
   try {
     const { prisma } = await import("../lib/prisma");
     const user = await prisma.user.findUnique({
       where: { id: payload.userId },
-      select: { isBanned: true },
+      select: { isBanned: true, deletedAt: true },
     });
 
-    if (!user || user.isBanned) {
+    if (!user) {
+      res.status(401).json({ error: "User not found" });
+      return;
+    }
+    if (user.deletedAt) {
+      res.status(401).json({ error: "Account deleted" });
+      return;
+    }
+    if (user.isBanned) {
       res.status(403).json({ error: "Account blocked" });
       return;
     }

--- a/api/src/routes/account.ts
+++ b/api/src/routes/account.ts
@@ -1,0 +1,84 @@
+import { Router, Request, Response } from "express";
+import { prisma } from "../lib/prisma";
+import { authMiddleware } from "../middleware/auth";
+
+const router = Router();
+
+/**
+ * POST /api/account/delete — soft-delete the authenticated user's account.
+ *
+ * NEVER hard-deletes the user row. Instead:
+ *   - sets `deletedAt = now()`
+ *   - anonymizes PII (email, firstName, lastName, avatarUrl)
+ *   - flips `isAvailable = false`, `isSpecialist = false`, `isBanned = true`
+ *     so the user is hidden from the catalog and cannot sign in even if
+ *     their old email is reused by someone else.
+ *   - revokes every refresh token (forces sign-out across devices)
+ *
+ * Threads/messages keep referencing the same user row so other participants
+ * still see a valid (anonymous) author. The auth middleware additionally
+ * rejects every request from a deleted user (401 Account deleted).
+ *
+ * Body: `{ confirm: string }` where `confirm` must equal the user's own
+ * (current, non-anonymized) email — basic confirmation step. We do not
+ * use a password (the project is OTP-only).
+ */
+router.post("/delete", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { confirm } = req.body ?? {};
+
+    if (typeof confirm !== "string" || confirm.trim().length === 0) {
+      res.status(400).json({ error: "confirm is required" });
+      return;
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true, deletedAt: true },
+    });
+
+    if (!user) {
+      res.status(404).json({ error: "User not found" });
+      return;
+    }
+
+    if (user.deletedAt) {
+      res.status(409).json({ error: "Account already deleted" });
+      return;
+    }
+
+    if (confirm.trim().toLowerCase() !== user.email.toLowerCase()) {
+      res.status(400).json({ error: "confirm must match your current email" });
+      return;
+    }
+
+    const now = new Date();
+    // NOTE: do NOT use prisma.user.delete() — soft-delete only.
+    await prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: userId },
+        data: {
+          deletedAt: now,
+          email: `deleted-${userId}@p2ptax.local`,
+          firstName: null,
+          lastName: null,
+          avatarUrl: null,
+          isAvailable: false,
+          isSpecialist: false,
+          isBanned: true,
+        },
+      });
+
+      // Revoke every refresh token so the user is signed out everywhere.
+      await tx.refreshToken.deleteMany({ where: { userId } });
+    });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("account/delete error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -36,6 +36,8 @@ async function notifyMatchingSpecialists(args: {
         specialistProfileCompletedAt: { not: null },
         isAvailable: true,
         isBanned: false,
+        // Skip soft-deleted accounts when fanning-out notifications.
+        deletedAt: null,
         id: { not: clientUserId },
         specialistFns: { some: { fnsId } },
       },

--- a/api/src/routes/saved-specialists.ts
+++ b/api/src/routes/saved-specialists.ts
@@ -26,7 +26,12 @@ router.get("/full", async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
     const saved = await prisma.savedSpecialist.findMany({
-      where: { userId },
+      where: {
+        userId,
+        // Hide soft-deleted specialists from the saved list (their PII has
+        // been anonymized — surfacing them would be confusing).
+        specialist: { deletedAt: null },
+      },
       orderBy: { savedAt: "desc" },
       include: {
         specialist: {
@@ -80,12 +85,12 @@ router.post("/:specialistId", async (req: Request, res: Response) => {
     const userId = req.user!.userId;
     const specialistId = String(req.params.specialistId);
 
-    // Verify target is a specialist
+    // Verify target is a specialist (and not soft-deleted)
     const target = await prisma.user.findUnique({
       where: { id: specialistId },
-      select: { isSpecialist: true },
+      select: { isSpecialist: true, deletedAt: true },
     });
-    if (!target) {
+    if (!target || target.deletedAt) {
       res.status(404).json({ error: "Specialist not found" });
       return;
     }

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -82,11 +82,12 @@ router.get("/featured", async (_req: Request, res: Response) => {
       where: {
         // Iter11: specialist catalog is driven by the flag, not the legacy
         // role enum. Require completed profile so we never surface half-seeded
-        // users who are still onboarding.
+        // users who are still onboarding. Hide soft-deleted accounts.
         isSpecialist: true,
         specialistProfileCompletedAt: { not: null },
         isAvailable: true,
         isBanned: false,
+        deletedAt: null,
       },
       take: 10,
       // Catalog ranking: specialists with avatar photos first, then newest.
@@ -173,6 +174,8 @@ router.get("/", async (req: Request, res: Response) => {
       specialistProfileCompletedAt: { not: null },
       isAvailable: true,
       isBanned: false,
+      // Hide soft-deleted accounts from the public catalog.
+      deletedAt: null,
       ...(callerId ? { id: { not: callerId } } : {}),
     };
 
@@ -380,8 +383,10 @@ router.get("/:id", async (req: Request, res: Response) => {
       where: {
         id,
         // Iter11: specialist detail checks the flag, not the legacy role.
+        // Hide soft-deleted accounts from the public detail page.
         isSpecialist: true,
         isBanned: false,
+        deletedAt: null,
       },
       include: {
         specialistProfile: true,

--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -80,10 +80,10 @@ router.get("/", async (req: Request, res: Response) => {
             select: { id: true, title: true, status: true },
           },
           client: {
-            select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+            select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true },
           },
           specialist: {
-            select: { id: true, firstName: true, lastName: true, avatarUrl: true },
+            select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true },
           },
           messages: {
             orderBy: { createdAt: "desc" },
@@ -125,6 +125,7 @@ router.get("/", async (req: Request, res: Response) => {
           firstName: otherUser.firstName,
           lastName: otherUser.lastName,
           avatarUrl: otherUser.avatarUrl,
+          isDeleted: otherUser.deletedAt !== null,
         },
         lastMessage: lastMessage
           ? {
@@ -220,8 +221,8 @@ router.get("/my", async (req: Request, res: Response) => {
         take: limit,
         include: {
           request: { select: { id: true, title: true, status: true, userId: true } },
-          client: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
-          specialist: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+          client: { select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true } },
+          specialist: { select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true } },
           messages: {
             orderBy: { createdAt: "desc" },
             take: 1,
@@ -302,6 +303,7 @@ router.get("/my", async (req: Request, res: Response) => {
           firstName: otherUser.firstName,
           lastName: otherUser.lastName,
           avatarUrl: otherUser.avatarUrl,
+          isDeleted: otherUser.deletedAt !== null,
         },
         lastMessage: lastMessage
           ? { text: lastMessage.text, createdAt: lastMessage.createdAt }
@@ -347,8 +349,8 @@ router.get("/:id", async (req: Request, res: Response) => {
       where: { id: threadId },
       include: {
         request: { select: { id: true, title: true, status: true } },
-        client: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
-        specialist: { select: { id: true, firstName: true, lastName: true, avatarUrl: true } },
+        client: { select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true } },
+        specialist: { select: { id: true, firstName: true, lastName: true, avatarUrl: true, deletedAt: true } },
       },
     });
 
@@ -365,19 +367,27 @@ router.get("/:id", async (req: Request, res: Response) => {
     const isClient = thread.clientId === userId;
     const otherUser = isClient ? thread.specialist : thread.client;
 
+    // Strip the raw `deletedAt` Date from the public payload — replace
+    // with the boolean `isDeleted` flag the FE consumes.
+    const stripDeletedAt = <T extends { deletedAt: Date | null }>(u: T) => {
+      const { deletedAt, ...rest } = u;
+      return { ...rest, isDeleted: deletedAt !== null };
+    };
+
     res.json({
       id: thread.id,
       requestId: thread.requestId,
       clientId: thread.clientId,
       specialistId: thread.specialistId,
       request: thread.request,
-      client: thread.client,
-      specialist: thread.specialist,
+      client: stripDeletedAt(thread.client),
+      specialist: stripDeletedAt(thread.specialist),
       otherUser: {
         id: otherUser.id,
         firstName: otherUser.firstName,
         lastName: otherUser.lastName,
         avatarUrl: otherUser.avatarUrl,
+        isDeleted: otherUser.deletedAt !== null,
       },
       createdAt: thread.createdAt,
     });

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -43,6 +43,8 @@ interface ThreadItem {
     firstName: string | null;
     lastName: string | null;
     avatarUrl: string | null;
+    /** Soft-deleted user — UI must render "Аккаунт удалён" instead of name. */
+    isDeleted?: boolean;
   };
   request: {
     id: string;
@@ -73,9 +75,10 @@ interface ThreadsMyGroup {
 }
 
 function displayName(
-  user: { firstName: string | null; lastName: string | null },
+  user: { firstName: string | null; lastName: string | null; isDeleted?: boolean },
   fallback: string
 ): string {
+  if (user.isDeleted) return "Аккаунт удалён";
   const parts = [user.firstName, user.lastName].filter(Boolean);
   return parts.length > 0 ? parts.join(" ") : fallback;
 }

--- a/app/requests/[id]/messages.tsx
+++ b/app/requests/[id]/messages.tsx
@@ -27,6 +27,8 @@ interface ThreadItem {
     firstName: string | null;
     lastName: string | null;
     avatarUrl: string | null;
+    /** Soft-deleted account — render "Аккаунт удалён" instead of the name. */
+    isDeleted?: boolean;
   };
   lastMessage: {
     text: string;
@@ -36,7 +38,8 @@ interface ThreadItem {
   createdAt: string;
 }
 
-function displayName(user: { firstName: string | null; lastName: string | null }): string {
+function displayName(user: { firstName: string | null; lastName: string | null; isDeleted?: boolean }): string {
+  if (user.isDeleted) return "Аккаунт удалён";
   const parts = [user.firstName, user.lastName].filter(Boolean);
   return parts.length > 0 ? parts.join(" ") : "Специалист";
 }

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -316,25 +316,40 @@ export default function UnifiedSettings() {
     ]);
   }, [signOut, router]);
 
+  // Soft-delete the account: anonymize PII server-side, sign out everywhere,
+  // navigate to home. The DB row is preserved so threads/messages keep
+  // referencing a valid user — other participants will see "Аккаунт удалён".
   const handleDeleteAccount = useCallback(() => {
     Alert.alert(
-      "Удалить аккаунт",
-      "Это действие необратимо. Все ваши данные будут удалены.",
+      "Удалить аккаунт навсегда?",
+      "Аккаунт будет анонимизирован и скрыт. Восстановление невозможно. История переписок останется у других участников.",
       [
         { text: "Отмена", style: "cancel" },
         {
           text: "Удалить",
           style: "destructive",
-          onPress: () => {
-            Alert.alert(
-              "Запрос отправлен",
-              "Ваш запрос на удаление аккаунта принят. Мы свяжемся с вами по email."
-            );
+          onPress: async () => {
+            const email = user?.email;
+            if (!email) {
+              Alert.alert("Ошибка", "Не удалось определить email аккаунта");
+              return;
+            }
+            try {
+              await apiPost("/api/account/delete", { confirm: email });
+              await signOut();
+              nav.replaceRoutes.home();
+            } catch (err) {
+              console.error("delete account error:", err);
+              Alert.alert(
+                "Ошибка",
+                "Не удалось удалить аккаунт. Попробуйте ещё раз."
+              );
+            }
           },
         },
       ]
     );
-  }, []);
+  }, [user?.email, signOut, nav]);
 
   // Toggle specialist mode on/off.
   // ON → if no FNS data configured yet, redirect to work-area; otherwise enable directly.
@@ -696,6 +711,9 @@ export default function UnifiedSettings() {
                 Удалить аккаунт
               </Text>
             </Pressable>
+            <Text className="text-xs text-text-mute mt-1">
+              Аккаунт будет анонимизирован и скрыт. Восстановление невозможно. История переписок останется у других участников.
+            </Text>
           </View>
 
           <Text className="text-xs text-text-dim text-center mb-4">

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -62,6 +62,8 @@ interface OtherUser {
   firstName: string | null;
   lastName: string | null;
   avatarUrl: string | null;
+  /** Soft-deleted account — render "Аккаунт удалён" instead of the name. */
+  isDeleted?: boolean;
 }
 
 interface ThreadInfo {
@@ -70,12 +72,13 @@ interface ThreadInfo {
   clientId: string;
   specialistId: string;
   request: { id: string; title: string; status: string };
-  client: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null };
-  specialist: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null };
+  client: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null; isDeleted?: boolean };
+  specialist: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null; isDeleted?: boolean };
   otherUser: OtherUser;
 }
 
-function displayName(user: { firstName: string | null; lastName: string | null }): string {
+function displayName(user: { firstName: string | null; lastName: string | null; isDeleted?: boolean }): string {
+  if (user.isDeleted) return "Аккаунт удалён";
   const parts = [user.firstName, user.lastName].filter(Boolean);
   return parts.length > 0 ? parts.join(" ") : "Пользователь";
 }


### PR DESCRIPTION
## Summary
- Adds `User.deletedAt: DateTime?` column + migration `20260428120000_add_user_soft_delete`.
- New endpoint `POST /api/account/delete` (auth required): sets `deletedAt = now()`, anonymizes PII (email rewritten to `deleted-{userId}@p2ptax.local`, firstName/lastName/avatarUrl nulled), flips `isAvailable=false`, `isSpecialist=false`, `isBanned=true`, deletes all refresh tokens.
- Public catalog/queries now filter `deletedAt: null` (specialists `/featured`, `/`, `/:id`, requests fan-out, saved-specialists list + add).
- `authMiddleware` rejects deleted users with 401 `Account deleted`, forcing sign-out across devices.
- Threads expose `otherUser.isDeleted: boolean` (raw `deletedAt` is stripped); FE renders "Аккаунт удалён" instead of name in inbox + chat header + per-request thread list.
- Settings UI rewires the existing "Удалить аккаунт" button to call the new endpoint, sign out, and navigate home — with a danger-zone copy clarifying the action is irreversible.

## NEVER hard-delete a user row
The user row is preserved so threads/messages keep a valid FK target. Other participants see "Аккаунт удалён" instead of the real name.

## Files
- Backend: `api/prisma/schema.prisma`, `api/prisma/migrations/20260428120000_add_user_soft_delete/migration.sql`, `api/src/routes/account.ts` (new), `api/src/index.ts`, `api/src/middleware/auth.ts`, `api/src/routes/specialists.ts`, `api/src/routes/requests.ts`, `api/src/routes/saved-specialists.ts`, `api/src/routes/threads.ts`.
- Frontend: `app/settings/index.tsx`, `app/(tabs)/messages.tsx`, `app/requests/[id]/messages.tsx`, `components/InlineChatView.tsx`.

## Verification
- `npx tsc --noEmit` passes on root.
- `cd api && npx tsc --noEmit` passes on api.
- Migration applied locally via `prisma migrate deploy` (shadow DB perms blocked `migrate dev`, manual SQL committed).

## Test plan
- [ ] User clicks "Удалить аккаунт" → confirms → API returns 204, AuthContext signs out, navigated to `/`.
- [ ] Re-login attempt with the same email returns 403 `Account blocked` (the email was rewritten so the original is reusable for a new account; the deleted user stays banned).
- [ ] Public catalog `/api/specialists` no longer lists the deleted account.
- [ ] Existing threads still load; the deleted participant displays as "Аккаунт удалён" with initials placeholder avatar.
- [ ] Saved-specialists list excludes deleted profiles.
- [ ] No `prisma.user.delete()` call exists anywhere in the diff.