### PR TITLE
fix(admin): ErrorBoundary + default arrays on dashboard

### DIFF
--- a/app/(admin-tabs)/dashboard.tsx
+++ b/app/(admin-tabs)/dashboard.tsx
@@ -21,6 +21,7 @@ import {
   UserPlus,
 } from "lucide-react-native";
 import DesktopScreen from "@/components/layout/DesktopScreen";
+import ErrorBoundary from "@/components/ui/ErrorBoundary";
 import ErrorState from "@/components/ui/ErrorState";
 import {
   DashboardGrid,
@@ -135,7 +136,7 @@ export default function AdminDashboard() {
         const recents = await api<{ items: AdminUser[] }>(
           "/api/admin/users?limit=5"
         );
-        setRecentUsers(recents.items ?? []);
+        setRecentUsers(Array.isArray(recents?.items) ? recents.items : []);
       } catch {
         setRecentUsers([]);
       }
@@ -144,7 +145,7 @@ export default function AdminDashboard() {
         const c = await api<{ items: ComplaintItem[]; total: number }>(
           "/api/admin/complaints?status=PENDING&limit=5"
         );
-        setComplaints(c.items ?? []);
+        setComplaints(Array.isArray(c?.items) ? c.items : []);
       } catch {
         setComplaints([]);
       }
@@ -169,7 +170,7 @@ export default function AdminDashboard() {
 
   const recentUsersItems: FeedItem[] = useMemo(
     () =>
-      recentUsers.map((u) => ({
+      (recentUsers ?? []).map((u) => ({
         id: u.id,
         title: formatUserName(u),
         meta: `${u.role} · ${formatDateShort(u.createdAt)}`,
@@ -183,7 +184,7 @@ export default function AdminDashboard() {
 
   const complaintsItems: FeedItem[] = useMemo(
     () =>
-      complaints.map((c) => ({
+      (complaints ?? []).map((c) => ({
         id: c.id,
         title: c.reason.length > 60 ? `${c.reason.slice(0, 60)}…` : c.reason,
         meta: `от ${formatUserName(c.reporter)} · ${formatDateShort(c.createdAt)}`,
@@ -195,7 +196,8 @@ export default function AdminDashboard() {
   );
 
   return (
-    <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
+    <ErrorBoundary fallbackMessage="Не удалось загрузить панель">
+      <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
       <ScrollView
         className="flex-1"
         refreshControl={
@@ -281,7 +283,7 @@ export default function AdminDashboard() {
                 <DashboardGrid.Col span={8} tabletSpan={2}>
                   <DashboardWidget
                     title="Recent signups"
-                    subtitle={`${recentUsers.length} последних`}
+                    subtitle={`${recentUsers?.length ?? 0} последних`}
                     icon={UserCheck}
                     actionLabel="Все →"
                     onActionPress={() =>
@@ -332,7 +334,7 @@ export default function AdminDashboard() {
                       title="Требуют реакции"
                       subtitle="Топ жалоб для модерации"
                       icon={AlertOctagon}
-                      accentBar={complaints.length > 0 ? "danger" : "success"}
+                      accentBar={(complaints?.length ?? 0) > 0 ? "danger" : "success"}
                       actionLabel="Все →"
                       onActionPress={() =>
                         nav.routes.adminComplaints()
@@ -415,6 +417,7 @@ export default function AdminDashboard() {
         </DesktopScreen>
       </ScrollView>
     </SafeAreaView>
+    </ErrorBoundary>
   );
 }
 

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { View, Text, Pressable } from "react-native";
+import { AlertCircle } from "lucide-react-native";
+import { colors } from "../../lib/theme";
+
+/**
+ * ErrorBoundary — catches render-time crashes in children and shows
+ * a friendly "Не удалось загрузить" overlay instead of the dev red-box
+ * or white screen of death. Use to wrap admin/data-heavy screens.
+ */
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallbackMessage?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // Surface the error to the JS console so it is still discoverable in
+    // dev tools, but do not propagate to the global error overlay.
+    if (typeof console !== "undefined" && console.error) {
+      console.error("[ErrorBoundary]", error, info?.componentStack);
+    }
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): React.ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <View
+        className="flex-1 items-center justify-center bg-surface2 p-8"
+        style={{ minHeight: 320 }}
+      >
+        <View
+          className="items-center justify-center rounded-full bg-danger-soft"
+          style={{ width: 72, height: 72 }}
+        >
+          <AlertCircle size={32} color={colors.error} />
+        </View>
+        <Text className="text-base font-medium text-text-base mt-4 text-center">
+          {this.props.fallbackMessage ?? "Не удалось загрузить"}
+        </Text>
+        <Text className="text-sm text-text-mute mt-1 text-center">
+          Попробуйте ещё раз
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Повторить"
+          onPress={this.handleRetry}
+          className="mt-4 rounded-xl bg-accent px-5 py-3"
+        >
+          <Text
+            className="text-white font-bold"
+            style={{ fontSize: 14 }}
+          >
+            Повторить
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+}


### PR DESCRIPTION
Closes #1514

## Summary
- Add `components/ui/ErrorBoundary.tsx` (class component with retry).
- Wrap admin dashboard render in ErrorBoundary so undefined-access crashes show a friendly "Не удалось загрузить" + Повторить instead of full-screen error overlay.
- Defensive `Array.isArray(...) ? ... : []` on API response items, `(arr ?? []).map(...)`, and `arr?.length ?? 0` on dashboard arrays.

## Test plan
- [x] `npx tsc --noEmit` passes (frontend + api)
- [ ] Manual verification on staging blocked by #1513 (auth DB). Local-first merge per instruction.