### PR TITLE
feat(messages): unify ChatComposer for threads and request detail (#1566)

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -18,12 +18,16 @@ import { File, FileImage, Download, ChevronLeft, X, Link } from "lucide-react-na
 import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { api, apiPatch } from "@/lib/api";
+import ChatComposer, { type PendingFile } from "@/components/ChatComposer";
+import { api, apiPatch, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, BREAKPOINT } from "@/lib/theme";
 import ThreadsList, { ThreadSummary } from "@/components/requests/ThreadsList";
 import SpecialistRecommendations, { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
 import EmptyState from "@/components/ui/EmptyState";
+
+const FIRST_MESSAGE_MIN = 10;
+const FIRST_MESSAGE_MAX = 2000;
 
 interface FileItem {
   id: string;
@@ -58,7 +62,7 @@ export default function MyRequestDetail() {
   const pathname = usePathname();
   const { width } = useWindowDimensions();
   const isDesktop = width >= BREAKPOINT;
-  const { isLoading: authLoading, isAuthenticated } = useAuth();
+  const { isLoading: authLoading, isAuthenticated, isSpecialistUser, user, token } = useAuth();
 
   const [request, setRequest] = useState<RequestDetailData | null>(null);
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
@@ -68,6 +72,12 @@ export default function MyRequestDetail() {
   const [closing, setClosing] = useState(false);
   const [copied, setCopied] = useState(false);
   const [togglingVisibility, setTogglingVisibility] = useState(false);
+
+  // Inline message composer state — issue #1566 (specialist quick-reply).
+  const [composerText, setComposerText] = useState("");
+  const [composerFiles, setComposerFiles] = useState<PendingFile[]>([]);
+  const [composerSending, setComposerSending] = useState(false);
+  const [composerError, setComposerError] = useState<string | null>(null);
 
   const handleCopyLink = useCallback(async () => {
     const url =
@@ -135,6 +145,90 @@ export default function MyRequestDetail() {
     }
     action();
   }, [isAuthenticated, nav, pathname]);
+
+  // Inline composer send — creates a thread (mirrors /requests/:id/write).
+  // Files are uploaded immediately on pick by FileUploadZone, so by send-time
+  // each "done" file already has its uploadedToken (single-attachment first
+  // message — limit enforced by maxFiles=1 below).
+  const handleComposerSend = useCallback(async () => {
+    if (!isAuthenticated) {
+      nav.replaceAny({ pathname: "/login", params: { returnTo: pathname } });
+      return;
+    }
+    const trimmed = composerText.trim();
+    if (trimmed.length < FIRST_MESSAGE_MIN) {
+      setComposerError(`Минимум ${FIRST_MESSAGE_MIN} символов`);
+      return;
+    }
+    if (trimmed.length > FIRST_MESSAGE_MAX) {
+      setComposerError(`Максимум ${FIRST_MESSAGE_MAX} символов`);
+      return;
+    }
+    const stillBusy = composerFiles.some(
+      (f) => f.status === "uploading" || f.status === "pending",
+    );
+    if (stillBusy) {
+      setComposerError("Файл ещё загружается. Подождите.");
+      return;
+    }
+    const failedFile = composerFiles.find((f) => f.status === "error");
+    if (failedFile) {
+      setComposerError(failedFile.errorMessage ?? "Не удалось загрузить файл");
+      return;
+    }
+    const readyFile = composerFiles.find(
+      (f) => f.status === "done" && f.uploadedToken,
+    );
+    const uploadToken = readyFile?.uploadedToken;
+
+    setComposerSending(true);
+    setComposerError(null);
+    try {
+      const result = await api<{ id: string }>("/api/threads", {
+        method: "POST",
+        body: {
+          requestId: id,
+          firstMessage: trimmed,
+          ...(uploadToken ? { uploadToken } : {}),
+        },
+      });
+      setComposerText("");
+      setComposerFiles([]);
+      nav.replaceAny(`/threads/${result.id}`);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          const existingThreadId =
+            typeof err.data?.threadId === "string" ? err.data.threadId : null;
+          if (existingThreadId) {
+            // Already wrote to this request — open the existing thread.
+            nav.replaceAny(`/threads/${existingThreadId}`);
+          } else {
+            setComposerError("Запрос закрыт — сообщение отправить невозможно");
+          }
+        } else if (err.status === 429) {
+          setComposerError(
+            "Лимит новых диалогов на сегодня исчерпан (20 в день). Попробуйте завтра.",
+          );
+        } else if (err.status === 403) {
+          setComposerError("Только специалисты могут начать диалог");
+        } else {
+          setComposerError("Не удалось отправить сообщение. Попробуйте ещё раз.");
+        }
+      } else {
+        setComposerError("Не удалось отправить сообщение. Попробуйте ещё раз.");
+      }
+    } finally {
+      setComposerSending(false);
+    }
+  }, [
+    composerText,
+    composerFiles,
+    id,
+    isAuthenticated,
+    nav,
+    pathname,
+  ]);
 
   const handleCloseRequest = useCallback(async () => {
     if (closing) return;
@@ -226,6 +320,54 @@ export default function MyRequestDetail() {
   });
 
   const isActive = request.status !== "CLOSED";
+
+  // Inline composer eligibility — specialist with completed profile, request open.
+  // Non-specialists / unauth users / closed requests don't see the composer.
+  const showInlineComposer =
+    isActive &&
+    isAuthenticated &&
+    isSpecialistUser &&
+    !!user?.specialistProfileCompletedAt;
+
+  const inlineComposerSection = showInlineComposer ? (
+    <View
+      className="bg-white rounded-2xl mb-4 overflow-hidden"
+      style={{
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 8,
+        elevation: 2,
+      }}
+    >
+      <View className="px-4 pt-4 pb-2">
+        <Text className="text-xs font-semibold text-text-mute mb-1 uppercase tracking-wide">
+          Написать клиенту
+        </Text>
+        <Text className="text-xs text-text-mute mb-2">
+          Минимум {FIRST_MESSAGE_MIN} символов · можно прикрепить один файл (PDF, JPG, PNG до 10 МБ)
+        </Text>
+      </View>
+      <ChatComposer
+        value={composerText}
+        onChangeText={setComposerText}
+        files={composerFiles}
+        onFilesChange={setComposerFiles}
+        onSend={handleComposerSend}
+        sending={composerSending}
+        authToken={token}
+        maxFiles={1}
+        maxLength={FIRST_MESSAGE_MAX}
+        placeholder="Напишите первое сообщение клиенту..."
+        accessibilityLabel="Сообщение клиенту"
+      />
+      {composerError ? (
+        <View className="px-4 py-2">
+          <Text className="text-xs text-danger">{composerError}</Text>
+        </View>
+      ) : null}
+    </View>
+  ) : null;
 
   // ── DESKTOP LAYOUT ────────────────────────────────────────────────────
   if (isDesktop) {
@@ -351,6 +493,11 @@ export default function MyRequestDetail() {
                     />
                   </View>
                 )}
+
+                {/* Inline message composer — issue #1566. Shown only for
+                    authenticated specialists with completed profile on
+                    non-closed requests. */}
+                {inlineComposerSection}
 
                 {/* Threads */}
                 <ThreadsList
@@ -756,6 +903,10 @@ export default function MyRequestDetail() {
                 />
               </View>
             </View>
+
+            {/* Inline message composer — issue #1566. Specialist-only,
+                visible on non-closed requests for users with completed profile. */}
+            {inlineComposerSection}
 
             <ThreadsList
               threads={threads}

--- a/components/ChatComposer.tsx
+++ b/components/ChatComposer.tsx
@@ -1,0 +1,138 @@
+import { View, Pressable, ActivityIndicator } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import FileUploadZone, { type PendingFile } from "@/components/ui/FileUploadZone";
+import Input from "@/components/ui/Input";
+import { colors, radiusValue } from "@/lib/theme";
+
+export type { PendingFile };
+
+interface ChatComposerProps {
+  /** Text value (controlled). */
+  value: string;
+  /** Text change handler. */
+  onChangeText: (next: string) => void;
+  /** Pending files (uploaded immediately on pick by FileUploadZone). */
+  files: PendingFile[];
+  /** Pending files setter. */
+  onFilesChange: (files: PendingFile[]) => void;
+  /** Send handler — invoked on send button press. */
+  onSend: () => void;
+  /** Sending in flight (disables send + shows spinner). */
+  sending?: boolean;
+  /** Disable everything (e.g. closed thread / rate-limited). */
+  disabled?: boolean;
+  /** Bearer token for the upload endpoint. */
+  authToken?: string | null;
+  /** Upload endpoint — e.g. `/api/upload/chat-file`. */
+  uploadEndpoint?: string;
+  /** Max files to attach. Defaults to 3. */
+  maxFiles?: number;
+  /** Max bytes per file (in MB). Defaults to 10. */
+  maxSizeMB?: number;
+  /** Allowed mime types. Defaults to PDF / JPG / PNG. */
+  allowedTypes?: string[];
+  /** Placeholder text inside the input. */
+  placeholder?: string;
+  /** Hard cap for character count. */
+  maxLength?: number;
+  /** Accessibility label for the text field. */
+  accessibilityLabel?: string;
+}
+
+/**
+ * Unified chat-style composer used by:
+ *   - `/threads/:id` (live chat — InlineChatView)
+ *   - `/requests/:id/detail` (specialist quick-reply / new-thread send)
+ *
+ * Combines the three building blocks of a chat input bar into one
+ * component so both screens render the same UX:
+ *
+ *   - `FileUploadZone` (compact mode) — paperclip + chip strip +
+ *     drag-and-drop overlay; uploads files immediately on pick.
+ *   - `Input` (multi-line) — the actual text field, with NativeWind
+ *     double-border guards.
+ *   - send button — paperplane / spinner with disabled-state styling.
+ *
+ * For the long-form first-message textarea (character counter + min-length
+ * hint) used inside `/requests/:id/write`, see
+ * `components/requests/MessageComposer.tsx`.
+ */
+export default function ChatComposer({
+  value,
+  onChangeText,
+  files,
+  onFilesChange,
+  onSend,
+  sending = false,
+  disabled = false,
+  authToken,
+  uploadEndpoint = "/api/upload/chat-file",
+  maxFiles = 3,
+  maxSizeMB = 10,
+  allowedTypes,
+  placeholder = "Введите сообщение...",
+  maxLength = 5000,
+  accessibilityLabel = "Введите сообщение",
+}: ChatComposerProps) {
+  const canSend = !disabled && !sending && (value.trim().length > 0 || files.length > 0);
+
+  return (
+    <View className="flex-row items-end border-t border-border px-3 py-2 bg-white">
+      {/* Shared upload control: paperclip button, chip preview strip,
+          immediate upload to the chat-file endpoint, drag-and-drop overlay. */}
+      <FileUploadZone
+        files={files}
+        onFilesChange={onFilesChange}
+        uploadEndpoint={uploadEndpoint}
+        authToken={authToken}
+        maxFiles={maxFiles}
+        maxSizeMB={maxSizeMB}
+        allowedTypes={allowedTypes}
+        compact
+        disabled={disabled || sending}
+      />
+
+      {/* Text input — strip Input's underline; only the parent strip's
+          top border is visible, otherwise web stacks a double-border. */}
+      <Input
+        accessibilityLabel={accessibilityLabel}
+        placeholder={placeholder}
+        value={value}
+        onChangeText={onChangeText}
+        multiline
+        maxLength={maxLength}
+        editable={!disabled}
+        style={{ flex: 1 }}
+        containerStyle={{
+          borderRadius: radiusValue.xl,
+          minHeight: 40,
+          maxHeight: 120,
+          borderBottomWidth: 0,
+          borderTopWidth: 0,
+          borderLeftWidth: 0,
+          borderRightWidth: 0,
+        }}
+      />
+
+      {/* Send button. */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Отправить сообщение"
+        onPress={onSend}
+        disabled={!canSend}
+        className="w-11 h-11 items-center justify-center ml-2"
+        style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+      >
+        {sending ? (
+          <ActivityIndicator size="small" color={colors.primary} />
+        ) : (
+          <FontAwesome
+            name="send"
+            size={20}
+            color={canSend ? colors.primary : colors.textSecondary}
+          />
+        )}
+      </Pressable>
+    </View>
+  );
+}

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -17,13 +17,12 @@ import * as Linking from "expo-linking";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import { FileText, ChevronRight } from "lucide-react-native";
 import MessageBubble from "@/components/MessageBubble";
+import ChatComposer, { type PendingFile } from "@/components/ChatComposer";
 import { Avatar } from "@/components/ui";
-import Input from "@/components/ui/Input";
 import PerspectiveBadge from "@/components/ui/PerspectiveBadge";
-import FileUploadZone, { type PendingFile } from "@/components/ui/FileUploadZone";
 import { API_URL, api, apiPost, apiPatch, apiDelete } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { colors, radiusValue } from "@/lib/theme";
+import { colors } from "@/lib/theme";
 
 
 interface FileAttachment {
@@ -728,64 +727,17 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
           </View>
         )}
 
-        {/* Input bar — paperclip + chip strip + drag overlay live inside FileUploadZone (compact) */}
+        {/* Unified chat composer (text + files + drag-and-drop). */}
         {!isClosed && (
-          <View className="flex-row items-end border-t border-border px-3 py-2 bg-white">
-            {/* Shared upload control: paperclip button, chip preview strip,
-                immediate upload to /api/upload/chat-file, drag-and-drop overlay. */}
-            <FileUploadZone
-              files={pendingFiles}
-              onFilesChange={setPendingFiles}
-              uploadEndpoint="/api/upload/chat-file"
-              authToken={token}
-              maxFiles={3}
-              maxSizeMB={10}
-              compact
-              disabled={sending}
-            />
-
-            {/* Text input — strip Input's bottom underline; the chat-strip's
-                top border (border-t border-border on parent) is the only
-                visible edge, otherwise web shows a stacked double-border. */}
-            <Input
-              accessibilityLabel="Введите сообщение"
-              placeholder="Введите сообщение..."
-              value={text}
-              onChangeText={setText}
-              multiline
-              maxLength={5000}
-              style={{ flex: 1 }}
-              containerStyle={{
-                borderRadius: radiusValue.xl,
-                minHeight: 40,
-                maxHeight: 120,
-                borderBottomWidth: 0,
-                borderTopWidth: 0,
-                borderLeftWidth: 0,
-                borderRightWidth: 0,
-              }}
-            />
-
-            {/* Send button */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Отправить сообщение"
-              onPress={handleSend}
-              disabled={(!text.trim() && pendingFiles.length === 0) || sending}
-              className="w-11 h-11 items-center justify-center ml-2"
-              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
-            >
-              {sending ? (
-                <ActivityIndicator size="small" color={colors.primary} />
-              ) : (
-                <FontAwesome
-                  name="send"
-                  size={20}
-                  color={(text.trim() || pendingFiles.length > 0) ? colors.primary : colors.textSecondary}
-                />
-              )}
-            </Pressable>
-          </View>
+          <ChatComposer
+            value={text}
+            onChangeText={setText}
+            files={pendingFiles}
+            onFilesChange={setPendingFiles}
+            onSend={handleSend}
+            sending={sending}
+            authToken={token}
+          />
         )}
       </KeyboardAvoidingView>
 


### PR DESCRIPTION
## Summary

Wrap the chat-style input bar (`FileUploadZone` + `Input` + send button) into a single reusable `ChatComposer` component so both screens render the same composer:

- `/threads/:id` (`InlineChatView`) — replaces the inline triple-component layout
- `/requests/:id/detail` — adds an inline quick-reply for specialists with a completed profile, creating a new thread on send (mirrors the `/requests/:id/write` flow, but inline)

`ChatComposer` is a thin wrapper that delegates file handling (drag-and-drop, hidden `<input type=file>` picker on web, immediate upload to `/api/upload/chat-file` with correct File-vs-uri payload) to the existing `FileUploadZone` (compact mode), and the text input to the existing `Input`. No duplicated upload logic — the existing chat upload pipeline is reused as-is.

Detail-page composer:
- Files upload immediately on pick (FileUploadZone behaviour); on send only the resulting `uploadedToken` is emitted.
- 409 from `POST /api/threads` (existing thread) → redirect to that thread.
- 429 / 403 / closed-request errors surfaced inline.
- Hidden for unauthenticated users / non-specialists / closed requests.

Closes #1566.

## Test plan

- [ ] `/threads/:id` — type a message, attach a file (PDF/JPG/PNG), drag-and-drop a file, send; lightbox + file chips render as before
- [ ] `/threads/:id` — verify the closed-request banner still shows and the composer is hidden when the request is `CLOSED`
- [ ] `/requests/:id/detail` — as a specialist with completed profile: composer is visible; send creates a new thread and redirects to `/threads/{id}`
- [ ] `/requests/:id/detail` — as a specialist that already wrote in the thread: send returns 409 → redirects to existing thread
- [ ] `/requests/:id/detail` — as an unauthenticated user / non-specialist / closed request: composer is hidden
- [ ] `/requests/:id/write` — long-form first-message form still works (untouched)
- [ ] `npx tsc --noEmit` (frontend) and `cd api && npx tsc --noEmit` (backend) — both pass with 0 errors