### PR TITLE
feat(ui): unified StyledSwitch component (#1595)

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -8,9 +8,9 @@ import {
   Alert,
   Linking,
   Platform,
-  Switch,
   useWindowDimensions,
 } from "react-native";
+import StyledSwitch from "@/components/ui/StyledSwitch";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter, usePathname } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
@@ -653,12 +653,10 @@ export default function MyRequestDetail() {
                           : "Запрос виден только зарегистрированным пользователям"}
                       </Text>
                     </View>
-                    <Switch
+                    <StyledSwitch
                       value={request.isPublic}
                       onValueChange={handleToggleVisibility}
                       disabled={togglingVisibility || !isActive}
-                      trackColor={{ false: "#D1D5DB", true: "#6366F1" }}
-                      thumbColor="#FFFFFF"
                     />
                   </View>
                 </View>
@@ -942,12 +940,10 @@ export default function MyRequestDetail() {
                       : "Запрос виден только зарегистрированным пользователям"}
                   </Text>
                 </View>
-                <Switch
+                <StyledSwitch
                   value={request.isPublic}
                   onValueChange={handleToggleVisibility}
                   disabled={togglingVisibility || !isActive}
-                  trackColor={{ false: "#D1D5DB", true: "#6366F1" }}
-                  thumbColor="#FFFFFF"
                 />
               </View>
             </View>

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -7,9 +7,9 @@ import {
   Alert,
   Platform,
   Pressable,
-  Switch,
   useWindowDimensions,
 } from "react-native";
+import StyledSwitch from "@/components/ui/StyledSwitch";
 import LandingHeader from "@/components/landing/LandingHeader";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
@@ -428,12 +428,10 @@ export default function CreateRequest() {
                   Видна всем в каталоге. Выключите, если хотите показывать только авторизованным пользователям.
                 </Text>
               </View>
-              <Switch
+              <StyledSwitch
                 value={isPublic}
                 onValueChange={setIsPublic}
                 disabled={submitting}
-                trackColor={{ false: "#D1D5DB", true: "#6366F1" }}
-                thumbColor="#FFFFFF"
               />
             </View>
 

--- a/components/ui/StyledSwitch.tsx
+++ b/components/ui/StyledSwitch.tsx
@@ -1,0 +1,73 @@
+import { useRef, useEffect } from "react";
+import { Animated, Pressable } from "react-native";
+import { colors } from "@/lib/theme";
+
+/**
+ * Unified iOS-style toggle switch.
+ * Replaces all bare RN <Switch> usages across the app.
+ * Matches the design used in components/settings/ProfileTab.tsx (IosToggle).
+ */
+interface StyledSwitchProps {
+  value: boolean;
+  onValueChange: (v: boolean) => void;
+  disabled?: boolean;
+}
+
+export default function StyledSwitch({ value, onValueChange, disabled = false }: StyledSwitchProps) {
+  const anim = useRef(new Animated.Value(value ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: value ? 1 : 0,
+      duration: 150,
+      useNativeDriver: false,
+    }).start();
+  }, [value]);
+
+  const trackColor = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ["#E5E5EA", colors.primary],
+  });
+
+  const thumbPos = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [2, 22],
+  });
+
+  return (
+    <Pressable
+      accessibilityRole="switch"
+      accessibilityState={{ checked: value, disabled }}
+      onPress={() => {
+        if (!disabled) onValueChange(!value);
+      }}
+      style={{ width: 51, height: 31, opacity: disabled ? 0.4 : 1 }}
+    >
+      <Animated.View
+        style={{
+          width: 51,
+          height: 31,
+          borderRadius: 15.5,
+          backgroundColor: trackColor,
+          justifyContent: "center",
+        }}
+      >
+        <Animated.View
+          style={{
+            width: 27,
+            height: 27,
+            borderRadius: 13.5,
+            backgroundColor: "white",
+            position: "absolute",
+            left: thumbPos,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.15,
+            shadowRadius: 2,
+            elevation: 2,
+          }}
+        />
+      </Animated.View>
+    </Pressable>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -9,6 +9,7 @@ export { default as LoadingState } from "./LoadingState";
 export { default as MetricCard } from "./MetricCard";
 export { default as Text } from "./Text";
 export { default as FileUploadZone } from "./FileUploadZone";
+export { default as StyledSwitch } from "./StyledSwitch";
 
 export type { PendingFile } from "./FileUploadZone";
 export type { ButtonProps } from "./Button";


### PR DESCRIPTION
## Summary
- New `components/ui/StyledSwitch.tsx` — iOS-style animated toggle, matches design from `ProfileTab.tsx` (etalon)
- Replaced 3 bare RN `<Switch>` usages in `app/requests/new.tsx` and `app/requests/[id]/detail.tsx`
- Exported from `components/ui/index.ts`
- TSC 0 errors (frontend + backend)

Closes #1595

## Test plan
- [ ] Toggle "Публичная заявка" in new request form — animated, matches settings toggle
- [ ] Toggle visibility in request detail (owner view, both desktop and mobile panels)
- [ ] Disabled state (while submitting / togglingVisibility) — opacity 0.4, non-interactive