### PR TITLE
fix(wave6): anon sidebar leak, avatar initials, atLimit empty state

### DIFF
--- a/app/requests/create.tsx
+++ b/app/requests/create.tsx
@@ -10,8 +10,8 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
-import { useTypedRouter } from "@/lib/navigation";
-import { MapPin, ChevronLeft } from "lucide-react-native";
+import { useTypedRouter, ROUTES } from "@/lib/navigation";
+import { MapPin, ChevronLeft, Inbox } from "lucide-react-native";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import EmptyState from "@/components/ui/EmptyState";
@@ -289,6 +289,38 @@ export default function CreateRequest() {
     );
   }
 
+  // Authenticated user at the active-request limit (5/5). Show EmptyState
+  // only — no form. Anonymous users still see the form (they haven't hit
+  // any limit yet). Wave 6 R3.
+  if (isAuthenticated && atLimit) {
+    return (
+      <SafeAreaView className="flex-1 bg-surface2">
+        <View className="px-4 pt-4">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Назад"
+            onPress={() => router.back()}
+            className="flex-row items-center mb-2"
+            style={{ minHeight: 44 }}
+          >
+            <ChevronLeft size={20} color={colors.text} />
+            <Text className="text-text-base ml-1">Назад</Text>
+          </Pressable>
+          <Text className="text-2xl font-extrabold text-text-base mb-3">Создать заявку</Text>
+        </View>
+        <View className="flex-1 items-center justify-center">
+          <EmptyState
+            icon={Inbox}
+            title="Лимит активных заявок исчерпан (5/5)"
+            subtitle="Закройте одну активную заявку, чтобы создать новую"
+            actionLabel="Открыть мои заявки"
+            onAction={() => nav.any(ROUTES.tabsRequests)}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <View className="px-4 pt-4">
@@ -325,17 +357,6 @@ export default function CreateRequest() {
               </Text>
               <Text className="text-sm text-accent">
                 Подтверждение по email кодом. Без паролей.
-              </Text>
-            </View>
-          )}
-
-          {atLimit && (
-            <View className="bg-danger-soft border border-danger rounded-xl p-4 mb-4">
-              <Text className="text-danger text-sm font-semibold mb-0.5">
-                Лимит заявок исчерпан
-              </Text>
-              <Text className="text-danger text-sm">
-                Закройте неактуальные заявки, чтобы создать новую.
               </Text>
             </View>
           )}

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -206,11 +206,6 @@ export default function UnifiedSettings() {
     }
   }, [ready, isAdminUser, loadSpecialistData, router]);
 
