### PR TITLE
UX: auth intent specialist flow

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -15,12 +15,18 @@ export default function AuthEmailScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { isAuthenticated, user } = useAuth();
-  const params = useLocalSearchParams<{ returnTo?: string }>();
+  const params = useLocalSearchParams<{ returnTo?: string; intent?: string }>();
   const returnTo =
     typeof params.returnTo === "string"
       ? params.returnTo
       : Array.isArray(params.returnTo)
         ? params.returnTo[0]
+        : undefined;
+  const intent =
+    typeof params.intent === "string"
+      ? params.intent
+      : Array.isArray(params.intent)
+        ? params.intent[0]
         : undefined;
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
@@ -60,6 +66,7 @@ export default function AuthEmailScreen() {
         params: {
           email: email.trim().toLowerCase(),
           ...(returnTo ? { returnTo } : {}),
+          ...(intent ? { intent } : {}),
         },
       });
     } catch (e: unknown) {

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -16,8 +16,15 @@ import { colors, textStyle } from "@/lib/theme";
 export default function OnboardingNameScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
-  const params = useLocalSearchParams<{ from?: string }>();
+  const params = useLocalSearchParams<{ from?: string; role?: string }>();
   const fromSettings = params.from === "settings";
+  const role =
+    typeof params.role === "string"
+      ? params.role
+      : Array.isArray(params.role)
+        ? params.role[0]
+        : undefined;
+  const isSpecialistIntent = role === "specialist";
   const { ready, user } = useRequireAuth();
   const { updateUser, isSpecialistUser, isAdminUser } = useAuth();
   const [firstName, setFirstName] = useState(user?.firstName ?? "");
@@ -29,14 +36,18 @@ export default function OnboardingNameScreen() {
       nav.replaceRoutes.adminDashboard();
       return;
     }
-    if (!isSpecialistUser) {
+    // Wave 1/B — landing CTA "Я специалист" routes here with ?role=specialist
+    // even when isSpecialist is still false. Allow the screen to render so
+    // the user can fill name first; work-area then flips isSpecialist via
+    // /api/user/become-specialist.
+    if (!isSpecialistUser && !isSpecialistIntent) {
       nav.replaceRoutes.tabs();
       return;
     }
     if (!fromSettings && user?.specialistProfileCompletedAt) {
       nav.replaceRoutes.tabs();
     }
-  }, [ready, isAdminUser, isSpecialistUser, user, fromSettings]);
+  }, [ready, isAdminUser, isSpecialistUser, isSpecialistIntent, user, fromSettings]);
   const [agreed, setAgreed] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
@@ -88,7 +99,14 @@ export default function OnboardingNameScreen() {
         lastName: data.user.lastName,
       });
 
-      nav.routes.onboardingWorkArea();
+      if (isSpecialistIntent) {
+        nav.replaceAny({
+          pathname: "/onboarding/work-area",
+          params: { role: "specialist" },
+        });
+      } else {
+        nav.routes.onboardingWorkArea();
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Что-то пошло не так";
       setError(msg);
@@ -97,7 +115,7 @@ export default function OnboardingNameScreen() {
     }
   };
 
-  if (!ready || isAdminUser || !isSpecialistUser) {
+  if (!ready || isAdminUser || (!isSpecialistUser && !isSpecialistIntent)) {
     return <LoadingState />;
   }
 

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -54,8 +54,15 @@ interface FnsResponse {
  */
 export default function OnboardingWorkAreaScreen() {
   const nav = useTypedRouter();
-  const params = useLocalSearchParams<{ from?: string }>();
+  const params = useLocalSearchParams<{ from?: string; role?: string }>();
   const fromSettings = params.from === "settings";
+  const role =
+    typeof params.role === "string"
+      ? params.role
+      : Array.isArray(params.role)
+        ? params.role[0]
+        : undefined;
+  const isSpecialistIntent = role === "specialist";
   const { ready, user } = useRequireAuth();
   const { isSpecialistUser, isAdminUser, updateUser } = useAuth();
 
@@ -65,14 +72,17 @@ export default function OnboardingWorkAreaScreen() {
       nav.replaceRoutes.adminDashboard();
       return;
     }
-    if (!isSpecialistUser) {
+    // Wave 1/B — when user arrives here from "Я специалист" landing CTA,
+    // isSpecialist is still false; the form's submit will call
+    // /api/user/become-specialist which flips the flag. Allow render.
+    if (!isSpecialistUser && !isSpecialistIntent) {
       nav.replaceRoutes.tabs();
       return;
     }
     if (!fromSettings && user?.specialistProfileCompletedAt) {
       nav.replaceRoutes.tabs();
     }
-  }, [ready, isAdminUser, isSpecialistUser, user, fromSettings, nav]);
+  }, [ready, isAdminUser, isSpecialistUser, isSpecialistIntent, user, fromSettings, nav]);
 
   // Catalogs (loaded once)
   const [cities, setCities] = useState<CityOpt[]>([]);
