### PR TITLE
feat: specialist access to search + view-profile button (#1603 #1604)

### DIFF
--- a/components/settings/ProfileTab.tsx
+++ b/components/settings/ProfileTab.tsx
@@ -5,7 +5,8 @@ import AvatarUploader from "@/components/settings/AvatarUploader";
 import RoleBadge from "@/components/layout/RoleBadge";
 import type { UserRole } from "@/contexts/AuthContext";
 import { colors } from "@/lib/theme";
-import { Share2 } from "lucide-react-native";
+import { Share2, ExternalLink } from "lucide-react-native";
+import { router } from "expo-router";
 
 /**
  * Внутренний iOS-style toggle. Дублируется здесь чтобы tab был самодостаточным
@@ -226,33 +227,60 @@ export default function ProfileTab({
               )}
             </View>
             {isAvailable && userId && (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Поделиться профилем"
-                onPress={handleShareProfile}
-                style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  paddingVertical: 10,
-                  paddingHorizontal: 12,
-                  borderRadius: 8,
-                  backgroundColor: colors.surface2,
-                  alignSelf: "flex-start",
-                  marginBottom: 4,
-                }}
-              >
-                <Share2 size={14} color={colors.accent} />
-                <Text
+              <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginBottom: 4 }}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Посмотреть мой профиль"
+                  onPress={() => router.push(`/specialists/${userId}` as never)}
                   style={{
-                    marginLeft: 6,
-                    fontSize: 13,
-                    fontWeight: "600",
-                    color: colors.accent,
+                    flexDirection: "row",
+                    alignItems: "center",
+                    paddingVertical: 10,
+                    paddingHorizontal: 12,
+                    borderRadius: 8,
+                    backgroundColor: colors.surface2,
+                    alignSelf: "flex-start",
                   }}
                 >
-                  Поделиться профилем
-                </Text>
-              </Pressable>
+                  <ExternalLink size={14} color={colors.accent} />
+                  <Text
+                    style={{
+                      marginLeft: 6,
+                      fontSize: 13,
+                      fontWeight: "600",
+                      color: colors.accent,
+                    }}
+                  >
+                    Посмотреть мой профиль
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Поделиться профилем"
+                  onPress={handleShareProfile}
+                  style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    paddingVertical: 10,
+                    paddingHorizontal: 12,
+                    borderRadius: 8,
+                    backgroundColor: colors.surface2,
+                    alignSelf: "flex-start",
+                  }}
+                >
+                  <Share2 size={14} color={colors.accent} />
+                  <Text
+                    style={{
+                      marginLeft: 6,
+                      fontSize: 13,
+                      fontWeight: "600",
+                      color: colors.accent,
+                    }}
+                  >
+                    Поделиться профилем
+                  </Text>
+                </Pressable>
+              </View>
             )}
           </View>
         )}

--- a/lib/nav-items.ts
+++ b/lib/nav-items.ts
@@ -162,8 +162,10 @@ export const ADMIN_ITEMS: NavItem[] = [
 // ─────────────────────────────────────────── build helpers
 
 export function buildUserItems(isSpecialist: boolean): NavItem[] {
+  // Issue #1603 — specialists can also search for other specialists and save
+  // favourites, so CLIENT_EXTRA items are included for both roles.
   return isSpecialist
-    ? [...USER_BASE_ITEMS, ...USER_SPECIALIST_EXTRA, ...USER_TAIL_ITEMS]
+    ? [...USER_BASE_ITEMS, ...USER_SPECIALIST_EXTRA, ...USER_CLIENT_EXTRA, ...USER_TAIL_ITEMS]
     : [...USER_BASE_ITEMS, ...USER_CLIENT_EXTRA, ...USER_TAIL_ITEMS];
 }
 


### PR DESCRIPTION
## Summary

- **#1603** — `lib/nav-items.ts`: `buildUserItems` now includes `USER_CLIENT_EXTRA` (Специалисты + Избранные) for specialists, so they see the search catalog and favourites in sidebar/mobile drawer alongside their existing "Запросы" item. No backend changes needed — the API endpoints are already open to all authenticated users.
- **#1604** — `components/settings/ProfileTab.tsx`: added "Посмотреть мой профиль" button (ExternalLink icon, `router.push('/specialists/<id>')`) next to the existing "Поделиться профилем" button. Rendered only when `isAvailable && userId` (i.e. `user.isPublicProfile === true` equivalent — the `isAvailable` flag controls public visibility).

## Test plan

- [ ] Log in as a specialist — sidebar/drawer should show "Специалисты" and "Избранные" in addition to "Запросы"
- [ ] Navigate to /specialists — page loads, filters work, specialist can bookmark others
- [ ] Navigate to /saved-specialists — saved list works for specialist
- [ ] Settings → Профиль tab → enable "Публичный профиль" toggle → both buttons appear: "Посмотреть мой профиль" + "Поделиться профилем"
- [ ] Click "Посмотреть мой профиль" → navigates to /specialists/<myId>
- [ ] Log in as a client — nav unchanged (still shows Специалисты + Избранные, no Запросы)
- [ ] TSC 0 errors: `npx tsc --noEmit` + `cd api && npx tsc --noEmit`

Closes #1603
Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)