### PR TITLE
fix: avatar upload via MinIO (#1558) and remove 'Я: Клиент' label (#1559)

### DIFF
--- a/api/src/lib/minio.ts
+++ b/api/src/lib/minio.ts
@@ -57,3 +57,22 @@ export async function ensureBucket() {
     await minioClient.makeBucket(MINIO_BUCKET);
   }
 }
+
+// Max presigned URL expiry allowed by S3-compatible storage is 7 days (604800s).
+const PRESIGN_EXPIRY_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/**
+ * Generate a fresh presigned GET URL for an avatar key.
+ * avatarKey is the raw storage key, e.g. "avatars/1234-uuid.jpg".
+ * Returns null if key is falsy (no avatar set).
+ */
+export async function presignAvatarUrl(avatarKey: string | null | undefined): Promise<string | null> {
+  if (!avatarKey) return null;
+  // If the value is already a full URL (legacy presigned URL), return as-is.
+  if (avatarKey.startsWith("http")) return avatarKey;
+  try {
+    return await minioClient.presignedGetObject(MINIO_BUCKET, avatarKey, PRESIGN_EXPIRY_SECONDS);
+  } catch {
+    return null;
+  }
+}

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -7,6 +7,7 @@ import {
   generateOtpCode,
 } from "../lib/jwt";
 import { authMiddleware } from "../middleware/auth";
+import { presignAvatarUrl } from "../lib/minio";
 
 const router = Router();
 
