### PR TITLE
fix(specialist): reposition Back button on desktop (#1564)

### DIFF
--- a/app/specialists/[id].tsx
+++ b/app/specialists/[id].tsx
@@ -320,22 +320,24 @@ export default function SpecialistPublicProfile() {
           className="w-full items-center"
           style={{ paddingHorizontal: isDesktop ? 32 : 16, paddingTop: 16 }}
         >
-          <View
-            className="w-full flex-row items-center justify-between mb-3"
-            style={{ maxWidth: 720 }}
-          >
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Назад"
-              onPress={() => router.back()}
-              className="flex-row items-center"
-              style={{ minHeight: 44 }}
+          {!isDesktop && (
+            <View
+              className="w-full flex-row items-center justify-between mb-3"
+              style={{ maxWidth: 720 }}
             >
-              <ChevronLeft size={20} color={colors.text} />
-              <Text className="text-text-base ml-1">Назад</Text>
-            </Pressable>
-            {rightAction}
-          </View>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Назад"
+                onPress={() => router.back()}
+                className="flex-row items-center"
+                style={{ minHeight: 44 }}
+              >
+                <ChevronLeft size={20} color={colors.text} />
+                <Text className="text-text-base ml-1">Назад</Text>
+              </Pressable>
+              {rightAction}
+            </View>
+          )}
           <View
             className={`${isDesktop ? "flex-row" : "flex-col"} w-full`}
             style={{ maxWidth: 1200, gap: isDesktop ? spacing.xl : 0 }}
@@ -345,6 +347,21 @@ export default function SpecialistPublicProfile() {
               className="flex-1"
               style={{ maxWidth: isDesktop ? 860 : undefined }}
             >
+              {isDesktop && (
+                <View className="flex-row items-center justify-between mb-4">
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Назад"
+                    onPress={() => router.back()}
+                    className="flex-row items-center"
+                    style={{ minHeight: 44 }}
+                  >
+                    <ChevronLeft size={20} color={colors.text} />
+                    <Text className="text-text-base ml-1">Назад</Text>
+                  </Pressable>
+                  {rightAction}
+                </View>
+              )}
               {mainContent}
             </View>
 


### PR DESCRIPTION
## Summary
- Desktop (>=1024px): Back button moved out of the narrow centered max-720 wrapper that sat above the layout
- Now placed inline at the top of the main content column (above SpecialistHero), aligned with the profile card's left edge
- Edit pencil icon (own-profile) follows the back button into the same row on desktop
- Mobile (<1024px): unchanged

## Why
The Back button was constrained to a `maxWidth: 720` centered wrapper, which on desktop displayed it visually disconnected from the main content area (max 1200, main column 860 + sidebar 320). Moving it inside the main column places it where users expect it on desktop layouts.

## Files
- `app/specialists/[id].tsx` — split mobile vs desktop rendering of the Back/Edit row

## Test plan
- [ ] Open `/specialists/:id` on desktop (>=1024px): Back button at top-left of profile card, above SpecialistHero
- [ ] Open `/specialists/:id` on mobile (<1024px): Back button position unchanged (above hero, alongside edit if own profile)
- [ ] Own profile (edit pencil): pencil still aligned to the right of the same row
- [ ] `tsc --noEmit` clean (verified)

Closes #1564