### PR TITLE
fix(#1610,#1611): hide empty docs block; prevent thread page flash

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -23,7 +23,6 @@ import { api, apiPatch, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, BREAKPOINT } from "@/lib/theme";
 import SpecialistRecommendations, { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
-import EmptyState from "@/components/ui/EmptyState";
 
 const FIRST_MESSAGE_MIN = 10;
 const FIRST_MESSAGE_MAX = 2000;
@@ -442,24 +441,22 @@ export default function MyRequestDetail() {
                   </Text>
                 </View>
 
-                {/* Files */}
-                <View
-                  className="bg-white rounded-2xl p-5 mb-4"
-                  style={{
-                    shadowColor: colors.text,
-                    shadowOffset: { width: 0, height: 1 },
-                    shadowOpacity: 0.05,
-                    shadowRadius: 8,
-                    elevation: 2,
-                  }}
-                >
-                  <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
-                    Прикреплённые документы
-                  </Text>
-                  {request.files.length === 0 ? (
-                    <EmptyState title="Нет документов" subtitle="К этому запросу не прикреплены файлы" />
-                  ) : (
-                    request.files.map((file) => (
+                {/* Files — issue #1610: hide block entirely when no files attached */}
+                {request.files.length > 0 && (
+                  <View
+                    className="bg-white rounded-2xl p-5 mb-4"
+                    style={{
+                      shadowColor: colors.text,
+                      shadowOffset: { width: 0, height: 1 },
+                      shadowOpacity: 0.05,
+                      shadowRadius: 8,
+                      elevation: 2,
+                    }}
+                  >
+                    <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
+                      Прикреплённые документы
+                    </Text>
+                    {request.files.map((file) => (
                       <Pressable
                         accessibilityRole="button"
                         key={file.id}
@@ -482,9 +479,9 @@ export default function MyRequestDetail() {
                         </View>
                         <Download size={14} color={colors.placeholder} />
                       </Pressable>
-                    ))
-                  )}
-                </View>
+                    ))}
+                  </View>
+                )}
 
                 {/* Recommended specialists feed (horizontal scroll) — issue #1550 */}
                 {recommendations.length > 0 && (
@@ -736,24 +733,22 @@ export default function MyRequestDetail() {
               </Text>
             </View>
 
-            {/* Files */}
-            <View
-              className="bg-white rounded-2xl p-4 mb-4"
-              style={{
-                shadowColor: colors.text,
-                shadowOffset: { width: 0, height: 1 },
-                shadowOpacity: 0.05,
-                shadowRadius: 8,
-                elevation: 2,
-              }}
-            >
-              <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
-                Прикреплённые документы
-              </Text>
-              {request.files.length === 0 ? (
-                <EmptyState title="Нет документов" subtitle="К этому запросу не прикреплены файлы" />
-              ) : (
-                request.files.map((file) => (
+            {/* Files — issue #1610: hide block entirely when no files attached */}
+            {request.files.length > 0 && (
+              <View
+                className="bg-white rounded-2xl p-4 mb-4"
+                style={{
+                  shadowColor: colors.text,
+                  shadowOffset: { width: 0, height: 1 },
+                  shadowOpacity: 0.05,
+                  shadowRadius: 8,
+                  elevation: 2,
+                }}
+              >
+                <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
+                  Прикреплённые документы
+                </Text>
+                {request.files.map((file) => (
                   <Pressable
                     accessibilityRole="button"
                     key={file.id}
@@ -776,9 +771,9 @@ export default function MyRequestDetail() {
                     </View>
                     <Download size={14} color={colors.placeholder} />
                   </Pressable>
-                ))
-              )}
-            </View>
+                ))}
+              </View>
+            )}
 
             {/* Recommended specialists feed (horizontal scroll) — issue #1550.
                 Placed under main info, before actions (per acceptance criteria). */}

--- a/app/threads/[id].tsx
+++ b/app/threads/[id].tsx
@@ -16,7 +16,7 @@ const SAFE_EDGES = Platform.OS === "web"
 export default function ChatThread() {
   const { id, requestId } = useLocalSearchParams<{ id: string; requestId?: string }>();
   const router = useRouter();
-  const { ready } = useRequireAuth();
+  const { ready, isLoading: authLoading } = useRequireAuth();
 
   function handleBack() {
     if (requestId) {
@@ -28,7 +28,11 @@ export default function ChatThread() {
     }
   }
 
-  if (!ready) {
+  // Show spinner while auth is loading OR while unauthenticated (redirect pending).
+  // This prevents InlineChatView from mounting before auth is resolved, which
+  // caused a flash: InlineChatView would fetch/render then vanish on redirect.
+  // issue #1611
+  if (authLoading || !ready) {
     return (
       <SafeAreaView className="flex-1 bg-white" edges={SAFE_EDGES}>
         <LoadingState />


### PR DESCRIPTION
## Summary

- **#1611** Thread page (`app/threads/[id].tsx`): guard `InlineChatView` mount on `authLoading` — spinner shown while auth resolves, preventing specialist content flash before redirect fires on reload
- **#1610** Request detail (`app/requests/[id]/detail.tsx`): wrap "Прикреплённые документы" block with `{request.files.length > 0 && ...}` in both desktop and mobile layouts — block hidden entirely when no files; removed unused `EmptyState` import

## Test plan

- [ ] Open `/threads/<id>` while logged out → spinner, then redirect to login (no content flash)
- [ ] Open `/threads/<id>` while logged in → spinner briefly, then chat renders normally
- [ ] Open request detail with no files → "Прикреплённые документы" block not visible
- [ ] Open request detail with files → block visible, files listed normally
- [ ] TSC frontend: 0 errors
- [ ] TSC backend: 0 errors

Closes #1610
Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)