### PR TITLE
feat(i18n): Russian pluralization + first-name genitive (Wave 6 / track U)

### DIFF
--- a/api/src/lib/ru.ts
+++ b/api/src/lib/ru.ts
@@ -1,0 +1,53 @@
+/**
+ * Russian language helpers — backend mirror of frontend lib/ru.ts.
+ *
+ * Pragmatic suffix-based rules. Returns original string for unknown patterns.
+ * No external dependencies on purpose.
+ */
+
+export function pluralizeRu(n: number, forms: [string, string, string]): string {
+  const abs = Math.abs(n) % 100;
+  const n1 = abs % 10;
+  if (abs > 10 && abs < 20) return forms[2];
+  if (n1 > 1 && n1 < 5) return forms[1];
+  if (n1 === 1) return forms[0];
+  return forms[2];
+}
+
+const GENITIVE_EXCEPTIONS: Record<string, string> = {
+  лев: "льва",
+  пётр: "петра",
+  петр: "петра",
+  павел: "павла",
+  александр: "александра",
+};
+
+/**
+ * Russian first-name in genitive case for "от Сергея / для Анны" style messages.
+ * See lib/ru.ts in the frontend for the full rule list.
+ */
+export function firstNameInGenitive(name: string): string {
+  if (!name) return name;
+  const trimmed = name.trim();
+  if (!trimmed) return name;
+
+  const lower = trimmed.toLowerCase();
+  if (GENITIVE_EXCEPTIONS[lower]) {
+    const out = GENITIVE_EXCEPTIONS[lower];
+    return trimmed[0] === trimmed[0].toUpperCase()
+      ? out[0].toUpperCase() + out.slice(1)
+      : out;
+  }
+
+  if (/ей$/.test(lower)) return trimmed.slice(0, -2) + "ея";
+  if (/ий$/.test(lower)) return trimmed.slice(0, -2) + "ия";
+  if (/й$/.test(lower)) return trimmed.slice(0, -1) + "я";
+  if (/ия$/.test(lower)) return trimmed.slice(0, -1) + "и";
+  if (/я$/.test(lower)) return trimmed.slice(0, -1) + "и";
+  if (/[жшщч]а$/.test(lower)) return trimmed.slice(0, -1) + "и";
+  if (/а$/.test(lower)) return trimmed.slice(0, -1) + "ы";
+  if (/ь$/.test(lower)) return trimmed.slice(0, -1) + "я";
+  if (/[бвгджзклмнпрстфхцчшщ]$/.test(lower)) return trimmed + "а";
+
+  return trimmed;
+}

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
 import { sendNotification } from "../notifications/notification.service";
 import { sendNewMessageEmail } from "../lib/email";
+import { firstNameInGenitive } from "../lib/ru";
 import type * as Minio from "minio";
 import { minioClient, MINIO_BUCKET } from "../lib/minio";
 
@@ -400,7 +401,7 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
     sendNotification({
       userId: recipientId,
       type: "new_message",
-      title: `Новое сообщение от ${senderName}`,
+      title: `Новое сообщение от ${firstNameInGenitive(senderName)}`,
       body: trimmedText ? trimmedText.slice(0, 200) : "Вложение",
       entityId: threadId,
     }).catch((err: Error) => console.warn("[notifications] new_message trigger failed:", err.message));

