### PR TITLE
feat(onboarding): public profile visibility toggle as first onboarding step (#1583)

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -33,6 +33,9 @@ model User {
   avatarUrl   String?  @map("avatar_url")
   isAvailable Boolean  @default(false) @map("is_available")
   isBanned    Boolean  @default(false) @map("is_banned")
+  // Iter13 — specialist catalog visibility. When true, appears in public catalog.
+  // Default false; specialist opts in during onboarding or via settings.
+  isPublicProfile Boolean @default(false) @map("is_public_profile")
   // Soft-delete timestamp. When non-null the user is considered deleted —
   // PII is anonymized in-place and they're hidden from public catalog/queries
   // but the row is preserved so threads/messages keep a valid FK target.

--- a/api/src/routes/onboarding.ts
+++ b/api/src/routes/onboarding.ts
@@ -158,11 +158,36 @@ router.put("/work-area", authMiddleware, async (req: Request, res: Response) => 
   }
 });
 
+// PUT /api/onboarding/visibility — set isPublicProfile before completing onboarding
+// Called from the first onboarding step (name screen). Idempotent.
+router.put("/visibility", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { isPublicProfile } = req.body as { isPublicProfile?: boolean };
+
+    if (typeof isPublicProfile !== "boolean") {
+      res.status(400).json({ error: "isPublicProfile must be a boolean" });
+      return;
+    }
+
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { isPublicProfile },
+      select: { id: true, isPublicProfile: true },
+    });
+
+    res.json({ user });
+  } catch (error) {
+    console.error("onboarding/visibility error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // PUT /api/onboarding/profile
 router.put("/profile", authMiddleware, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
-    const { description, phone, telegram, whatsapp, officeAddress, workingHours, avatarUrl } =
+    const { description, phone, telegram, whatsapp, officeAddress, workingHours, avatarUrl, isPublicProfile } =
       req.body;
 
     // Verify user has specialist features enabled (Iter11 — flag-based).
@@ -208,6 +233,10 @@ router.put("/profile", authMiddleware, async (req: Request, res: Response) => {
     };
     if (avatarUrl !== undefined) {
       userPatch.avatarUrl = avatarUrl || null;
+    }
+    // Iter13: persist isPublicProfile if sent with profile completion.
+    if (typeof isPublicProfile === "boolean") {
+      userPatch.isPublicProfile = isPublicProfile;
     }
     await prisma.user.update({
       where: { id: userId },

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -86,6 +86,7 @@ router.get("/featured", async (_req: Request, res: Response) => {
         // role enum. Require completed profile so we never surface half-seeded
         // users who are still onboarding. Hide soft-deleted accounts.
         isSpecialist: true,
+        isPublicProfile: true,
         specialistProfileCompletedAt: { not: null },
         isAvailable: true,
         isBanned: false,
@@ -175,6 +176,8 @@ router.get("/", async (req: Request, res: Response) => {
     const seedUserNot = notSeedUserWhere();
     const where: Prisma.UserWhereInput = {
       isSpecialist: true,
+      // Iter13: only show specialists who opted in to public catalog.
+      isPublicProfile: true,
       specialistProfileCompletedAt: { not: null },
       isAvailable: true,
       isBanned: false,

--- a/app/otp.tsx
+++ b/app/otp.tsx
@@ -83,7 +83,7 @@ export default function AuthOtpScreen() {
       // resume-onboarding / tabs logic below.
       if (intent === "specialist" && !user.isSpecialist) {
         nav.replaceAny({
-          pathname: "/onboarding/name",
+          pathname: "/onboarding/visibility",
           params: { role: "specialist" },
         });
         return;
@@ -106,7 +106,7 @@ export default function AuthOtpScreen() {
       // is the authoritative gate: it's set only after `/api/onboarding/profile`
       // succeeds, so any falsy value means onboarding is incomplete.
       if (user.isSpecialist && !user.specialistProfileCompletedAt) {
-        nav.replaceRoutes.onboardingName();
+        nav.replaceRoutes.onboardingVisibility();
         return;
       }
       nav.replaceRoutes.dashboard();
@@ -151,7 +151,7 @@ export default function AuthOtpScreen() {
             } catch {
               // optimistic update already applied; next /me call will re-sync
             }
-            nav.replaceRoutes.onboardingName();
+            nav.replaceRoutes.onboardingVisibility();
             return;
           }
           setPendingAuth(data);
@@ -222,7 +222,7 @@ export default function AuthOtpScreen() {
       // Silent: optimistic update keeps the UI responsive.
     }
     if (becomeSpecialist) {
-      nav.replaceRoutes.onboardingName();
+      nav.replaceRoutes.onboardingVisibility();
     } else if (returnTo) {
       nav.replaceAny(returnTo);
     } else {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -38,6 +38,8 @@ export interface UserData {
   lastName: string | null;
   avatarUrl?: string | null;
   isAvailable?: boolean;
+  /** Iter13 — specialist catalog visibility toggle. Default false. */
+  isPublicProfile?: boolean;
 }
 
 interface AuthContextType {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -51,6 +51,7 @@ export const ROUTES = {
 
   // Auth / onboarding
   authEmail: "/login",
+  onboardingVisibility: "/onboarding/visibility",
   onboardingName: "/onboarding/name",
   onboardingVisibility: "/onboarding/visibility",
   onboardingProfile: "/onboarding/profile",


### PR DESCRIPTION
## Summary

- Adds `isPublicProfile Boolean @default(false)` to User model, `prisma db push` applied
- New first onboarding screen `/onboarding/visibility`: card picker (Public/Private), benefits list, confirmation card when choosing private, default ON
- New API route `PUT /api/onboarding/visibility` — persists `isPublicProfile` before rest of onboarding
- Catalog routes `GET /api/specialists` and `/featured` now filter by `isPublicProfile: true`
- All otp.tsx entry points redirect to `/onboarding/visibility` instead of `/onboarding/name`
- `AuthContext.UserData` extended with `isPublicProfile` field

## Test plan

- [ ] New specialist registration → visibility screen shown first (default ON)
- [ ] Toggle OFF → "Продолжить без публичного профиля" label + confirmation card appears
- [ ] Confirm private → navigates to name screen with isPublicProfile=false saved
- [ ] Completing onboarding with public=true → specialist appears in catalog
- [ ] Completing onboarding with public=false → specialist NOT in catalog
- [ ] Returning specialist (incomplete onboarding) → visibility screen shown
- [ ] TSC 0 errors frontend + backend