### PR TITLE
Refactor: catalog + work-area sub-components

### DIFF
--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -1,23 +1,25 @@
-import { View, Text, Pressable, ScrollView } from "react-native";
+import { View, Text, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { Plus, ChevronLeft } from "lucide-react-native";
 import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { colors, textStyle } from "@/lib/theme";
+import { colors } from "@/lib/theme";
 import SpecialistSearchBar, {
   CityOpt,
   FnsOpt,
 } from "@/components/filters/SpecialistSearchBar";
-import WorkAreaEntry, {
-  WorkAreaEntryData,
-} from "@/components/onboarding/WorkAreaEntry";
+import { WorkAreaEntryData } from "@/components/onboarding/WorkAreaEntry";
+import BackHeader from "@/components/onboarding/workarea/BackHeader";
+import WorkAreaIntro from "@/components/onboarding/workarea/WorkAreaIntro";
+import PendingFnsPicker from "@/components/onboarding/workarea/PendingFnsPicker";
+import EntriesList from "@/components/onboarding/workarea/EntriesList";
+import { saveWorkArea } from "@/components/onboarding/workarea/saveWorkArea";
 
 interface ServiceItem {
   id: string;
@@ -251,60 +253,18 @@ export default function OnboardingWorkAreaScreen() {
     setError("");
     setIsLoading(true);
     try {
-      // Build cityIds / fnsIds / services-matrix from entries.
-      const cityIdSet = new Set<string>();
-      const fnsIds: string[] = [];
-      const fnsServices: { fnsId: string; serviceIds: string[] }[] = [];
-      const allServiceIds = services.map((s) => s.id);
-
-      for (const e of entries) {
-        cityIdSet.add(e.cityId);
-        fnsIds.push(e.fnsId);
-        // "Не знаю" / any-service → expand to ALL service ids so the API
-        // (which skips entries with empty serviceIds) still persists the row.
-        const sids = e.isAnyService ? allServiceIds : e.serviceIds;
-        fnsServices.push({ fnsId: e.fnsId, serviceIds: sids });
-      }
-      const cityIds = Array.from(cityIdSet);
-
-      if (!isSpecialistUser) {
-        const res = await api<{
-          user: {
-            isSpecialist: boolean;
-            specialistProfileCompletedAt: string | null;
-          };
-        }>("/api/user/become-specialist", {
-          method: "POST",
-          body: {
-            cities: cityIds,
-            fns: fnsIds,
-            services: fnsServices,
-          },
-        });
-        if (res.user) {
-          updateUser({
-            isSpecialist: res.user.isSpecialist,
-            specialistProfileCompletedAt:
-              res.user.specialistProfileCompletedAt ?? null,
-          });
-        }
-      } else {
-        await api("/api/onboarding/work-area", {
-          method: "PUT",
-          body: {
-            cities: cityIds,
-            fns: fnsIds,
-            fnsServices,
-            specialist_services: fnsServices.flatMap((f) =>
-              f.serviceIds.map((sid) => ({
-                fns_id: f.fnsId,
-                service_id: sid,
-              }))
-            ),
-          },
+      const { user: updatedUser } = await saveWorkArea({
+        entries,
+        allServiceIds: services.map((s) => s.id),
+        isSpecialistUser,
+      });
+      if (updatedUser) {
+        updateUser({
+          isSpecialist: updatedUser.isSpecialist,
+          specialistProfileCompletedAt:
+            updatedUser.specialistProfileCompletedAt ?? null,
         });
       }
-
       if (fromSettings) {
         nav.routes.settings();
       } else {
@@ -324,18 +284,7 @@ export default function OnboardingWorkAreaScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
-      <View className="px-6 pt-4 pb-2">
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={fromSettings ? "Назад к настройкам" : "Назад"}
-          onPress={() => router.back()}
-          className="flex-row items-center"
-          style={{ minHeight: 44 }}
-        >
-          <ChevronLeft size={20} color={colors.text} />
-          <Text className="text-text-base ml-1">{fromSettings ? "Назад к настройкам" : "Назад"}</Text>
-        </Pressable>
-      </View>
+      <BackHeader fromSettings={fromSettings} onBack={() => router.back()} />
 
       {!fromSettings && (
         <View className="px-6 pb-4">
@@ -356,42 +305,7 @@ export default function OnboardingWorkAreaScreen() {
             paddingHorizontal: 24,
           }}
         >
-          {/* Heading */}
-          <Text
-            style={{
-              ...textStyle.h1,
-              color: colors.text,
-              fontSize: 32,
-              lineHeight: 38,
-              marginTop: 16,
-              marginBottom: 12,
-            }}
-          >
-            Где вы работаете?
-          </Text>
-          <Text
-            style={{
-              ...textStyle.body,
-              color: colors.textSecondary,
-              fontSize: 16,
-              lineHeight: 24,
-              marginBottom: 20,
-            }}
-          >
-            Добавьте инспекции ФНС, в которых ведёте дела, и услуги по
-            каждой. По этим данным клиенты вас найдут.
-          </Text>
-
-          {catalogError && (
-            <View
-              className="mb-4 px-4 py-3 rounded-xl"
-              style={{ backgroundColor: colors.errorBg }}
-            >
-              <Text className="text-sm text-danger leading-5">
-                {catalogError}
-              </Text>
-            </View>
-          )}
+          <WorkAreaIntro catalogError={catalogError} />
 
           {/* Step 1 — search */}
           <View style={{ zIndex: 20 }}>
@@ -408,124 +322,20 @@ export default function OnboardingWorkAreaScreen() {
 
           {/* Step 2 — service picker (only after FNS picked) */}
           {pendingFns && (
-            <View
-              className="mt-4 border border-border rounded-xl p-4"
-              style={{ backgroundColor: colors.surface2 }}
-            >
-              <Text
-                className="text-xs font-semibold uppercase tracking-wide mb-1"
-                style={{ color: colors.textMuted }}
-              >
-                Услуги в этой инспекции
-              </Text>
-              <Text className="text-sm text-text-base mb-3">
-                {pendingFns.code ? `${pendingFns.code} · ` : ""}
-                {pendingFns.name}
-              </Text>
-
-              <View className="flex-row flex-wrap" style={{ gap: 8 }}>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel="Не знаю — любая услуга"
-                  onPress={pickAnyService}
-                  className={`px-3 h-9 items-center justify-center rounded-full border ${
-                    pendingAnyService
-                      ? "bg-accent border-accent"
-                      : "bg-white border-border"
-                  }`}
-                >
-                  <Text
-                    className={`text-sm ${
-                      pendingAnyService
-                        ? "text-white font-medium"
-                        : "text-text-base"
-                    }`}
-                  >
-                    Не знаю
-                  </Text>
-                </Pressable>
-                {services.map((svc) => {
-                  const active = pendingServiceIds.includes(svc.id);
-                  return (
-                    <Pressable
-                      key={svc.id}
-                      accessibilityRole="button"
-                      accessibilityLabel={svc.name}
-                      onPress={() => toggleService(svc.id)}
-                      className={`px-3 h-9 items-center justify-center rounded-full border ${
-                        active
-                          ? "bg-accent border-accent"
-                          : "bg-white border-border"
-                      }`}
-                    >
-                      <Text
-                        className={`text-sm ${
-                          active
-                            ? "text-white font-medium"
-                            : "text-text-base"
-                        }`}
-                      >
-                        {svc.name}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-
-              <View className="mt-4 flex-row" style={{ gap: 8 }}>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel="Добавить запись"
-                  onPress={addEntry}
-                  disabled={!canAddEntry}
-                  className={`flex-row items-center justify-center px-4 h-10 rounded-xl ${
-                    canAddEntry ? "bg-accent" : "bg-border"
-                  }`}
-                  style={{ gap: 6 }}
-                >
-                  <Plus
-                    size={16}
-                    color={canAddEntry ? "#ffffff" : colors.textMuted}
-                  />
-                  <Text
-                    className="text-sm font-medium"
-                    style={{
-                      color: canAddEntry ? "#ffffff" : colors.textMuted,
-                    }}
-                  >
-                    Добавить
-                  </Text>
-                </Pressable>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel="Отменить выбор инспекции"
-                  onPress={handleClearLocation}
-                  className="flex-row items-center justify-center px-4 h-10 rounded-xl border border-border bg-white"
-                >
-                  <Text className="text-sm text-text-base">Отменить</Text>
-                </Pressable>
-              </View>
-            </View>
+            <PendingFnsPicker
+              pendingFns={pendingFns}
+              services={services}
+              pendingServiceIds={pendingServiceIds}
+              pendingAnyService={pendingAnyService}
+              canAddEntry={canAddEntry}
+              onPickAny={pickAnyService}
+              onToggleService={toggleService}
+              onAdd={addEntry}
+              onCancel={handleClearLocation}
+            />
           )}
 
-          {/* Entries list */}
-          {entries.length > 0 && (
-            <View className="mt-6">
-              <Text
-                className="text-xs font-semibold uppercase tracking-wide mb-3"
-                style={{ color: colors.textMuted }}
-              >
-                Добавлено ({entries.length})
-              </Text>
-              {entries.map((e) => (
-                <WorkAreaEntry
-                  key={e.fnsId}
-                  entry={e}
-                  onRemove={() => removeEntry(e.fnsId)}
-                />
-              ))}
-            </View>
-          )}
+          <EntriesList entries={entries} onRemove={removeEntry} />
 
           {error ? (
             <View

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,28 +1,20 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import {
-  View,
-  Text,
-  FlatList,
-  ActivityIndicator,
-  RefreshControl,
-  ScrollView,
-  Pressable,
-  useWindowDimensions,
-} from "react-native";
+import { View, useWindowDimensions } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTypedRouter } from "@/lib/navigation";
 import { useLocalSearchParams, router } from "expo-router";
-import SpecialistCard from "@/components/SpecialistCard";
 import SpecialistSearchBar, {
   CityOpt,
   FnsOpt,
 } from "@/components/filters/SpecialistSearchBar";
 import { AlertCircle, Search, UserX } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
-import LoadingState from "@/components/ui/LoadingState";
+import CatalogHeader from "@/components/specialists/CatalogHeader";
+import CatalogSkeleton from "@/components/specialists/CatalogSkeleton";
+import ServiceChipsRow from "@/components/specialists/ServiceChipsRow";
+import SpecialistsGrid from "@/components/specialists/SpecialistsGrid";
 import { api, apiGet, apiPost, apiDelete } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, textStyle } from "@/lib/theme";
 
 interface ServiceOption {
   id: string;
@@ -311,31 +303,9 @@ export default function SpecialistsCatalog() {
     return total > 0 ? total : specialists.length;
   }, [loading, total, specialists.length]);
 
-  const allServicesActive = selectedServiceIds.length === 0;
-
   return (
     <SafeAreaView className="flex-1 bg-surface2">
-      {/* Compact header — Row 1: title + count */}
-      <View
-        className={`flex-row items-center justify-between px-4 ${
-          isDesktop ? "pt-4" : "pt-2"
-        } pb-1`}
-      >
-        <Text
-          style={
-            isDesktop
-              ? { ...textStyle.h3, color: colors.text }
-              : { ...textStyle.h4, color: colors.text }
-          }
-        >
-          Специалисты
-        </Text>
-        {headerCount !== null && headerCount > 0 && (
-          <Text className="text-xs" style={{ color: colors.textMuted }}>
-            {headerCount} специалистов
-          </Text>
-        )}
-      </View>
+      <CatalogHeader isDesktop={isDesktop} count={headerCount} />
 
       {/* Row 2: typeahead search bar */}
       <View className="px-4 pt-2" style={{ zIndex: 20 }}>
@@ -351,72 +321,16 @@ export default function SpecialistsCatalog() {
       </View>
 
       {/* Row 3: compact service chips — always visible */}
-      {services.length > 0 && (
-        <View className="pt-2 pb-2" style={{ zIndex: 1 }}>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{
-              gap: 8,
-              paddingHorizontal: 16,
-            }}
-          >
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Не знаю — все услуги"
-              onPress={handleClearServices}
-              className={`px-3 h-8 items-center justify-center rounded-full border ${
-                allServicesActive
-                  ? "bg-accent border-accent"
-                  : "bg-white border-border"
-              }`}
-            >
-              <Text
-                className={`text-xs ${
-                  allServicesActive ? "text-white font-medium" : "text-text-base"
-                }`}
-              >
-                Не знаю
-              </Text>
-            </Pressable>
-            {services.map((s) => {
-              const active = selectedServiceIds.includes(s.id);
-              return (
-                <Pressable
-                  key={s.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={s.name}
-                  onPress={() => handleServiceToggle(s.id)}
-                  className={`px-3 h-8 items-center justify-center rounded-full border ${
-                    active ? "bg-accent border-accent" : "bg-white border-border"
-                  }`}
-                >
-                  <Text
-                    className={`text-xs ${
-                      active ? "text-white font-medium" : "text-text-base"
-                    }`}
-                  >
-                    {s.name}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-        </View>
-      )}
+      <ServiceChipsRow
+        services={services}
+        selectedServiceIds={selectedServiceIds}
+        onToggle={handleServiceToggle}
+        onClearAll={handleClearServices}
+      />
 
       {/* Specialist list */}
       {loading && specialists.length === 0 ? (
-        <View className="py-4 px-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <View
-              key={i}
-              className="mb-3 bg-white rounded-2xl overflow-hidden border border-border"
-            >
-              <LoadingState variant="skeleton" lines={4} />
-            </View>
-          ))}
-        </View>
+        <CatalogSkeleton count={5} />
       ) : error && specialists.length === 0 ? (
         <EmptyState
           icon={AlertCircle}
@@ -450,57 +364,18 @@ export default function SpecialistsCatalog() {
           />
         )
       ) : (
-        <FlatList
-          key={`grid-${gridCols}`}
-          data={specialists}
-          keyExtractor={(item) => item.id}
-          numColumns={gridCols}
-          columnWrapperStyle={
-            gridCols > 1
-              ? { gap: 16, paddingHorizontal: isWide ? 32 : 16 }
-              : undefined
-          }
-          contentContainerStyle={{
-            paddingHorizontal: gridCols > 1 ? 0 : 16,
-            paddingBottom: 48,
-            paddingTop: 8,
-            maxWidth: isWide ? 1200 : isDesktop ? 900 : undefined,
-            alignSelf: isDesktop ? ("center" as const) : undefined,
-            width: "100%" as const,
-          }}
-          renderItem={({ item }) => (
-            <View style={gridCols > 1 ? { flex: 1 } : undefined}>
-              <SpecialistCard
-                id={item.id}
-                firstName={item.firstName}
-                lastName={item.lastName}
-                avatarUrl={item.avatarUrl}
-                createdAt={item.createdAt}
-                services={item.services}
-                cities={item.cities}
-                specialistFns={item.specialistFns}
-                description={item.description}
-                onPress={handleSpecialistPress}
-                onBookmark={handleBookmark}
-                bookmarked={bookmarkedIds.has(item.id)}
-                variant="vertical"
-              />
-            </View>
-          )}
-          refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
-          }
-          onEndReached={handleLoadMore}
-          onEndReachedThreshold={0.5}
-          ListFooterComponent={
-            loadingMore ? (
-              <ActivityIndicator
-                size="small"
-                color={colors.primary}
-                style={{ paddingVertical: 16 }}
-              />
-            ) : null
-          }
+        <SpecialistsGrid
+          specialists={specialists}
+          gridCols={gridCols}
+          isDesktop={isDesktop}
+          isWide={isWide}
+          refreshing={refreshing}
+          loadingMore={loadingMore}
+          bookmarkedIds={bookmarkedIds}
+          onRefresh={handleRefresh}
+          onLoadMore={handleLoadMore}
+          onPress={handleSpecialistPress}
+          onBookmark={handleBookmark}
         />
       )}
     </SafeAreaView>

--- a/components/onboarding/workarea/BackHeader.tsx
+++ b/components/onboarding/workarea/BackHeader.tsx
@@ -1,0 +1,26 @@
+import { View, Text, Pressable } from "react-native";
+import { ChevronLeft } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+
+interface Props {
+  fromSettings: boolean;
+  onBack: () => void;
+}
+
+export default function BackHeader({ fromSettings, onBack }: Props) {
+  const label = fromSettings ? "Назад к настройкам" : "Назад";
+  return (
+    <View className="px-6 pt-4 pb-2">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        onPress={onBack}
+        className="flex-row items-center"
+        style={{ minHeight: 44 }}
+      >
+        <ChevronLeft size={20} color={colors.text} />
+        <Text className="text-text-base ml-1">{label}</Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/components/onboarding/workarea/EntriesList.tsx
+++ b/components/onboarding/workarea/EntriesList.tsx
@@ -1,0 +1,31 @@
+import { View, Text } from "react-native";
+import WorkAreaEntry, {
+  WorkAreaEntryData,
+} from "@/components/onboarding/WorkAreaEntry";
+import { colors } from "@/lib/theme";
+
+interface Props {
+  entries: WorkAreaEntryData[];
+  onRemove: (fnsId: string) => void;
+}
+
+export default function EntriesList({ entries, onRemove }: Props) {
+  if (entries.length === 0) return null;
+  return (
+    <View className="mt-6">
+      <Text
+        className="text-xs font-semibold uppercase tracking-wide mb-3"
+        style={{ color: colors.textMuted }}
+      >
+        Добавлено ({entries.length})
+      </Text>
+      {entries.map((e) => (
+        <WorkAreaEntry
+          key={e.fnsId}
+          entry={e}
+          onRemove={() => onRemove(e.fnsId)}
+        />
+      ))}
+    </View>
+  );
+}

--- a/components/onboarding/workarea/PendingFnsPicker.tsx
+++ b/components/onboarding/workarea/PendingFnsPicker.tsx
@@ -1,0 +1,134 @@
+import { View, Text, Pressable } from "react-native";
+import { Plus } from "lucide-react-native";
+import { FnsOpt } from "@/components/filters/SpecialistSearchBar";
+import { colors } from "@/lib/theme";
+
+interface ServiceItem {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  pendingFns: FnsOpt;
+  services: ServiceItem[];
+  pendingServiceIds: string[];
+  pendingAnyService: boolean;
+  canAddEntry: boolean;
+  onPickAny: () => void;
+  onToggleService: (id: string) => void;
+  onAdd: () => void;
+  onCancel: () => void;
+}
+
+export default function PendingFnsPicker({
+  pendingFns,
+  services,
+  pendingServiceIds,
+  pendingAnyService,
+  canAddEntry,
+  onPickAny,
+  onToggleService,
+  onAdd,
+  onCancel,
+}: Props) {
+  return (
+    <View
+      className="mt-4 border border-border rounded-xl p-4"
+      style={{ backgroundColor: colors.surface2 }}
+    >
+      <Text
+        className="text-xs font-semibold uppercase tracking-wide mb-1"
+        style={{ color: colors.textMuted }}
+      >
+        Услуги в этой инспекции
+      </Text>
+      <Text className="text-sm text-text-base mb-3">
+        {pendingFns.code ? `${pendingFns.code} · ` : ""}
+        {pendingFns.name}
+      </Text>
+
+      <View className="flex-row flex-wrap" style={{ gap: 8 }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Не знаю — любая услуга"
+          onPress={onPickAny}
+          className={`px-3 h-9 items-center justify-center rounded-full border ${
+            pendingAnyService
+              ? "bg-accent border-accent"
+              : "bg-white border-border"
+          }`}
+        >
+          <Text
+            className={`text-sm ${
+              pendingAnyService
+                ? "text-white font-medium"
+                : "text-text-base"
+            }`}
+          >
+            Не знаю
+          </Text>
+        </Pressable>
+        {services.map((svc) => {
+          const active = pendingServiceIds.includes(svc.id);
+          return (
+            <Pressable
+              key={svc.id}
+              accessibilityRole="button"
+              accessibilityLabel={svc.name}
+              onPress={() => onToggleService(svc.id)}
+              className={`px-3 h-9 items-center justify-center rounded-full border ${
+                active
+                  ? "bg-accent border-accent"
+                  : "bg-white border-border"
+              }`}
+            >
+              <Text
+                className={`text-sm ${
+                  active
+                    ? "text-white font-medium"
+                    : "text-text-base"
+                }`}
+              >
+                {svc.name}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View className="mt-4 flex-row" style={{ gap: 8 }}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Добавить запись"
+          onPress={onAdd}
+          disabled={!canAddEntry}
+          className={`flex-row items-center justify-center px-4 h-10 rounded-xl ${
+            canAddEntry ? "bg-accent" : "bg-border"
+          }`}
+          style={{ gap: 6 }}
+        >
+          <Plus
+            size={16}
+            color={canAddEntry ? "#ffffff" : colors.textMuted}
+          />
+          <Text
+            className="text-sm font-medium"
+            style={{
+              color: canAddEntry ? "#ffffff" : colors.textMuted,
+            }}
+          >
+            Добавить
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Отменить выбор инспекции"
+          onPress={onCancel}
+          className="flex-row items-center justify-center px-4 h-10 rounded-xl border border-border bg-white"
+        >
+          <Text className="text-sm text-text-base">Отменить</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/components/onboarding/workarea/WorkAreaIntro.tsx
+++ b/components/onboarding/workarea/WorkAreaIntro.tsx
@@ -1,0 +1,48 @@
+import { View, Text } from "react-native";
+import { colors, textStyle } from "@/lib/theme";
+
+interface Props {
+  catalogError: string | null;
+}
+
+export default function WorkAreaIntro({ catalogError }: Props) {
+  return (
+    <>
+      <Text
+        style={{
+          ...textStyle.h1,
+          color: colors.text,
+          fontSize: 32,
+          lineHeight: 38,
+          marginTop: 16,
+          marginBottom: 12,
+        }}
+      >
+        Где вы работаете?
+      </Text>
+      <Text
+        style={{
+          ...textStyle.body,
+          color: colors.textSecondary,
+          fontSize: 16,
+          lineHeight: 24,
+          marginBottom: 20,
+        }}
+      >
+        Добавьте инспекции ФНС, в которых ведёте дела, и услуги по
+        каждой. По этим данным клиенты вас найдут.
+      </Text>
+
+      {catalogError && (
+        <View
+          className="mb-4 px-4 py-3 rounded-xl"
+          style={{ backgroundColor: colors.errorBg }}
+        >
+          <Text className="text-sm text-danger leading-5">
+            {catalogError}
+          </Text>
+        </View>
+      )}
+    </>
+  );
+}

--- a/components/onboarding/workarea/saveWorkArea.ts
+++ b/components/onboarding/workarea/saveWorkArea.ts
@@ -1,0 +1,74 @@
+import { api } from "@/lib/api";
+import { WorkAreaEntryData } from "@/components/onboarding/WorkAreaEntry";
+
+interface SaveArgs {
+  entries: WorkAreaEntryData[];
+  allServiceIds: string[];
+  isSpecialistUser: boolean;
+}
+
+interface SaveResult {
+  user?: {
+    isSpecialist: boolean;
+    specialistProfileCompletedAt: string | null;
+  };
+}
+
+/**
+ * Persist the work-area entries.
+ * - Non-specialists: POST /api/user/become-specialist (flips role + saves).
+ * - Specialists: PUT /api/onboarding/work-area (updates only).
+ *
+ * "Не знаю" / any-service entries get expanded to ALL service ids so the API
+ * (which skips empty serviceIds) still persists the row.
+ */
+export async function saveWorkArea({
+  entries,
+  allServiceIds,
+  isSpecialistUser,
+}: SaveArgs): Promise<SaveResult> {
+  const cityIdSet = new Set<string>();
+  const fnsIds: string[] = [];
+  const fnsServices: { fnsId: string; serviceIds: string[] }[] = [];
+
+  for (const e of entries) {
+    cityIdSet.add(e.cityId);
+    fnsIds.push(e.fnsId);
+    const sids = e.isAnyService ? allServiceIds : e.serviceIds;
+    fnsServices.push({ fnsId: e.fnsId, serviceIds: sids });
+  }
+  const cityIds = Array.from(cityIdSet);
+
+  if (!isSpecialistUser) {
+    const res = await api<{
+      user: {
+        isSpecialist: boolean;
+        specialistProfileCompletedAt: string | null;
+      };
+    }>("/api/user/become-specialist", {
+      method: "POST",
+      body: {
+        cities: cityIds,
+        fns: fnsIds,
+        services: fnsServices,
+      },
+    });
+    return { user: res.user };
+  }
+
+  await api("/api/onboarding/work-area", {
+    method: "PUT",
+    body: {
+      cities: cityIds,
+      fns: fnsIds,
+      fnsServices,
+      specialist_services: fnsServices.flatMap((f) =>
+        f.serviceIds.map((sid) => ({
+          fns_id: f.fnsId,
+          service_id: sid,
+        }))
+      ),
+    },
+  });
+  return {};
+}

--- a/components/specialists/CatalogHeader.tsx
+++ b/components/specialists/CatalogHeader.tsx
@@ -1,0 +1,32 @@
+import { View, Text } from "react-native";
+import { colors, textStyle } from "@/lib/theme";
+
+interface Props {
+  isDesktop: boolean;
+  count: number | null;
+}
+
+export default function CatalogHeader({ isDesktop, count }: Props) {
+  return (
+    <View
+      className={`flex-row items-center justify-between px-4 ${
+        isDesktop ? "pt-4" : "pt-2"
+      } pb-1`}
+    >
+      <Text
+        style={
+          isDesktop
+            ? { ...textStyle.h3, color: colors.text }
+            : { ...textStyle.h4, color: colors.text }
+        }
+      >
+        Специалисты
+      </Text>
+      {count !== null && count > 0 && (
+        <Text className="text-xs" style={{ color: colors.textMuted }}>
+          {count} специалистов
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/components/specialists/CatalogSkeleton.tsx
+++ b/components/specialists/CatalogSkeleton.tsx
@@ -1,0 +1,21 @@
+import { View } from "react-native";
+import LoadingState from "@/components/ui/LoadingState";
+
+interface Props {
+  count?: number;
+}
+
+export default function CatalogSkeleton({ count = 5 }: Props) {
+  return (
+    <View className="py-4 px-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <View
+          key={i}
+          className="mb-3 bg-white rounded-2xl overflow-hidden border border-border"
+        >
+          <LoadingState variant="skeleton" lines={4} />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/specialists/ServiceChipsRow.tsx
+++ b/components/specialists/ServiceChipsRow.tsx
@@ -1,0 +1,77 @@
+import { View, Text, Pressable, ScrollView } from "react-native";
+
+interface ServiceOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  services: ServiceOption[];
+  selectedServiceIds: string[];
+  onToggle: (id: string) => void;
+  onClearAll: () => void;
+}
+
+export default function ServiceChipsRow({
+  services,
+  selectedServiceIds,
+  onToggle,
+  onClearAll,
+}: Props) {
+  if (services.length === 0) return null;
+  const allActive = selectedServiceIds.length === 0;
+
+  return (
+    <View className="pt-2 pb-2" style={{ zIndex: 1 }}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{
+          gap: 8,
+          paddingHorizontal: 16,
+        }}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Не знаю — все услуги"
+          onPress={onClearAll}
+          className={`px-3 h-8 items-center justify-center rounded-full border ${
+            allActive
+              ? "bg-accent border-accent"
+              : "bg-white border-border"
+          }`}
+        >
+          <Text
+            className={`text-xs ${
+              allActive ? "text-white font-medium" : "text-text-base"
+            }`}
+          >
+            Не знаю
+          </Text>
+        </Pressable>
+        {services.map((s) => {
+          const active = selectedServiceIds.includes(s.id);
+          return (
+            <Pressable
+              key={s.id}
+              accessibilityRole="button"
+              accessibilityLabel={s.name}
+              onPress={() => onToggle(s.id)}
+              className={`px-3 h-8 items-center justify-center rounded-full border ${
+                active ? "bg-accent border-accent" : "bg-white border-border"
+              }`}
+            >
+              <Text
+                className={`text-xs ${
+                  active ? "text-white font-medium" : "text-text-base"
+                }`}
+              >
+                {s.name}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/specialists/SpecialistsGrid.tsx
+++ b/components/specialists/SpecialistsGrid.tsx
@@ -1,0 +1,103 @@
+import { View, FlatList, ActivityIndicator, RefreshControl } from "react-native";
+import SpecialistCard from "@/components/SpecialistCard";
+import { colors } from "@/lib/theme";
+
+interface SpecialistItem {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  createdAt: string;
+  services: { id: string; name: string }[];
+  cities: { id: string; name: string }[];
+  specialistFns?: {
+    fnsId: string;
+    fnsName: string;
+    city: { id: string; name: string };
+    services: { id: string; name: string }[];
+  }[];
+  description?: string | null;
+}
+
+interface Props {
+  specialists: SpecialistItem[];
+  gridCols: number;
+  isDesktop: boolean;
+  isWide: boolean;
+  refreshing: boolean;
+  loadingMore: boolean;
+  bookmarkedIds: Set<string>;
+  onRefresh: () => void;
+  onLoadMore: () => void;
+  onPress: (id: string) => void;
+  onBookmark: (id: string) => void;
+}
+
+export default function SpecialistsGrid({
+  specialists,
+  gridCols,
+  isDesktop,
+  isWide,
+  refreshing,
+  loadingMore,
+  bookmarkedIds,
+  onRefresh,
+  onLoadMore,
+  onPress,
+  onBookmark,
+}: Props) {
+  return (
+    <FlatList
+      key={`grid-${gridCols}`}
+      data={specialists}
+      keyExtractor={(item) => item.id}
+      numColumns={gridCols}
+      columnWrapperStyle={
+        gridCols > 1
+          ? { gap: 16, paddingHorizontal: isWide ? 32 : 16 }
+          : undefined
+      }
+      contentContainerStyle={{
+        paddingHorizontal: gridCols > 1 ? 0 : 16,
+        paddingBottom: 48,
+        paddingTop: 8,
+        maxWidth: isWide ? 1200 : isDesktop ? 900 : undefined,
+        alignSelf: isDesktop ? ("center" as const) : undefined,
+        width: "100%" as const,
+      }}
+      renderItem={({ item }) => (
+        <View style={gridCols > 1 ? { flex: 1 } : undefined}>
+          <SpecialistCard
+            id={item.id}
+            firstName={item.firstName}
+            lastName={item.lastName}
+            avatarUrl={item.avatarUrl}
+            createdAt={item.createdAt}
+            services={item.services}
+            cities={item.cities}
+            specialistFns={item.specialistFns}
+            description={item.description}
+            onPress={onPress}
+            onBookmark={onBookmark}
+            bookmarked={bookmarkedIds.has(item.id)}
+            variant="vertical"
+          />
+        </View>
+      )}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+      onEndReached={onLoadMore}
+      onEndReachedThreshold={0.5}
+      ListFooterComponent={
+        loadingMore ? (
+          <ActivityIndicator
+            size="small"
+            color={colors.primary}
+            style={{ paddingVertical: 16 }}
+          />
+        ) : null
+      }
+    />
+  );
+}


### PR DESCRIPTION
Wave 5/O. Pure refactor, no visual changes.

## specialists/index.tsx (509 -> 383 LOC)
Extracts:
- components/specialists/CatalogHeader.tsx
- components/specialists/CatalogSkeleton.tsx
- components/specialists/ServiceChipsRow.tsx
- components/specialists/SpecialistsGrid.tsx

## onboarding/work-area.tsx (554 -> 363 LOC)
Extracts:
- components/onboarding/workarea/BackHeader.tsx
- components/onboarding/workarea/WorkAreaIntro.tsx
- components/onboarding/workarea/PendingFnsPicker.tsx
- components/onboarding/workarea/EntriesList.tsx
- components/onboarding/workarea/saveWorkArea.ts (submit helper)

## Verify
- npx tsc --noEmit (root + api): 0 errors
- No StyleSheet.create added: confirmed
- NativeWind className only