-  const initials = [firstName, lastName]
-    .map((n) => n?.charAt(0)?.toUpperCase())
-    .filter(Boolean)
-    .join("");
-
   // Per-tab change tracking.
   const hasProfileChanges = useMemo(
     () =>
@@ -502,7 +497,6 @@ export default function UnifiedSettings() {
               email={user?.email ?? ""}
               avatarUrl={avatarUrl}
               avatarUploading={avatarUploading}
-              initials={initials}
               isSpecialistUser={isSpecialistUser}
               isAvailable={isAvailable}
               availabilityLoading={availabilityLoading}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { View, useWindowDimensions, Platform } from "react-native";
 import { usePathname, useSegments } from "expo-router";
 import { colors, overlay } from "@/lib/theme";
+import { useAuth } from "@/contexts/AuthContext";
 import SidebarNav, { detectSidebarGroup, SIDEBAR_WIDTH } from "./SidebarNav";
 
 /**
@@ -51,6 +52,7 @@ export default function AppShell({ children }: AppShellProps) {
   const { width } = useWindowDimensions();
   const pathname = usePathname() ?? "";
   const segments = useSegments();
+  const { isAuthenticated } = useAuth();
 
   useEffect(() => {
     if (Platform.OS === "web") installFocusRingCSS();
@@ -63,7 +65,10 @@ export default function AppShell({ children }: AppShellProps) {
 
   const isDesktop = width >= SIDEBAR_BREAKPOINT;
   const group = detectSidebarGroup(pathname, segments as readonly string[]);
-  const showSidebar = isDesktop && group !== null;
+  // Anonymous users never see the auth sidebar — even on routes that fall
+  // into the "main" group (/specialists, /requests/create). They only
+  // get marketing chrome from the page itself. Issue: anon sidebar leak.
+  const showSidebar = isDesktop && group !== null && isAuthenticated;
 
   // Mobile web or public-chrome routes: pass-through.
   if (!showSidebar) {

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -22,20 +22,50 @@ import { colors } from "@/lib/theme";
 interface AvatarUploaderProps {
   avatarUrl: string | null;
   avatarUploading: boolean;
-  initials: string;
+  /**
+   * Full display name (e.g. "Сергей Терещенко") used to derive initials
+   * when no avatarUrl is set. Cyrillic-safe — uses plain `.toUpperCase()`,
+   * never `toLocaleUpperCase('en')` (which would strip Cyrillic).
+   *
+   * Pattern mirrors components/ui/Avatar.tsx (Wave 3).
+   */
+  name?: string;
+  /** Fallback identifier (typically email) when name is empty. */
+  fallback?: string;
   onAvatarChange: (url: string) => void;
   onUploadStart: () => void;
   onUploadEnd: () => void;
 }
 
+/**
+ * Cyrillic-safe initials extractor — IMPORTANT: use plain `.toUpperCase()`
+ * (locale-agnostic). Never use `toLocaleUpperCase('en')` here — it would
+ * strip Cyrillic ("С" → "C") and break Russian-language fallbacks.
+ */
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
 export default function AvatarUploader({
   avatarUrl,
   avatarUploading,
-  initials,
+  name,
+  fallback,
   onAvatarChange,
   onUploadStart,
   onUploadEnd,
 }: AvatarUploaderProps) {
+  const trimmedName = (name ?? "").trim();
+  const initials =
+    getInitials(trimmedName) ||
+    (fallback ? fallback.charAt(0).toUpperCase() : "") ||
+    "?";
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [lastFile, setLastFile] = useState<File | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -131,7 +161,7 @@ export default function AvatarUploader({
             style={{ width: 80, height: 80 }}
           >
             <Text className="text-white text-2xl font-bold">
-              {initials || "?"}
+              {initials}
             </Text>
           </View>
         )}

--- a/components/settings/ProfileTab.tsx
+++ b/components/settings/ProfileTab.tsx
@@ -75,7 +75,6 @@ interface ProfileTabProps {
   email: string;
   avatarUrl: string | null;
   avatarUploading: boolean;
-  initials: string;
   isSpecialistUser: boolean;
   isAvailable: boolean;
   availabilityLoading: boolean;
@@ -95,7 +94,6 @@ export default function ProfileTab({
   email,
   avatarUrl,
   avatarUploading,
-  initials,
   isSpecialistUser,
   isAvailable,
   availabilityLoading,
@@ -120,7 +118,8 @@ export default function ProfileTab({
           <AvatarUploader
             avatarUrl={avatarUrl}
             avatarUploading={avatarUploading}
-            initials={initials}
+            name={`${firstName} ${lastName}`.trim()}
+            fallback={email}
             onAvatarChange={onAvatarChange}
             onUploadStart={onUploadStart}
             onUploadEnd={onUploadEnd}


### PR DESCRIPTION
## Summary

Wave 6 — three critical UX fixes (track R from HANDOVER.md).

### R1. Anon sidebar leak
`components/layout/AppShell.tsx` now gates the desktop sidebar on `isAuthenticated`. Anonymous users on `/specialists` and `/requests/create` no longer see the auth sidebar (Дашборд / Мои заявки / Сообщения / Открытые заявки + "U Пользователь" avatar). They get marketing chrome from the page itself.

### R2. AvatarUploader initials fallback
`components/settings/AvatarUploader.tsx` now derives initials internally from a `name` prop using the same Cyrillic-safe `.toUpperCase()` pattern as `components/ui/Avatar.tsx` (Wave 3). When `avatarUrl=null` it shows e.g. "СТ" instead of an empty circle. Falls back to email's first char, then "?". Upload functionality untouched.

`components/settings/ProfileTab.tsx` and `app/settings/index.tsx` updated to pass `name` + `fallback` (email) instead of pre-computed `initials`.

### R3. /requests/create at-limit empty state
`app/requests/create.tsx` — when `isAuthenticated && atLimit`, renders `EmptyState` only:
- title: "Лимит активных заявок исчерпан (5/5)"
- subtitle: "Закройте одну активную заявку, чтобы создать новую"
- CTA: "Открыть мои заявки" → `ROUTES.tabsRequests`

No form rendered. Anonymous users still see the form (atLimit only fires when authenticated). The redundant red `atLimit` banner inside the form is removed.

## Verification

- [x] `npx tsc --noEmit` (frontend) — 0 errors
- [x] `cd api && npx tsc --noEmit` — 0 errors
- [ ] Manual: anon visits `/specialists` and `/requests/create` — sidebar gone
- [ ] Manual: settings → profile with empty avatar — shows "СТ" initials
- [ ] Manual: auth user at 5/5 visits `/requests/create` — empty state with CTA, no form