### PR TITLE
Wave 6 (T): collapsible filters + compact specialist card + uniform breadcrumbs

### DIFF
--- a/app/(tabs)/public-requests.tsx
+++ b/app/(tabs)/public-requests.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   FlatList,
   ActivityIndicator,
-  Pressable,
   RefreshControl,
   useWindowDimensions,
 } from "react-native";
@@ -13,8 +12,8 @@ import { useRouter } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import DesktopScreen from "@/components/layout/DesktopScreen";
 import RequestCard from "@/components/RequestCard";
-import FilterBar from "@/components/FilterBar";
-import { TriangleAlert, FileText, Filter } from "lucide-react-native";
+import FilterPanel from "@/components/public-requests/FilterPanel";
+import { TriangleAlert, FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
@@ -242,40 +241,7 @@ export default function SpecialistPublicRequests() {
           )}
         </View>
 
-        {/* Pre-filter banner: badge while filtered, CTA "Show all" to clear. */}
-        <View className="flex-row items-center justify-between px-4 mb-2" style={{ gap: 8 }}>
-          {isPrefiltered ? (
-            <View
-              className="flex-row items-center px-3 h-9 rounded-full bg-white border border-border"
-              style={{ gap: 6 }}
-            >
-              <Filter size={14} color={colors.primary} />
-              <Text className="text-xs text-text-base">Фильтр по моим ФНС</Text>
-            </View>
-          ) : (
-            <View />
-          )}
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={isPrefiltered ? "Показать все заявки" : "Только мои ФНС"}
-            onPress={() => {
-              if (isPrefiltered) {
-                setSelectedFnsId(null);
-                setSelectedCityId(null);
-                setSelectedServiceId(null);
-              } else if (specialistFnsServices.length > 0) {
-                setSelectedFnsId(specialistFnsServices[0].fns.id);
-              }
-            }}
-            className="px-3 h-9 rounded-full border border-border bg-white items-center justify-center"
-          >
-            <Text className="text-xs text-text-base">
-              {isPrefiltered ? "Показать все" : "Только мои ФНС"}
-            </Text>
-          </Pressable>
-        </View>
-
-        <FilterBar
+        <FilterPanel
           cities={cities}
           selectedCityId={selectedCityId}
           onCityChange={setSelectedCityId}
