### PR TITLE
refactor: extract useSettingsForm hook from settings shell

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,28 +1,16 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Constants from "expo-constants";
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  Alert,
-  Platform,
-} from "react-native";
+import { View, Text, ScrollView, Pressable, Alert, Platform } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useRouter, useLocalSearchParams } from "expo-router";
-import { useTypedRouter } from "@/lib/navigation";
+import { useLocalSearchParams } from "expo-router";
 import { ChevronLeft } from "lucide-react-native";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
-import { apiGet, apiPatch, apiPost } from "@/lib/api";
 import { colors } from "@/lib/theme";
-import { ContactMethodItem } from "@/components/settings/ContactMethodsList";
+import { useSettingsForm, SettingsTab } from "@/lib/useSettingsForm";
 import ProfileTab from "@/components/settings/ProfileTab";
-import SpecialistTab, {
-  SpecialistProfileData,
-} from "@/components/settings/SpecialistTab";
+import SpecialistTab from "@/components/settings/SpecialistTab";
 import NotificationsTab from "@/components/settings/NotificationsTab";
 import AccountTab from "@/components/settings/AccountTab";
 
@@ -30,10 +18,9 @@ import AccountTab from "@/components/settings/AccountTab";
  * Unified Settings page — tabbed layout (Wave 2/F, refactored Wave 4/J).
  * Tabs: Профиль / Специалист / Уведомления / Аккаунт. Bodies live in
  * `components/settings/{Profile,Specialist,Notifications,Account}Tab.tsx`.
+ * Form state + per-tab save handlers live in `lib/useSettingsForm`.
  * ADMIN users are redirected to /admin/settings.
  */
-
-type SettingsTab = "profile" | "specialist" | "notifications" | "account";
 
 const VALID_TABS: SettingsTab[] = ["profile", "specialist", "notifications", "account"];
 
