### PR TITLE
fix(auth): preserve route identity + onboarding progress

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -98,10 +98,45 @@ export default function AuthEmailScreen() {
           </Text>
           <Text
             className="text-text-mute text-center"
-            style={{ fontSize: 14, lineHeight: 20, marginBottom: 28 }}
+            style={{ fontSize: 14, lineHeight: 20, marginBottom: returnTo ? 16 : 28 }}
           >
             Введите email — отправим код подтверждения
           </Text>
+
+          {/*
+            Issues #1515 / #1520 — when the user reached /login via the
+            auth gate (useRequireAuth), surface the original target so
+            the screen no longer reads as a dead end / wrong destination.
+            Without this hint, deep-links to /onboarding/name and other
+            protected routes silently rendered as /login with no clue
+            that login was an intermediate step.
+          */}
+          {returnTo ? (
+            <View
+              accessibilityRole="alert"
+              testID="auth-return-hint"
+              className="rounded-xl mb-6 px-4 py-3"
+              style={{
+                backgroundColor: colors.accentSoft,
+                borderWidth: 1,
+                borderColor: colors.accent,
+              }}
+            >
+              <Text
+                className="font-semibold text-accent"
+                style={{ fontSize: 13, lineHeight: 18, marginBottom: 2 }}
+              >
+                Войдите, чтобы продолжить
+              </Text>
+              <Text
+                className="text-text-base"
+                style={{ fontSize: 12, lineHeight: 18 }}
+                numberOfLines={2}
+              >
+                После входа мы вернём вас на запрошенную страницу.
+              </Text>
+            </View>
+          ) : null}
 
           {/* Email input with leading icon */}
           <View

--- a/lib/useRequireAuth.ts
+++ b/lib/useRequireAuth.ts
@@ -1,23 +1,59 @@
 import { useEffect } from "react";
-import { useRouter } from "expo-router";
+import { useRouter, usePathname, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import { useAuth } from "@/contexts/AuthContext";
 
 /**
- * Redirects unauthenticated users to /auth/email with a returnTo param
- * so the user is redirected back after login.
- * Returns { user, isLoading, isAuthenticated } for rendering guards.
+ * Redirects unauthenticated users to /login with a `returnTo` param
+ * pointing back at the current route, so the user lands back on the
+ * intended screen after a successful OTP verify.
+ *
+ * Issues #1515 / #1520 / #1522 — previously the redirect was silent
+ * (no returnTo, no hint), which made deep-links to protected screens
+ * (e.g. /onboarding/name) render as /login with no indication that
+ * the user was mid-flow. Browsers / password managers therefore
+ * treated /login as the canonical destination and the back button
+ * left them stranded.
+ *
+ * `intent` is forwarded when set (e.g. "specialist" from landing CTA)
+ * so /otp can route to the correct onboarding branch after login.
+ *
+ * Returns `{ user, isLoading, isAuthenticated, ready }` for guarding
+ * UI render.
  */
 export function useRequireAuth() {
   const { user, isLoading, isAuthenticated } = useAuth();
-  const router = useRouter()
+  const router = useRouter();
   const nav = useTypedRouter();
+  const pathname = usePathname();
+  const params = useLocalSearchParams<{ intent?: string }>();
+  const intent =
+    typeof params.intent === "string"
+      ? params.intent
+      : Array.isArray(params.intent)
+        ? params.intent[0]
+        : undefined;
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
-      nav.replaceRoutes.authEmail();
+      // Preserve the originally-requested route so /login + /otp can
+      // restore it after auth. Skip preservation for "/" — the
+      // landing/dashboard split is handled by /index + role routing.
+      const shouldPreserve =
+        typeof pathname === "string" && pathname !== "" && pathname !== "/";
+      if (shouldPreserve) {
+        nav.replaceAny({
+          pathname: "/login",
+          params: {
+            returnTo: pathname as string,
+            ...(intent ? { intent } : {}),
+          },
+        });
+      } else {
+        nav.replaceRoutes.authEmail();
+      }
     }
-  }, [isLoading, isAuthenticated, router]);
+  }, [isLoading, isAuthenticated, router, pathname, intent]);
 
   return { user, isLoading, isAuthenticated, ready: !isLoading && isAuthenticated };
 }


### PR DESCRIPTION
## Summary
- `useRequireAuth` now redirects to `/login?returnTo=<pathname>` (with optional `intent`) instead of silently replacing the route, so deep-links to `/onboarding/{name,profile,work-area}` and other auth-gated screens no longer dead-end at the login form.
- `/login` shows a "Войдите чтобы продолжить" accent banner whenever `returnTo` is set so users see the redirect is intermediate, not the destination.
- Existing `returnTo` plumbing on `/login` + `/otp` already restores the original route after OTP verify; `OnboardingProgress` (Шаг 1/2/3 bar + dots) was already rendered on all three onboarding screens but was unreachable for unauth deep-links until this fix.

Closes #1515, #1520, #1522.

## Test plan
- [ ] Open `/onboarding/name` while logged out → land on `/login` with the new "Войдите чтобы продолжить" banner; URL contains `?returnTo=/onboarding/name`.
- [ ] Complete OTP login → should land back on `/onboarding/name` with the existing Шаг 1/3 progress bar visible.
- [ ] Direct hit `/notifications`, `/settings`, `/threads/<id>` while logged out → same banner + returnTo round-trip.
- [ ] Landing CTA "Я специалист" still routes to `/login?intent=specialist` and onboarding starts at name → work-area as before (no regression).
- [ ] `tsc --noEmit` passes for both `/` and `/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)