### PR TITLE
fix(api): CORS allow 8081+8082 for /better sessions

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -30,7 +30,7 @@ import { runRequestLifecycleCron } from "./cron/requestLifecycle";
 const app = express();
 
 app.use(helmet());
-app.use(cors({ origin: process.env.CORS_ORIGIN || "http://localhost:8081" }));
+app.use(cors({ origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(",").map(s => s.trim()) : [/^http:\/\/localhost:(8081|8082)$/] }));
 app.use(express.json({ limit: "1mb" }));
 
 // Health check


### PR DESCRIPTION
## Summary
- Replaces hardcoded `http://localhost:8081` CORS origin with a regex allowing both 8081 and 8082
- Supports `CORS_ORIGIN` env var (comma-separated) for production overrides
- Fixes `/better` session preview (running on port 8082) getting `Failed to fetch` errors

Closes #1535

## Test plan
- [ ] `tsc --noEmit` passes with 0 errors (verified)
- [ ] Frontend on port 8082 can reach backend without CORS errors
- [ ] `CORS_ORIGIN` env var still works for production