### PR TITLE
fix: guard dev-only mosaic routes behind __DEV__ (closes #1519)

### DIFF
--- a/app/mosaic-d.tsx
+++ b/app/mosaic-d.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react';
+import { Redirect } from 'expo-router';
 
 const METROMAP = 'http://localhost:8091';
 const PROJECT_ROOT = '/Users/sergei/Documents/Projects/Ruslan/p2ptax';
-
-// No __DEV__ guard — this is a local-only dev page, always render
 
 interface PageItem {
   idx: number;
@@ -48,6 +47,8 @@ function imageUrl(pagesDir: string, file: string) {
 }
 
 export default function MosaicDesktop() {
+  if (!__DEV__) return <Redirect href="/" />;
+
   const [data, setData] = useState<MosaicData | null>(null);
   const [error, setError] = useState('');
 

--- a/app/mosaic-m.tsx
+++ b/app/mosaic-m.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react';
+import { Redirect } from 'expo-router';
 
 const METROMAP = 'http://localhost:8091';
 const PROJECT_ROOT = '/Users/sergei/Documents/Projects/Ruslan/p2ptax';
-
-// No __DEV__ guard — this is a local-only dev page, always render
 
 interface PageItem {
   idx: number;
@@ -48,6 +47,8 @@ function imageUrl(pagesDir: string, file: string) {
 }
 
 export default function MosaicMobile() {
+  if (!__DEV__) return <Redirect href="/" />;
+
   const [data, setData] = useState<MosaicData | null>(null);
   const [error, setError] = useState('');
 


### PR DESCRIPTION
## Summary
- `/mosaic-d` and `/mosaic-m` routes now redirect to `/` in production via `if (!__DEV__) return <Redirect href="/" />`
- In dev mode they still work as metromap mosaic viewers
- Stack.Screen registrations in `_layout.tsx` kept as-is (Expo Router requires them)

## Test plan
- [ ] In production build: visiting `/mosaic-d` or `/mosaic-m` redirects to home
- [ ] In dev: routes still show metromap mosaic viewer when metromap is running
- [ ] tsc --noEmit passes (0 errors)

Closes #1519