### PR TITLE
fix(onboarding): render route identity during auth resolution

### DIFF
--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -8,9 +8,9 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import { api } from "@/lib/api";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
-import LoadingState from "@/components/ui/LoadingState";
 import { colors, textStyle } from "@/lib/theme";
 
 export default function OnboardingNameScreen() {
@@ -116,7 +116,15 @@ export default function OnboardingNameScreen() {
   };
 
   if (!ready || isAdminUser || (!isSpecialistUser && !isSpecialistIntent)) {
-    return <LoadingState />;
+    return (
+      <OnboardingShell
+        step={1}
+        title="Как вас зовут?"
+        subtitle="Это имя увидят клиенты в карточке специалиста и в переписке."
+        loading
+        onBack={() => router.back()}
+      />
+    );
   }
 
   return (

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -23,9 +23,9 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
-import LoadingState from "@/components/ui/LoadingState";
 import { colors, overlay, textStyle } from "@/lib/theme";
 
 export default function OnboardingProfileScreen() {
@@ -178,7 +178,15 @@ export default function OnboardingProfileScreen() {
   };
 
   if (!ready || isAdminUser || !isSpecialistUser) {
-    return <LoadingState />;
+    return (
+      <OnboardingShell
+        step={3}
+        title="Заполните профиль"
+        subtitle="Аватар, контакты и краткое описание помогут клиенту быстрее выбрать именно вас."
+        loading
+        onBack={() => router.back()}
+      />
+    );
   }
 
   return (

--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -7,8 +7,8 @@ import { api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
 import Button from "@/components/ui/Button";
-import LoadingState from "@/components/ui/LoadingState";
 import { colors } from "@/lib/theme";
 import SpecialistSearchBar, {
   CityOpt,
@@ -279,7 +279,17 @@ export default function OnboardingWorkAreaScreen() {
   };
 
   if (!ready || isAdminUser || (!isSpecialistUser && !isSpecialistIntent)) {
-    return <LoadingState />;
+    return (
+      <OnboardingShell
+        step={2}
+        title="Где вы работаете?"
+        subtitle="Выберите город и налоговую — клиенты найдут вас по подведомственности."
+        loading
+        onBack={() => router.back()}
+        hideProgress={fromSettings}
+        maxWidth={720}
+      />
+    );
   }
 
   return (

--- a/components/onboarding/OnboardingShell.tsx
+++ b/components/onboarding/OnboardingShell.tsx
@@ -1,0 +1,121 @@
+import { ReactNode } from "react";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ChevronLeft } from "lucide-react-native";
+import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
+import { colors, textStyle } from "@/lib/theme";
+
+export interface OnboardingShellProps {
+  /** Onboarding step (1=name, 2=work-area, 3=profile). */
+  step: 1 | 2 | 3;
+  /** Title shown directly under the progress bar — preserves route identity. */
+  title: string;
+  /** Optional subtitle / one-line description. */
+  subtitle?: string;
+  /** When true, render a spinner under the title instead of `children`. */
+  loading?: boolean;
+  /** Optional `onBack` override — defaults to `router.back()` upstream. */
+  onBack?: () => void;
+  /** Hide the progress bar (used by /onboarding/work-area when fromSettings). */
+  hideProgress?: boolean;
+  /** Custom max content width — `name`/`profile` use 640, `work-area` uses 720. */
+  maxWidth?: number;
+  children?: ReactNode;
+}
+
+/**
+ * Shared chrome for /onboarding/{name,work-area,profile} so that route
+ * identity (back button + Шаг N/3 progress + page title) is visible even
+ * while the screen is still resolving auth/specialist state.
+ *
+ * Issues #1515 / #1520 / #1522 — previously the screens returned a bare
+ * `<LoadingState />` (spinner only) while `useRequireAuth()` was still
+ * loading or while the screen-level effect was bouncing a non-specialist
+ * back to /tabs. Mosaic snapshots taken during that window had no signal
+ * that the route was "/onboarding/<step>" at all, which read as the
+ * route silently rendering a generic auth/login shell. Shipping the
+ * chrome unconditionally keeps the route self-identifying.
+ */
+export default function OnboardingShell({
+  step,
+  title,
+  subtitle,
+  loading = false,
+  onBack,
+  hideProgress = false,
+  maxWidth = 640,
+  children,
+}: OnboardingShellProps) {
+  return (
+    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      {onBack ? (
+        <View className="px-6 pt-4 pb-2">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Назад"
+            onPress={onBack}
+            className="flex-row items-center"
+            style={{ minHeight: 44 }}
+          >
+            <ChevronLeft size={20} color={colors.text} />
+            <Text className="text-text-base ml-1">Назад</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
+      {!hideProgress && (
+        <View className="px-6 pb-4">
+          <OnboardingProgress step={step} />
+        </View>
+      )}
+
+      <View
+        style={{
+          width: "100%",
+          maxWidth,
+          alignSelf: "center",
+          paddingHorizontal: 24,
+        }}
+      >
+        <Text
+          style={{
+            ...textStyle.h1,
+            color: colors.text,
+            fontSize: 32,
+            lineHeight: 38,
+            marginTop: 16,
+            marginBottom: subtitle ? 12 : 24,
+          }}
+        >
+          {title}
+        </Text>
+        {subtitle ? (
+          <Text
+            style={{
+              ...textStyle.body,
+              color: colors.textSecondary,
+              fontSize: 16,
+              lineHeight: 24,
+              marginBottom: loading ? 24 : 32,
+            }}
+          >
+            {subtitle}
+          </Text>
+        ) : null}
+
+        {loading ? (
+          <View
+            accessibilityRole="progressbar"
+            accessibilityLabel="Загрузка"
+            className="items-center justify-center"
+            style={{ paddingVertical: 48 }}
+          >
+            <ActivityIndicator size="large" color={colors.accent} />
+          </View>
+        ) : null}
+      </View>
+
+      {!loading ? children : null}
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
## Summary
- Add shared `components/onboarding/OnboardingShell.tsx` so the back button + Шаг N/3 progress bar + heading are visible from first paint.
- Wire `/onboarding/{name,work-area,profile}` loading branches through it so the route is self-identifying while `useRequireAuth` is still resolving or while the screen useEffect is bouncing a non-specialist back to /tabs.
- PR #1529 added the `/login?returnTo=…` banner for the unauth deep-link case; this addresses the second half of the bug — the in-screen loading state was a bare spinner and read as a generic auth/login shell.

Real follow-up to #1515, #1520, #1522.

## Test plan
- [ ] `tsc --noEmit` passes for both `/` and `/api`.
- [ ] Open `/onboarding/name` while authed but state still resolving → shell shows back button + Шаг 1/3 + "Как вас зовут?" heading + spinner instead of an empty page.
- [ ] Open `/onboarding/work-area?role=specialist` while authed (non-specialist) → identity visible during the network round-trip; UI swaps to the search bar once `ready`.
- [ ] Open `/onboarding/profile` while authed specialist → identity visible until isSpecialistUser resolves; full form renders after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)