### PR TITLE
fix(request-detail): chip shows service only when actually selected (closes #1578)

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -321,6 +321,11 @@ export default function MyRequestDetail() {
 
   const isActive = request.status !== "CLOSED";
 
+  // Service is shown in the chip only when actually selected — issue #1578.
+  // Backend may return null/undefined or an object with empty name; treat all
+  // those cases as "not selected" so the chip falls back to plain [ФНС].
+  const serviceName = request.service?.name?.trim() || null;
+
   // Inline composer eligibility — specialist with completed profile, request open.
   // Non-specialists / unauth users / closed requests don't see the composer.
   const showInlineComposer =
@@ -410,12 +415,15 @@ export default function MyRequestDetail() {
                   {request.title}
                 </Text>
 
-                {/* Unified FNS · service chip (city is already inside FNS name) */}
+                {/* Unified FNS · service chip — issue #1578.
+                    City already lives inside FNS name (e.g. "ИФНС №1 по г. Москве"),
+                    so we never include it separately. Service is appended only
+                    when it is actually selected. */}
                 <View className="flex-row flex-wrap gap-2 mb-5">
                   <View className="bg-white border border-border rounded-lg px-2.5 py-1">
                     <Text className="text-xs font-medium text-text-base">
                       {request.fns.name}
-                      {request.service ? ` · ${request.service.name}` : ""}
+                      {serviceName ? ` · ${serviceName}` : ""}
                     </Text>
                   </View>
                 </View>
@@ -696,12 +704,15 @@ export default function MyRequestDetail() {
               {request.title}
             </Text>
 
-            {/* Unified FNS · service chip (city is already inside FNS name) */}
+            {/* Unified FNS · service chip — issue #1578.
+                City already lives inside FNS name (e.g. "ИФНС №1 по г. Москве"),
+                so we never include it separately. Service is appended only
+                when it is actually selected. */}
             <View className="flex-row flex-wrap gap-2 mb-4">
               <View className="bg-white border border-border rounded-lg px-2.5 py-1">
                 <Text className="text-xs text-text-base">
                   {request.fns.name}
-                  {request.service ? ` · ${request.service.name}` : ""}
+                  {serviceName ? ` · ${serviceName}` : ""}
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## Summary
- Refines the unified chip from PR #1556 per issue #1578
- City was already removed from the chip (it lives inside FNS name like "ИФНС №1 по г. Москве"); this PR tightens service detection
- Service is appended (`[ФНС · Услуга]`) **only** when actually selected; otherwise the chip is plain `[ФНС]`

## Implementation
- New derived value at top of `MyRequestDetail`:
  ```ts
  const serviceName = request.service?.name?.trim() || null;
  ```
- Chip JSX (desktop + mobile) appends `" · <serviceName>"` only when `serviceName` is truthy. Handles all three "not selected" shapes: `null`, `undefined`, and `{ name: "" }`.

## Files
- `app/requests/[id]/detail.tsx`

## Test plan
- [ ] Open `/requests/<id>/detail` for a request **with** service — chip reads `[ФНС · Услуга]`
- [ ] Open a request **without** service (null) — chip reads just `[ФНС]`
- [ ] Open a request whose service has empty name — chip reads just `[ФНС]`
- [ ] Same on desktop and mobile (<640px)
- [ ] City does not appear separately in the chip
- [ ] `npx tsc --noEmit` passes (frontend)

Closes #1578