### PR TITLE
feat: register aux screens in root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -180,6 +180,10 @@ export default function RootLayout() {
             <Stack.Screen name="requests/[id]" />
             <Stack.Screen name="requests" />
             <Stack.Screen name="specialists" />
+            <Stack.Screen name="legal" />
+            <Stack.Screen name="mosaic-d" />
+            <Stack.Screen name="mosaic-m" />
+            <Stack.Screen name="saved-specialists" />
           </Stack>
         </AuthenticatedHeaderGate>
       </AppShell>


### PR DESCRIPTION
Adds Stack.Screen entries for legal, mosaic-d, mosaic-m, saved-specialists. Closes leftover stash from prior session and silences metromap unregistered-screens warning.