### PR TITLE
fix(#1616,#1617,#1618): back nav /legal, SafeAreaView specialists, clean dead routes

### DIFF
--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -58,7 +58,6 @@ export const ROUTES = {
   // Requests
   requests: "/requests",
   requestsNew: "/requests/new",
-  requestsCreate: "/requests/create",
 
   // Settings
   settings: "/settings",


### PR DESCRIPTION
## Summary

- **#1618** — Back nav on `/legal` (`app/legal/index.tsx`): `ChevronLeft` + `nav.back()` button already present in development since previous session; confirmed working.
- **#1616** — `SafeAreaView` on `/specialists` and `/saved-specialists`: both pages delegate to `SpecialistFeed` which wraps in `SafeAreaView` (line 524 of `components/specialists/SpecialistFeed.tsx`); already correct.
- **#1617** — Dead pages (`app/mosaic-d.tsx`, `app/mosaic-m.tsx`, `app/requests/create.tsx`) already deleted in `ae7ce20`. This PR adds the final cleanup: removes orphaned `requestsCreate` route constant from `lib/navigation.ts`.

## Changes

- `lib/navigation.ts`: removed `requestsCreate: "/requests/create"` from `ROUTES` (route file deleted in ae7ce20)

## Test plan

- [ ] TSC 0 errors frontend: `npx tsc --noEmit`
- [ ] TSC 0 errors backend: `cd api && npx tsc --noEmit`
- [ ] `/legal` page shows back nav button, `nav.back()` works
- [ ] `/specialists` and `/saved-specialists` pages render without notch overlap on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)