@@ -308,7 +318,7 @@ export default function OnboardingWorkAreaScreen() {
     }
   };
 
-  if (!ready || isAdminUser || !isSpecialistUser) {
+  if (!ready || isAdminUser || (!isSpecialistUser && !isSpecialistIntent)) {
     return <LoadingState />;
   }
 

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -43,7 +43,7 @@ function formatCountdown(seconds: number): string {
 export default function AuthOtpScreen() {
   const router = useRouter()
   const nav = useTypedRouter();
-  const params = useLocalSearchParams<{ email: string; returnTo?: string }>();
+  const params = useLocalSearchParams<{ email: string; returnTo?: string; intent?: string }>();
   const email =
     typeof params.email === "string"
       ? params.email
@@ -55,6 +55,12 @@ export default function AuthOtpScreen() {
       ? params.returnTo
       : Array.isArray(params.returnTo)
         ? params.returnTo[0]
+        : undefined;
+  const intent =
+    typeof params.intent === "string"
+      ? params.intent
+      : Array.isArray(params.intent)
+        ? params.intent[0]
         : undefined;
   const { signIn } = useAuth();
 
@@ -83,6 +89,18 @@ export default function AuthOtpScreen() {
 
   const routeByRole = useCallback(
     (user: UserData) => {
+      // Landing CTA "Я специалист" passes intent=specialist through the auth
+      // chain. If the authenticated user is not yet a specialist, drop them
+      // into the specialist onboarding (name -> work-area) instead of the
+      // generic dashboard. Existing specialists fall through to the regular
+      // resume-onboarding / tabs logic below.
+      if (intent === "specialist" && !user.isSpecialist) {
+        nav.replaceAny({
+          pathname: "/onboarding/name",
+          params: { role: "specialist" },
+        });
+        return;
+      }
       // If there's a returnTo param, navigate there after login
       if (returnTo) {
         nav.replaceAny(returnTo);
@@ -106,7 +124,7 @@ export default function AuthOtpScreen() {
       }
       nav.replaceRoutes.tabs();
     },
-    [router, returnTo]
+    [router, returnTo, intent]
   );
 
   const handleVerify = useCallback(


### PR DESCRIPTION
Wave 1/B. Pipes ?intent=specialist through login -> otp -> onboarding/name?role=specialist -> work-area, so CTA "Я специалист" routes correctly without dropping to client dashboard.

## Changes
- `app/login.tsx` — read `intent` from URL params, forward to /otp
- `app/otp.tsx` — read `intent`, after OTP verify route specialist intent (non-specialist user) to `/onboarding/name?role=specialist`
- `app/onboarding/name.tsx` — read `role` param, allow render when `role=specialist` even if `isSpecialist=false`; forward role param when navigating to work-area
- `app/onboarding/work-area.tsx` — read `role` param, allow render when `role=specialist` even if `isSpecialist=false`. Existing submit calls `/api/user/become-specialist` which flips `isSpecialist=true`.

## Flow
1. Landing CTA: `/login?intent=specialist`
2. Submit email → `/otp?email=...&intent=specialist`
3. Enter 000000 → routeByRole sees intent + non-specialist → `/onboarding/name?role=specialist`
4. Submit name → `/onboarding/work-area?role=specialist`
5. Submit FNS+services → `/api/user/become-specialist` flips flag → `/onboarding/profile`

## Verify
- npx tsc --noEmit (root) — PASS
- npx tsc --noEmit (api) — PASS
- Existing flow without intent param unchanged (returnTo / admin / tabs branches untouched)