### PR TITLE
fix(request-detail): unify FNS + service into one white chip (closes #1548)

### DIFF
--- a/app/(tabs)/public-requests.tsx
+++ b/app/(tabs)/public-requests.tsx
@@ -72,7 +72,7 @@ export default function SpecialistPublicRequests() {
   const isDesktop = width >= BREAKPOINT;
   const { ready, isLoading: authLoading, isAuthenticated } = useRequireAuth();
   const { isSpecialistUser } = useAuth();
-  const segments = useSegments();
+  const segments = useSegments() as string[];
 
   // Only redirect away when the user is actually on this screen (active tab).
   // Without the segment guard this effect fires for background tab instances

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -229,25 +229,14 @@ export default function MyRequestDetail() {
                   {request.title}
                 </Text>
 
-                {/* FNS + service chips — prominent */}
+                {/* Unified FNS · service chip (city is already inside FNS name) */}
                 <View className="flex-row flex-wrap gap-2 mb-5">
-                  <View className="bg-accent-soft border border-accent rounded-xl px-3 py-1.5">
-                    <Text className="text-sm font-semibold text-accent">
-                      {request.city.name}
+                  <View className="bg-white border border-border rounded-lg px-2.5 py-1">
+                    <Text className="text-xs font-medium text-text-base">
+                      {request.fns.name}
+                      {request.service ? ` · ${request.service.name}` : ""}
                     </Text>
                   </View>
-                  <View className="bg-white border border-border rounded-xl px-3 py-1.5">
-                    <Text className="text-sm font-medium text-text-base">
-                      {request.fns.name} ({request.fns.code})
-                    </Text>
-                  </View>
-                  {request.service && (
-                    <View className="bg-white border border-border rounded-xl px-3 py-1.5">
-                      <Text className="text-sm font-medium text-text-base">
-                        {request.service.name}
-                      </Text>
-                    </View>
-                  )}
                 </View>
 
                 {/* Description */}
@@ -490,21 +479,14 @@ export default function MyRequestDetail() {
               {request.title}
             </Text>
 
-            {/* City + FNS chips */}
+            {/* Unified FNS · service chip (city is already inside FNS name) */}
             <View className="flex-row flex-wrap gap-2 mb-4">
-              <View className="bg-accent-soft border border-accent rounded-lg px-3 py-1">
-                <Text className="text-sm font-semibold text-accent">{request.city.name}</Text>
-              </View>
-              <View className="bg-white border border-border px-3 py-1 rounded-lg">
-                <Text className="text-sm text-text-base">
-                  {request.fns.name} ({request.fns.code})
+              <View className="bg-white border border-border rounded-lg px-2.5 py-1">
+                <Text className="text-xs text-text-base">
+                  {request.fns.name}
+                  {request.service ? ` · ${request.service.name}` : ""}
                 </Text>
               </View>
-              {request.service && (
-                <View className="bg-white border border-border px-3 py-1 rounded-lg">
-                  <Text className="text-sm text-text-base">{request.service.name}</Text>
-                </View>
-              )}
             </View>
 
             {/* Description */}


### PR DESCRIPTION
## Summary
- Drop redundant blue city chip from `/requests/:id/detail` header (city is already inside FNS name "ИФНС №1 по г. Москве")
- Merge FNS name and service type into one small white chip with " · " separator
- Apply on both desktop and mobile layouts

## Before / After
- Before: `[blue: Москва]` `[ФНС №1 по г. Москве (7701)]` `[Выездная проверка]`
- After: `[white: ИФНС №1 по г. Москве · Выездная проверка]`

## Drive-by
- Cast `useSegments()` to `string[]` in `app/(tabs)/public-requests.tsx` to fix a pre-existing tsc error that was blocking the pre-commit hook on every commit.

## Test plan
- [ ] Open `/requests/<id>/detail` on desktop — header shows status + date, title, then a single white pill with FNS · service
- [ ] Same on mobile (<640px) — single white pill
- [ ] Request without service — pill still renders, just FNS name
- [ ] `npx tsc --noEmit` passes (frontend + api)

Closes #1548