### PR TITLE
fix(settings): hide tabs during inline onboarding; remove "Не знаю" service option

### DIFF
--- a/app/onboarding/work-area.tsx
+++ b/app/onboarding/work-area.tsx
@@ -104,7 +104,6 @@ export default function OnboardingWorkAreaScreen() {
 
   // Step 2 — service picker state for the pending entry
   const [pendingServiceIds, setPendingServiceIds] = useState<string[]>([]);
-  const [pendingAnyService, setPendingAnyService] = useState(false);
 
   // Accepted entries
   const [entries, setEntries] = useState<WorkAreaEntryData[]>([]);
@@ -169,35 +168,25 @@ export default function OnboardingWorkAreaScreen() {
     setPendingCityId(fns.cityId);
     setPendingFns(fns);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
   }, []);
 
   const handleClearLocation = useCallback(() => {
     setPendingCityId(null);
     setPendingFns(null);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
   }, []);
 
   const toggleService = useCallback((id: string) => {
-    setPendingAnyService(false);
     setPendingServiceIds((prev) =>
       prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
     );
   }, []);
 
-  const pickAnyService = useCallback(() => {
-    setPendingServiceIds([]);
-    setPendingAnyService(true);
-  }, []);
-
-  const canAddEntry =
-    pendingFns !== null &&
-    (pendingAnyService || pendingServiceIds.length > 0);
+  const canAddEntry = pendingFns !== null && pendingServiceIds.length > 0;
 
   const addEntry = useCallback(() => {
     if (!pendingFns) return;
-    if (!pendingAnyService && pendingServiceIds.length === 0) return;
+    if (pendingServiceIds.length === 0) return;
 
     // Prevent duplicate FNS rows — replace existing if present.
     const cityName =
@@ -205,11 +194,9 @@ export default function OnboardingWorkAreaScreen() {
       cities.find((c) => c.id === pendingFns.cityId)?.name ||
       "";
 
-    const serviceNames = pendingAnyService
-      ? []
-      : services
-          .filter((s) => pendingServiceIds.includes(s.id))
-          .map((s) => s.name);
+    const serviceNames = services
+      .filter((s) => pendingServiceIds.includes(s.id))
+      .map((s) => s.name);
 
     const next: WorkAreaEntryData = {
       fnsId: pendingFns.id,
@@ -217,9 +204,9 @@ export default function OnboardingWorkAreaScreen() {
       fnsCode: pendingFns.code,
       cityId: pendingFns.cityId,
       cityName,
-      serviceIds: pendingAnyService ? [] : pendingServiceIds,
+      serviceIds: pendingServiceIds,
       serviceNames,
-      isAnyService: pendingAnyService,
+      isAnyService: false,
     };
 
     setEntries((prev) => {
@@ -231,10 +218,8 @@ export default function OnboardingWorkAreaScreen() {
     setPendingCityId(null);
     setPendingFns(null);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
   }, [
     pendingFns,
-    pendingAnyService,
     pendingServiceIds,
     cities,
     services,
@@ -342,9 +327,7 @@ export default function OnboardingWorkAreaScreen() {
               pendingFns={pendingFns}
               services={services}
               pendingServiceIds={pendingServiceIds}
-              pendingAnyService={pendingAnyService}
               canAddEntry={canAddEntry}
-              onPickAny={pickAnyService}
               onToggleService={toggleService}
               onAdd={addEntry}
               onCancel={handleClearLocation}

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -22,7 +22,8 @@ import InlineWorkArea from "@/components/settings/InlineWorkArea";
  *
  * Issue #1582 — specialist onboarding (work-area step) now renders inline
  * inside this layout instead of redirecting to /onboarding/work-area.
- * The sidebar tabs remain visible; active label = "Профиль".
+ * Issue #1599 — tabs are hidden while inline onboarding is active so the
+ * onboarding content takes the full screen.
  */
 
 const VALID_TABS: SettingsTab[] = ["profile", "specialist"];
@@ -35,11 +36,9 @@ interface SettingsTabsProps {
   activeTab: SettingsTab;
   onChange: (tab: SettingsTab) => void;
   canEditSpecialist: boolean;
-  /** When true, tabs are shown but pointer-events disabled (onboarding active). */
-  muted?: boolean;
 }
 
-function SettingsTabs({ activeTab, onChange, canEditSpecialist, muted }: SettingsTabsProps) {
+function SettingsTabs({ activeTab, onChange, canEditSpecialist }: SettingsTabsProps) {
   const tabs: { id: SettingsTab; label: string; disabled?: boolean }[] = [
     { id: "profile", label: "Профиль" },
     { id: "specialist", label: "Специалист", disabled: !canEditSpecialist },
@@ -50,8 +49,7 @@ function SettingsTabs({ activeTab, onChange, canEditSpecialist, muted }: Setting
       horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{ paddingHorizontal: 16 }}
-      style={{ flexGrow: 0, borderBottomWidth: 1, borderBottomColor: colors.border, opacity: muted ? 0.4 : 1 }}
-      scrollEnabled={!muted}
+      style={{ flexGrow: 0, borderBottomWidth: 1, borderBottomColor: colors.border }}
     >
       <View style={{ flexDirection: "row" }}>
         {tabs.map((t) => {
@@ -60,9 +58,8 @@ function SettingsTabs({ activeTab, onChange, canEditSpecialist, muted }: Setting
             <Pressable
               key={t.id}
               accessibilityRole="tab"
-              accessibilityState={{ selected: active, disabled: t.disabled || muted }}
+              accessibilityState={{ selected: active, disabled: t.disabled }}
               onPress={() => {
-                if (muted) return;
                 if (t.disabled) {
                   if (Platform.OS === "web") {
                     if (typeof window !== "undefined" && typeof window.alert === "function") {
@@ -191,13 +188,14 @@ export default function UnifiedSettings() {
         <Text className="text-2xl font-extrabold text-text-base mb-3">Настройки</Text>
       </View>
 
-      {/* Tabs always visible; muted (non-interactive) while inline onboarding is active */}
-      <SettingsTabs
-        activeTab={activeTab}
-        onChange={handleTabChange}
-        canEditSpecialist={isSpecialistUser}
-        muted={inlineOnboarding}
-      />
+      {/* Tabs hidden during inline onboarding — content takes full screen */}
+      {!inlineOnboarding && (
+        <SettingsTabs
+          activeTab={activeTab}
+          onChange={handleTabChange}
+          canEditSpecialist={isSpecialistUser}
+        />
+      )}
 
       {/* Inline work-area onboarding — renders inside settings, sidebar stays visible */}
       {inlineOnboarding ? (

--- a/components/onboarding/workarea/PendingFnsPicker.tsx
+++ b/components/onboarding/workarea/PendingFnsPicker.tsx
@@ -12,9 +12,7 @@ interface Props {
   pendingFns: FnsOpt;
   services: ServiceItem[];
   pendingServiceIds: string[];
-  pendingAnyService: boolean;
   canAddEntry: boolean;
-  onPickAny: () => void;
   onToggleService: (id: string) => void;
   onAdd: () => void;
   onCancel: () => void;
@@ -24,9 +22,7 @@ export default function PendingFnsPicker({
   pendingFns,
   services,
   pendingServiceIds,
-  pendingAnyService,
   canAddEntry,
-  onPickAny,
   onToggleService,
   onAdd,
   onCancel,
@@ -48,26 +44,6 @@ export default function PendingFnsPicker({
       </Text>
 
       <View className="flex-row flex-wrap" style={{ gap: 8 }}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Не знаю — любая услуга"
-          onPress={onPickAny}
-          className={`px-3 h-9 items-center justify-center rounded-full border ${
-            pendingAnyService
-              ? "bg-accent border-accent"
-              : "bg-white border-border"
-          }`}
-        >
-          <Text
-            className={`text-sm ${
-              pendingAnyService
-                ? "text-white font-medium"
-                : "text-text-base"
-            }`}
-          >
-            Не знаю
-          </Text>
-        </Pressable>
         {services.map((svc) => {
           const active = pendingServiceIds.includes(svc.id);
           return (

--- a/components/settings/InlineWorkArea.tsx
+++ b/components/settings/InlineWorkArea.tsx
@@ -60,7 +60,6 @@ export default function InlineWorkArea({ onDone, onCancel }: Props) {
 
   // Step 2 — service picker
   const [pendingServiceIds, setPendingServiceIds] = useState<string[]>([]);
-  const [pendingAnyService, setPendingAnyService] = useState(false);
 
   // Accepted entries
   const [entries, setEntries] = useState<WorkAreaEntryData[]>([]);
@@ -116,42 +115,32 @@ export default function InlineWorkArea({ onDone, onCancel }: Props) {
     setPendingCityId(fns.cityId);
     setPendingFns(fns);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
   }, []);
 
   const handleClearLocation = useCallback(() => {
     setPendingCityId(null);
     setPendingFns(null);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
   }, []);
 
   const toggleService = useCallback((id: string) => {
-    setPendingAnyService(false);
     setPendingServiceIds((prev) =>
       prev.includes(id) ? prev.filter((s) => s !== id) : [...prev, id]
     );
   }, []);
 
-  const pickAnyService = useCallback(() => {
-    setPendingServiceIds([]);
-    setPendingAnyService(true);
-  }, []);
-
-  const canAddEntry = pendingFns !== null && (pendingAnyService || pendingServiceIds.length > 0);
+  const canAddEntry = pendingFns !== null && pendingServiceIds.length > 0;
 
   const addEntry = useCallback(() => {
     if (!pendingFns) return;
-    if (!pendingAnyService && pendingServiceIds.length === 0) return;
+    if (pendingServiceIds.length === 0) return;
 
     const cityName =
       pendingFns.cityName ||
       cities.find((c) => c.id === pendingFns.cityId)?.name ||
       "";
 
-    const serviceNames = pendingAnyService
-      ? []
-      : services.filter((s) => pendingServiceIds.includes(s.id)).map((s) => s.name);
+    const serviceNames = services.filter((s) => pendingServiceIds.includes(s.id)).map((s) => s.name);
 
     const next: WorkAreaEntryData = {
       fnsId: pendingFns.id,
@@ -159,9 +148,9 @@ export default function InlineWorkArea({ onDone, onCancel }: Props) {
       fnsCode: pendingFns.code,
       cityId: pendingFns.cityId,
       cityName,
-      serviceIds: pendingAnyService ? [] : pendingServiceIds,
+      serviceIds: pendingServiceIds,
       serviceNames,
-      isAnyService: pendingAnyService,
+      isAnyService: false,
     };
 
     setEntries((prev) => {
@@ -172,8 +161,7 @@ export default function InlineWorkArea({ onDone, onCancel }: Props) {
     setPendingCityId(null);
     setPendingFns(null);
     setPendingServiceIds([]);
-    setPendingAnyService(false);
-  }, [pendingFns, pendingAnyService, pendingServiceIds, cities, services]);
+  }, [pendingFns, pendingServiceIds, cities, services]);
 
   const removeEntry = useCallback((fnsId: string) => {
     setEntries((prev) => prev.filter((e) => e.fnsId !== fnsId));
@@ -253,9 +241,7 @@ export default function InlineWorkArea({ onDone, onCancel }: Props) {
             pendingFns={pendingFns}
             services={services}
             pendingServiceIds={pendingServiceIds}
-            pendingAnyService={pendingAnyService}
             canAddEntry={canAddEntry}
-            onPickAny={pickAnyService}
             onToggleService={toggleService}
             onAdd={addEntry}
             onCancel={handleClearLocation}


### PR DESCRIPTION
## Summary
- **Fix 1**: `SettingsTabs` is conditionally hidden (not just muted) when `inlineOnboarding=true` — onboarding content takes the full screen with no tab bar visible
- **Fix 2**: Removed "Не знаю" button from `PendingFnsPicker` — specialist must select explicit services (Камеральная / Выездная / ОКК). Removed `pendingAnyService` state and `pickAnyService` handler from both `work-area.tsx` and `InlineWorkArea.tsx`

## Test plan
- [ ] Open Settings → toggle on specialist mode → inline onboarding appears → tabs (Профиль/Специалист) are not visible
- [ ] Pick an FNS in work-area → service picker shows only Камеральная/Выездная/ОКК, no "Не знаю"
- [ ] "Добавить" button disabled until at least one explicit service selected
- [ ] Both flows (inline in settings + standalone /onboarding/work-area) work correctly

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)