### PR TITLE
fix: chronological chat sort + instrumental padezh + thread name truncation

### DIFF
--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -83,6 +83,96 @@ function displayName(user: { firstName: string | null; lastName: string | null; 
   return parts.length > 0 ? parts.join(" ") : "Пользователь";
 }
 
+/**
+ * Inline Russian instrumental-case helper for first+last names.
+ * Pragmatic suffix rules — handles common cases for "переписываетесь с <Name>".
+ * Track U will replace this with a proper library-level helper (lib/ru.ts) later.
+ *
+ * Rules covered:
+ *   мужские имена: -ей → -еем (Алексей → Алексеем), -й → -ем (Сергей → Сергеем), -а/я → -ой/ей,
+ *                   -consonant → +ом (Иван → Иваном)
+ *   мужские фамилии: -ов/ев/ёв/ин/ын → +ым (Воронов → Вороновым, Пушкин → Пушкиным)
+ *   женские: -а → -ой, -я → -ей (Анна → Анной, Юлия → Юлией)
+ *   фамилии на -ова/ева/ина/ына → -овой/евой/иной/ыной
+ * Unknowns return original token.
+ */
+function tokenInInstrumental(token: string): string {
+  if (!token) return token;
+  const lower = token.toLowerCase();
+
+  // Female surnames: -ова/ева/ёва/ина/ына → -овой/евой/ёвой/иной/ыной
+  if (/(?:ова|ева|ёва|ина|ына)$/.test(lower)) {
+    return token.slice(0, -1) + "ой";
+  }
+  // Female surnames: -ская → -ской
+  if (/ская$/.test(lower)) {
+    return token.slice(0, -2) + "ой";
+  }
+  // Male surnames: -ов/ев/ёв/ин/ын → +ым
+  if (/(?:ов|ев|ёв|ин|ын)$/.test(lower)) {
+    return token + "ым";
+  }
+  // Male surnames: -ский/цкий → -ским/цким
+  if (/(?:ский|цкий)$/.test(lower)) {
+    return token.slice(0, -2) + "им";
+  }
+
+  // First names ending -ей (Алексей, Андрей, Сергей*) → -еем
+  // (Сергей → Сергеем — collapses with -ей rule)
+  if (/ей$/.test(lower)) {
+    return token.slice(0, -2) + "еем";
+  }
+  // -ай/-ой/-уй ends → -аем/-оем/-уем (rare but safer than -ем)
+  if (/[аоу]й$/.test(lower)) {
+    return token.slice(0, -1) + "ем";
+  }
+  // Generic -й → -ем (Николай → Николаем would match -ай above; Юрий → Юрием handled below)
+  if (/ий$/.test(lower)) {
+    return token.slice(0, -2) + "ием";
+  }
+  if (/й$/.test(lower)) {
+    return token.slice(0, -1) + "ем";
+  }
+
+  // -ия (female): Юлия → Юлией, Мария → Марией
+  if (/ия$/.test(lower)) {
+    return token.slice(0, -1) + "ей";
+  }
+  // -я (female/male soft): Аня → Аней, Илья → Ильёй (not handled — return -ей as best-effort)
+  if (/я$/.test(lower)) {
+    return token.slice(0, -1) + "ей";
+  }
+  // -а (female or male like Никита): default to -ой
+  // Special: hissing stems (ж/ш/щ/ч/ц + а) → -ей (Саша → Сашей). Approximate.
+  if (/[жшщчц]а$/.test(lower)) {
+    return token.slice(0, -1) + "ей";
+  }
+  if (/а$/.test(lower)) {
+    return token.slice(0, -1) + "ой";
+  }
+
+  // Male names ending in soft sign -ь (Игорь → Игорем)
+  if (/ь$/.test(lower)) {
+    return token.slice(0, -1) + "ем";
+  }
+
+  // Male names ending in consonant (Иван, Петр) → +ом
+  // Russian consonant set check (last letter)
+  if (/[бвгджзйклмнпрстфхцчшщ]$/.test(lower)) {
+    return token + "ом";
+  }
+
+  return token;
+}
+
+function nameInInstrumental(fullName: string): string {
+  if (!fullName) return fullName;
+  return fullName
+    .split(/\s+/)
+    .map((part) => tokenInInstrumental(part))
+    .join(" ");
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
@@ -353,6 +443,20 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     [myId, handleFilePress]
   );
 
+  // S1 fix — render-time defensive sort: ascending by createdAt (Date timestamp).
+  // The API already returns ASC, but optimistic appends in handleSend + polling races
+  // can interleave messages so a reply lands above older ones. Sorting here guarantees
+  // chronological order regardless of how state was updated. Stable sort keeps within-ms ties.
+  const sortedMessages = (() => {
+    if (messages.length < 2) return messages;
+    return [...messages].sort((a, b) => {
+      const ta = new Date(a.createdAt).getTime();
+      const tb = new Date(b.createdAt).getTime();
+      if (ta !== tb) return ta - tb;
+      return a.id.localeCompare(b.id);
+    });
+  })();
+
   if (loading) {
     return (
       <View className="flex-1 bg-white">
@@ -444,7 +548,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
               const counterpartyFallback =
                 myPerspective === "as_client" ? "Специалистом" : "Клиентом";
               const namedCounterparty = otherUser && !otherUser.isDeleted
-                ? displayName(otherUser)
+                ? nameInInstrumental(displayName(otherUser))
                 : counterpartyFallback;
               return (
                 <Text
@@ -495,7 +599,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
       >
         <FlatList
           ref={flatListRef}
-          data={messages}
+          data={sortedMessages}
           keyExtractor={(item) => item.id}
           renderItem={renderMessage}
           contentContainerStyle={{ padding: 16, flexGrow: 1, justifyContent: "flex-end" }}

--- a/components/messages/ThreadCard.tsx
+++ b/components/messages/ThreadCard.tsx
@@ -117,28 +117,33 @@ export default function ThreadCard({
       </Pressable>
 
       <View className="flex-1 min-w-0 py-3.5">
-        <View className="flex-row items-center justify-between gap-2">
+        {/* S3 fix — give the name flex-1 + min-w-0 so it gets the bulk of the row width
+            and only ellipsises for genuinely long names. Timestamp is fixed-width on the
+            right (flex-shrink-0). Perspective badge sits between name and timestamp, also
+            shrink-proof. Removed the spacer-View that previously starved the name. */}
+        <View className="flex-row items-center gap-2">
           <Text
-            className={`text-base flex-shrink ${
+            className={`flex-1 min-w-0 text-base ${
               hasUnread
                 ? "font-bold text-text-base"
                 : "font-semibold text-text-base"
             }`}
             numberOfLines={1}
+            ellipsizeMode="tail"
           >
             {name}
           </Text>
           {item.perspective ? (
-            <View className="ml-2 flex-shrink-0">
+            <View className="flex-shrink-0">
               <PerspectiveBadge perspective={item.perspective} size="sm" />
             </View>
           ) : null}
-          <View style={{ flex: 1 }} />
           {item.lastMessage && (
             <Text
               className={`text-xs flex-shrink-0 ${
                 hasUnread ? "text-accent font-semibold" : "text-text-dim"
               }`}
+              numberOfLines={1}
             >
               {formatTime(item.lastMessage.createdAt)}
             </Text>


### PR DESCRIPTION
## Summary

Three Wave-6 UX fixes (track S):

- **S1 (CRITICAL)** — `InlineChatView` now sorts messages ASC by `createdAt` (Date timestamp) at render time. The API already returns ASC, but optimistic appends in `handleSend` plus polling races could interleave messages so a new reply landed above older ones. Defensive sort guarantees chronological order.
- **S2** — `InlineChatView` chat header now puts the counterparty name in instrumental case: "переписываетесь **с Алексеем Вороновым**" (was "с Алексей Воронов"). Implemented as inline `nameInInstrumental()` helper with pragmatic Russian suffix rules. Track U will replace with a library-level helper later.
- **S3** — `ThreadCard` row flex rebalanced. Name now uses `flex-1 min-w-0` so it gets the available width; timestamp is fixed-width (`flex-shrink-0`) on the right; perspective badge sits between, also shrink-proof. Removed the `<View style={{flex: 1}} />` spacer that was starving the name column.

## Test plan

- [ ] Open `/threads/[id]` with at least 5 messages spanning different times — confirm chronological order.
- [ ] Header shows "Вы переписываетесь с <Name in instrumental>" for common Russian names (Алексей → Алексеем, Сергей → Сергеем, Иван → Иваном, Анна → Анной, Юлия → Юлией; Воронов → Вороновым, Пушкин → Пушкиным).
- [ ] `/(tabs)/messages` thread list shows full names (not "Алексе..." / "Сер...") on desktop; reasonable truncation only for genuinely long names.
- [x] `npx tsc --noEmit` 0 errors (frontend + api).