@@ -167,7 +168,7 @@ router.post("/verify-otp", verifyOtpRateLimiter, async (req: Request, res: Respo
         isAvailable: user.isAvailable,
         firstName: user.firstName,
         lastName: user.lastName,
-        avatarUrl: user.avatarUrl,
+        avatarUrl: await presignAvatarUrl(user.avatarUrl),
         specialistProfileCompletedAt: user.specialistProfileCompletedAt
           ? user.specialistProfileCompletedAt.toISOString()
           : null,
@@ -246,7 +247,7 @@ router.post("/refresh", refreshRateLimiter, async (req: Request, res: Response) 
         isAvailable: storedToken.user.isAvailable,
         firstName: storedToken.user.firstName,
         lastName: storedToken.user.lastName,
-        avatarUrl: storedToken.user.avatarUrl,
+        avatarUrl: await presignAvatarUrl(storedToken.user.avatarUrl),
         specialistProfileCompletedAt: storedToken.user.specialistProfileCompletedAt
           ? storedToken.user.specialistProfileCompletedAt.toISOString()
           : null,
@@ -300,7 +301,7 @@ router.get("/me", authMiddleware, async (req: Request, res: Response) => {
       return;
     }
 
-    res.json({ user });
+    res.json({ user: { ...user, avatarUrl: await presignAvatarUrl(user.avatarUrl) } });
   } catch (error) {
     console.error("me error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -5,7 +5,7 @@ import crypto from "crypto";
 import path from "path";
 import sharp from "sharp";
 import { authMiddleware } from "../middleware/auth";
-import { minioClient, MINIO_BUCKET, ensureBucket as ensureMinioBucket } from "../lib/minio";
+import { minioClient, MINIO_BUCKET, ensureBucket as ensureMinioBucket, presignAvatarUrl } from "../lib/minio";
 import { prisma } from "../lib/prisma";
 
 const router = Router();
@@ -124,9 +124,14 @@ router.post("/avatar", authMiddleware, uploadRateLimiter, avatarUpload.single("f
       "Content-Type": "image/jpeg",
     });
 
-    // Return 1-year presigned URL so the avatar is directly usable in <Image>.
-    // The raw key is also returned so callers can re-presign on future loads.
-    const url = await minioClient.presignedGetObject(MINIO_BUCKET, key, 365 * 24 * 60 * 60);
+    // Save the storage key in user.avatarUrl so URLs never expire in the DB.
+    // Return a 7-day presigned URL (S3 max) for immediate display in <Image>.
+    await prisma.user.update({
+      where: { id: req.user!.userId },
+      data: { avatarUrl: key },
+    });
+
+    const url = await presignAvatarUrl(key);
     res.json({ url, key });
   } catch (error) {
     console.error("avatar upload error:", error);

--- a/api/src/routes/user.ts
+++ b/api/src/routes/user.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { prisma } from "../lib/prisma";
 import { authMiddleware } from "../middleware/auth";
+import { presignAvatarUrl } from "../lib/minio";
 
 const router = Router();
 
@@ -28,7 +29,7 @@ router.patch("/profile", authMiddleware, async (req: Request, res: Response) => 
       },
     });
 
-    res.json({ user });
+    res.json({ user: { ...user, avatarUrl: await presignAvatarUrl(user.avatarUrl) } });
   } catch (error) {
     console.error("user/profile error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/components/settings/AvatarUploader.tsx
+++ b/components/settings/AvatarUploader.tsx
@@ -34,7 +34,12 @@ interface AvatarUploaderProps {
   name?: string;
   /** Fallback identifier (typically email) when name is empty. */
   fallback?: string;
-  onAvatarChange: (url: string) => void;
+  /**
+   * Called after successful upload with:
+   *   url  — 7-day presigned URL for immediate display in <Image>
+   *   key  — storage key (e.g. "avatars/uuid.jpg") that must be saved in the DB
+   */
+  onAvatarChange: (url: string, key: string) => void;
   onUploadStart: () => void;
   onUploadEnd: () => void;
 }
@@ -90,8 +95,8 @@ export default function AvatarUploader({
     setErrorMessage(null);
     onUploadStart();
     try {
-      const fullUrl = await uploadAvatarFile(file);
-      onAvatarChange(fullUrl);
+      const { url, key } = await uploadAvatarFile(file);
+      onAvatarChange(url, key);
       setLastFile(null);
     } catch (e: unknown) {
       const status = e instanceof ApiError ? e.status : -1;

--- a/components/settings/ProfileTab.tsx
+++ b/components/settings/ProfileTab.tsx
@@ -84,7 +84,7 @@ interface ProfileTabProps {
   userId?: string;
   onFirstNameChange: (v: string) => void;
   onLastNameChange: (v: string) => void;
-  onAvatarChange: (url: string | null) => void;
+  onAvatarChange: (url: string, key: string) => void;
   onUploadStart: () => void;
   onUploadEnd: () => void;
   onToggleSpecialist: (v: boolean) => void;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -140,9 +140,12 @@ export function avatarUploadErrorMessage(status: number): string {
 /**
  * Upload an avatar file (web). Performs client-side size pre-check, throws ApiError on
  * server error (with mapped Russian message), or a network ApiError(0, ...) on fetch failure.
- * Returns the absolute URL of the uploaded avatar.
+ * Returns { url, key } — url is a 7-day presigned URL for immediate display,
+ * key is the storage key that should be persisted in the DB (never expires).
+ * The upload endpoint already saves key to user.avatarUrl in the DB, but the
+ * profile PATCH also sends the key so the user profile stays in sync.
  */
-export async function uploadAvatarFile(file: File): Promise<string> {
+export async function uploadAvatarFile(file: File): Promise<{ url: string; key: string }> {
   if (file.size > AVATAR_MAX_BYTES) {
     throw new ApiError(413, avatarUploadErrorMessage(413));
   }
@@ -166,8 +169,9 @@ export async function uploadAvatarFile(file: File): Promise<string> {
     throw new ApiError(res.status, avatarUploadErrorMessage(res.status));
   }
 
-  const data = (await res.json()) as { url: string };
-  return data.url.startsWith("http") ? data.url : `${API_URL}${data.url}`;
+  const data = (await res.json()) as { url: string; key: string };
+  const url = data.url && data.url.startsWith("http") ? data.url : `${API_URL}${data.url}`;
+  return { url, key: data.key };
 }
 
 /**

--- a/lib/useSettingsForm.ts
+++ b/lib/useSettingsForm.ts
@@ -31,6 +31,9 @@ export function useSettingsForm({ ready, activeTab, onTabChange, onStartInlineOn
   const [firstName, setFirstName] = useState(user?.firstName ?? "");
   const [lastName, setLastName] = useState(user?.lastName ?? "");
   const [avatarUrl, setAvatarUrl] = useState<string | null>(user?.avatarUrl ?? null);
+  // avatarKey: the storage key (e.g. "avatars/uuid.jpg") set after a successful upload.
+  // Sent to the profile PATCH so the DB stores the key, not a presigned URL.
+  const [avatarKey, setAvatarKey] = useState<string | null>(null);
   const [avatarUploading, setAvatarUploading] = useState(false);
   const [saving, setSaving] = useState(false);
 
@@ -106,8 +109,10 @@ export function useSettingsForm({ ready, activeTab, onTabChange, onStartInlineOn
     () =>
       firstName !== (user?.firstName ?? "") ||
       lastName !== (user?.lastName ?? "") ||
-      avatarUrl !== (user?.avatarUrl ?? null),
-    [firstName, lastName, avatarUrl, user?.firstName, user?.lastName, user?.avatarUrl],
+      // avatarKey is set only after a new upload — use it as the dirty flag for avatar.
+      avatarKey !== null ||
+      (!avatarKey && avatarUrl !== (user?.avatarUrl ?? null)),
+    [firstName, lastName, avatarUrl, avatarKey, user?.firstName, user?.lastName, user?.avatarUrl],
   );
 
   const hasSpecialistChanges = useMemo(
@@ -131,12 +136,18 @@ export function useSettingsForm({ ready, activeTab, onTabChange, onStartInlineOn
         firstName: firstName.trim(),
         lastName: lastName.trim(),
       };
-      if (avatarUrl !== (user?.avatarUrl ?? null)) {
+      // Send storage key (not presigned URL) to the profile PATCH — key never expires in DB.
+      // avatarKey is set by AvatarUploader after a successful upload.
+      if (avatarKey !== null) {
+        body.avatarUrl = avatarKey;
+      } else if (avatarUrl !== (user?.avatarUrl ?? null)) {
         body.avatarUrl = avatarUrl;
       }
       const res = await apiPatch<{
         user: { firstName: string; lastName: string; avatarUrl?: string | null };
       }>("/api/user/profile", body);
+      // Clear the pending key after save — the context now holds the fresh presigned URL.
+      setAvatarKey(null);
       updateUser({
         firstName: res.user.firstName,
         lastName: res.user.lastName,
@@ -397,6 +408,8 @@ export function useSettingsForm({ ready, activeTab, onTabChange, onStartInlineOn
     setLastName,
     avatarUrl,
     setAvatarUrl,
+    avatarKey,
+    setAvatarKey,
     avatarUploading,
     setAvatarUploading,
     // Save state


### PR DESCRIPTION
## Summary

- **#1558**: Fixed broken avatar upload. Root cause: `presignedGetObject` was called with a 1-year expiry (`365 * 24 * 60 * 60`), but S3-compatible storage caps presigned URLs at 7 days (604800s), throwing an error after the file was already uploaded to MinIO. Fix: store the storage key (e.g. `avatars/uuid.jpg`) in `user.avatarUrl` — keys never expire. The upload endpoint now saves the key to DB directly. Auth endpoints (`/me`, `/refresh`, `verify-otp`) and the profile PATCH generate a fresh 7-day presigned URL via `presignAvatarUrl()` helper before responding. This means avatar URLs are always valid and never rot in the DB.

- **#1559**: `PerspectiveBadge` showed `"Я: Клиент"` / `"Я: Специалист"` — simplified to `"Клиент"` / `"Специалист"`. The role is already clear from the badge icon (User / Briefcase) and color (blue / green).

- Also resolved a pre-existing merge conflict in `app/requests/[id]/detail.tsx` (kept the newer `запрос` rename).

## Files changed

- `api/src/lib/minio.ts` — added `presignAvatarUrl(key)` helper (7-day presign)
- `api/src/routes/upload.ts` — save key to DB, return 7-day presigned URL
- `api/src/routes/auth.ts` — presign avatarUrl in verify-otp / refresh / /me
- `api/src/routes/user.ts` — presign avatarUrl in profile PATCH response
- `lib/api.ts` — `uploadAvatarFile` returns `{ url, key }` instead of just `url`
- `components/settings/AvatarUploader.tsx` — pass `key` to `onAvatarChange`
- `components/settings/ProfileTab.tsx` — updated `onAvatarChange` signature
- `lib/useSettingsForm.ts` — track `avatarKey`, send key to profile PATCH
- `app/settings/index.tsx` — wire `setAvatarKey` to the uploader callback
- `app/onboarding/profile.tsx` — same key-vs-url fix for onboarding flow
- `components/ui/PerspectiveBadge.tsx` — simplified labels

## Test plan

- [ ] Upload avatar in Settings → file appears immediately
- [ ] Save profile → avatar persists after page reload
- [ ] Log out and log back in → avatar still shown (presigned URL generated fresh)
- [ ] `PerspectiveBadge` shows "Клиент" / "Специалист" without "Я:"
- [ ] TSC: 0 errors frontend + backend

Closes #1558
Closes #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)