### PR TITLE
feat(shared): unified CityFnsServicePicker component

### DIFF
--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -22,7 +22,7 @@ import { colors } from "@/lib/theme";
 import type {
   CityOption,
   ServiceOption,
-} from "@/components/requests/CityFnsServicePicker";
+} from "@/components/shared/CityFnsServicePicker";
 import CityFnsCascade from "@/components/filters/CityFnsCascade";
 import InlineOtpFlow from "@/components/requests/InlineOtpFlow";
 import { draftStorage } from "@/lib/draftStorage";

--- a/components/filters/CityFnsCascade.tsx
+++ b/components/filters/CityFnsCascade.tsx
@@ -16,6 +16,7 @@ import { colors } from "@/lib/theme";
 export interface CityCascadeOption {
   id: string;
   name: string;
+  slug?: string;
 }
 
 export interface FnsCascadeOption {

--- a/components/requests/RequestForm.tsx
+++ b/components/requests/RequestForm.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable } from "react-native";
 import Input from "@/components/ui/Input";
-import CityFnsServicePicker, { CityOption, FnsOption, ServiceOption } from "@/components/requests/CityFnsServicePicker";
+import CityFnsServicePicker from "@/components/shared/CityFnsServicePicker";
+import type { CityOption as CityCascadeOption, ServiceOption } from "@/components/shared/CityFnsServicePicker";
 import FileUploadSection, { AttachedFile } from "@/components/requests/FileUploadSection";
 import { ChevronUp, ChevronDown } from "lucide-react-native";
 import { colors } from "@/lib/theme";
