### PR TITLE
UX: inbox perspective badges + role filter

### DIFF
--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -114,7 +114,7 @@ export default function UnifiedInbox() {
   const router = useRouter()
   const nav = useTypedRouter();
   const { ready } = useRequireAuth();
-  const { isSpecialistUser } = useAuth();
+  const { isSpecialistUser, user } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= BREAKPOINT;
   const params = useLocalSearchParams<{ thread?: string }>();
@@ -127,6 +127,15 @@ export default function UnifiedInbox() {
   const [error, setError] = useState<string | null>(null);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | "unread">("all");
+  const [roleFilter, setRoleFilter] = useState<"all" | "client" | "specialist">("all");
+
+  /**
+   * Dual-role users (USER.isSpecialist === true) can have threads in both
+   * `as_client` and `as_specialist` perspectives. Show the second filter
+   * chip row only for them — single-role users would never see anything
+   * but "all".
+   */
+  const isDualRole = user?.isSpecialist === true;
 
   const fetchThreads = useCallback(async () => {
     setError(null);
@@ -166,8 +175,16 @@ export default function UnifiedInbox() {
   }, [fetchThreads]);
 
   const sorted = sortThreads(threads);
-  const filtered =
+  const afterUnread =
     filter === "unread" ? sorted.filter((t) => t.unreadCount > 0) : sorted;
+  const filtered =
+    roleFilter === "all"
+      ? afterUnread
+      : afterUnread.filter(
+          (t) =>
+            t.perspective ===
+            (roleFilter === "client" ? "as_client" : "as_specialist")
+        );
   const unreadTotal = threads.reduce((sum, t) => sum + t.unreadCount, 0);
 
   const renderThread = useCallback(
@@ -273,7 +290,7 @@ export default function UnifiedInbox() {
               </Text>
               {item.perspective ? (
                 <View className="ml-2 flex-shrink-0">
-                  <PerspectiveBadge perspective={item.perspective} />
+                  <PerspectiveBadge perspective={item.perspective} size="sm" />
                 </View>
               ) : null}
               <View style={{ flex: 1 }} />
@@ -432,6 +449,25 @@ export default function UnifiedInbox() {
                     onPress={() => setFilter("unread")}
                   />
                 </View>
+                {isDualRole && (
+                  <View className="flex-row gap-2 mt-2">
+                    <FilterChip
+                      label="Все"
+                      active={roleFilter === "all"}
+                      onPress={() => setRoleFilter("all")}
+                    />
+                    <FilterChip
+                      label="Как клиент"
+                      active={roleFilter === "client"}
+                      onPress={() => setRoleFilter("client")}
+                    />
+                    <FilterChip
+                      label="Как специалист"
+                      active={roleFilter === "specialist"}
+                      onPress={() => setRoleFilter("specialist")}
+                    />
+                  </View>
+                )}
               </View>
               <FlatList
                 data={filtered}
@@ -541,6 +577,25 @@ export default function UnifiedInbox() {
                 </View>
               )}
             </View>
+            {isDualRole && (
+              <View className="flex-row gap-2 pb-2">
+                <FilterChip
+                  label="Все"
+                  active={roleFilter === "all"}
+                  onPress={() => setRoleFilter("all")}
+                />
+                <FilterChip
+                  label="Как клиент"
+                  active={roleFilter === "client"}
+                  onPress={() => setRoleFilter("client")}
+                />
+                <FilterChip
+                  label="Как специалист"
+                  active={roleFilter === "specialist"}
+                  onPress={() => setRoleFilter("specialist")}
+                />
+              </View>
+            )}
           </View>
         }
         ListEmptyComponent={emptyState}

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -384,8 +384,8 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
 
   return (
     <View className="flex-1 bg-white">
-      {/* Header with avatar + other party name + request title */}
-      <View className="flex-row items-center px-4 py-3 border-b border-border bg-white">
+      {/* Header with avatar + other party name + perspective badge + counterparty hint */}
+      <View className="flex-row items-start px-4 py-3 border-b border-border bg-white">
         {!isDesktop && (
           <Pressable accessibilityRole="button" accessibilityLabel="Назад" onPress={() => router.back()} className="mr-3 w-11 h-11 items-center justify-center" style={({ pressed }) => [pressed && { opacity: 0.7 }]}>
             <FontAwesome name="chevron-left" size={18} color={colors.primary} />
@@ -402,16 +402,43 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
             <FontAwesome name="user" size={16} color={colors.textSecondary} />
           </View>
         )}
-        <View className="ml-3 flex-1 flex-row items-center" style={{ gap: 8 }}>
-          <Text className="text-base font-semibold flex-shrink" style={{ color: colors.text }} numberOfLines={1}>
-            {otherName}
-          </Text>
+        <View className="ml-3 flex-1" style={{ gap: 4 }}>
+          <View className="flex-row items-center" style={{ gap: 8 }}>
+            <Text className="text-base font-semibold flex-shrink" style={{ color: colors.text }} numberOfLines={1}>
+              {otherName}
+            </Text>
+            {thread && myId ? (
+              thread.clientId === myId ? (
+                <PerspectiveBadge perspective="as_client" size="md" />
+              ) : thread.specialistId === myId ? (
+                <PerspectiveBadge perspective="as_specialist" size="md" />
+              ) : null
+            ) : null}
+          </View>
           {thread && myId ? (
-            thread.clientId === myId ? (
-              <PerspectiveBadge perspective="as_client" />
-            ) : thread.specialistId === myId ? (
-              <PerspectiveBadge perspective="as_specialist" />
-            ) : null
+            (() => {
+              const myPerspective: "as_client" | "as_specialist" | null =
+                thread.clientId === myId
+                  ? "as_client"
+                  : thread.specialistId === myId
+                    ? "as_specialist"
+                    : null;
+              if (!myPerspective) return null;
+              const counterpartyFallback =
+                myPerspective === "as_client" ? "Специалистом" : "Клиентом";
+              const namedCounterparty = otherUser && !otherUser.isDeleted
+                ? displayName(otherUser)
+                : counterpartyFallback;
+              return (
+                <Text
+                  className="text-xs"
+                  style={{ color: colors.textSecondary }}
+                  numberOfLines={1}
+                >
+                  Вы переписываетесь с {namedCounterparty}
+                </Text>
+              );
+            })()
           ) : null}
         </View>
       </View>

--- a/components/ui/PerspectiveBadge.tsx
+++ b/components/ui/PerspectiveBadge.tsx
@@ -1,41 +1,63 @@
 import { View, Text } from "react-native";
+import { User, Briefcase } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 /**
- * PerspectiveBadge — small uppercase chip indicating whether the current
- * user is participating in a thread as the client or as the specialist.
+ * PerspectiveBadge — chip indicating whether the current user is
+ * participating in a thread as the client or as the specialist.
  *
  * Used in:
  *  - Inbox row (`app/(tabs)/messages.tsx`) — distinguish dual-role threads.
  *  - Thread header (`components/InlineChatView.tsx`) — reinforce context.
+ *
+ * Two visual variants make the perspective glanceable:
+ *   as_client      → blue (accentSoft / accent) + User icon
+ *   as_specialist  → green (greenSoft / success) + Briefcase icon
+ *
+ * Two sizes:
+ *   sm  — for thread cards in the inbox list (compact, dense)
+ *   md  — for chat header (more prominent)
  */
 export interface PerspectiveBadgeProps {
   perspective: "as_client" | "as_specialist";
+  size?: "sm" | "md";
 }
 
-export default function PerspectiveBadge({ perspective }: PerspectiveBadgeProps) {
+export default function PerspectiveBadge({
+  perspective,
+  size = "sm",
+}: PerspectiveBadgeProps) {
   const isClient = perspective === "as_client";
-  const label = isClient ? "Я КЛИЕНТ" : "Я СПЕЦИАЛИСТ";
+  const label = isClient ? "Я: Клиент" : "Я: Специалист";
 
-  const bg = isClient ? colors.surface2 : colors.accentSoft;
-  const fg = isClient ? colors.textSecondary : colors.accentSoftInk;
+  const bg = isClient ? colors.accentSoft : colors.greenSoft;
+  const fg = isClient ? colors.accent : colors.success;
+
+  const isMd = size === "md";
+  const fontSize = isMd ? 12 : 11;
+  const paddingH = isMd ? 10 : 8;
+  const paddingV = isMd ? 4 : 2;
+  const iconSize = isMd ? 13 : 11;
+  const Icon = isClient ? User : Briefcase;
 
   return (
     <View
-      className="rounded-full"
+      className="flex-row items-center rounded-full"
       style={{
         backgroundColor: bg,
-        paddingHorizontal: 8,
-        paddingVertical: 2,
+        paddingHorizontal: paddingH,
+        paddingVertical: paddingV,
         alignSelf: "flex-start",
+        gap: 4,
       }}
     >
+      <Icon size={iconSize} color={fg} strokeWidth={2.25} />
       <Text
         style={{
           color: fg,
-          fontSize: 11,
+          fontSize,
           fontWeight: "600",
-          letterSpacing: 0.6,
+          letterSpacing: 0.2,
         }}
       >
         {label}


### PR DESCRIPTION
Wave 2/E. Adds visual perspective badges (Я: Клиент / Я: Специалист) on every thread card. Dual-role users get a second filter chip row to filter by perspective. Same badge in chat header for context.