### PR TITLE
ci: baseline _prisma_migrations (closes #1510)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,23 @@ jobs:
             # Backend
             cd api
             npm ci
+
+            # One-shot baseline _prisma_migrations (idempotent — fixes #1510).
+            # `migrate resolve --applied` is a no-op when the row already exists,
+            # so this stays safe on every subsequent deploy. After all 7 rows are
+            # registered, the regular `migrate deploy` below runs cleanly.
+            for m in \
+              20250417000000_add_complaints_table \
+              20250419000000_add_schema_fields \
+              20250428000000_add_is_specialist \
+              20260423000000_iter5_credibility_stack \
+              20260424000000_unify_roles_user_and_specialist \
+              20260428000000_add_saved_specialists \
+              20260428120000_add_user_soft_delete; do
+              echo "==> resolving $m"
+              npx prisma migrate resolve --applied "$m" || echo "  (already applied or harmless skip)"
+            done
+
             npx prisma migrate deploy || echo "WARN P3005 — DB unbaselined, migrations skipped (see issue #1510 for baseline plan)"
             npx prisma generate
             npm run build


### PR DESCRIPTION
## Summary

Resolves the P3005 baseline debt tracked in #1510. Adds an idempotent `prisma migrate resolve --applied` loop **inside the existing staging deploy script**, run **before** `prisma migrate deploy`. After this PR merges and runs once, the staging `_prisma_migrations` table will contain all 7 expected rows; subsequent deploys treat the loop as a no-op.

## Migrations baselined

1. `20250417000000_add_complaints_table`
2. `20250419000000_add_schema_fields`
3. `20250428000000_add_is_specialist`
4. `20260423000000_iter5_credibility_stack`
5. `20260424000000_unify_roles_user_and_specialist`
6. `20260428000000_add_saved_specialists`
7. `20260428120000_add_user_soft_delete`

## Why idempotent

`npx prisma migrate resolve --applied <name>` simply inserts a row into `_prisma_migrations` for that migration. If the row already exists, prisma exits non-zero with a benign error — caught by `|| echo "(already applied or harmless skip)"`. So this is safe to leave in `deploy.yml` indefinitely; every future deploy will just print "already applied" 7 times and continue.

## Why the softener stays for now

The existing `|| echo "WARN P3005..."` on `migrate deploy` (added in #1511) is preserved as a belt-and-suspenders safety net for this single deploy. Once this PR merges, CI runs, and the `_prisma_migrations` table is correct on staging, a follow-up PR will revert that softener so future schema drift surfaces loudly.

## Test plan

- [ ] CI green for this PR
- [ ] After merge, `Deploy Staging` workflow succeeds
- [ ] `https://p2ptax.smartlaunchhub.com/version.json` matches development HEAD
- [ ] `https://p2ptax.smartlaunchhub.com/api/health` returns 200 (Wave 6 API live)
- [ ] Follow-up PR opened to remove `|| echo "WARN P3005..."` softener

Closes #1510