### PR TITLE
UX: soft stranded specialist guard

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,12 @@
 import "../global.css";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useWindowDimensions, Platform, View, ActivityIndicator } from "react-native";
-import { Stack, usePathname, useRouter } from "expo-router";
+import { Stack, usePathname } from "expo-router";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
 import AppShell from "@/components/layout/AppShell";
 import AppHeader, { shouldShowAppHeader } from "@/components/layout/AppHeader";
 import MobileDrawer from "@/components/layout/MobileDrawer";
+import StrandedSpecialistBanner from "@/components/layout/StrandedSpecialistBanner";
 import { colors } from "@/lib/theme";
 
 import MetroBridge from "@/components/MetroBridge";
@@ -13,41 +14,40 @@ import MetroBridge from "@/components/MetroBridge";
 const MOBILE_BREAKPOINT = 768;
 
 /**
- * Runtime guard for stranded specialists.
+ * Read-only computed signal for "stranded specialist" state.
  *
  * A user who picks "Я специалист" and abandons after step 1 has
  * `isSpecialist=true` but `specialistProfileCompletedAt=null`. They
- * cannot appear in the catalog or write threads — so they must finish
- * onboarding before doing anything else. This effect catches every
- * authenticated entry point (deep links, token-only restore, browser
- * back nav) and bounces them to /onboarding/name. Allowed pass-through:
- * onboarding screens themselves, auth flow, legal pages, and the public
- * landing page (which redirects on its own).
+ * cannot appear in the catalog or write threads. Previously we hard-
+ * redirected them to /onboarding/name from any route — that turned
+ * the app into a trap. Now we expose this as a flag so the parent can
+ * render a soft persistent banner. The hard gate lives only on actual
+ * write actions (chat send / requests/[id]/write).
+ *
+ * Returns `false` on auth/onboarding/legal/landing routes so the banner
+ * doesn't appear during the very flow that resolves the condition.
  */