--- a/app/(tabs)/public-requests.tsx
+++ b/app/(tabs)/public-requests.tsx
@@ -17,6 +17,7 @@ import { TriangleAlert, FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { api } from "@/lib/api";
+import { pluralizeRu } from "@/lib/ru";
 import { colors, overlay, BREAKPOINT } from "@/lib/theme";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
@@ -237,7 +238,9 @@ export default function SpecialistPublicRequests() {
           <Text className="text-xl font-bold text-white mb-0.5">Публичные заявки</Text>
           <Text className="text-sm" style={{ color: overlay.white90 }}>Находите клиентов по своей специализации</Text>
           {total > 0 && (
-            <Text className="text-sm font-semibold text-white mt-2">{total} заявок доступно</Text>
+            <Text className="text-sm font-semibold text-white mt-2">
+              {total} {pluralizeRu(total, ["заявка", "заявки", "заявок"])} доступно
+            </Text>
           )}
         </View>
 

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable } from "react-native";
 import StatusBadge from "./StatusBadge";
 import { colors } from "@/lib/theme";
+import { pluralizeRu } from "@/lib/ru";
 
 interface RequestCardProps {
   id: string;
@@ -64,7 +65,17 @@ export default function RequestCard({
       </Text>
 
       <Text className="text-xs text-text-mute">
-        {threadsCount} {threadsCount === 1 ? "специалист уже написал" : "специалистов уже написали"}
+        {threadsCount === 0
+          ? "Никто пока не откликнулся"
+          : `${threadsCount} ${pluralizeRu(threadsCount, [
+              "специалист",
+              "специалиста",
+              "специалистов",
+            ])} уже ${pluralizeRu(threadsCount, [
+              "написал",
+              "написали",
+              "написали",
+            ])}`}
       </Text>
     </Pressable>
   );

--- a/components/landing/SpecialistCTASection.tsx
+++ b/components/landing/SpecialistCTASection.tsx
@@ -1,5 +1,6 @@
 import { View, Text, Pressable } from "react-native";
 import { colors, overlay } from "@/lib/theme";
+import { pluralizeRu } from "@/lib/ru";
 
 interface SpecialistCTASectionProps {
   isDesktop: boolean;
@@ -128,7 +129,11 @@ export default function SpecialistCTASection({
           </Pressable>
           <Text style={{ color: overlay.white50, fontSize: 12, lineHeight: 18 }}>
             {specialistsCount > 0
-              ? `${specialistsCount} специалистов уже с нами`
+              ? `${specialistsCount} ${pluralizeRu(specialistsCount, [
+                  "специалист",
+                  "специалиста",
+                  "специалистов",
+                ])} уже с нами`
               : "Присоединяйтесь к растущему сообществу"}
           </Text>
         </View>

--- a/components/requests/ThreadsList.tsx
+++ b/components/requests/ThreadsList.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import Avatar from "@/components/ui/Avatar";
 import { colors } from "@/lib/theme";
+import { pluralizeRu } from "@/lib/ru";
 
 export interface ThreadSummary {
   id: string;
@@ -72,9 +73,12 @@ export default function ThreadsList({
         <>
           <Text className="text-sm text-text-mute mb-3">
             {threadsCount}{" "}
-            {threadsCount === 1
-              ? "специалист написал"
-              : "специалистов написали"}{" "}
+            {pluralizeRu(threadsCount, [
+              "специалист",
+              "специалиста",
+              "специалистов",
+            ])}{" "}
+            {pluralizeRu(threadsCount, ["написал", "написали", "написали"])}{" "}
             вам
           </Text>
           {threads.map((thread) => {

--- a/components/specialists/CatalogHeader.tsx
+++ b/components/specialists/CatalogHeader.tsx
@@ -1,5 +1,6 @@
 import { View, Text } from "react-native";
 import { colors, textStyle } from "@/lib/theme";
+import { pluralizeRu } from "@/lib/ru";
 
 interface Props {
   isDesktop: boolean;
@@ -24,7 +25,7 @@ export default function CatalogHeader({ isDesktop, count }: Props) {
       </Text>
       {count !== null && count > 0 && (
         <Text className="text-xs" style={{ color: colors.textMuted }}>
-          {count} специалистов
+          {count} {pluralizeRu(count, ["специалист", "специалиста", "специалистов"])}
         </Text>
       )}
     </View>

--- a/lib/ru.ts
+++ b/lib/ru.ts
@@ -1,0 +1,149 @@
+/**
+ * Russian language helpers — pluralization + name declension.
+ *
+ * Pragmatic suffix-based rules. Returns original string for unknown patterns.
+ * No external dependencies on purpose (no `petrovich`).
+ */
+
+/**
+ * Russian plural form selector (one / few / many).
+ *
+ * Examples:
+ *   pluralizeRu(1, ['заявка', 'заявки', 'заявок']) -> 'заявка'
+ *   pluralizeRu(2, ['заявка', 'заявки', 'заявок']) -> 'заявки'
+ *   pluralizeRu(5, ['заявка', 'заявки', 'заявок']) -> 'заявок'
+ *   pluralizeRu(0, ['заявка', 'заявки', 'заявок']) -> 'заявок'
+ */
+export function pluralizeRu(n: number, forms: [string, string, string]): string {
+  const abs = Math.abs(n) % 100;
+  const n1 = abs % 10;
+  if (abs > 10 && abs < 20) return forms[2];
+  if (n1 > 1 && n1 < 5) return forms[1];
+  if (n1 === 1) return forms[0];
+  return forms[2];
+}
+
+// Small dictionary of irregular first names (genitive case).
+const GENITIVE_EXCEPTIONS: Record<string, string> = {
+  лев: "льва",
+  пётр: "петра",
+  петр: "петра",
+  павел: "павла",
+  александр: "александра",
+};
+
+/**
+ * Russian first-name in genitive case for "от Сергея / для Анны" style messages.
+ *
+ * Handled (pragmatic):
+ *   - exceptions dictionary (Лев, Пётр, Павел, Александр)
+ *   - male -ей  -> -ея   (Алексей -> Алексея, Андрей -> Андрея, Сергей -> Сергея)
+ *   - male -й   -> -я    (Юрий -> Юрия — soft i; Николай -> Николая)
+ *   - male -ь   -> -я    (Игорь -> Игоря)
+ *   - male consonant -> +а (Иван -> Ивана, Виктор -> Виктора)
+ *   - female -ия -> -ии  (Юлия -> Юлии, Мария -> Марии)
+ *   - female -я  -> -и   (Илья m / Аня f -> Ильи / Ани)
+ *   - female -а  -> -ы   (Анна -> Анны, Никита m -> Никиты)
+ *
+ * Unknown patterns return original.
+ */
+export function firstNameInGenitive(name: string): string {
+  if (!name) return name;
+  const trimmed = name.trim();
+  if (!trimmed) return name;
+
+  const lower = trimmed.toLowerCase();
+  if (GENITIVE_EXCEPTIONS[lower]) {
+    // Preserve original capitalization on first letter.
+    const out = GENITIVE_EXCEPTIONS[lower];
+    return trimmed[0] === trimmed[0].toUpperCase()
+      ? out[0].toUpperCase() + out.slice(1)
+      : out;
+  }
+
+  // Male names ending -ей -> -ея (Алексей, Андрей, Сергей)
+  if (/ей$/.test(lower)) {
+    return trimmed.slice(0, -2) + "ея";
+  }
+  // Male names ending -ий -> -ия (Юрий -> Юрия, Дмитрий -> Дмитрия)
+  if (/ий$/.test(lower)) {
+    return trimmed.slice(0, -2) + "ия";
+  }
+  // Male names ending -й -> -я (Николай -> Николая, Виталий handled above)
+  if (/й$/.test(lower)) {
+    return trimmed.slice(0, -1) + "я";
+  }
+  // Female -ия -> -ии (Юлия -> Юлии, Мария -> Марии)
+  if (/ия$/.test(lower)) {
+    return trimmed.slice(0, -1) + "и";
+  }
+  // -я (Илья -> Ильи, Аня -> Ани)
+  if (/я$/.test(lower)) {
+    return trimmed.slice(0, -1) + "и";
+  }
+  // -а (Анна -> Анны, Никита -> Никиты, Саша -> Саши for hissing)
+  if (/[жшщч]а$/.test(lower)) {
+    // hissing consonant + а -> -и (Саша -> Саши)
+    return trimmed.slice(0, -1) + "и";
+  }
+  if (/а$/.test(lower)) {
+    return trimmed.slice(0, -1) + "ы";
+  }
+  // Male soft -ь -> -я (Игорь -> Игоря)
+  if (/ь$/.test(lower)) {
+    return trimmed.slice(0, -1) + "я";
+  }
+  // Male consonant -> +а (Иван -> Ивана, Виктор -> Виктора)
+  if (/[бвгджзклмнпрстфхцчшщ]$/.test(lower)) {
+    return trimmed + "а";
+  }
+
+  return trimmed;
+}
+
+/**
+ * Russian first+last name in instrumental for "переписываетесь с <Имя Фамилия>".
+ *
+ * Mirrors the inline implementation in components/InlineChatView.tsx so other
+ * call sites can reuse it without depending on that component.
+ *
+ * Rules (pragmatic):
+ *   мужские имена: -ей -> -еем, -й -> -ем, -consonant -> +ом
+ *   мужские фамилии: -ов/ев/ёв/ин/ын -> +ым; -ский/цкий -> -ским/цким
+ *   женские: -а -> -ой, -ия/-я -> -ией/-ей, -ова/ева/ина/ына -> -овой/евой/иной/ыной
+ *   женские фамилии: -ская -> -ской
+ */
+function tokenInInstrumental(token: string): string {
+  if (!token) return token;
+  const lower = token.toLowerCase();
+
+  if (/(?:ова|ева|ёва|ина|ына)$/.test(lower)) return token.slice(0, -1) + "ой";
+  if (/ская$/.test(lower)) return token.slice(0, -2) + "ой";
+  if (/(?:ов|ев|ёв|ин|ын)$/.test(lower)) return token + "ым";
+  if (/(?:ский|цкий)$/.test(lower)) return token.slice(0, -2) + "им";
+
+  if (/ей$/.test(lower)) return token.slice(0, -2) + "еем";
+  if (/[аоу]й$/.test(lower)) return token.slice(0, -1) + "ем";
+  if (/ий$/.test(lower)) return token.slice(0, -2) + "ием";
+  if (/й$/.test(lower)) return token.slice(0, -1) + "ем";
+
+  if (/ия$/.test(lower)) return token.slice(0, -1) + "ей";
+  if (/я$/.test(lower)) return token.slice(0, -1) + "ей";
+
+  if (/[жшщчц]а$/.test(lower)) return token.slice(0, -1) + "ей";
+  if (/а$/.test(lower)) return token.slice(0, -1) + "ой";
+
+  if (/ь$/.test(lower)) return token.slice(0, -1) + "ем";
+
+  if (/[бвгджзйклмнпрстфхцчшщ]$/.test(lower)) return token + "ом";
+
+  return token;
+}
+
+export function nameInInstrumental(fullName: string): string {
+  if (!fullName) return fullName;
+  return fullName
+    .split(/\s+/)
+    .map((part) => tokenInInstrumental(part))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Add `lib/ru.ts` (frontend) and `api/src/lib/ru.ts` (backend mirror) — pragmatic suffix-based helpers, no external deps
- `pluralizeRu(n, [one, few, many])` applied across the app (заявки, специалисты, написал/написали)
- `firstNameInGenitive(name)` used in the "new_message" push title ("Новое сообщение от **Сергея**")
- `nameInInstrumental` reusable export (mirrors the inline impl in InlineChatView — that file is intentionally left untouched per HANDOVER)

## Places pluralized
- `app/(tabs)/public-requests.tsx` — hero "{n} заявок доступно" -> "{n} {заявка|заявки|заявок} доступно"
- `components/RequestCard.tsx` — "{n} специалистов уже написали" -> empty: "Никто пока не откликнулся" / "{n} {специалист|...} уже {написал|написали}"
- `components/requests/ThreadsList.tsx` — "{n} специалистов написали вам" -> proper plural
- `components/specialists/CatalogHeader.tsx` — count caption
- `components/landing/SpecialistCTASection.tsx` — "{n} специалистов уже с нами"

## Backend
- `api/src/routes/messages.ts` — notification title now `Новое сообщение от ${firstNameInGenitive(senderName)}` (was `... от Сергей`).

## Verification
- [x] `npx tsc --noEmit` (frontend) — 0 errors
- [x] `npx tsc --noEmit` (api) — 0 errors
- [x] NativeWind className only — zero `StyleSheet.create`
- [x] No external deps added (no `petrovich`)
- [x] InlineChatView.tsx untouched (per HANDOVER)