@@ -286,8 +252,20 @@ export default function SpecialistPublicRequests() {
           selectedFnsId={selectedFnsId}
           onFnsChange={setSelectedFnsId}
           services={services}
-          selectedServiceIds={selectedServiceId ? [selectedServiceId] : []}
+          selectedServiceId={selectedServiceId}
           onServiceToggle={handleServiceToggle}
+          fnsToggle={{
+            isPrefiltered,
+            onToggle: () => {
+              if (isPrefiltered) {
+                setSelectedFnsId(null);
+                setSelectedCityId(null);
+                setSelectedServiceId(null);
+              } else if (specialistFnsServices.length > 0) {
+                setSelectedFnsId(specialistFnsServices[0].fns.id);
+              }
+            },
+          }}
         />
 
         {loading ? (

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,5 +1,4 @@
 import { View, Text, Pressable, Image } from "react-native";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { Bookmark } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
@@ -40,11 +39,9 @@ export default function SpecialistCard({
   firstName,
   lastName,
   avatarUrl,
-  createdAt,
   services,
   cities,
   specialistFns,
-  description,
   onPress,
   variant,
   horizontal = false,
@@ -54,7 +51,6 @@ export default function SpecialistCard({
   const resolvedVariant = variant ?? (horizontal ? "horizontal" : "vertical");
   const name = [firstName, lastName].filter(Boolean).join(" ") || "Специалист";
   const initials = getInitials(firstName, lastName);
-  const joinYear = createdAt ? new Date(createdAt).getFullYear() : null;
 
   if (resolvedVariant === "horizontal") {
     return (
@@ -90,37 +86,76 @@ export default function SpecialistCard({
     );
   }
 
-  // Vertical variant (new default for catalog grid)
+  // Vertical variant — compact 3-row layout (T2 redesign):
+  //   Row 1: avatar + name (bold) + city (muted) + bookmark
+  //   Row 2: ИФНС text (1 line, truncated)
+  //   Row 3: up to 3 service chips ("+N" if more)
+  const cityLabel = cities.length > 0 ? cities.map((c) => c.name).join(", ") : null;
+
+  // Resolve flat list of services + ИФНС label (prefer specialistFns when available).
+  const fnsLabel = specialistFns && specialistFns.length > 0
+    ? specialistFns.map((g) => g.fnsName).join(", ")
+    : null;
+  const flatServices = specialistFns && specialistFns.length > 0
+    ? specialistFns.flatMap((g) => g.services)
+    : services;
+
+  // Dedupe services by id (FNS groups can repeat the same service across offices).
+  const uniqueServices = flatServices.filter(
+    (svc, idx, arr) => arr.findIndex((s) => s.id === svc.id) === idx
+  );
+  const visibleServices = uniqueServices.slice(0, 3);
+  const overflow = uniqueServices.length - visibleServices.length;
+
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={name}
       onPress={() => onPress(id)}
-      className="bg-white border border-border rounded-2xl p-4 mb-3"
+      className="bg-white border border-border rounded-2xl p-3 mb-3"
       style={({ pressed }) => [
         { shadowColor: colors.black, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
         pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
       ]}
     >
-      {/* Top row: avatar + bookmark */}
-      <View className="flex-row items-start justify-between">
-        {/* Avatar */}
+      {/* Row 1: avatar + name + city (same line) + bookmark */}
+      <View className="flex-row items-center" style={{ gap: 10 }}>
         {avatarUrl ? (
           <Image
             source={{ uri: avatarUrl }}
-            style={{ width: 56, height: 56, borderRadius: 28 }}
+            style={{ width: 40, height: 40, borderRadius: 20 }}
             accessibilityLabel={name}
           />
         ) : (
           <View
             className="rounded-full items-center justify-center"
-            style={{ width: 56, height: 56, backgroundColor: colors.primary }}
+            style={{ width: 40, height: 40, backgroundColor: colors.primary }}
           >
-            <Text className="text-white font-bold text-lg">{initials}</Text>
+            <Text className="text-white font-bold text-sm">{initials}</Text>
           </View>
         )}
 
-        {/* Bookmark button */}
+        <View style={{ flex: 1, minWidth: 0 }}>
+          <View className="flex-row items-baseline" style={{ gap: 6 }}>
+            <Text
+              className="text-sm font-bold flex-shrink"
+              style={{ color: colors.text }}
+              numberOfLines={1}
+            >
+              {name}
+            </Text>
+            {cityLabel ? (
+              <Text
+                className="text-xs flex-shrink"
+                style={{ color: colors.textMuted }}
+                numberOfLines={1}
+              >
+                · {cityLabel}
+              </Text>
+            ) : null}
+          </View>
+        </View>
+
         {onBookmark && (
           <Pressable
             accessibilityRole="button"
@@ -137,96 +172,38 @@ export default function SpecialistCard({
         )}
       </View>
 
-      {/* Name */}
-      <Text className="text-base font-bold mt-2" style={{ color: colors.text }} numberOfLines={1}>
-        {name}
-      </Text>
-
-      {/* Join year */}
-      {joinYear && (
-        <Text className="text-xs mt-0.5" style={{ color: colors.textMuted }}>
-          На сайте с {joinYear}
-        </Text>
-      )}
-
-      {/* Description */}
-      {description ? (
-        <Text className="text-sm mt-2" style={{ color: colors.textSecondary }} numberOfLines={2}>
-          {description}
+      {/* Row 2: ИФНС (1 line, truncated) */}
+      {fnsLabel ? (
+        <Text
+          className="text-xs mt-1.5"
+          style={{ color: colors.textMuted }}
+          numberOfLines={1}
+        >
+          {fnsLabel}
         </Text>
       ) : null}
 
-      {/* FNS-grouped services (vertical variant) */}
-      {specialistFns && specialistFns.length > 0
-        ? (() => {
-            // Show max 2 FNS groups, max 3 services each; rest as overflow pill
-            const visibleFns = specialistFns.slice(0, 2);
-            const totalServices = specialistFns.reduce((acc, g) => acc + g.services.length, 0);
-            const shownServices = visibleFns.reduce(
-              (acc, g) => acc + Math.min(g.services.length, 3),
-              0
-            );
-            const overflow = totalServices - shownServices;
-            return (
-              <View className="mt-2" style={{ gap: 8 }}>
-                {visibleFns.map((group) => (
-                  <View key={group.fnsId}>
-                    {/* FNS label */}
-                    <View className="flex-row items-center mb-1" style={{ gap: 4 }}>
-                      <FontAwesome name="map-marker" size={10} color={colors.textMuted} />
-                      <Text className="text-xs" style={{ color: colors.textMuted }} numberOfLines={1}>
-                        {group.city.name} — {group.fnsName}
-                      </Text>
-                    </View>
-                    {/* Service pills for this FNS */}
-                    <View className="flex-row flex-wrap" style={{ gap: 6 }}>
-                      {group.services.slice(0, 3).map((s) => (
-                        <View
-                          key={s.id}
-                          className="px-2.5 py-1 rounded-full"
-                          style={{ backgroundColor: colors.accentSoft }}
-                        >
-                          <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
-                        </View>
-                      ))}
-                    </View>
-                  </View>
-                ))}
-                {overflow > 0 && (
-                  <Text className="text-xs mt-1" style={{ color: colors.textMuted }}>
-                    +{overflow} ещё
-                  </Text>
-                )}
-              </View>
-            );
-          })()
-        : (
-          <>
-            {/* Fallback: flat service pills */}
-            {services.length > 0 && (
-              <View className="flex-row flex-wrap mt-2" style={{ gap: 8 }}>
-                {services.map((s) => (
-                  <View
-                    key={s.id}
-                    className="px-2.5 py-1 rounded-full"
-                    style={{ backgroundColor: colors.accentSoft }}
-                  >
-                    <Text className="text-xs font-medium" style={{ color: colors.primary }}>{s.name}</Text>
-                  </View>
-                ))}
-              </View>
-            )}
-            {/* City */}
-            {cities.length > 0 && (
-              <View className="flex-row items-center mt-2">
-                <FontAwesome name="map-marker" size={12} color={colors.textMuted} />
-                <Text className="text-xs ml-1" style={{ color: colors.textMuted }} numberOfLines={1}>
-                  {cities.map((c) => c.name).join(", ")}
-                </Text>
-              </View>
-            )}
-          </>
-        )}
+      {/* Row 3: up to 3 service chips + "+N" */}
+      {visibleServices.length > 0 ? (
+        <View className="flex-row flex-wrap items-center mt-1.5" style={{ gap: 6 }}>
+          {visibleServices.map((s) => (
+            <View
+              key={s.id}
+              className="px-2 py-0.5 rounded-full"
+              style={{ backgroundColor: colors.accentSoft }}
+            >
+              <Text className="text-xs" style={{ color: colors.primary }} numberOfLines={1}>
+                {s.name}
+              </Text>
+            </View>
+          ))}
+          {overflow > 0 && (
+            <Text className="text-xs" style={{ color: colors.textMuted }}>
+              +{overflow}
+            </Text>
+          )}
+        </View>
+      ) : null}
     </Pressable>
   );
 }

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -54,13 +54,19 @@ function toAccentKey(
 }
 
 // Shallow breadcrumb mapping — exact-prefix first, then longest-prefix wins.
+//
+// T3 (Wave 6): consistent breadcrumbs on ALL tab screens — Expo Router strips
+// the (tabs) group from `usePathname()`, so the dashboard tab arrives as "/"
+// and other tabs as "/messages", "/dashboard" etc. We add explicit entries so
+// every tab gets a label (no more inconsistent "Заявки" but blank dashboard).
 const BREADCRUMB_MAP: ReadonlyArray<{ prefix: string; label: string }> = [
   // Iter11 — unified (tabs) replaces split groups.
-  { prefix: "/(tabs)/public-requests", label: "Публичные заявки" },
-  { prefix: "/(tabs)/requests", label: "Мои заявки" },
+  { prefix: "/(tabs)/public-requests", label: "Открытые заявки" },
+  { prefix: "/(tabs)/requests", label: "Заявки" },
   { prefix: "/(tabs)/messages", label: "Сообщения" },
-  { prefix: "/(tabs)/profile", label: "Профиль" },
-  { prefix: "/(tabs)", label: "Дашборд" },
+  { prefix: "/(tabs)/dashboard", label: "Главная" },
+  { prefix: "/(tabs)/profile", label: "Настройки" },
+  { prefix: "/(tabs)", label: "Главная" },
   { prefix: "/(admin-tabs)/dashboard", label: "Админ · Обзор" },
   { prefix: "/(admin-tabs)/users", label: "Пользователи" },
   { prefix: "/(admin-tabs)/moderation", label: "Модерация" },
@@ -71,10 +77,17 @@ const BREADCRUMB_MAP: ReadonlyArray<{ prefix: string; label: string }> = [
   { prefix: "/requests", label: "Заявки" },
   { prefix: "/threads", label: "Переписки" },
   { prefix: "/settings", label: "Настройки" },
+  // Bare paths (Expo Router strips (tabs) group from usePathname()).
+  { prefix: "/dashboard", label: "Главная" },
+  { prefix: "/messages", label: "Сообщения" },
+  { prefix: "/public-requests", label: "Открытые заявки" },
+  { prefix: "/profile", label: "Настройки" },
 ];
 
 function inferBreadcrumb(pathname: string): string | null {
   if (!pathname) return null;
+  // Root "/" → dashboard label (Expo Router emits "/" for /(tabs)/index).
+  if (pathname === "/") return "Главная";
   const sorted = [...BREADCRUMB_MAP].sort((a, b) => b.prefix.length - a.prefix.length);
   for (const entry of sorted) {
     // Normalise paren-group markers: Expo Router may emit either form.

--- a/components/public-requests/FilterPanel.tsx
+++ b/components/public-requests/FilterPanel.tsx
@@ -1,0 +1,280 @@
+import { useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronDown, ChevronUp, Filter as FilterIcon, X } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+
+interface SelectOption {
+  id: string;
+  name: string;
+}
+
+interface FilterPanelProps {
+  cities: SelectOption[];
+  selectedCityId: string | null;
+  onCityChange: (id: string | null) => void;
+  fnsOffices: SelectOption[];
+  selectedFnsId: string | null;
+  onFnsChange: (id: string | null) => void;
+  services: SelectOption[];
+  selectedServiceId: string | null;
+  onServiceToggle: (id: string) => void;
+  /** Specialist-only toggle: "Только мои ФНС" / "Показать все". */
+  fnsToggle?: {
+    isPrefiltered: boolean;
+    onToggle: () => void;
+  };
+}
+
+interface ActiveFilter {
+  key: string;
+  label: string;
+  onRemove: () => void;
+}
+
+function FilterChip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      className={`px-3 h-11 items-center justify-center rounded-full border ${
+        active ? "bg-accent border-accent" : "bg-white border-border"
+      }`}
+    >
+      <Text
+        className={`text-sm ${active ? "text-white font-medium" : "text-text-base"}`}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+export default function FilterPanel({
+  cities,
+  selectedCityId,
+  onCityChange,
+  fnsOffices,
+  selectedFnsId,
+  onFnsChange,
+  services,
+  selectedServiceId,
+  onServiceToggle,
+  fnsToggle,
+}: FilterPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const activeFilters = useMemo<ActiveFilter[]>(() => {
+    const list: ActiveFilter[] = [];
+    if (selectedCityId) {
+      const city = cities.find((c) => c.id === selectedCityId);
+      if (city) {
+        list.push({
+          key: `city:${city.id}`,
+          label: city.name,
+          onRemove: () => onCityChange(null),
+        });
+      }
+    }
+    if (selectedFnsId) {
+      const fns = fnsOffices.find((f) => f.id === selectedFnsId);
+      if (fns) {
+        list.push({
+          key: `fns:${fns.id}`,
+          label: fns.name,
+          onRemove: () => onFnsChange(null),
+        });
+      }
+    }
+    if (selectedServiceId) {
+      const svc = services.find((s) => s.id === selectedServiceId);
+      if (svc) {
+        list.push({
+          key: `svc:${svc.id}`,
+          label: svc.name,
+          onRemove: () => onServiceToggle(svc.id),
+        });
+      }
+    }
+    return list;
+  }, [
+    cities,
+    fnsOffices,
+    services,
+    selectedCityId,
+    selectedFnsId,
+    selectedServiceId,
+    onCityChange,
+    onFnsChange,
+    onServiceToggle,
+  ]);
+
+  const activeCount = activeFilters.length;
+
+  return (
+    <View className="px-4 pt-2 pb-1">
+      {/* Compact ФНС toggle (always visible) */}
+      {fnsToggle && (
+        <View className="flex-row items-center mb-2" style={{ gap: 8 }}>
+          {fnsToggle.isPrefiltered ? (
+            <View
+              className="flex-row items-center px-3 h-9 rounded-full bg-white border border-border"
+              style={{ gap: 6 }}
+            >
+              <FilterIcon size={14} color={colors.primary} />
+              <Text className="text-xs text-text-base">Фильтр по моим ФНС</Text>
+            </View>
+          ) : (
+            <View />
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              fnsToggle.isPrefiltered ? "Показать все заявки" : "Только мои ФНС"
+            }
+            onPress={fnsToggle.onToggle}
+            className="px-3 h-9 rounded-full border border-border bg-white items-center justify-center"
+            style={{ marginLeft: fnsToggle.isPrefiltered ? "auto" : 0 }}
+          >
+            <Text className="text-xs text-text-base">
+              {fnsToggle.isPrefiltered ? "Показать все" : "Только мои ФНС"}
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {/* Header (collapse trigger) */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={
+          expanded ? "Свернуть фильтры" : "Развернуть фильтры"
+        }
+        onPress={() => setExpanded((v) => !v)}
+        className="flex-row items-center justify-between h-11 px-3 rounded-xl bg-white border border-border"
+      >
+        <View className="flex-row items-center" style={{ gap: 8 }}>
+          <FilterIcon size={16} color={colors.text} />
+          <Text className="text-sm font-medium" style={{ color: colors.text }}>
+            Фильтры{activeCount > 0 ? ` (${activeCount} активн${activeCount === 1 ? "ый" : "ых"})` : ""}
+          </Text>
+        </View>
+        {expanded ? (
+          <ChevronUp size={18} color={colors.textMuted} />
+        ) : (
+          <ChevronDown size={18} color={colors.textMuted} />
+        )}
+      </Pressable>
+
+      {/* Active-filter summary chips (visible when collapsed and any active) */}
+      {!expanded && activeFilters.length > 0 && (
+        <View className="flex-row flex-wrap mt-2" style={{ gap: 6 }}>
+          {activeFilters.map((f) => (
+            <Pressable
+              key={f.key}
+              accessibilityRole="button"
+              accessibilityLabel={`Убрать фильтр ${f.label}`}
+              onPress={f.onRemove}
+              className="flex-row items-center px-2.5 h-8 rounded-full bg-accent-soft border border-border"
+              style={{ gap: 4 }}
+            >
+              <Text className="text-xs" style={{ color: colors.primary }}>
+                {f.label}
+              </Text>
+              <X size={12} color={colors.primary} />
+            </Pressable>
+          ))}
+        </View>
+      )}
+
+      {/* Expanded grid */}
+      {expanded && (
+        <View className="mt-2">
+          {cities.length > 0 && (
+            <View className="mb-2">
+              <Text
+                className="text-xs mb-1.5"
+                style={{ color: colors.textMuted }}
+              >
+                Город
+              </Text>
+              <View className="flex-row flex-wrap" style={{ gap: 8 }}>
+                <FilterChip
+                  label="Все города"
+                  active={!selectedCityId}
+                  onPress={() => onCityChange(null)}
+                />
+                {cities.map((city) => (
+                  <FilterChip
+                    key={city.id}
+                    label={city.name}
+                    active={selectedCityId === city.id}
+                    onPress={() =>
+                      onCityChange(selectedCityId === city.id ? null : city.id)
+                    }
+                  />
+                ))}
+              </View>
+            </View>
+          )}
+
+          {fnsOffices.length > 0 && (
+            <View className="mb-2">
+              <Text
+                className="text-xs mb-1.5"
+                style={{ color: colors.textMuted }}
+              >
+                ИФНС
+              </Text>
+              <View className="flex-row flex-wrap" style={{ gap: 8 }}>
+                <FilterChip
+                  label="Все ИФНС"
+                  active={!selectedFnsId}
+                  onPress={() => onFnsChange(null)}
+                />
+                {fnsOffices.map((fns) => (
+                  <FilterChip
+                    key={fns.id}
+                    label={fns.name}
+                    active={selectedFnsId === fns.id}
+                    onPress={() =>
+                      onFnsChange(selectedFnsId === fns.id ? null : fns.id)
+                    }
+                  />
+                ))}
+              </View>
+            </View>
+          )}
+
+          {services.length > 0 && (
+            <View className="mb-1">
+              <Text
+                className="text-xs mb-1.5"
+                style={{ color: colors.textMuted }}
+              >
+                Услуги
+              </Text>
+              <View className="flex-row flex-wrap" style={{ gap: 8 }}>
+                {services.map((s) => (
+                  <FilterChip
+                    key={s.id}
+                    label={s.name}
+                    active={selectedServiceId === s.id}
+                    onPress={() => onServiceToggle(s.id)}
+                  />
+                ))}
+              </View>
+            </View>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary (3 medium UX bugs from Wave 6 / track T)

- **T1** `app/(tabs)/public-requests.tsx`: filter UI was 4 rows (FNS toggle + 11 cities + 5 ИФНС + 3 services) eating half the screen. Extracted `components/public-requests/FilterPanel.tsx` with default-collapsed expand/expand panel ("Фильтры (N активных)" + chevron). The ФНС "Только мои ФНС/Показать все" toggle stays compact at the top. When collapsed and any filter is active, a small chip row underneath shows active filters with X to remove each.
- **T2** `components/SpecialistCard.tsx`: vertical variant shrunk to 3 rows max:
  1. avatar (40×40) + name + city (muted, same line) + bookmark
  2. ИФНС label (1 line, truncated)
  3. up to 3 service chips ("+N" if more)
  Dropped "На сайте с 2026" from the card. Horizontal variant unchanged.
- **T3** `components/layout/AppHeader.tsx`: breadcrumb was inconsistent — `/dashboard` and `/messages` showed nothing, while `/requests`, `/threads/[id]`, `/settings` had labels. Picked Option A: every tab gets a label ("Главная", "Сообщения", "Заявки", "Открытые заявки", "Настройки") plus a fallback for the root "/" that Expo Router emits for /(tabs)/index.

## Verification

- `npx tsc --noEmit` (root) → 0 errors
- `npx tsc --noEmit` (api) → 0 errors
- All NativeWind className; zero `StyleSheet.create`
- File sizes: public-requests.tsx 334 LOC, FilterPanel.tsx 280 LOC, SpecialistCard.tsx 209 LOC, AppHeader.tsx 460 LOC

## Test plan

- [ ] open `/public-requests` as specialist — panel collapsed by default, "Фильтры" header + chevron visible
- [ ] tap header → panel expands showing City / ИФНС / Услуги groups
- [ ] tap a chip in expanded view → it activates, header counter updates
- [ ] collapse panel → active filter pills show below header with X remove
- [ ] open `/specialists` — cards now 3 rows tall, name+city same line, no "На сайте с"
- [ ] click on a specialist card → still navigates to detail
- [ ] visit `/dashboard`, `/messages`, `/requests`, `/public-requests`, `/settings` — every header shows the right label