### PR TITLE
fix(threads): pass ?requestId= when opening threads from request flows

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -340,7 +340,9 @@ export default function MyRequestDetail() {
                   requestId={id}
                   threadsCount={request.threadsCount}
                   unreadMessages={request.unreadMessages}
-                  onOpenThread={(threadId) => nav.dynamic.thread(threadId)}
+                  onOpenThread={(threadId) =>
+                    nav.any(`/threads/${threadId}?requestId=${id}`)
+                  }
                 />
               </View>
 
@@ -672,7 +674,9 @@ export default function MyRequestDetail() {
               requestId={id}
               threadsCount={request.threadsCount}
               unreadMessages={request.unreadMessages}
-              onOpenThread={(threadId) => nav.any(`/threads/${threadId}`)}
+              onOpenThread={(threadId) =>
+                nav.any(`/threads/${threadId}?requestId=${id}`)
+              }
             />
 
             {/* Meta stats */}

--- a/app/requests/[id]/write.tsx
+++ b/app/requests/[id]/write.tsx
@@ -214,7 +214,7 @@ export default function SpecialistConfirmWrite() {
           ...(uploadToken ? { uploadToken } : {}),
         },
       });
-      nav.replaceAny(`/threads/${result.id}`);
+      nav.replaceAny(`/threads/${result.id}?requestId=${id}`);
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.status === 409) {
@@ -222,7 +222,7 @@ export default function SpecialistConfirmWrite() {
             typeof err.data?.threadId === "string" ? err.data.threadId : null;
           if (existingThreadId) {
             const goToThread = () =>
-              nav.replaceAny(`/threads/${existingThreadId}`);
+              nav.replaceAny(`/threads/${existingThreadId}?requestId=${id}`);
             Alert.alert(
               "Вы уже откликнулись",
               "Перейдём к существующему диалогу.",


### PR DESCRIPTION
## Summary
The back button on `/threads/:id` (added in d188c83) reads `requestId` from query params to return to `/requests/:id/detail`, falling back to `router.canGoBack()` otherwise. The fallback fails after a page refresh, deep-link, or push-notification entry — leaving users stranded on the messages inbox even though the request context is known.

This PR makes the back navigation deterministic by propagating `?requestId=` from every callsite that opens a thread from a request flow.

## Changes
- `app/requests/[id]/detail.tsx` — append `?requestId=` to `onOpenThread` in both the desktop and mobile layouts.
- `app/requests/[id]/write.tsx` — append `?requestId=` on the first-message redirect and on the 409 (existing thread) fallback.

## Test plan
- [ ] From a request detail page, click an existing thread chip → land on `/threads/:id?requestId=...` → click "Назад" → returns to `/requests/:id/detail` (verify after a full page reload too).
- [ ] From request detail click "Написать", send a message → land on `/threads/:id?requestId=...` → "Назад" → returns to request detail.
- [ ] From request detail click "Написать" while an existing thread already exists → confirm alert → land on `/threads/:id?requestId=...` → "Назад" → returns to request detail.
- [ ] Threads opened from `/notifications` (no `requestId` param) still work via the existing `canGoBack()` fallback.
- [ ] Desktop (>= 640px) and mobile (< 640px) both show and use the back button.
- [ ] `npx tsc --noEmit` passes for `/` and `/api`.

Closes #1567