### PR TITLE
hotfix(detail): resolve unmerged conflict markers + close #1549 #1551

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -525,7 +525,6 @@ export default function MyRequestDetail() {
               )}
             </View>
 
-<<<<<<< HEAD
             {/* Recommended specialists feed (horizontal scroll) — issue #1550.
                 Placed under main info, before actions (per acceptance criteria). */}
             {recommendations.length > 0 && (
@@ -538,32 +537,6 @@ export default function MyRequestDetail() {
               </View>
             )}
 
-            {/* Close button — mobile */}
-            {isActive && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Закрыть заявку"
-                onPress={handleCloseRequest}
-                disabled={closing}
-                className="flex-row items-center justify-center rounded-xl py-3 mb-4"
-                style={({ pressed }) => [
-                  { backgroundColor: colors.danger, minHeight: 44 },
-                  pressed && { opacity: 0.8 },
-                ]}
-              >
-                {closing ? (
-                  <ActivityIndicator color="#fff" size="small" />
-                ) : (
-                  <>
-                    <X size={16} color="#fff" />
-                    <Text className="text-white font-semibold text-base ml-2">
-                      Закрыть заявку
-                    </Text>
-                  </>
-                )}
-              </Pressable>
-            )}
-=======
             {/* Actions card — mobile (matches desktop, prominent border + shadow) */}
             <View
               className="bg-white rounded-2xl p-4 mb-4"
@@ -626,7 +599,6 @@ export default function MyRequestDetail() {
                 </View>
               )}
             </View>
->>>>>>> 00b398d (refactor(i18n): rename 'заявка' to 'запрос' across UI strings)
 
             <ThreadsList
               threads={threads}


### PR DESCRIPTION
## Problem

PR #1560 (which closed #1549 + #1551) was merged into `development` with **unresolved git conflict markers** still in the source:

```
<<<<<<< HEAD
... mobile actions / recommendations branch from origin
=======
... visibility-fix branch
>>>>>>> 00b398d (refactor(i18n): rename ...)
```

Located in `app/requests/[id]/detail.tsx` mobile section (line ~528). This breaks TypeScript compilation and web build.

## Fix

Resolved the conflict by keeping **both** halves:

- `<SpecialistRecommendations>` block from `feat-recommended-1550` (issue #1550 — already on dev) is preserved.
- New `Действия` card with prominent border + shadow + redesigned closed state (issue #1551 — new visibility fix).

Old inline `Close button — mobile` is replaced by the new card so we don't end up with two close buttons.

## Verification

- [x] `grep '<<<<<<<' -r app/ components/ api/src/` -> 0 hits
- [x] Frontend `tsc --noEmit` -> 0 errors
- [x] Backend `tsc --noEmit` -> 0 errors

## Closes

Closes #1549
Closes #1551