### PR TITLE
fix(header): Dashboard button route /(tabs) → /(tabs)/dashboard

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -103,7 +103,7 @@ export default function Header() {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Личный кабинет"
-            onPress={() => router.push("/(tabs)" as never)}
+            onPress={() => router.push("/(tabs)/dashboard" as never)}
             className="px-4 h-11 rounded-lg items-center justify-center active:bg-slate-100"
           >
             <Text className="text-sm font-semibold text-blue-900">Личный кабинет</Text>


### PR DESCRIPTION
## Summary
- Fixes #1546 — кнопка "Дашборд" в личном кабинете вела на `/(tabs)` (bare group без index), что вызывало ошибку Expo Router "Unmatched Route"
- Изменён `router.push("/(tabs)")` → `router.push("/(tabs)/dashboard")` в `components/Header.tsx` (line 106)
- Единственный файл с этой проблемой

## Test plan
- [ ] Авторизоваться, нажать "Личный кабинет" в шапке — должен открыться дашборд без ошибки "Unmatched Route"
- [ ] `tsc --noEmit` — 0 errors

Closes #1546