@@ -106,15 +93,15 @@ function SettingsTabs({ activeTab, onChange, canEditSpecialist }: SettingsTabsPr
 }
 
 export default function UnifiedSettings() {
-  const router = useRouter();
-  const nav = useTypedRouter();
   const params = useLocalSearchParams<{ tab?: string }>();
   const { ready } = useRequireAuth();
-  const { user, isSpecialistUser, isAdminUser, signOut, updateUser } = useAuth();
 
   // Active tab — initial from ?tab= query, default 'profile'.
   const initialTab: SettingsTab = isValidTab(params.tab) ? params.tab : "profile";
   const [activeTab, setActiveTab] = useState<SettingsTab>(initialTab);
+
+  const form = useSettingsForm({ ready, activeTab, onTabChange: setActiveTab });
+  const { router, nav, user, isSpecialistUser } = form;
 
   // Sync tab from URL when query changes (e.g. browser back/forward).
   useEffect(() => {
@@ -130,307 +117,6 @@ export default function UnifiedSettings() {
       router.setParams({ tab });
     },
     [router],
-  );
-
-  // Shared state for name/avatar (always editable).
-  const [firstName, setFirstName] = useState(user?.firstName ?? "");
-  const [lastName, setLastName] = useState(user?.lastName ?? "");
-  const [avatarUrl, setAvatarUrl] = useState<string | null>(
-    user?.avatarUrl ?? null
-  );
-  const [avatarUploading, setAvatarUploading] = useState(false);
-  const [saving, setSaving] = useState(false);
-
-  // Specialist-only state (lazy-loaded when section expands).
-  const [specData, setSpecData] = useState<SpecialistProfileData | null>(null);
-  const [specLoading, setSpecLoading] = useState(false);
-  const [description, setDescription] = useState("");
-  const [officeAddress, setOfficeAddress] = useState("");
-  const [workingHours, setWorkingHours] = useState("");
-  const [isAvailable, setIsAvailable] = useState(user?.isAvailable ?? false);
-  const [availabilityLoading, setAvailabilityLoading] = useState(false);
-
-  const [contacts, setContacts] = useState<ContactMethodItem[]>([]);
-  const [addingContact, setAddingContact] = useState(false);
-  const [newContactType, setNewContactType] = useState("phone");
-  const [newContactValue, setNewContactValue] = useState("");
-  const [contactSaving, setContactSaving] = useState(false);
-  const [showTypePicker, setShowTypePicker] = useState(false);
-
-  // Notification preferences — MVP is local-state only (SA email-only).
-  const [emailEnabled, setEmailEnabled] = useState(true);
-  const [pushEnabled, setPushEnabled] = useState(true);
-
-  useEffect(() => {
-    if (user) {
-      setFirstName(user.firstName ?? "");
-      setLastName(user.lastName ?? "");
-      setAvatarUrl(user.avatarUrl ?? null);
-      setIsAvailable(user.isAvailable ?? false);
-    }
-  }, [user]);
-
-  const loadSpecialistData = useCallback(async () => {
-    setSpecLoading(true);
-    try {
-      const [profile, contactsData] = await Promise.all([
-        apiGet<SpecialistProfileData>("/api/specialist/profile"),
-        apiGet<{ items: ContactMethodItem[] }>("/api/profile/contacts"),
-      ]);
-      setSpecData(profile);
-      setIsAvailable(profile.isAvailable);
-      if (profile.profile) {
-        setDescription(profile.profile.description ?? "");
-        setOfficeAddress(profile.profile.officeAddress ?? "");
-        setWorkingHours(profile.profile.workingHours ?? "");
-      }
-      setContacts(contactsData.items);
-    } catch (err) {
-      console.error("Settings: specialist profile load error", err);
-    } finally {
-      setSpecLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    // Admin users don't belong here.
-    if (ready && isAdminUser) {
-      nav.replaceRoutes.adminSettings();
-      return;
-    }
-    // Load specialist profile for any non-admin user. Returning specialists
-    // who toggled off keep their FNS data — we need it to skip onboarding
-    // when they re-enable from client mode.
-    if (ready && !isAdminUser) {
-      loadSpecialistData();
-    }
-  }, [ready, isAdminUser, loadSpecialistData, router]);
-
-  // Per-tab change tracking.
-  const hasProfileChanges = useMemo(
-    () =>
-      firstName !== (user?.firstName ?? "") ||
-      lastName !== (user?.lastName ?? "") ||
-      avatarUrl !== (user?.avatarUrl ?? null),
-    [firstName, lastName, avatarUrl, user?.firstName, user?.lastName, user?.avatarUrl],
-  );
-
-  const hasSpecialistChanges = useMemo(
-    () =>
-      !!specData &&
-      (description !== (specData.profile?.description ?? "") ||
-        officeAddress !== (specData.profile?.officeAddress ?? "") ||
-        workingHours !== (specData.profile?.workingHours ?? "")),
-    [specData, description, officeAddress, workingHours],
-  );
-
-  const showSaveBar =
-    (activeTab === "profile" && hasProfileChanges) ||
-    (activeTab === "specialist" && hasSpecialistChanges);
-
-  const handleSaveClient = useCallback(async () => {
-    if (saving) return;
-    setSaving(true);
-    try {
-      const body: Record<string, string | null> = {
-        firstName: firstName.trim(),
-        lastName: lastName.trim(),
-      };
-      if (avatarUrl !== (user?.avatarUrl ?? null)) {
-        body.avatarUrl = avatarUrl;
-      }
-      const res = await apiPatch<{
-        user: { firstName: string; lastName: string; avatarUrl?: string | null };
-      }>("/api/user/profile", body);
-      updateUser({
-        firstName: res.user.firstName,
-        lastName: res.user.lastName,
-        avatarUrl: res.user.avatarUrl,
-      });
-      Alert.alert("Готово", "Изменения сохранены");
-    } catch (err) {
-      console.error("Save profile error:", err);
-      Alert.alert(
-        "Ошибка сохранения",
-        "Не удалось сохранить изменения. Попробуйте ещё раз."
-      );
-    } finally {
-      setSaving(false);
-    }
-  }, [saving, firstName, lastName, avatarUrl, user?.avatarUrl, updateUser]);
-
-  const handleSaveSpecialist = useCallback(async () => {
-    if (!firstName.trim() || firstName.trim().length < 2) {
-      Alert.alert("Ошибка", "Имя должно быть от 2 до 50 символов");
-      return;
-    }
-    if (!lastName.trim() || lastName.trim().length < 2) {
-      Alert.alert("Ошибка", "Фамилия должна быть от 2 до 50 символов");
-      return;
-    }
-    setSaving(true);
-    try {
-      await apiPatch("/api/specialist/profile", {
-        firstName: firstName.trim(),
-        lastName: lastName.trim(),
-        avatarUrl: avatarUrl || null,
-        description: description.trim() || null,
-        officeAddress: officeAddress.trim() || null,
-        workingHours: workingHours.trim() || null,
-      });
-      updateUser({
-        firstName: firstName.trim(),
-        lastName: lastName.trim(),
-        avatarUrl: avatarUrl || null,
-      });
-      await loadSpecialistData();
-      Alert.alert("Сохранено", "Профиль обновлён");
-    } catch {
-      Alert.alert("Ошибка", "Не удалось сохранить");
-    } finally {
-      setSaving(false);
-    }
-  }, [
-    firstName,
-    lastName,
-    avatarUrl,
-    description,
-    officeAddress,
-    workingHours,
-    updateUser,
-    loadSpecialistData,
-  ]);
-
-  const handleSave = useCallback(() => {
-    if (activeTab === "specialist") return handleSaveSpecialist();
-    if (activeTab === "profile") {
-      return isSpecialistUser ? handleSaveSpecialist() : handleSaveClient();
-    }
-    return undefined;
-  }, [activeTab, isSpecialistUser, handleSaveClient, handleSaveSpecialist]);
-
-  const applyAvailabilityChange = async (value: boolean) => {
-    setIsAvailable(value);
-    setAvailabilityLoading(true);
-    try {
-      await apiPatch("/api/specialist/profile", { isAvailable: value });
-      updateUser({ isAvailable: value });
-    } catch {
-      setIsAvailable(!value);
-      Alert.alert("Ошибка", "Не удалось обновить статус доступности");
-    } finally {
-      setAvailabilityLoading(false);
-    }
-  };
-
-  const handleToggleAvailable = (value: boolean) => {
-    if (availabilityLoading) return;
-    if (isAvailable && !value) {
-      Alert.alert(
-        "Скрыть профиль из каталога?",
-        "Новые клиенты не смогут вас найти. Существующие переписки сохранятся, и вы сможете отвечать как обычно. Включить обратно — в любой момент.",
-        [
-          { text: "Отмена", style: "cancel" },
-          {
-            text: "Скрыть",
-            style: "destructive",
-            onPress: () => {
-              void applyAvailabilityChange(value);
-            },
-          },
-        ],
-      );
-      return;
-    }
-    void applyAvailabilityChange(value);
-  };
-
-  const handleLogout = useCallback(() => {
-    Alert.alert("Выйти из аккаунта", "Вы уверены, что хотите выйти?", [
-      { text: "Отмена", style: "cancel" },
-      {
-        text: "Выйти",
-        style: "destructive",
-        onPress: async () => {
-          await signOut();
-          nav.replaceRoutes.home();
-        },
-      },
-    ]);
-  }, [signOut, router]);
-
-  const handleDeleteAccount = useCallback(() => {
-    Alert.alert(
-      "Удалить аккаунт навсегда?",
-      "Аккаунт будет анонимизирован и скрыт. Восстановление невозможно. История переписок останется у других участников.",
-      [
-        { text: "Отмена", style: "cancel" },
-        {
-          text: "Удалить",
-          style: "destructive",
-          onPress: async () => {
-            const email = user?.email;
-            if (!email) {
-              Alert.alert("Ошибка", "Не удалось определить email аккаунта");
-              return;
-            }
-            try {
-              await apiPost("/api/account/delete", { confirm: email });
-              await signOut();
-              nav.replaceRoutes.home();
-            } catch (err) {
-              console.error("delete account error:", err);
-              Alert.alert(
-                "Ошибка",
-                "Не удалось удалить аккаунт. Попробуйте ещё раз."
-              );
-            }
-          },
-        },
-      ]
-    );
-  }, [user?.email, signOut, nav]);
-
-  const handleToggleSpecialist = useCallback(
-    (value: boolean) => {
-      if (value) {
-        const hasData = specData && specData.fnsServices.length > 0;
-        if (!hasData) {
-          nav.any("/onboarding/work-area?from=settings");
-          return;
-        }
-        apiPost("/api/user/leave-specialist-toggle", { enable: true })
-          .then(async () => {
-            updateUser({ isSpecialist: true });
-            await loadSpecialistData();
-          })
-          .catch(() => Alert.alert("Ошибка", "Не удалось включить режим специалиста"));
-      } else {
-        Alert.alert(
-          "Выключить режим специалиста?",
-          "Вы исчезнете из каталога, новые заявки не будут поступать. История переписок сохранится.",
-          [
-            { text: "Отмена", style: "cancel" },
-            {
-              text: "Выключить",
-              style: "destructive",
-              onPress: async () => {
-                try {
-                  await apiPost("/api/user/leave-specialist", {});
-                  updateUser({ isSpecialist: false, isAvailable: false });
-                  if (activeTab === "specialist") {
-                    handleTabChange("profile");
-                  }
-                } catch {
-                  Alert.alert("Ошибка", "Не удалось выключить режим специалиста");
-                }
-              },
-            },
-          ]
-        );
-      }
-    },
-    [specData, updateUser, loadSpecialistData, router, activeTab, handleTabChange, nav]
   );
 
   if (!ready) {
@@ -479,7 +165,7 @@ export default function UnifiedSettings() {
       <ScrollView
         className="flex-1"
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingBottom: showSaveBar ? 96 : 32 }}
+        contentContainerStyle={{ paddingBottom: form.showSaveBar ? 96 : 32 }}
       >
         <View
           style={{
@@ -492,48 +178,48 @@ export default function UnifiedSettings() {
         >
           {activeTab === "profile" && (
             <ProfileTab
-              firstName={firstName}
-              lastName={lastName}
+              firstName={form.firstName}
+              lastName={form.lastName}
               email={user?.email ?? ""}
-              avatarUrl={avatarUrl}
-              avatarUploading={avatarUploading}
+              avatarUrl={form.avatarUrl}
+              avatarUploading={form.avatarUploading}
               isSpecialistUser={isSpecialistUser}
-              isAvailable={isAvailable}
-              availabilityLoading={availabilityLoading}
+              isAvailable={form.isAvailable}
+              availabilityLoading={form.availabilityLoading}
               role={user?.role ?? null}
-              onFirstNameChange={setFirstName}
-              onLastNameChange={setLastName}
-              onAvatarChange={setAvatarUrl}
-              onUploadStart={() => setAvatarUploading(true)}
-              onUploadEnd={() => setAvatarUploading(false)}
-              onToggleSpecialist={handleToggleSpecialist}
-              onToggleAvailable={handleToggleAvailable}
+              onFirstNameChange={form.setFirstName}
+              onLastNameChange={form.setLastName}
+              onAvatarChange={form.setAvatarUrl}
+              onUploadStart={() => form.setAvatarUploading(true)}
+              onUploadEnd={() => form.setAvatarUploading(false)}
+              onToggleSpecialist={form.handleToggleSpecialist}
+              onToggleAvailable={form.handleToggleAvailable}
             />
           )}
 
           {activeTab === "specialist" && (
             <SpecialistTab
               isSpecialistUser={isSpecialistUser}
-              specLoading={specLoading}
-              specData={specData}
-              description={description}
-              officeAddress={officeAddress}
-              workingHours={workingHours}
-              contacts={contacts}
-              addingContact={addingContact}
-              newContactType={newContactType}
-              newContactValue={newContactValue}
-              contactSaving={contactSaving}
-              showTypePicker={showTypePicker}
-              onDescriptionChange={setDescription}
-              onOfficeAddressChange={setOfficeAddress}
-              onWorkingHoursChange={setWorkingHours}
-              onContactsChange={setContacts}
-              onAddingContactChange={setAddingContact}
-              onNewContactTypeChange={setNewContactType}
-              onNewContactValueChange={setNewContactValue}
-              onContactSavingChange={setContactSaving}
-              onShowTypePickerChange={setShowTypePicker}
+              specLoading={form.specLoading}
+              specData={form.specData}
+              description={form.description}
+              officeAddress={form.officeAddress}
+              workingHours={form.workingHours}
+              contacts={form.contacts}
+              addingContact={form.addingContact}
+              newContactType={form.newContactType}
+              newContactValue={form.newContactValue}
+              contactSaving={form.contactSaving}
+              showTypePicker={form.showTypePicker}
+              onDescriptionChange={form.setDescription}
+              onOfficeAddressChange={form.setOfficeAddress}
+              onWorkingHoursChange={form.setWorkingHours}
+              onContactsChange={form.setContacts}
+              onAddingContactChange={form.setAddingContact}
+              onNewContactTypeChange={form.setNewContactType}
+              onNewContactValueChange={form.setNewContactValue}
+              onContactSavingChange={form.setContactSaving}
+              onShowTypePickerChange={form.setShowTypePicker}
               onGoToProfileTab={() => handleTabChange("profile")}
               onGoToWorkArea={() => nav.any("/onboarding/work-area?from=settings")}
             />
@@ -541,25 +227,25 @@ export default function UnifiedSettings() {
 
           {activeTab === "notifications" && (
             <NotificationsTab
-              emailEnabled={emailEnabled}
-              pushEnabled={pushEnabled}
-              onEmailChange={setEmailEnabled}
-              onPushChange={setPushEnabled}
+              emailEnabled={form.emailEnabled}
+              pushEnabled={form.pushEnabled}
+              onEmailChange={form.setEmailEnabled}
+              onPushChange={form.setPushEnabled}
             />
           )}
 
           {activeTab === "account" && (
             <AccountTab
               appVersion={Constants.expoConfig?.version ?? "1.0.0"}
-              onLogout={handleLogout}
-              onDeleteAccount={handleDeleteAccount}
+              onLogout={form.handleLogout}
+              onDeleteAccount={form.handleDeleteAccount}
               onLegal={() => nav.routes.legalIndex()}
             />
           )}
         </View>
       </ScrollView>
 
-      {showSaveBar ? (
+      {form.showSaveBar ? (
         <View
           className="border-t border-border bg-white px-6 py-3 flex-row justify-end items-center"
           style={{
@@ -578,9 +264,9 @@ export default function UnifiedSettings() {
             <View style={{ minWidth: 180 }}>
               <Button
                 label="Сохранить"
-                onPress={handleSave}
-                disabled={saving}
-                loading={saving}
+                onPress={form.handleSave}
+                disabled={form.saving}
+                loading={form.saving}
               />
             </View>
           </View>

--- a/lib/useSettingsForm.ts
+++ b/lib/useSettingsForm.ts
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert } from "react-native";
+import { useRouter } from "expo-router";
+import { useAuth } from "@/contexts/AuthContext";
+import { useTypedRouter } from "@/lib/navigation";
+import { apiGet, apiPatch, apiPost } from "@/lib/api";
+import type { ContactMethodItem } from "@/components/settings/ContactMethodsList";
+import type { SpecialistProfileData } from "@/components/settings/SpecialistTab";
+
+export type SettingsTab = "profile" | "specialist" | "notifications" | "account";
+
+interface UseSettingsFormArgs {
+  ready: boolean;
+  activeTab: SettingsTab;
+  onTabChange: (tab: SettingsTab) => void;
+}
+
+/**
+ * Holds all settings-form state, dirty tracking and per-tab save handlers.
+ * The shell (`app/settings/index.tsx`) uses this to keep its own surface
+ * focused on layout, deeplink parsing and tab rendering.
+ */
+export function useSettingsForm({ ready, activeTab, onTabChange }: UseSettingsFormArgs) {
+  const router = useRouter();
+  const nav = useTypedRouter();
+  const { user, isSpecialistUser, isAdminUser, signOut, updateUser } = useAuth();
+
+  // Shared profile fields (always editable).
+  const [firstName, setFirstName] = useState(user?.firstName ?? "");
+  const [lastName, setLastName] = useState(user?.lastName ?? "");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(user?.avatarUrl ?? null);
+  const [avatarUploading, setAvatarUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Specialist-only state.
+  const [specData, setSpecData] = useState<SpecialistProfileData | null>(null);
+  const [specLoading, setSpecLoading] = useState(false);
+  const [description, setDescription] = useState("");
+  const [officeAddress, setOfficeAddress] = useState("");
+  const [workingHours, setWorkingHours] = useState("");
+  const [isAvailable, setIsAvailable] = useState(user?.isAvailable ?? false);
+  const [availabilityLoading, setAvailabilityLoading] = useState(false);
+
+  const [contacts, setContacts] = useState<ContactMethodItem[]>([]);
+  const [addingContact, setAddingContact] = useState(false);
+  const [newContactType, setNewContactType] = useState("phone");
+  const [newContactValue, setNewContactValue] = useState("");
+  const [contactSaving, setContactSaving] = useState(false);
+  const [showTypePicker, setShowTypePicker] = useState(false);
+
+  // Notification preferences — MVP is local-state only (SA email-only).
+  const [emailEnabled, setEmailEnabled] = useState(true);
+  const [pushEnabled, setPushEnabled] = useState(true);
+
+  // Sync local fields when user object updates (login/refresh).
+  useEffect(() => {
+    if (user) {
+      setFirstName(user.firstName ?? "");
+      setLastName(user.lastName ?? "");
+      setAvatarUrl(user.avatarUrl ?? null);
+      setIsAvailable(user.isAvailable ?? false);
+    }
+  }, [user]);
+
+  const loadSpecialistData = useCallback(async () => {
+    setSpecLoading(true);
+    try {
+      const [profile, contactsData] = await Promise.all([
+        apiGet<SpecialistProfileData>("/api/specialist/profile"),
+        apiGet<{ items: ContactMethodItem[] }>("/api/profile/contacts"),
+      ]);
+      setSpecData(profile);
+      setIsAvailable(profile.isAvailable);
+      if (profile.profile) {
+        setDescription(profile.profile.description ?? "");
+        setOfficeAddress(profile.profile.officeAddress ?? "");
+        setWorkingHours(profile.profile.workingHours ?? "");
+      }
+      setContacts(contactsData.items);
+    } catch (err) {
+      console.error("Settings: specialist profile load error", err);
+    } finally {
+      setSpecLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Admin users don't belong here.
+    if (ready && isAdminUser) {
+      nav.replaceRoutes.adminSettings();
+      return;
+    }
+    // Load specialist profile for any non-admin user. Returning specialists
+    // who toggled off keep their FNS data — we need it to skip onboarding
+    // when they re-enable from client mode.
+    if (ready && !isAdminUser) {
+      loadSpecialistData();
+    }
+  }, [ready, isAdminUser, loadSpecialistData, nav]);
+
+  // Per-tab change tracking.
+  const hasProfileChanges = useMemo(
+    () =>
+      firstName !== (user?.firstName ?? "") ||
+      lastName !== (user?.lastName ?? "") ||
+      avatarUrl !== (user?.avatarUrl ?? null),
+    [firstName, lastName, avatarUrl, user?.firstName, user?.lastName, user?.avatarUrl],
+  );
+
+  const hasSpecialistChanges = useMemo(
+    () =>
+      !!specData &&
+      (description !== (specData.profile?.description ?? "") ||
+        officeAddress !== (specData.profile?.officeAddress ?? "") ||
+        workingHours !== (specData.profile?.workingHours ?? "")),
+    [specData, description, officeAddress, workingHours],
+  );
+
+  const showSaveBar =
+    (activeTab === "profile" && hasProfileChanges) ||
+    (activeTab === "specialist" && hasSpecialistChanges);
+
+  const handleSaveClient = useCallback(async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const body: Record<string, string | null> = {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+      };
+      if (avatarUrl !== (user?.avatarUrl ?? null)) {
+        body.avatarUrl = avatarUrl;
+      }
+      const res = await apiPatch<{
+        user: { firstName: string; lastName: string; avatarUrl?: string | null };
+      }>("/api/user/profile", body);
+      updateUser({
+        firstName: res.user.firstName,
+        lastName: res.user.lastName,
+        avatarUrl: res.user.avatarUrl,
+      });
+      Alert.alert("Готово", "Изменения сохранены");
+    } catch (err) {
+      console.error("Save profile error:", err);
+      Alert.alert(
+        "Ошибка сохранения",
+        "Не удалось сохранить изменения. Попробуйте ещё раз.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [saving, firstName, lastName, avatarUrl, user?.avatarUrl, updateUser]);
+
+  const handleSaveSpecialist = useCallback(async () => {
+    if (!firstName.trim() || firstName.trim().length < 2) {
+      Alert.alert("Ошибка", "Имя должно быть от 2 до 50 символов");
+      return;
+    }
+    if (!lastName.trim() || lastName.trim().length < 2) {
+      Alert.alert("Ошибка", "Фамилия должна быть от 2 до 50 символов");
+      return;
+    }
+    setSaving(true);
+    try {
+      await apiPatch("/api/specialist/profile", {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        avatarUrl: avatarUrl || null,
+        description: description.trim() || null,
+        officeAddress: officeAddress.trim() || null,
+        workingHours: workingHours.trim() || null,
+      });
+      updateUser({
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        avatarUrl: avatarUrl || null,
+      });
+      await loadSpecialistData();
+      Alert.alert("Сохранено", "Профиль обновлён");
+    } catch {
+      Alert.alert("Ошибка", "Не удалось сохранить");
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    firstName,
+    lastName,
+    avatarUrl,
+    description,
+    officeAddress,
+    workingHours,
+    updateUser,
+    loadSpecialistData,
+  ]);
+
+  const handleSave = useCallback(() => {
+    if (activeTab === "specialist") return handleSaveSpecialist();
+    if (activeTab === "profile") {
+      return isSpecialistUser ? handleSaveSpecialist() : handleSaveClient();
+    }
+    return undefined;
+  }, [activeTab, isSpecialistUser, handleSaveClient, handleSaveSpecialist]);
+
+  const applyAvailabilityChange = useCallback(
+    async (value: boolean) => {
+      setIsAvailable(value);
+      setAvailabilityLoading(true);
+      try {
+        await apiPatch("/api/specialist/profile", { isAvailable: value });
+        updateUser({ isAvailable: value });
+      } catch {
+        setIsAvailable(!value);
+        Alert.alert("Ошибка", "Не удалось обновить статус доступности");
+      } finally {
+        setAvailabilityLoading(false);
+      }
+    },
+    [updateUser],
+  );
+
+  const handleToggleAvailable = useCallback(
+    (value: boolean) => {
+      if (availabilityLoading) return;
+      if (isAvailable && !value) {
+        Alert.alert(
+          "Скрыть профиль из каталога?",
+          "Новые клиенты не смогут вас найти. Существующие переписки сохранятся, и вы сможете отвечать как обычно. Включить обратно — в любой момент.",
+          [
+            { text: "Отмена", style: "cancel" },
+            {
+              text: "Скрыть",
+              style: "destructive",
+              onPress: () => {
+                void applyAvailabilityChange(value);
+              },
+            },
+          ],
+        );
+        return;
+      }
+      void applyAvailabilityChange(value);
+    },
+    [availabilityLoading, isAvailable, applyAvailabilityChange],
+  );
+
+  const handleLogout = useCallback(() => {
+    Alert.alert("Выйти из аккаунта", "Вы уверены, что хотите выйти?", [
+      { text: "Отмена", style: "cancel" },
+      {
+        text: "Выйти",
+        style: "destructive",
+        onPress: async () => {
+          await signOut();
+          nav.replaceRoutes.home();
+        },
+      },
+    ]);
+  }, [signOut, nav]);
+
+  const handleDeleteAccount = useCallback(() => {
+    Alert.alert(
+      "Удалить аккаунт навсегда?",
+      "Аккаунт будет анонимизирован и скрыт. Восстановление невозможно. История переписок останется у других участников.",
+      [
+        { text: "Отмена", style: "cancel" },
+        {
+          text: "Удалить",
+          style: "destructive",
+          onPress: async () => {
+            const email = user?.email;
+            if (!email) {
+              Alert.alert("Ошибка", "Не удалось определить email аккаунта");
+              return;
+            }
+            try {
+              await apiPost("/api/account/delete", { confirm: email });
+              await signOut();
+              nav.replaceRoutes.home();
+            } catch (err) {
+              console.error("delete account error:", err);
+              Alert.alert(
+                "Ошибка",
+                "Не удалось удалить аккаунт. Попробуйте ещё раз.",
+              );
+            }
+          },
+        },
+      ],
+    );
+  }, [user?.email, signOut, nav]);
+
+  const handleToggleSpecialist = useCallback(
+    (value: boolean) => {
+      if (value) {
+        const hasData = specData && specData.fnsServices.length > 0;
+        if (!hasData) {
+          nav.any("/onboarding/work-area?from=settings");
+          return;
+        }
+        apiPost("/api/user/leave-specialist-toggle", { enable: true })
+          .then(async () => {
+            updateUser({ isSpecialist: true });
+            await loadSpecialistData();
+          })
+          .catch(() =>
+            Alert.alert("Ошибка", "Не удалось включить режим специалиста"),
+          );
+      } else {
+        Alert.alert(
+          "Выключить режим специалиста?",
+          "Вы исчезнете из каталога, новые заявки не будут поступать. История переписок сохранится.",
+          [
+            { text: "Отмена", style: "cancel" },
+            {
+              text: "Выключить",
+              style: "destructive",
+              onPress: async () => {
+                try {
+                  await apiPost("/api/user/leave-specialist", {});
+                  updateUser({ isSpecialist: false, isAvailable: false });
+                  if (activeTab === "specialist") {
+                    onTabChange("profile");
+                  }
+                } catch {
+                  Alert.alert("Ошибка", "Не удалось выключить режим специалиста");
+                }
+              },
+            },
+          ],
+        );
+      }
+    },
+    [specData, updateUser, loadSpecialistData, activeTab, onTabChange, nav],
+  );
+
+  return {
+    // Auth-derived
+    user,
+    isSpecialistUser,
+    isAdminUser,
+    router,
+    nav,
+    // Profile fields
+    firstName,
+    setFirstName,
+    lastName,
+    setLastName,
+    avatarUrl,
+    setAvatarUrl,
+    avatarUploading,
+    setAvatarUploading,
+    // Save state
+    saving,
+    showSaveBar,
+    handleSave,
+    // Specialist state
+    specData,
+    specLoading,
+    description,
+    setDescription,
+    officeAddress,
+    setOfficeAddress,
+    workingHours,
+    setWorkingHours,
+    isAvailable,
+    availabilityLoading,
+    contacts,
+    setContacts,
+    addingContact,
+    setAddingContact,
+    newContactType,
+    setNewContactType,
+    newContactValue,
+    setNewContactValue,
+    contactSaving,
+    setContactSaving,
+    showTypePicker,
+    setShowTypePicker,
+    // Notifications
+    emailEnabled,
+    setEmailEnabled,
+    pushEnabled,
+    setPushEnabled,
+    // Action handlers
+    handleToggleAvailable,
+    handleToggleSpecialist,
+    handleLogout,
+    handleDeleteAccount,
+  };
+}


### PR DESCRIPTION
## Summary

Wave 6 tail-task: `app/settings/index.tsx` was 591 LOC, over the 500-LOC soft limit. This PR extracts all form state, dirty tracking, and per-tab save handlers into a new `lib/useSettingsForm` hook.

The shell now owns only:
- layout (header, back button, tab switcher, save-bar wiring)
- deeplink `?tab=` parsing and URL sync
- rendering of the active tab

The hook owns:
- profile fields (firstName, lastName, avatar, etc.)
- specialist fields (description, officeAddress, workingHours, contacts, isAvailable)
- notification flags
- specialist-data lazy loader
- per-tab save handlers (`handleSaveClient`, `handleSaveSpecialist`, `handleSave`)
- toggle/logout/delete-account handlers

Pure structural refactor — zero behavior changes, zero UX changes. The 4 tab components (Profile/Specialist/Notifications/Account, extracted in PR #1496) are untouched.

## LOC

| File | Before | After |
|---|---|---|
| `app/settings/index.tsx` | 591 | 277 |
| `lib/useSettingsForm.ts` | — | 390 |

Shell now well under the 500 soft-limit.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (frontend)
- [x] `cd api && npx tsc --noEmit` — 0 errors (backend)
- [ ] Smoke on staging: open `/settings`, switch tabs, edit profile, save, toggle availability, toggle specialist, logout