-function useStrandedSpecialistGuard() {
+function useStrandedSpecialistInfo(): { stranded: boolean } {
   const { user, isAuthenticated, isLoading } = useAuth();
   const pathname = usePathname() ?? "";
-  const router = useRouter();
 
-  useEffect(() => {
-    if (isLoading || !isAuthenticated || !user) return;
-    if (!user.isSpecialist) return;
-    if (user.specialistProfileCompletedAt) return;
+  if (isLoading || !isAuthenticated || !user) return { stranded: false };
+  if (!user.isSpecialist) return { stranded: false };
+  if (user.specialistProfileCompletedAt) return { stranded: false };
 
-    if (
-      pathname.startsWith("/onboarding") ||
-      pathname.startsWith("/auth") ||
-      pathname.startsWith("/legal") ||
-      pathname === "/login" ||
-      pathname === "/otp" ||
-      pathname === "/" ||
-      pathname === ""
-    ) {
-      return;
-    }
+  if (
+    pathname.startsWith("/onboarding") ||
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/legal") ||
+    pathname === "/login" ||
+    pathname === "/otp" ||
+    pathname === "/" ||
+    pathname === ""
+  ) {
+    return { stranded: false };
+  }
 
-    router.replace("/onboarding/name" as never);
-  }, [isLoading, isAuthenticated, user, pathname, router]);
+  return { stranded: true };
 }
 
 /**
@@ -69,9 +69,10 @@ function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
   const { width } = useWindowDimensions();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  // Bounce stranded specialists (incomplete onboarding) to /onboarding/name
-  // regardless of how they reached the current route.
-  useStrandedSpecialistGuard();
+  // Wave 2/G — soft guard. Render a persistent banner for stranded
+  // specialists instead of force-redirecting them. The hard gate lives
+  // on the actual write actions (chat send + /requests/[id]/write).
+  const { stranded } = useStrandedSpecialistInfo();
 
   // Block rendering until AsyncStorage token restoration is complete.
   // Without this, authenticated users briefly see the public landing page.
@@ -111,10 +112,14 @@ function AuthenticatedHeaderGate({ children }: { children: React.ReactNode }) {
               : { flex: 1 }
           }
         >
+          <StrandedSpecialistBanner stranded={stranded} />
           {children}
         </View>
       ) : (
-        children
+        <>
+          <StrandedSpecialistBanner stranded={stranded} />
+          {children}
+        </>
       )}
       {showDrawer && (
         <MobileDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -18,10 +18,11 @@ import HeaderBack from "@/components/HeaderBack";
 import ResponsiveContainer from "@/components/ResponsiveContainer";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { Send, Paperclip, X } from "lucide-react-native";
+import { Send, Paperclip, X, UserCheck } from "lucide-react-native";
 import { api, ApiError, API_URL } from "@/lib/api";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { useAuth } from "@/contexts/AuthContext";
+import EmptyState from "@/components/ui/EmptyState";
 import { colors, radiusValue, fontSizeValue, BREAKPOINT } from "@/lib/theme";
 
 interface PendingFile {
@@ -72,9 +73,15 @@ export default function SpecialistConfirmWrite() {
   const nav = useTypedRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
   const { ready } = useRequireAuth();
-  const { isSpecialistUser } = useAuth();
+  const { isSpecialistUser, user } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= BREAKPOINT;
+
+  // Wave 2/G — hard gate for stranded specialists. They can browse, but
+  // before they can write to a client they MUST finish onboarding (ИФНС,
+  // services, description). Otherwise the message goes out from a profile
+  // that's invisible in the catalog.
+  const isStrandedSpecialist = isSpecialistUser && !user?.specialistProfileCompletedAt;
 
   const [request, setRequest] = useState<RequestSummary | null>(null);
   const [rateLimit, setRateLimit] = useState<RateLimitInfo | null>(null);
@@ -262,6 +269,23 @@ export default function SpecialistConfirmWrite() {
       <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
         <HeaderBack title="Написать клиенту" />
         <LoadingState />
+      </SafeAreaView>
+    );
+  }
+
+  if (isStrandedSpecialist) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface2" edges={["top", "bottom"]}>
+        <HeaderBack title="Написать клиенту" />
+        <View className="flex-1 justify-center">
+          <EmptyState
+            icon={UserCheck}
+            title="Завершите профиль специалиста"
+            subtitle="Перед тем как написать клиенту, нужно указать ИФНС, услуги и описание."
+            actionLabel="Завершить"
+            onAction={() => router.replace("/onboarding/name" as never)}
+          />
+        </View>
       </SafeAreaView>
     );
   }

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -94,7 +94,7 @@ interface InlineChatViewProps {
 }
 
 export default function InlineChatView({ threadId }: InlineChatViewProps) {
-  const { user } = useAuth();
+  const { user, isSpecialistUser } = useAuth();
   const { width } = useWindowDimensions();
   const isDesktop = width >= 640;
 
@@ -288,6 +288,23 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
   const handleSend = useCallback(async () => {
     const trimmed = text.trim();
     if ((!trimmed && pendingFiles.length === 0) || sending || !threadId) return;
+
+    // Wave 2/G — hard gate: stranded specialists (isSpecialist=true,
+    // specialistProfileCompletedAt=null) cannot send messages because
+    // they're invisible in the catalog. Force them to finish onboarding
+    // before the message leaves the client.
+    if (isSpecialistUser && !user?.specialistProfileCompletedAt) {
+      Alert.alert(
+        "Завершите профиль",
+        "Перед тем как писать клиенту, завершите профиль специалиста.",
+        [
+          { text: "Отмена", style: "cancel" },
+          { text: "Завершить", onPress: () => router.push("/onboarding/name" as never) },
+        ]
+      );
+      return;
+    }
+
     setSending(true);
     try {
       let uploadToken: string | undefined;
@@ -314,7 +331,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     } finally {
       setSending(false);
     }
-  }, [text, pendingFiles, sending, threadId, uploadChatFile]);
+  }, [text, pendingFiles, sending, threadId, uploadChatFile, isSpecialistUser, user?.specialistProfileCompletedAt]);
 
   const handleFilePress = useCallback((file: FileAttachment) => {
     const fullUrl = file.url.startsWith("http") ? file.url : `${API_URL}${file.url}`;

--- a/components/layout/StrandedSpecialistBanner.tsx
+++ b/components/layout/StrandedSpecialistBanner.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState, useCallback } from "react";
+import { View, Text, Pressable, Platform } from "react-native";
+import { useRouter } from "expo-router";
+import { X } from "lucide-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { colors } from "@/lib/theme";
+
+const DISMISSED_KEY = "p2ptax_stranded_dismissed_v1";
+
+/**
+ * Cross-platform persistence shim — web uses localStorage (sync, survives
+ * tab close), native uses AsyncStorage. Banner stays dismissed until the
+ * key is cleared on logout.
+ */
+async function readDismissed(): Promise<boolean> {
+  try {
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.localStorage) {
+      return window.localStorage.getItem(DISMISSED_KEY) === "true";
+    }
+    const v = await AsyncStorage.getItem(DISMISSED_KEY);
+    return v === "true";
+  } catch {
+    return false;
+  }
+}
+
+async function writeDismissed(): Promise<void> {
+  try {
+    if (Platform.OS === "web" && typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(DISMISSED_KEY, "true");
+      return;
+    }
+    await AsyncStorage.setItem(DISMISSED_KEY, "true");
+  } catch {
+    // ignore — non-fatal, banner just shows again next session
+  }
+}
+
+export interface StrandedSpecialistBannerProps {
+  stranded: boolean;
+}
+
+/**
+ * Persistent inline banner for specialists who started onboarding but
+ * never finished — `isSpecialist=true && specialistProfileCompletedAt=null`.
+ * Replaces the previous force-redirect to /onboarding/name. The user can
+ * navigate freely; only writing to a chat is hard-gated (see write.tsx
+ * and InlineChatView). Dismissable until logout via X button.
+ */
+export default function StrandedSpecialistBanner({ stranded }: StrandedSpecialistBannerProps) {
+  const router = useRouter();
+  const [dismissed, setDismissed] = useState(true); // start hidden, fade in if not yet dismissed
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    readDismissed().then((d) => {
+      if (!cancelled) {
+        setDismissed(d);
+        setHydrated(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    setDismissed(true);
+    writeDismissed();
+  }, []);
+
+  const handleFinish = useCallback(() => {
+    router.push("/onboarding/name" as never);
+  }, [router]);
+
+  if (!stranded || !hydrated || dismissed) return null;
+
+  return (
+    <View
+      accessibilityRole="alert"
+      style={{ backgroundColor: "#FEF3C7", borderBottomWidth: 1, borderBottomColor: "#FDE68A" }}
+      className="px-4 py-3 flex-row items-center"
+    >
+      <Text className="flex-1 text-sm" style={{ color: "#78350F" }}>
+        Профиль специалиста не завершён — клиенты не видят вас в каталоге.
+      </Text>
+      <Pressable
+        accessibilityLabel="Завершить профиль специалиста"
+        onPress={handleFinish}
+        className="ml-3 px-3 py-1.5 rounded-md"
+        style={{ backgroundColor: colors.primary }}
+      >
+        <Text className="text-sm font-semibold text-white">Завершить →</Text>
+      </Pressable>
+      <Pressable
+        accessibilityLabel="Скрыть уведомление"
+        onPress={handleDismiss}
+        hitSlop={8}
+        className="ml-2 p-1"
+      >
+        <X size={16} color="#78350F" />
+      </Pressable>
+    </View>
+  );
+}

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -91,6 +91,16 @@ async function storeTokens(accessToken: string, refreshToken: string) {
 async function clearTokens() {
   await AsyncStorage.removeItem(TOKEN_KEY);
   await AsyncStorage.removeItem(REFRESH_KEY);
+  // Wave 2/G — clear stranded-specialist banner dismissal flag on logout
+  // so it shows again on next login if the user is still stranded.
+  try {
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.removeItem("p2ptax_stranded_dismissed_v1");
+    }
+    await AsyncStorage.removeItem("p2ptax_stranded_dismissed_v1");
+  } catch {
+    // ignore
+  }
 }
 
 /**


### PR DESCRIPTION
Wave 2/G. Replaces force-redirect with persistent banner. Hard gate only when specialist tries to write (chat send / write screen). Banner dismissable until logout.

## Changes
- `app/_layout.tsx` — `useStrandedSpecialistGuard` (force `router.replace`) replaced with read-only `useStrandedSpecialistInfo()` returning `{ stranded }`. Banner rendered after `AppHeader`, before children, on both mobile and desktop branches.
- `components/layout/StrandedSpecialistBanner.tsx` — new inline banner. Background `#FEF3C7`, copy "Профиль специалиста не завершён — клиенты не видят вас в каталоге.", "Завершить →" button → `/onboarding/name`, X dismiss persists to `localStorage` (web) / `AsyncStorage` (native) under key `p2ptax_stranded_dismissed_v1`.
- `app/requests/[id]/write.tsx` — `EmptyState` (`UserCheck` icon, "Завершите профиль специалиста") replaces the form when `isSpecialistUser && !user.specialistProfileCompletedAt`.
- `components/InlineChatView.tsx` — `handleSend` Alert-gates stranded specialists with "Отмена / Завершить" before send call.
- `contexts/AuthContext.tsx` — `clearTokens` removes the dismissal key on logout.

## Test plan
- [ ] Stranded specialist on `/(tabs)/dashboard` sees banner, can navigate freely.
- [ ] Stranded specialist clicks "Завершить" in banner → `/onboarding/name`.
- [ ] Stranded specialist visits `/requests/[id]/write` → EmptyState replaces form.
- [ ] Stranded specialist clicks send in `/threads/[id]` → Alert "Завершите профиль".
- [ ] Banner X dismisses banner until next logout.
- [ ] Non-stranded specialist: banner hidden, chat send works, `/write` form renders.
- [ ] `/onboarding/*`, `/login`, `/otp`, `/legal/*`, `/` — banner not rendered.