### PR TITLE
fix: admin must soft-delete (not hard) + RU translation for delete button

### DIFF
--- a/api/src/routes/admin/users.ts
+++ b/api/src/routes/admin/users.ts
@@ -186,7 +186,7 @@ router.post(
   }
 );
 
-// DELETE /api/admin/users/:id — hard delete with proper FK dependency order
+// DELETE /api/admin/users/:id — soft-delete only (admin moderation must not lose audit trail)
 router.delete("/:id", adminWriteRateLimiter, async (req: Request, res: Response) => {
   try {
     const id = req.params.id as string;
@@ -231,11 +231,23 @@ router.delete("/:id", adminWriteRateLimiter, async (req: Request, res: Response)
       // 4. Delete threads where user is client or specialist (Thread → User has no cascade)
       await tx.thread.deleteMany({ where: { OR: [{ clientId: id }, { specialistId: id }] } });
 
-      // 5. Delete user record — remaining relations cascade automatically:
-      //    notifications, notificationPreferences, refreshTokens, complaints,
-      //    requests (→ threads that cascade from request), specialistFns,
-      //    specialistServices, specialistProfile (→ contactMethods)
-      await tx.user.delete({ where: { id } });
+      // 5. Soft-delete only — admin moderation must not lose audit trail.
+      //    Anonymize PII, mark deletedAt, ban + hide from catalog. The user
+      //    row is preserved so referential integrity (and audit history) holds.
+      await tx.user.update({
+        where: { id },
+        data: {
+          deletedAt: new Date(),
+          email: `deleted-${id}@p2ptax.local`,
+          firstName: null,
+          lastName: null,
+          avatarUrl: null,
+          isAvailable: false,
+          isSpecialist: false,
+          isBanned: true,
+        },
+      });
+      await tx.refreshToken.deleteMany({ where: { userId: id } });
     });
 
     res.json({ ok: true });


### PR DESCRIPTION
## Summary

- **api/src/routes/admin/users.ts** — replace `tx.user.delete()` with the soft-delete pattern from `account.ts`. Admin moderation now anonymizes PII, sets `deletedAt`, flips `isBanned/isAvailable/isSpecialist`, revokes refresh tokens, and preserves the User row for referential integrity / audit trail.
- Side-data cleanup (files, messages, threads) before the user record is preserved as instructed.
- **app/settings/index.tsx** — verified the delete-account button is already labeled "Удалить аккаунт" (line 711) with matching `accessibilityLabel="Удалить аккаунт"`. No English "Delete Account" string exists anywhere in `app/` or `components/` (grep confirmed). Verifier's `[button "Delete Account"]` was likely a stale DOM snapshot — current code is already Russian.

## Verification

- `npx tsc --noEmit` (root) — 0 errors
- `cd api && npx tsc --noEmit` — 0 errors

## Test plan

- [ ] Admin DELETE `/api/admin/users/:id` returns `{ok: true}`
- [ ] Target User row remains in DB with `deletedAt != null`, anonymized email, `isBanned=true`
- [ ] All `RefreshToken` rows for that user are gone
- [ ] User cannot sign in afterwards (auth middleware rejects deleted users)
- [ ] Settings screen renders "Удалить аккаунт" button on web/mobile