@@ -8,16 +9,11 @@ import { colors } from "@/lib/theme";
 interface RequestFormProps {
   title: string;
   description: string;
-  cities: CityOption[];
-  fnsOffices: FnsOption[];
+  cities: CityCascadeOption[];
   services: ServiceOption[];
-  selectedCity?: CityOption;
-  selectedFns?: FnsOption;
-  selectedService?: ServiceOption;
-  cityOpen: boolean;
-  fnsOpen: boolean;
-  serviceOpen: boolean;
-  loadingFns: boolean;
+  selectedCityId: string | null;
+  selectedFnsId: string | null;
+  selectedServiceId: string | null;
   submitted: boolean;
   atLimit: boolean;
   submitting: boolean;
@@ -28,26 +24,18 @@ interface RequestFormProps {
   setTitle: (val: string) => void;
   setDescription: (val: string) => void;
   setFiles: (val: AttachedFile[]) => void;
-  setCityOpen: (val: boolean) => void;
-  setFnsOpen: (val: boolean) => void;
-  setServiceOpen: (val: boolean) => void;
   setTipsOpen: (val: boolean) => void;
-  handleCitySelect: (city: CityOption) => void;
-  handleFnsSelect: (fns: FnsOption) => void;
-  handleServiceSelect: (svc: ServiceOption) => void;
-  handleServiceClear: () => void;
+  onPickerChange: (v: { cityId: string | null; fnsId: string | null; serviceId: string | null }) => void;
 }
 
 export default function RequestForm({
-  title, description, cities, fnsOffices, services,
-  selectedCity, selectedFns, selectedService,
-  cityOpen, fnsOpen, serviceOpen, loadingFns,
+  title, description, cities, services,
+  selectedCityId, selectedFnsId, selectedServiceId,
   submitted, atLimit, submitting,
   titleValid, descriptionValid,
   files, tipsOpen,
-  setTitle, setDescription, setFiles,
-  setCityOpen, setFnsOpen, setServiceOpen, setTipsOpen,
-  handleCitySelect, handleFnsSelect, handleServiceSelect, handleServiceClear,
+  setTitle, setDescription, setFiles, setTipsOpen,
+  onPickerChange,
 }: RequestFormProps) {
 
   return (
@@ -79,27 +67,20 @@ export default function RequestForm({
         </Text>
       </View>
 
-      <CityFnsServicePicker
-        cities={cities}
-        fnsOffices={fnsOffices}
-        services={services}
-        selectedCity={selectedCity}
-        selectedFns={selectedFns}
-        selectedService={selectedService}
-        cityOpen={cityOpen}
-        fnsOpen={fnsOpen}
-        serviceOpen={serviceOpen}
-        loadingFns={loadingFns}
-        submitted={submitted}
-        disabled={atLimit || submitting}
-        onCitySelect={handleCitySelect}
-        onFnsSelect={handleFnsSelect}
-        onServiceSelect={handleServiceSelect}
-        onServiceClear={handleServiceClear}
-        onCityOpenChange={setCityOpen}
-        onFnsOpenChange={setFnsOpen}
-        onServiceOpenChange={setServiceOpen}
-      />
+      {/* Negative margin compensates for cascade's internal px-4 so its
+          chip rows align with the card's edge padding. */}
+      <View className="mb-4 -mx-4">
+        <CityFnsServicePicker
+          cities={cities}
+          services={services}
+          cityId={selectedCityId}
+          fnsId={selectedFnsId}
+          serviceId={selectedServiceId}
+          onChange={onPickerChange}
+          submitted={submitted}
+          disabled={atLimit || submitting}
+        />
+      </View>
 
       <View className="mb-4">
         <Text className="text-sm font-medium text-text-base mb-1.5">

--- a/components/shared/CityFnsServicePicker.tsx
+++ b/components/shared/CityFnsServicePicker.tsx
@@ -1,0 +1,100 @@
+/**
+ * CityFnsServicePicker — unified city → FNS → service selector.
+ *
+ * Wraps CityFnsCascade (chip city row + typeahead FNS dropdown + service chips)
+ * with a simplified value/onChange API used by forms.
+ *
+ * Usage (single selection):
+ *   <CityFnsServicePicker
+ *     cities={cities}
+ *     services={services}
+ *     cityId={selectedCityId}
+ *     fnsId={selectedFnsId}
+ *     serviceId={selectedServiceId}
+ *     onChange={({ cityId, fnsId, serviceId }) => { ... }}
+ *     submitted={submitted}
+ *   />
+ */
+import { View, Text } from "react-native";
+import CityFnsCascade, {
+  CityCascadeOption,
+  ServiceOption,
+} from "@/components/filters/CityFnsCascade";
+
+export interface CityFnsServicePickerValue {
+  cityId: string | null;
+  fnsId: string | null;
+  serviceId: string | null;
+}
+
+export interface CityFnsServicePickerProps {
+  cities: CityCascadeOption[];
+  services?: ServiceOption[];
+  cityId: string | null;
+  fnsId: string | null;
+  serviceId?: string | null;
+  onChange: (value: CityFnsServicePickerValue) => void;
+  /** Show validation errors for required fields */
+  submitted?: boolean;
+  disabled?: boolean;
+  labelCities?: string;
+  labelFns?: string;
+  labelServices?: string;
+}
+
+export default function CityFnsServicePicker({
+  cities,
+  services,
+  cityId,
+  fnsId,
+  serviceId,
+  onChange,
+  submitted = false,
+  disabled = false,
+  labelCities,
+  labelFns,
+  labelServices,
+}: CityFnsServicePickerProps) {
+  const handleCascadeChange = (v: { cities: string[]; fns: string[] }) => {
+    if (disabled) return;
+    onChange({
+      cityId: v.cities[0] ?? null,
+      fnsId: v.fns[0] ?? null,
+      serviceId: serviceId ?? null,
+    });
+  };
+
+  const handleServiceChange = (id: string | null) => {
+    if (disabled) return;
+    onChange({ cityId, fnsId, serviceId: id });
+  };
+
+  return (
+    <View>
+      <CityFnsCascade
+        mode="single"
+        value={{
+          cities: cityId ? [cityId] : [],
+          fns: fnsId ? [fnsId] : [],
+        }}
+        onChange={handleCascadeChange}
+        citiesSource={cities}
+        services={services}
+        selectedServiceId={serviceId ?? null}
+        onServiceChange={handleServiceChange}
+        labelCities={labelCities}
+        labelFns={labelFns}
+        labelServices={labelServices}
+      />
+      {submitted && !cityId && (
+        <Text className="text-xs text-danger mt-1 px-4">Выберите город</Text>
+      )}
+      {submitted && cityId && !fnsId && (
+        <Text className="text-xs text-danger mt-1 px-4">Выберите инспекцию</Text>
+      )}
+    </View>
+  );
+}
+
+// Re-export types for consumers that previously imported from requests/CityFnsServicePicker
+export type { CityCascadeOption as CityOption, ServiceOption };


### PR DESCRIPTION
## Summary

- Create `components/shared/CityFnsServicePicker.tsx` — unified city → FNS → service selector wrapping `CityFnsCascade` with a simplified `cityId/fnsId/serviceId` API
- Add `slug?: string` to `CityCascadeOption` in `CityFnsCascade.tsx` for draft persistence compatibility
- Refactor `RequestForm.tsx` to use the new unified component instead of the old dropdown-based `CityFnsServicePicker`
- Update `app/requests/new.tsx` type imports to point to the new shared component

## UX

All pickers now use: chip city row → typeahead FNS dropdown with search → service chips (via `CityFnsCascade`)

## Test plan

- [ ] `/requests/new` — city chips appear, selecting city shows FNS dropdown with search, selecting FNS shows service chips
- [ ] Validation: submit without city/FNS shows inline error messages
- [ ] Draft save/restore still works (citySlug preserved)
- [ ] `tsc --noEmit` — 0 errors ✓

Closes #1544