### PR TITLE
fix(detail): UX improvements — toggle labels, actions typography, specialist profile link (#1574)

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -516,6 +516,7 @@ export default function MyRequestDetail() {
                   onOpenThread={(threadId) =>
                     nav.any(`/threads/${threadId}?requestId=${id}`)
                   }
+                  onOpenSpecialistProfile={handleOpenSpecialistProfile}
                 />
               </View>
 
@@ -534,7 +535,10 @@ export default function MyRequestDetail() {
                     elevation: 4,
                   }}
                 >
-                  <Text className="text-xs font-bold text-text-base mb-3 uppercase tracking-wide">
+                  <Text
+                    className="uppercase tracking-wide mb-3"
+                    style={{ fontSize: 13, fontWeight: "600", color: "#111" }}
+                  >
                     Действия
                   </Text>
                   {isActive ? (
@@ -543,11 +547,12 @@ export default function MyRequestDetail() {
                       accessibilityLabel="Закрыть запрос"
                       onPress={handleCloseRequest}
                       disabled={closing}
-                      className="flex-row items-center justify-center rounded-xl py-3 px-4"
+                      className="flex-row items-center justify-center rounded-xl px-4"
                       style={({ pressed }) => [
                         {
                           backgroundColor: colors.danger,
-                          minHeight: 44,
+                          minHeight: 48,
+                          paddingVertical: 14,
                           shadowColor: colors.danger,
                           shadowOffset: { width: 0, height: 2 },
                           shadowOpacity: 0.25,
@@ -562,7 +567,10 @@ export default function MyRequestDetail() {
                       ) : (
                         <>
                           <X size={16} color={colors.white} />
-                          <Text className="text-white font-semibold text-sm ml-2">
+                          <Text
+                            className="text-white ml-2"
+                            style={{ fontSize: 15, fontWeight: "600" }}
+                          >
                             Закрыть запрос
                           </Text>
                         </>
@@ -570,16 +578,19 @@ export default function MyRequestDetail() {
                     </Pressable>
                   ) : (
                     <View
-                      className="rounded-xl py-3 px-4 items-center"
+                      className="rounded-xl px-4 items-center"
                       style={{
                         backgroundColor: colors.surface2,
                         borderWidth: 1,
                         borderColor: colors.border,
-                        minHeight: 44,
+                        minHeight: 48,
+                        paddingVertical: 14,
                         justifyContent: "center",
                       }}
                     >
-                      <Text className="text-sm font-medium text-text-base">Запрос закрыт</Text>
+                      <Text style={{ fontSize: 14, fontWeight: "500", color: "#111" }}>
+                        Запрос закрыт
+                      </Text>
                     </View>
                   )}
 
@@ -588,21 +599,26 @@ export default function MyRequestDetail() {
                     accessibilityRole="button"
                     accessibilityLabel="Скопировать ссылку"
                     onPress={handleCopyLink}
-                    className="flex-row items-center justify-center rounded-xl py-3 px-4 mt-2"
+                    className="flex-row items-center justify-center rounded-xl px-4 mt-2"
                     style={({ pressed }) => [
                       {
                         backgroundColor: colors.surface2,
                         borderWidth: 1,
                         borderColor: colors.border,
-                        minHeight: 44,
+                        minHeight: 48,
+                        paddingVertical: 14,
                       },
                       pressed && { opacity: 0.7 },
                     ]}
                   >
                     <Link size={16} color={copied ? colors.success : colors.text} />
                     <Text
-                      className="font-medium text-sm ml-2"
-                      style={{ color: copied ? colors.success : colors.text }}
+                      className="ml-2"
+                      style={{
+                        fontSize: 14,
+                        fontWeight: "600",
+                        color: copied ? colors.success : "#111",
+                      }}
                     >
                       {copied ? "Скопировано!" : "Скопировать ссылку"}
                     </Text>
@@ -621,17 +637,20 @@ export default function MyRequestDetail() {
                           }}
                         >
                           <Text
-                            className="text-xs font-semibold"
-                            style={{ color: request.isPublic ? "#065F46" : "#6B7280" }}
+                            style={{
+                              fontSize: 12,
+                              fontWeight: "600",
+                              color: request.isPublic ? "#065F46" : "#6B7280",
+                            }}
                           >
-                            {request.isPublic ? "Публичная" : "Только авторизованным"}
+                            {request.isPublic ? "Доступно публично" : "Только для участников"}
                           </Text>
                         </View>
                       </View>
-                      <Text className="text-xs text-text-mute">
+                      <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
                         {request.isPublic
-                          ? "Видна всем в каталоге"
-                          : "Видна только авторизованным"}
+                          ? "Запрос виден всем пользователям интернета"
+                          : "Запрос виден только зарегистрированным пользователям"}
                       </Text>
                     </View>
                     <Switch
@@ -805,7 +824,10 @@ export default function MyRequestDetail() {
                 elevation: 4,
               }}
             >
-              <Text className="text-xs font-bold text-text-base mb-3 uppercase tracking-wide">
+              <Text
+                className="uppercase tracking-wide mb-3"
+                style={{ fontSize: 13, fontWeight: "600", color: "#111" }}
+              >
                 Действия
               </Text>
               {isActive ? (
@@ -814,11 +836,12 @@ export default function MyRequestDetail() {
                   accessibilityLabel="Закрыть запрос"
                   onPress={handleCloseRequest}
                   disabled={closing}
-                  className="flex-row items-center justify-center rounded-xl py-3 px-4"
+                  className="flex-row items-center justify-center rounded-xl px-4"
                   style={({ pressed }) => [
                     {
                       backgroundColor: colors.danger,
-                      minHeight: 44,
+                      minHeight: 48,
+                      paddingVertical: 14,
                       shadowColor: colors.danger,
                       shadowOffset: { width: 0, height: 2 },
                       shadowOpacity: 0.25,
@@ -833,7 +856,10 @@ export default function MyRequestDetail() {
                   ) : (
                     <>
                       <X size={16} color={colors.white} />
-                      <Text className="text-white font-semibold text-base ml-2">
+                      <Text
+                        className="text-white ml-2"
+                        style={{ fontSize: 15, fontWeight: "600" }}
+                      >
                         Закрыть запрос
                       </Text>
                     </>
@@ -841,16 +867,19 @@ export default function MyRequestDetail() {
                 </Pressable>
               ) : (
                 <View
-                  className="rounded-xl py-3 px-4 items-center"
+                  className="rounded-xl px-4 items-center"
                   style={{
                     backgroundColor: colors.surface2,
                     borderWidth: 1,
                     borderColor: colors.border,
-                    minHeight: 44,
+                    minHeight: 48,
+                    paddingVertical: 14,
                     justifyContent: "center",
                   }}
                 >
-                  <Text className="text-sm font-medium text-text-base">Запрос закрыт</Text>
+                  <Text style={{ fontSize: 14, fontWeight: "500", color: "#111" }}>
+                    Запрос закрыт
+                  </Text>
                 </View>
               )}
 
@@ -859,21 +888,26 @@ export default function MyRequestDetail() {
                 accessibilityRole="button"
                 accessibilityLabel="Скопировать ссылку"
                 onPress={handleCopyLink}
-                className="flex-row items-center justify-center rounded-xl py-3 px-4 mt-2"
+                className="flex-row items-center justify-center rounded-xl px-4 mt-2"
                 style={({ pressed }) => [
                   {
                     backgroundColor: colors.surface2,
                     borderWidth: 1,
                     borderColor: colors.border,
-                    minHeight: 44,
+                    minHeight: 48,
+                    paddingVertical: 14,
                   },
                   pressed && { opacity: 0.7 },
                 ]}
               >
                 <Link size={16} color={copied ? colors.success : colors.text} />
                 <Text
-                  className="font-medium text-sm ml-2"
-                  style={{ color: copied ? colors.success : colors.text }}
+                  className="ml-2"
+                  style={{
+                    fontSize: 14,
+                    fontWeight: "600",
+                    color: copied ? colors.success : "#111",
+                  }}
                 >
                   {copied ? "Скопировано!" : "Скопировать ссылку"}
                 </Text>
@@ -892,17 +926,20 @@ export default function MyRequestDetail() {
                       }}
                     >
                       <Text
-                        className="text-xs font-semibold"
-                        style={{ color: request.isPublic ? "#065F46" : "#6B7280" }}
+                        style={{
+                          fontSize: 12,
+                          fontWeight: "600",
+                          color: request.isPublic ? "#065F46" : "#6B7280",
+                        }}
                       >
-                        {request.isPublic ? "Публичная" : "Только авторизованным"}
+                        {request.isPublic ? "Доступно публично" : "Только для участников"}
                       </Text>
                     </View>
                   </View>
-                  <Text className="text-xs text-text-mute">
+                  <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
                     {request.isPublic
-                      ? "Видна всем в каталоге"
-                      : "Видна только авторизованным"}
+                      ? "Запрос виден всем пользователям интернета"
+                      : "Запрос виден только зарегистрированным пользователям"}
                   </Text>
                 </View>
                 <Switch
@@ -927,6 +964,7 @@ export default function MyRequestDetail() {
               onOpenThread={(threadId) =>
                 nav.any(`/threads/${threadId}?requestId=${id}`)
               }
+              onOpenSpecialistProfile={handleOpenSpecialistProfile}
             />
 
             {/* Meta stats */}

--- a/components/requests/ThreadsList.tsx
+++ b/components/requests/ThreadsList.tsx
@@ -29,6 +29,8 @@ interface ThreadsListProps {
   threadsCount: number;
   unreadMessages: number;
   onOpenThread: (threadId: string) => void;
+  /** Navigate to a specialist's profile page. */
+  onOpenSpecialistProfile?: (specialistId: string) => void;
 }
 
 export default function ThreadsList({
@@ -37,6 +39,7 @@ export default function ThreadsList({
   threadsCount,
   unreadMessages,
   onOpenThread,
+  onOpenSpecialistProfile,
 }: ThreadsListProps) {
   const router = useRouter()
   const nav = useTypedRouter();
@@ -84,9 +87,16 @@ export default function ThreadsList({
           {threads.map((thread) => {
             const name = getSpecialistName(thread.otherUser);
             return (
-              <View
+              <Pressable
                 key={thread.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Профиль специалиста ${name}`}
+                onPress={() => onOpenSpecialistProfile
+                  ? onOpenSpecialistProfile(thread.otherUser.id)
+                  : nav.dynamic.specialist(thread.otherUser.id)
+                }
                 className="flex-row items-center py-3 border-b border-border"
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
                 <Avatar
                   name={name}
@@ -117,7 +127,11 @@ export default function ThreadsList({
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={`Открыть чат с ${name}`}
-                    onPress={() => onOpenThread(thread.id)}
+                    onPress={(e) => {
+                      // Prevent card press from also triggering profile navigation.
+                      e.stopPropagation?.();
+                      onOpenThread(thread.id);
+                    }}
                     className="bg-accent rounded-lg px-3 py-1.5"
                     style={({ pressed }) => [pressed && { opacity: 0.7 }]}
                   >
@@ -126,7 +140,7 @@ export default function ThreadsList({
                     </Text>
                   </Pressable>
                 </View>
-              </View>
+              </Pressable>
             );
           })}
 


### PR DESCRIPTION
## Summary

- **Toggle isPublic**: ON → "Доступно публично" + "Запрос виден всем пользователям интернета"; OFF → "Только для участников" + "Запрос виден только зарегистрированным пользователям"
- **Actions блок типографика**: заголовок 13px/600 (#111); кнопки minHeight 48 + paddingVertical 14; "Закрыть запрос" 15px/600; "Скопировать ссылку" 14px/600; "Запрос закрыт" 14px/500
- **Специалисты (ThreadsList)**: каждая карточка специалиста обёрнута в Pressable → `onOpenSpecialistProfile(id)` / `nav.dynamic.specialist(id)`; кнопка "Открыть чат" останавливает всплытие события

## Fixes

Closes #1574

## Test plan

- [ ] Открыть страницу /requests/[id]/detail (клиент)
- [ ] Тумблер isPublic: проверить метку и подпись в обоих состояниях (desktop + mobile)
- [ ] Блок "Действия": шрифты кнопок читаемые, padding нормальный
- [ ] Блок "Сообщения": клик по строке специалиста → открывается /specialists/[id]
- [ ] Клик "Открыть чат" → открывается thread, профиль не открывается

🤖 Generated with [Claude Code](https://claude.com/claude-code)