### PR TITLE
polish(wave6): avatar onError, thread column width, saved-specialists breadcrumb

### DIFF
--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -216,10 +216,15 @@ export default function UnifiedInbox() {
               marginBottom: isWide ? 24 : 0,
             }}
           >
+            {/* Wave 6 polish — widened from 320/360 to 360/400. At 320 the
+                ThreadCard squeezes the name column hard: with avatar (44 + 12
+                margin) + perspective badge (~70) + timestamp (~50) the name
+                gets ~140-160px and "Алексей Воронов" truncates to "Алексей
+                Во…". Bumping by 40px adds enough room for two-word names. */}
             <View
               style={{
-                width: 320,
-                maxWidth: 360,
+                width: 360,
+                maxWidth: 400,
                 flexShrink: 0,
                 borderRightWidth: 1,
                 borderRightColor: colors.border,

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -72,6 +72,10 @@ const BREADCRUMB_MAP: ReadonlyArray<{ prefix: string; label: string }> = [
   { prefix: "/(admin-tabs)/moderation", label: "Модерация" },
   { prefix: "/(admin-tabs)/complaints", label: "Жалобы" },
   { prefix: "/admin/settings", label: "Админ · Настройки" },
+  // Wave 6 polish — longer prefix listed first so the longest-prefix sort
+  // tie-break still picks the saved-specialists label over the generic
+  // "/specialists" entry below.
+  { prefix: "/saved-specialists", label: "Мои специалисты" },
   { prefix: "/specialists", label: "Специалисты" },
   { prefix: "/requests/new", label: "Новая заявка" },
   { prefix: "/requests", label: "Заявки" },

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -69,6 +69,14 @@ export default function AvatarUploader({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [lastFile, setLastFile] = useState<File | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Wave 6 polish — fall back to initials when avatarUrl 404s (MinIO rotation,
+  // deleted file, broken CDN). Without this, a stale URL renders a blank
+  // circle with just the edit-pencil overlay. Reset on every avatarUrl change
+  // so a successful re-upload is rendered immediately.
+  const [hasImageError, setHasImageError] = useState(false);
+  useEffect(() => {
+    setHasImageError(false);
+  }, [avatarUrl]);
 
   const uploadAvatar = async (file: File) => {
     // Pre-check size before any network call
@@ -135,11 +143,12 @@ export default function AvatarUploader({
           >
             <ActivityIndicator color={colors.primary} />
           </View>
-        ) : avatarUrl ? (
+        ) : avatarUrl && !hasImageError ? (
           <View>
             <Image
               source={{ uri: avatarUrl }}
               accessibilityLabel="Profile photo"
+              onError={() => setHasImageError(true)}
               style={{
                 width: 80,
                 height: 80,


### PR DESCRIPTION
Wave 6 reality-check polish — 3 issues the original 9-bug list missed.

## 1. AvatarUploader broken-image fallback
`components/settings/AvatarUploader.tsx`

When `avatarUrl` is set but the URL 404s (MinIO rotation, deleted file), the `<Image>` renders blank with just the edit-pencil overlay floating in nothing. Added `hasImageError` state + `onError` handler — falls back to the initials block on load failure. `useEffect` keyed on `avatarUrl` resets the flag so a successful re-upload renders immediately.

## 2. Thread list column width
`app/(tabs)/messages.tsx`

Desktop master-detail thread column was `width: 320, maxWidth: 360`. ThreadCard layout (avatar 44 + 12 margin + perspective badge ~70 + timestamp ~50) left the name ~140-160px and truncated "Алексей Воронов" to "Алексей Во…". Bumped to `360 / 400` — fits two-word Russian names cleanly. Detail panel keeps `flex: 1` so it absorbs the remaining width.

## 3. /saved-specialists breadcrumb
`components/layout/AppHeader.tsx`

Added `{ prefix: "/saved-specialists", label: "Мои специалисты" }` to `BREADCRUMB_MAP`, matching the page H1 in `app/saved-specialists/index.tsx`. Listed before `/specialists` so the longest-prefix sort tie-break still wins.

## Verification
- `npx tsc --noEmit` — 0 errors (frontend)
- `cd api && npx tsc --noEmit` — 0 errors (backend)
- All 3 edits via NativeWind `className` + inline style only, no `StyleSheet.create`.