### PR TITLE
feat(onboarding): correct step order + visibility screen (#1602)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -105,8 +105,9 @@ export default function RootLayout() {
             <Stack.Screen name="login" />
             <Stack.Screen name="otp" />
 
-            {/* Onboarding */}
+            {/* Onboarding — order: name → visibility → work-area → profile (#1602) */}
             <Stack.Screen name="onboarding/name" />
+            <Stack.Screen name="onboarding/visibility" />
             <Stack.Screen name="onboarding/work-area" />
             <Stack.Screen name="onboarding/profile" />
 

--- a/app/onboarding/name.tsx
+++ b/app/onboarding/name.tsx
@@ -109,8 +109,9 @@ export default function OnboardingNameScreen() {
 
       // Always replace so the back button doesn't return here and
       // re-trigger the guard redirect (#1522).
+      // Step order: name → visibility → work-area → profile (#1602).
       nav.replaceAny({
-        pathname: "/onboarding/work-area",
+        pathname: "/onboarding/visibility",
         params: { role: "specialist" },
       });
     } catch (e: unknown) {

--- a/app/onboarding/profile.tsx
+++ b/app/onboarding/profile.tsx
@@ -6,12 +6,14 @@ import {
   ScrollView,
   Image,
   Platform,
+  Switch,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams, useSegments } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import { useState, useRef, useEffect } from "react";
 import { Pencil, Camera, ChevronLeft } from "lucide-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   api,
   ApiError,
@@ -22,6 +24,7 @@ import {
 } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { useRequireAuth } from "@/lib/useRequireAuth";
+import { ONBOARDING_VISIBILITY_KEY } from "./visibility";
 import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
 import OnboardingShell from "@/components/onboarding/OnboardingShell";
 import Button from "@/components/ui/Button";
@@ -29,7 +32,7 @@ import Input from "@/components/ui/Input";
 import { colors, overlay, textStyle } from "@/lib/theme";
 
 export default function OnboardingProfileScreen() {
-  const router = useRouter()
+  const router = useRouter();
   const nav = useTypedRouter();
   const params = useLocalSearchParams<{ from?: string }>();
   const fromSettings = params.from === "settings";
@@ -40,6 +43,18 @@ export default function OnboardingProfileScreen() {
   // Without this guard, toggling specialist off from /settings causes this
   // background screen to fire nav.replaceRoutes.tabs() unintentionally.
   const isOnThisScreen = segments[0] === "onboarding" && segments[1] === "profile";
+
+  // Public-profile toggle — loaded from AsyncStorage (set by visibility step).
+  // Default true: most specialists want to be found.
+  const [isPublicProfile, setIsPublicProfile] = useState(true);
+
+  useEffect(() => {
+    AsyncStorage.getItem(ONBOARDING_VISIBILITY_KEY).then((val) => {
+      if (val !== null) {
+        setIsPublicProfile(val === "true");
+      }
+    });
+  }, []);
 
   useEffect(() => {
     if (!ready || !isOnThisScreen) return;
@@ -141,8 +156,13 @@ export default function OnboardingProfileScreen() {
     return Object.keys(errors).length === 0;
   };
 
+  // Public profile requires name (set in name.tsx), private has no extra requirements here.
+  // Button is always enabled for private; for public no extra block needed since name
+  // was already collected in the name step.
+  const canSubmit = !isLoading && !avatarUploading;
+
   const handleSubmit = async () => {
-    if (isLoading) return;
+    if (!canSubmit) return;
     setError("");
     if (!validateFields()) return;
     setIsLoading(true);
@@ -160,6 +180,7 @@ export default function OnboardingProfileScreen() {
             officeAddress: officeAddress.trim() || null,
             workingHours: workingHours.trim() || null,
             avatarUrl: avatarUrl || null,
+            isPublicProfile,
           },
         }
       );
@@ -172,6 +193,9 @@ export default function OnboardingProfileScreen() {
         specialistProfileCompletedAt: completedAt,
         ...(avatarUrl ? { avatarUrl } : {}),
       });
+
+      // Clean up visibility key after successful onboarding
+      await AsyncStorage.removeItem(ONBOARDING_VISIBILITY_KEY);
 
       nav.replaceRoutes.tabs();
     } catch (e: unknown) {
@@ -240,9 +264,55 @@ export default function OnboardingProfileScreen() {
               marginBottom: 24,
             }}
           >
-            Всё необязательно — можно заполнить позже. Аватар помогает клиенту
-            быстрее выбрать именно вас.
+            {isPublicProfile
+              ? "Аватар помогает клиенту быстрее выбрать именно вас."
+              : "Всё необязательно — можно заполнить позже."}
           </Text>
+
+          {/* Visibility toggle */}
+          <View
+            className="flex-row items-center justify-between rounded-xl px-4 py-3 mb-6"
+            style={{
+              borderWidth: 1,
+              borderColor: isPublicProfile ? overlay.accent10 : colors.border,
+              backgroundColor: isPublicProfile
+                ? overlay.accent10
+                : colors.surface,
+            }}
+          >
+            <View className="flex-1 mr-3">
+              <Text
+                style={{
+                  fontSize: 14,
+                  fontWeight: "600",
+                  color: colors.text,
+                  marginBottom: 2,
+                }}
+              >
+                {isPublicProfile ? "Публичный профиль" : "Приватный профиль"}
+              </Text>
+              <Text style={{ fontSize: 12, color: colors.textSecondary }}>
+                {isPublicProfile
+                  ? "Виден в каталоге специалистов"
+                  : "Скрыт из каталога"}
+              </Text>
+            </View>
+            <Switch
+              value={isPublicProfile}
+              onValueChange={(val) => {
+                setIsPublicProfile(val);
+                void AsyncStorage.setItem(
+                  ONBOARDING_VISIBILITY_KEY,
+                  val ? "true" : "false"
+                );
+              }}
+              trackColor={{
+                false: colors.border,
+                true: colors.accent,
+              }}
+              thumbColor={colors.surface}
+            />
+          </View>
 
           <Pressable
             accessibilityRole="button"
@@ -305,14 +375,16 @@ export default function OnboardingProfileScreen() {
             />
           )}
 
-          <View
-            className="bg-accent-soft rounded-xl px-4 py-3 mb-4"
-            style={{ borderWidth: 1, borderColor: overlay.accent10 }}
-          >
-            <Text className="text-xs text-accent text-center font-medium">
-              Контакты будут видны всем посетителям платформы
-            </Text>
-          </View>
+          {isPublicProfile && (
+            <View
+              className="bg-accent-soft rounded-xl px-4 py-3 mb-4"
+              style={{ borderWidth: 1, borderColor: overlay.accent10 }}
+            >
+              <Text className="text-xs text-accent text-center font-medium">
+                Контакты будут видны всем посетителям платформы
+              </Text>
+            </View>
+          )}
 
           <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider mb-3">
             О себе
@@ -430,20 +502,22 @@ export default function OnboardingProfileScreen() {
           <Button
             label="Завершить регистрацию"
             onPress={handleSubmit}
-            disabled={isLoading || avatarUploading}
+            disabled={!canSubmit}
             loading={isLoading}
           />
 
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Пропустить"
-            onPress={handleSubmit}
-            disabled={isLoading || avatarUploading}
-            className="items-center mt-4"
-            style={{ minHeight: 44, justifyContent: "center" }}
-          >
-            <Text className="text-sm text-text-mute">Пропустить</Text>
-          </Pressable>
+          {isPublicProfile && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Пропустить"
+              onPress={handleSubmit}
+              disabled={!canSubmit}
+              className="items-center mt-4"
+              style={{ minHeight: 44, justifyContent: "center" }}
+            >
+              <Text className="text-sm text-text-mute">Пропустить</Text>
+            </Pressable>
+          )}
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/onboarding/visibility.tsx
+++ b/app/onboarding/visibility.tsx
@@ -1,0 +1,295 @@
+import { View, Text, Pressable, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useRouter, useLocalSearchParams, useSegments } from "expo-router";
+import { useTypedRouter } from "@/lib/navigation";
+import { useState, useEffect } from "react";
+import { ChevronLeft, Eye, EyeOff } from "lucide-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useAuth } from "@/contexts/AuthContext";
+import { useRequireAuth } from "@/lib/useRequireAuth";
+import OnboardingProgress from "@/components/onboarding/OnboardingProgress";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
+import Button from "@/components/ui/Button";
+import { colors, textStyle, overlay } from "@/lib/theme";
+
+/** AsyncStorage key for specialist public-profile preference. */
+export const ONBOARDING_VISIBILITY_KEY = "onboarding_is_public_profile";
+
+export default function OnboardingVisibilityScreen() {
+  const router = useRouter();
+  const nav = useTypedRouter();
+  const params = useLocalSearchParams<{ from?: string; role?: string }>();
+  const fromSettings = params.from === "settings";
+  const role =
+    typeof params.role === "string"
+      ? params.role
+      : Array.isArray(params.role)
+        ? params.role[0]
+        : undefined;
+  const isSpecialistIntent = role === "specialist";
+  const { ready, user } = useRequireAuth();
+  const { isSpecialistUser, isAdminUser } = useAuth();
+  const segments = useSegments() as string[];
+  const isOnThisScreen =
+    segments[0] === "onboarding" && segments[1] === "visibility";
+
+  // Default: public profile
+  const [isPublic, setIsPublic] = useState(true);
+
+  useEffect(() => {
+    if (!ready || !isOnThisScreen) return;
+    if (isAdminUser) {
+      nav.replaceRoutes.adminDashboard();
+      return;
+    }
+    if (!isSpecialistUser && !isSpecialistIntent) {
+      nav.replaceRoutes.tabs();
+      return;
+    }
+    if (!fromSettings && user?.specialistProfileCompletedAt) {
+      nav.replaceRoutes.tabs();
+    }
+  }, [
+    ready,
+    isOnThisScreen,
+    isAdminUser,
+    isSpecialistUser,
+    isSpecialistIntent,
+    user,
+    fromSettings,
+    nav,
+  ]);
+
+  const handleNext = async () => {
+    // Persist choice so profile screen can read it
+    await AsyncStorage.setItem(
+      ONBOARDING_VISIBILITY_KEY,
+      isPublic ? "true" : "false"
+    );
+    nav.replaceAny({
+      pathname: "/onboarding/work-area",
+      params: { role: "specialist" },
+    });
+  };
+
+  if (
+    !ready ||
+    isAdminUser ||
+    (!isSpecialistUser && !isSpecialistIntent)
+  ) {
+    return (
+      <OnboardingShell
+        step={1}
+        title="Публичный профиль?"
+        subtitle="Выберите, будет ли ваш профиль виден всем пользователям платформы."
+        loading
+        onBack={() => router.back()}
+      />
+    );
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
+      <View className="px-6 pt-4 pb-2">
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Назад"
+          onPress={() => router.back()}
+          className="flex-row items-center"
+          style={{ minHeight: 44 }}
+        >
+          <ChevronLeft size={20} color={colors.text} />
+          <Text className="text-text-base ml-1">Назад</Text>
+        </Pressable>
+      </View>
+
+      <View className="px-6 pb-4">
+        <OnboardingProgress step={1} />
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingHorizontal: 24, paddingBottom: 32 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={{ width: "100%", maxWidth: 640, alignSelf: "center" }}>
+          <Text
+            style={{
+              ...textStyle.h1,
+              color: colors.text,
+              fontSize: 32,
+              lineHeight: 38,
+              marginTop: 16,
+              marginBottom: 12,
+            }}
+          >
+            Видимость профиля
+          </Text>
+          <Text
+            style={{
+              ...textStyle.body,
+              color: colors.textSecondary,
+              fontSize: 16,
+              lineHeight: 24,
+              marginBottom: 32,
+            }}
+          >
+            Выберите, как клиенты будут вас находить. Изменить можно в любой момент.
+          </Text>
+
+          {/* Public option */}
+          <Pressable
+            accessibilityRole="radio"
+            accessibilityLabel="Публичный профиль"
+            accessibilityState={{ checked: isPublic }}
+            onPress={() => setIsPublic(true)}
+            style={{
+              borderWidth: 2,
+              borderColor: isPublic ? colors.accent : colors.border,
+              borderRadius: 16,
+              padding: 20,
+              marginBottom: 12,
+              backgroundColor: isPublic ? overlay.accent10 : colors.surface,
+            }}
+          >
+            <View className="flex-row items-center mb-2" style={{ gap: 12 }}>
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                  backgroundColor: isPublic ? colors.accent : colors.border,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Eye size={20} color={colors.surface} />
+              </View>
+              <View className="flex-1">
+                <Text
+                  style={{
+                    fontSize: 16,
+                    fontWeight: "600",
+                    color: colors.text,
+                  }}
+                >
+                  Публичный профиль
+                </Text>
+              </View>
+              <View
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 11,
+                  borderWidth: 2,
+                  borderColor: isPublic ? colors.accent : colors.border,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: isPublic ? colors.accent : colors.surface,
+                }}
+              >
+                {isPublic && (
+                  <View
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 5,
+                      backgroundColor: colors.surface,
+                    }}
+                  />
+                )}
+              </View>
+            </View>
+            <Text
+              style={{
+                fontSize: 14,
+                color: colors.textSecondary,
+                lineHeight: 20,
+              }}
+            >
+              Ваша карточка отображается в каталоге специалистов. Клиенты могут
+              найти вас по городу и услугам, написать и оставить отзыв.
+            </Text>
+          </Pressable>
+
+          {/* Private option */}
+          <Pressable
+            accessibilityRole="radio"
+            accessibilityLabel="Приватный профиль"
+            accessibilityState={{ checked: !isPublic }}
+            onPress={() => setIsPublic(false)}
+            style={{
+              borderWidth: 2,
+              borderColor: !isPublic ? colors.accent : colors.border,
+              borderRadius: 16,
+              padding: 20,
+              marginBottom: 32,
+              backgroundColor: !isPublic ? overlay.accent10 : colors.surface,
+            }}
+          >
+            <View className="flex-row items-center mb-2" style={{ gap: 12 }}>
+              <View
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 20,
+                  backgroundColor: !isPublic ? colors.accent : colors.border,
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <EyeOff size={20} color={colors.surface} />
+              </View>
+              <View className="flex-1">
+                <Text
+                  style={{
+                    fontSize: 16,
+                    fontWeight: "600",
+                    color: colors.text,
+                  }}
+                >
+                  Приватный профиль
+                </Text>
+              </View>
+              <View
+                style={{
+                  width: 22,
+                  height: 22,
+                  borderRadius: 11,
+                  borderWidth: 2,
+                  borderColor: !isPublic ? colors.accent : colors.border,
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: !isPublic ? colors.accent : colors.surface,
+                }}
+              >
+                {!isPublic && (
+                  <View
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: 5,
+                      backgroundColor: colors.surface,
+                    }}
+                  />
+                )}
+              </View>
+            </View>
+            <Text
+              style={{
+                fontSize: 14,
+                color: colors.textSecondary,
+                lineHeight: 20,
+              }}
+            >
+              Профиль скрыт из каталога. Вы можете работать на платформе, но
+              клиенты не найдут вас самостоятельно.
+            </Text>
+          </Pressable>
+
+          <Button label="Далее" onPress={handleNext} />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/components/onboarding/OnboardingProgress.tsx
+++ b/components/onboarding/OnboardingProgress.tsx
@@ -2,12 +2,12 @@ import { View, Text } from "react-native";
 import { colors } from "@/lib/theme";
 
 interface Props {
-  /** Current step: 1, 2, or 3 (matches Имя / Работа / Профиль). */
+  /** Current step: 1, 2, or 3 (matches Видимость / Работа / Профиль). */
   step: 1 | 2 | 3;
 }
 
 const STEPS: { label: string }[] = [
-  { label: "Имя" },
+  { label: "Видимость" },
   { label: "Работа" },
   { label: "Профиль" },
 ];

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -51,6 +51,7 @@ export const ROUTES = {
   // Auth / onboarding
   authEmail: "/login",
   onboardingName: "/onboarding/name",
+  onboardingVisibility: "/onboarding/visibility",
   onboardingProfile: "/onboarding/profile",
   onboardingWorkArea: "/onboarding/work-area",
 


### PR DESCRIPTION
## Summary

- New onboarding step order: `name` → `visibility` (step 1) → `work-area` (step 2) → `profile` (step 3)
- New `/onboarding/visibility` screen with public/private radio cards; choice persisted to AsyncStorage
- `OnboardingProgress` labels updated: Видимость / Работа / Профиль
- `profile.tsx`: reads `isPublicProfile` from AsyncStorage on mount, shows inline Switch toggle, sends `isPublicProfile` flag to API; cleans up key after successful submit
- Conditional validation: private profile → button always active; public → same (name already collected in step 0)
- `navigation.ts` + `_layout.tsx` updated with `onboardingVisibility` route

## Test plan
- [ ] Register as specialist → complete name step → lands on /onboarding/visibility
- [ ] Select public → work-area → profile shows public toggle ON, info banner visible
- [ ] Select private → work-area → profile shows private toggle OFF, no banner
- [ ] Toggle on profile page flips text + banner
- [ ] Submit completes onboarding for both public and private
- [ ] TSC 0 errors: `npx tsc --noEmit && cd api && npx tsc --noEmit`

Closes #1602