### PR TITLE
refactor(#1619): split detail.tsx into 4 sub-components

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -4,54 +4,31 @@ import {
   Text,
   ScrollView,
   Pressable,
-  ActivityIndicator,
   Alert,
   Linking,
   Platform,
   useWindowDimensions,
 } from "react-native";
-import StyledSwitch from "@/components/ui/StyledSwitch";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams, useRouter, usePathname } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
-import { File, FileImage, Download, ChevronLeft, X, Link } from "lucide-react-native";
-import StatusBadge from "@/components/StatusBadge";
+import { ChevronLeft } from "lucide-react-native";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import ChatComposer, { type PendingFile } from "@/components/ChatComposer";
+import { type PendingFile } from "@/components/ChatComposer";
 import { api, apiPatch, ApiError } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, BREAKPOINT } from "@/lib/theme";
-import SpecialistRecommendations, { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
+import { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
+
+import RequestHeader from "@/components/requests/detail/RequestHeader";
+import RequestActions from "@/components/requests/detail/RequestActions";
+import RequestDocuments from "@/components/requests/detail/RequestDocuments";
+import RequestSpecialists from "@/components/requests/detail/RequestSpecialists";
+import { RequestDetailData, FileItem } from "@/components/requests/detail/types";
 
 const FIRST_MESSAGE_MIN = 10;
 const FIRST_MESSAGE_MAX = 2000;
-
-interface FileItem {
-  id: string;
-  url: string;
-  filename: string;
-  size: number;
-  mimeType: string;
-}
-
-interface RequestDetailData {
-  id: string;
-  title: string;
-  description: string;
-  status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";
-  isPublic: boolean;
-  createdAt: string;
-  lastActivityAt: string;
-  extensionsCount: number;
-  maxExtensions: number;
-  city: { id: string; name: string };
-  fns: { id: string; name: string; code: string };
-  service?: { id: string; name: string } | null;
-  files: FileItem[];
-  threadsCount: number;
-  unreadMessages: number;
-}
 
 export default function MyRequestDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -141,9 +118,6 @@ export default function MyRequestDetail() {
   }, [isAuthenticated, nav, pathname]);
 
   // Inline composer send — creates a thread (mirrors /requests/:id/write).
-  // Files are uploaded immediately on pick by FileUploadZone, so by send-time
-  // each "done" file already has its uploadedToken (single-attachment first
-  // message — limit enforced by maxFiles=1 below).
   const handleComposerSend = useCallback(async () => {
     if (!isAuthenticated) {
       nav.replaceAny({ pathname: "/login", params: { returnTo: pathname } });
@@ -195,7 +169,6 @@ export default function MyRequestDetail() {
           const existingThreadId =
             typeof err.data?.threadId === "string" ? err.data.threadId : null;
           if (existingThreadId) {
-            // Already wrote to this request — open the existing thread.
             nav.replaceAny(`/threads/${existingThreadId}`);
           } else {
             setComposerError("Запрос закрыт — сообщение отправить невозможно");
@@ -215,14 +188,7 @@ export default function MyRequestDetail() {
     } finally {
       setComposerSending(false);
     }
-  }, [
-    composerText,
-    composerFiles,
-    id,
-    isAuthenticated,
-    nav,
-    pathname,
-  ]);
+  }, [composerText, composerFiles, id, isAuthenticated, nav, pathname]);
 
   const handleCloseRequest = useCallback(async () => {
     if (closing) return;
@@ -316,57 +282,14 @@ export default function MyRequestDetail() {
   const isActive = request.status !== "CLOSED";
 
   // Service is shown in the chip only when actually selected — issue #1578.
-  // Backend may return null/undefined or an object with empty name; treat all
-  // those cases as "not selected" so the chip falls back to plain [ФНС].
   const serviceName = request.service?.name?.trim() || null;
 
   // Inline composer eligibility — specialist with completed profile, request open.
-  // Non-specialists / unauth users / closed requests don't see the composer.
   const showInlineComposer =
     isActive &&
     isAuthenticated &&
     isSpecialistUser &&
     !!user?.specialistProfileCompletedAt;
-
-  const inlineComposerSection = showInlineComposer ? (
-    <View
-      className="bg-white rounded-2xl mb-4 overflow-hidden"
-      style={{
-        shadowColor: colors.text,
-        shadowOffset: { width: 0, height: 1 },
-        shadowOpacity: 0.05,
-        shadowRadius: 8,
-        elevation: 2,
-      }}
-    >
-      <View className="px-4 pt-4 pb-2">
-        <Text className="text-xs font-semibold text-text-mute mb-1 uppercase tracking-wide">
-          Написать клиенту
-        </Text>
-        <Text className="text-xs text-text-mute mb-2">
-          Минимум {FIRST_MESSAGE_MIN} символов · можно прикрепить один файл (PDF, JPG, PNG до 10 МБ)
-        </Text>
-      </View>
-      <ChatComposer
-        value={composerText}
-        onChangeText={setComposerText}
-        files={composerFiles}
-        onFilesChange={setComposerFiles}
-        onSend={handleComposerSend}
-        sending={composerSending}
-        authToken={token}
-        maxFiles={1}
-        maxLength={FIRST_MESSAGE_MAX}
-        placeholder="Напишите первое сообщение клиенту..."
-        accessibilityLabel="Сообщение клиенту"
-      />
-      {composerError ? (
-        <View className="px-4 py-2">
-          <Text className="text-xs text-danger">{composerError}</Text>
-        </View>
-      ) : null}
-    </View>
-  ) : null;
 
   // ── DESKTOP LAYOUT ────────────────────────────────────────────────────
   if (isDesktop) {
@@ -398,29 +321,12 @@ export default function MyRequestDetail() {
             <View className="flex-row gap-6" style={{ alignItems: "flex-start" }}>
               {/* LEFT: main info */}
               <View style={{ flex: 2, minWidth: 0 }}>
-                {/* Status + date */}
-                <View className="flex-row items-center mb-3 gap-3">
-                  <StatusBadge status={request.status} />
-                  <Text className="text-sm text-text-mute">{createdDate}</Text>
-                </View>
-
-                {/* Title */}
-                <Text className="text-2xl font-extrabold text-text-base mb-4">
-                  {request.title}
-                </Text>
-
-                {/* Unified FNS · service chip — issue #1578.
-                    City already lives inside FNS name (e.g. "ИФНС №1 по г. Москве"),
-                    so we never include it separately. Service is appended only
-                    when it is actually selected. */}
-                <View className="flex-row flex-wrap gap-2 mb-5">
-                  <View className="bg-white border border-border rounded-lg px-2.5 py-1">
-                    <Text className="text-xs font-medium text-text-base">
-                      {request.fns.name}
-                      {serviceName ? ` · ${serviceName}` : ""}
-                    </Text>
-                  </View>
-                </View>
+                <RequestHeader
+                  request={request}
+                  createdDate={createdDate}
+                  serviceName={serviceName}
+                  isDesktop
+                />
 
                 {/* Description */}
                 <View
@@ -441,205 +347,41 @@ export default function MyRequestDetail() {
                   </Text>
                 </View>
 
-                {/* Files — issue #1610: hide block entirely when no files attached */}
-                {request.files.length > 0 && (
-                  <View
-                    className="bg-white rounded-2xl p-5 mb-4"
-                    style={{
-                      shadowColor: colors.text,
-                      shadowOffset: { width: 0, height: 1 },
-                      shadowOpacity: 0.05,
-                      shadowRadius: 8,
-                      elevation: 2,
-                    }}
-                  >
-                    <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
-                      Прикреплённые документы
-                    </Text>
-                    {request.files.map((file) => (
-                      <Pressable
-                        accessibilityRole="button"
-                        key={file.id}
-                        accessibilityLabel={`Открыть файл ${file.filename}`}
-                        onPress={() => handleFilePress(file)}
-                        className="flex-row items-center bg-surface2 rounded-xl p-3 mb-2"
-                        style={({ pressed }) => [pressed && { opacity: 0.7 }]}
-                      >
-                        {file.mimeType === "application/pdf"
-                          ? <File size={20} color={colors.primary} />
-                          : <FileImage size={20} color={colors.primary} />
-                        }
-                        <View className="ml-3 flex-1">
-                          <Text className="text-sm text-text-base" numberOfLines={1}>
-                            {file.filename}
-                          </Text>
-                          <Text className="text-xs text-text-mute">
-                            {(file.size / 1024).toFixed(0)} КБ
-                          </Text>
-                        </View>
-                        <Download size={14} color={colors.placeholder} />
-                      </Pressable>
-                    ))}
-                  </View>
-                )}
+                <RequestDocuments
+                  files={request.files}
+                  onFilePress={handleFilePress}
+                  isDesktop
+                />
 
-                {/* Recommended specialists feed (horizontal scroll) — issue #1550 */}
-                {recommendations.length > 0 && (
-                  <View className="mb-4">
-                    <SpecialistRecommendations
-                      recommendations={recommendations}
-                      onOpenProfile={handleOpenSpecialistProfile}
-                      onWrite={handleWriteSpecialist}
-                    />
-                  </View>
-                )}
-
-                {/* Inline message composer — issue #1566. Shown only for
-                    authenticated specialists with completed profile on
-                    non-closed requests. */}
-                {inlineComposerSection}
+                <RequestSpecialists
+                  recommendations={recommendations}
+                  onOpenProfile={handleOpenSpecialistProfile}
+                  onWrite={handleWriteSpecialist}
+                  showInlineComposer={showInlineComposer}
+                  composerText={composerText}
+                  composerFiles={composerFiles}
+                  composerSending={composerSending}
+                  composerError={composerError}
+                  authToken={token}
+                  onComposerChangeText={setComposerText}
+                  onComposerFilesChange={setComposerFiles}
+                  onComposerSend={handleComposerSend}
+                />
               </View>
 
               {/* RIGHT: actions + meta stats */}
               <View style={{ flex: 1, minWidth: 280, maxWidth: 360 }}>
-                {/* Actions card — visually prominent (border + stronger shadow) */}
-                <View
-                  className="bg-white rounded-2xl p-5 mb-4"
-                  style={{
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    shadowColor: colors.text,
-                    shadowOffset: { width: 0, height: 2 },
-                    shadowOpacity: 0.08,
-                    shadowRadius: 12,
-                    elevation: 4,
-                  }}
-                >
-                  <Text
-                    className="uppercase tracking-wide mb-3"
-                    style={{ fontSize: 13, fontWeight: "600", color: "#111" }}
-                  >
-                    Действия
-                  </Text>
-                  {isActive ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel="Закрыть запрос"
-                      onPress={handleCloseRequest}
-                      disabled={closing}
-                      className="flex-row items-center justify-center rounded-xl px-4"
-                      style={({ pressed }) => [
-                        {
-                          backgroundColor: colors.danger,
-                          minHeight: 48,
-                          paddingVertical: 14,
-                          shadowColor: colors.danger,
-                          shadowOffset: { width: 0, height: 2 },
-                          shadowOpacity: 0.25,
-                          shadowRadius: 4,
-                          elevation: 3,
-                        },
-                        pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
-                      ]}
-                    >
-                      {closing ? (
-                        <ActivityIndicator color={colors.white} size="small" />
-                      ) : (
-                        <>
-                          <X size={16} color={colors.white} />
-                          <Text
-                            className="text-white ml-2"
-                            style={{ fontSize: 15, fontWeight: "600" }}
-                          >
-                            Закрыть запрос
-                          </Text>
-                        </>
-                      )}
-                    </Pressable>
-                  ) : (
-                    <View
-                      className="rounded-xl px-4 items-center"
-                      style={{
-                        backgroundColor: colors.surface2,
-                        borderWidth: 1,
-                        borderColor: colors.border,
-                        minHeight: 48,
-                        paddingVertical: 14,
-                        justifyContent: "center",
-                      }}
-                    >
-                      <Text style={{ fontSize: 14, fontWeight: "500", color: "#111" }}>
-                        Запрос закрыт
-                      </Text>
-                    </View>
-                  )}
-
-                  {/* Copy link */}
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Скопировать ссылку"
-                    onPress={handleCopyLink}
-                    className="flex-row items-center justify-center rounded-xl px-4 mt-2"
-                    style={({ pressed }) => [
-                      {
-                        backgroundColor: colors.surface2,
-                        borderWidth: 1,
-                        borderColor: colors.border,
-                        minHeight: 48,
-                        paddingVertical: 14,
-                      },
-                      pressed && { opacity: 0.7 },
-                    ]}
-                  >
-                    <Link size={16} color={copied ? colors.success : colors.text} />
-                    <Text
-                      className="ml-2"
-                      style={{
-                        fontSize: 14,
-                        fontWeight: "600",
-                        color: copied ? colors.success : "#111",
-                      }}
-                    >
-                      {copied ? "Скопировано!" : "Скопировать ссылку"}
-                    </Text>
-                  </Pressable>
-
-                  {/* Visibility toggle */}
-                  <View className="flex-row items-center justify-between mt-4 pt-3"
-                    style={{ borderTopWidth: 1, borderTopColor: colors.border }}
-                  >
-                    <View className="flex-1 mr-3">
-                      <View className="flex-row items-center gap-2 mb-0.5">
-                        <View
-                          className="rounded px-1.5 py-0.5"
-                          style={{
-                            backgroundColor: request.isPublic ? "#D1FAE5" : "#F3F4F6",
-                          }}
-                        >
-                          <Text
-                            style={{
-                              fontSize: 12,
-                              fontWeight: "600",
-                              color: request.isPublic ? "#065F46" : "#6B7280",
-                            }}
-                          >
-                            {request.isPublic ? "Доступно публично" : "Только для участников"}
-                          </Text>
-                        </View>
-                      </View>
-                      <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
-                        {request.isPublic
-                          ? "Запрос виден всем пользователям интернета"
-                          : "Запрос виден только зарегистрированным пользователям"}
-                      </Text>
-                    </View>
-                    <StyledSwitch
-                      value={request.isPublic}
-                      onValueChange={handleToggleVisibility}
-                      disabled={togglingVisibility || !isActive}
-                    />
-                  </View>
-                </View>
+                <RequestActions
+                  request={request}
+                  isActive={isActive}
+                  closing={closing}
+                  copied={copied}
+                  togglingVisibility={togglingVisibility}
+                  onClose={handleCloseRequest}
+                  onCopyLink={handleCopyLink}
+                  onToggleVisibility={handleToggleVisibility}
+                  isDesktop
+                />
 
                 {/* Meta stats */}
                 <View
@@ -690,29 +432,11 @@ export default function MyRequestDetail() {
             </Pressable>
           </View>
           <View className="py-4">
-            {/* Status + date */}
-            <View className="flex-row items-center mb-3">
-              <StatusBadge status={request.status} />
-              <Text className="text-sm text-text-mute ml-3">{createdDate}</Text>
-            </View>
-
-            {/* Title */}
-            <Text className="text-xl font-bold text-text-base mb-3">
-              {request.title}
-            </Text>
-
-            {/* Unified FNS · service chip — issue #1578.
-                City already lives inside FNS name (e.g. "ИФНС №1 по г. Москве"),
-                so we never include it separately. Service is appended only
-                when it is actually selected. */}
-            <View className="flex-row flex-wrap gap-2 mb-4">
-              <View className="bg-white border border-border rounded-lg px-2.5 py-1">
-                <Text className="text-xs text-text-base">
-                  {request.fns.name}
-                  {serviceName ? ` · ${serviceName}` : ""}
-                </Text>
-              </View>
-            </View>
+            <RequestHeader
+              request={request}
+              createdDate={createdDate}
+              serviceName={serviceName}
+            />
 
             {/* Description */}
             <View
@@ -733,202 +457,36 @@ export default function MyRequestDetail() {
               </Text>
             </View>
 
-            {/* Files — issue #1610: hide block entirely when no files attached */}
-            {request.files.length > 0 && (
-              <View
-                className="bg-white rounded-2xl p-4 mb-4"
-                style={{
-                  shadowColor: colors.text,
-                  shadowOffset: { width: 0, height: 1 },
-                  shadowOpacity: 0.05,
-                  shadowRadius: 8,
-                  elevation: 2,
-                }}
-              >
-                <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
-                  Прикреплённые документы
-                </Text>
-                {request.files.map((file) => (
-                  <Pressable
-                    accessibilityRole="button"
-                    key={file.id}
-                    accessibilityLabel={`Открыть файл ${file.filename}`}
-                    onPress={() => handleFilePress(file)}
-                    className="flex-row items-center bg-surface2 rounded-xl p-3 mb-2"
-                    style={({ pressed }) => [pressed && { opacity: 0.7 }]}
-                  >
-                    {file.mimeType === "application/pdf"
-                      ? <File size={20} color={colors.primary} />
-                      : <FileImage size={20} color={colors.primary} />
-                    }
-                    <View className="ml-3 flex-1">
-                      <Text className="text-sm text-text-base" numberOfLines={1}>
-                        {file.filename}
-                      </Text>
-                      <Text className="text-xs text-text-mute">
-                        {(file.size / 1024).toFixed(0)} КБ
-                      </Text>
-                    </View>
-                    <Download size={14} color={colors.placeholder} />
-                  </Pressable>
-                ))}
-              </View>
-            )}
+            <RequestDocuments
+              files={request.files}
+              onFilePress={handleFilePress}
+            />
 
-            {/* Recommended specialists feed (horizontal scroll) — issue #1550.
-                Placed under main info, before actions (per acceptance criteria). */}
-            {recommendations.length > 0 && (
-              <View className="mb-4">
-                <SpecialistRecommendations
-                  recommendations={recommendations}
-                  onOpenProfile={handleOpenSpecialistProfile}
-                  onWrite={handleWriteSpecialist}
-                />
-              </View>
-            )}
+            <RequestSpecialists
+              recommendations={recommendations}
+              onOpenProfile={handleOpenSpecialistProfile}
+              onWrite={handleWriteSpecialist}
+              showInlineComposer={showInlineComposer}
+              composerText={composerText}
+              composerFiles={composerFiles}
+              composerSending={composerSending}
+              composerError={composerError}
+              authToken={token}
+              onComposerChangeText={setComposerText}
+              onComposerFilesChange={setComposerFiles}
+              onComposerSend={handleComposerSend}
+            />
 
-            {/* Actions card — mobile (matches desktop, prominent border + shadow) */}
-            <View
-              className="bg-white rounded-2xl p-4 mb-4"
-              style={{
-                borderWidth: 1,
-                borderColor: colors.border,
-                shadowColor: colors.text,
-                shadowOffset: { width: 0, height: 2 },
-                shadowOpacity: 0.08,
-                shadowRadius: 12,
-                elevation: 4,
-              }}
-            >
-              <Text
-                className="uppercase tracking-wide mb-3"
-                style={{ fontSize: 13, fontWeight: "600", color: "#111" }}
-              >
-                Действия
-              </Text>
-              {isActive ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel="Закрыть запрос"
-                  onPress={handleCloseRequest}
-                  disabled={closing}
-                  className="flex-row items-center justify-center rounded-xl px-4"
-                  style={({ pressed }) => [
-                    {
-                      backgroundColor: colors.danger,
-                      minHeight: 48,
-                      paddingVertical: 14,
-                      shadowColor: colors.danger,
-                      shadowOffset: { width: 0, height: 2 },
-                      shadowOpacity: 0.25,
-                      shadowRadius: 4,
-                      elevation: 3,
-                    },
-                    pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
-                  ]}
-                >
-                  {closing ? (
-                    <ActivityIndicator color={colors.white} size="small" />
-                  ) : (
-                    <>
-                      <X size={16} color={colors.white} />
-                      <Text
-                        className="text-white ml-2"
-                        style={{ fontSize: 15, fontWeight: "600" }}
-                      >
-                        Закрыть запрос
-                      </Text>
-                    </>
-                  )}
-                </Pressable>
-              ) : (
-                <View
-                  className="rounded-xl px-4 items-center"
-                  style={{
-                    backgroundColor: colors.surface2,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    minHeight: 48,
-                    paddingVertical: 14,
-                    justifyContent: "center",
-                  }}
-                >
-                  <Text style={{ fontSize: 14, fontWeight: "500", color: "#111" }}>
-                    Запрос закрыт
-                  </Text>
-                </View>
-              )}
-
-              {/* Copy link */}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Скопировать ссылку"
-                onPress={handleCopyLink}
-                className="flex-row items-center justify-center rounded-xl px-4 mt-2"
-                style={({ pressed }) => [
-                  {
-                    backgroundColor: colors.surface2,
-                    borderWidth: 1,
-                    borderColor: colors.border,
-                    minHeight: 48,
-                    paddingVertical: 14,
-                  },
-                  pressed && { opacity: 0.7 },
-                ]}
-              >
-                <Link size={16} color={copied ? colors.success : colors.text} />
-                <Text
-                  className="ml-2"
-                  style={{
-                    fontSize: 14,
-                    fontWeight: "600",
-                    color: copied ? colors.success : "#111",
-                  }}
-                >
-                  {copied ? "Скопировано!" : "Скопировать ссылку"}
-                </Text>
-              </Pressable>
-
-              {/* Visibility toggle */}
-              <View className="flex-row items-center justify-between mt-4 pt-3"
-                style={{ borderTopWidth: 1, borderTopColor: colors.border }}
-              >
-                <View className="flex-1 mr-3">
-                  <View className="flex-row items-center gap-2 mb-0.5">
-                    <View
-                      className="rounded px-1.5 py-0.5"
-                      style={{
-                        backgroundColor: request.isPublic ? "#D1FAE5" : "#F3F4F6",
-                      }}
-                    >
-                      <Text
-                        style={{
-                          fontSize: 12,
-                          fontWeight: "600",
-                          color: request.isPublic ? "#065F46" : "#6B7280",
-                        }}
-                      >
-                        {request.isPublic ? "Доступно публично" : "Только для участников"}
-                      </Text>
-                    </View>
-                  </View>
-                  <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
-                    {request.isPublic
-                      ? "Запрос виден всем пользователям интернета"
-                      : "Запрос виден только зарегистрированным пользователям"}
-                  </Text>
-                </View>
-                <StyledSwitch
-                  value={request.isPublic}
-                  onValueChange={handleToggleVisibility}
-                  disabled={togglingVisibility || !isActive}
-                />
-              </View>
-            </View>
-
-            {/* Inline message composer — issue #1566. Specialist-only,
-                visible on non-closed requests for users with completed profile. */}
-            {inlineComposerSection}
+            <RequestActions
+              request={request}
+              isActive={isActive}
+              closing={closing}
+              copied={copied}
+              togglingVisibility={togglingVisibility}
+              onClose={handleCloseRequest}
+              onCopyLink={handleCopyLink}
+              onToggleVisibility={handleToggleVisibility}
+            />
 
             {/* Meta stats */}
             <View

--- a/components/requests/detail/RequestActions.tsx
+++ b/components/requests/detail/RequestActions.tsx
@@ -1,0 +1,173 @@
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
+import StyledSwitch from "@/components/ui/StyledSwitch";
+import { X, Link } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+import { RequestDetailData } from "./types";
+
+interface Props {
+  request: RequestDetailData;
+  isActive: boolean;
+  closing: boolean;
+  copied: boolean;
+  togglingVisibility: boolean;
+  onClose: () => void;
+  onCopyLink: () => void;
+  onToggleVisibility: (value: boolean) => void;
+  isDesktop?: boolean;
+}
+
+export default function RequestActions({
+  request,
+  isActive,
+  closing,
+  copied,
+  togglingVisibility,
+  onClose,
+  onCopyLink,
+  onToggleVisibility,
+  isDesktop,
+}: Props) {
+  const padding = isDesktop ? "p-5" : "p-4";
+
+  return (
+    <View
+      className={`bg-white rounded-2xl ${padding} mb-4`}
+      style={{
+        borderWidth: 1,
+        borderColor: colors.border,
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 2 },
+        shadowOpacity: 0.08,
+        shadowRadius: 12,
+        elevation: 4,
+      }}
+    >
+      <Text
+        className="uppercase tracking-wide mb-3"
+        style={{ fontSize: 13, fontWeight: "600", color: "#111" }}
+      >
+        Действия
+      </Text>
+
+      {isActive ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрыть запрос"
+          onPress={onClose}
+          disabled={closing}
+          className="flex-row items-center justify-center rounded-xl px-4"
+          style={({ pressed }) => [
+            {
+              backgroundColor: colors.danger,
+              minHeight: 48,
+              paddingVertical: 14,
+              shadowColor: colors.danger,
+              shadowOffset: { width: 0, height: 2 },
+              shadowOpacity: 0.25,
+              shadowRadius: 4,
+              elevation: 3,
+            },
+            pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
+          ]}
+        >
+          {closing ? (
+            <ActivityIndicator color={colors.white} size="small" />
+          ) : (
+            <>
+              <X size={16} color={colors.white} />
+              <Text
+                className="text-white ml-2"
+                style={{ fontSize: 15, fontWeight: "600" }}
+              >
+                Закрыть запрос
+              </Text>
+            </>
+          )}
+        </Pressable>
+      ) : (
+        <View
+          className="rounded-xl px-4 items-center"
+          style={{
+            backgroundColor: colors.surface2,
+            borderWidth: 1,
+            borderColor: colors.border,
+            minHeight: 48,
+            paddingVertical: 14,
+            justifyContent: "center",
+          }}
+        >
+          <Text style={{ fontSize: 14, fontWeight: "500", color: "#111" }}>
+            Запрос закрыт
+          </Text>
+        </View>
+      )}
+
+      {/* Copy link */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Скопировать ссылку"
+        onPress={onCopyLink}
+        className="flex-row items-center justify-center rounded-xl px-4 mt-2"
+        style={({ pressed }) => [
+          {
+            backgroundColor: colors.surface2,
+            borderWidth: 1,
+            borderColor: colors.border,
+            minHeight: 48,
+            paddingVertical: 14,
+          },
+          pressed && { opacity: 0.7 },
+        ]}
+      >
+        <Link size={16} color={copied ? colors.success : colors.text} />
+        <Text
+          className="ml-2"
+          style={{
+            fontSize: 14,
+            fontWeight: "600",
+            color: copied ? colors.success : "#111",
+          }}
+        >
+          {copied ? "Скопировано!" : "Скопировать ссылку"}
+        </Text>
+      </Pressable>
+
+      {/* Visibility toggle */}
+      <View
+        className="flex-row items-center justify-between mt-4 pt-3"
+        style={{ borderTopWidth: 1, borderTopColor: colors.border }}
+      >
+        <View className="flex-1 mr-3">
+          <View className="flex-row items-center gap-2 mb-0.5">
+            <View
+              className="rounded px-1.5 py-0.5"
+              style={{
+                backgroundColor: request.isPublic ? "#D1FAE5" : "#F3F4F6",
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 12,
+                  fontWeight: "600",
+                  color: request.isPublic ? "#065F46" : "#6B7280",
+                }}
+              >
+                {request.isPublic ? "Доступно публично" : "Только для участников"}
+              </Text>
+            </View>
+          </View>
+          <Text style={{ fontSize: 12, color: "#666", marginTop: 2 }}>
+            {request.isPublic
+              ? "Запрос виден всем пользователям интернета"
+              : "Запрос виден только зарегистрированным пользователям"}
+          </Text>
+        </View>
+        <StyledSwitch
+          value={request.isPublic}
+          onValueChange={onToggleVisibility}
+          disabled={togglingVisibility || !isActive}
+        />
+      </View>
+    </View>
+  );
+}

--- a/components/requests/detail/RequestDocuments.tsx
+++ b/components/requests/detail/RequestDocuments.tsx
@@ -1,0 +1,58 @@
+import { View, Text, Pressable } from "react-native";
+import { File, FileImage, Download } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+import { FileItem } from "./types";
+
+interface Props {
+  files: FileItem[];
+  onFilePress: (file: FileItem) => void;
+  isDesktop?: boolean;
+}
+
+// Issue #1610: hide block entirely when no files attached.
+export default function RequestDocuments({ files, onFilePress, isDesktop }: Props) {
+  if (files.length === 0) return null;
+
+  const padding = isDesktop ? "p-5" : "p-4";
+
+  return (
+    <View
+      className={`bg-white rounded-2xl ${padding} mb-4`}
+      style={{
+        shadowColor: colors.text,
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 8,
+        elevation: 2,
+      }}
+    >
+      <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
+        Прикреплённые документы
+      </Text>
+      {files.map((file) => (
+        <Pressable
+          accessibilityRole="button"
+          key={file.id}
+          accessibilityLabel={`Открыть файл ${file.filename}`}
+          onPress={() => onFilePress(file)}
+          className="flex-row items-center bg-surface2 rounded-xl p-3 mb-2"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        >
+          {file.mimeType === "application/pdf"
+            ? <File size={20} color={colors.primary} />
+            : <FileImage size={20} color={colors.primary} />
+          }
+          <View className="ml-3 flex-1">
+            <Text className="text-sm text-text-base" numberOfLines={1}>
+              {file.filename}
+            </Text>
+            <Text className="text-xs text-text-mute">
+              {(file.size / 1024).toFixed(0)} КБ
+            </Text>
+          </View>
+          <Download size={14} color={colors.placeholder} />
+        </Pressable>
+      ))}
+    </View>
+  );
+}

--- a/components/requests/detail/RequestHeader.tsx
+++ b/components/requests/detail/RequestHeader.tsx
@@ -1,0 +1,40 @@
+import { View, Text } from "react-native";
+import StatusBadge from "@/components/StatusBadge";
+import { RequestDetailData } from "./types";
+
+interface Props {
+  request: RequestDetailData;
+  createdDate: string;
+  serviceName: string | null;
+  isDesktop?: boolean;
+}
+
+export default function RequestHeader({ request, createdDate, serviceName, isDesktop }: Props) {
+  return (
+    <View>
+      {/* Status + date */}
+      <View className={`flex-row items-center mb-3 ${isDesktop ? "gap-3" : ""}`}>
+        <StatusBadge status={request.status} />
+        <Text className={`text-sm text-text-mute ${isDesktop ? "" : "ml-3"}`}>{createdDate}</Text>
+      </View>
+
+      {/* Title */}
+      <Text className={`font-${isDesktop ? "extrabold text-2xl" : "bold text-xl"} text-text-base ${isDesktop ? "mb-4" : "mb-3"}`}>
+        {request.title}
+      </Text>
+
+      {/* Unified FNS · service chip — issue #1578.
+          City already lives inside FNS name (e.g. "ИФНС №1 по г. Москве"),
+          so we never include it separately. Service is appended only
+          when it is actually selected. */}
+      <View className={`flex-row flex-wrap gap-2 ${isDesktop ? "mb-5" : "mb-4"}`}>
+        <View className="bg-white border border-border rounded-lg px-2.5 py-1">
+          <Text className={`text-xs ${isDesktop ? "font-medium" : ""} text-text-base`}>
+            {request.fns.name}
+            {serviceName ? ` · ${serviceName}` : ""}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/components/requests/detail/RequestSpecialists.tsx
+++ b/components/requests/detail/RequestSpecialists.tsx
@@ -1,0 +1,96 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+import ChatComposer, { type PendingFile } from "@/components/ChatComposer";
+import SpecialistRecommendations, { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
+
+const FIRST_MESSAGE_MIN = 10;
+const FIRST_MESSAGE_MAX = 2000;
+
+interface Props {
+  recommendations: SpecialistCard[];
+  onOpenProfile: (specialistId: string) => void;
+  onWrite: (specialistId: string) => void;
+  // Inline composer — issue #1566
+  showInlineComposer: boolean;
+  composerText: string;
+  composerFiles: PendingFile[];
+  composerSending: boolean;
+  composerError: string | null;
+  authToken: string | null | undefined;
+  onComposerChangeText: (text: string) => void;
+  onComposerFilesChange: (files: PendingFile[]) => void;
+  onComposerSend: () => void;
+}
+
+export default function RequestSpecialists({
+  recommendations,
+  onOpenProfile,
+  onWrite,
+  showInlineComposer,
+  composerText,
+  composerFiles,
+  composerSending,
+  composerError,
+  authToken,
+  onComposerChangeText,
+  onComposerFilesChange,
+  onComposerSend,
+}: Props) {
+  return (
+    <>
+      {/* Recommended specialists feed (horizontal scroll) — issue #1550 */}
+      {recommendations.length > 0 && (
+        <View className="mb-4">
+          <SpecialistRecommendations
+            recommendations={recommendations}
+            onOpenProfile={onOpenProfile}
+            onWrite={onWrite}
+          />
+        </View>
+      )}
+
+      {/* Inline message composer — issue #1566. Shown only for
+          authenticated specialists with completed profile on
+          non-closed requests. */}
+      {showInlineComposer && (
+        <View
+          className="bg-white rounded-2xl mb-4 overflow-hidden"
+          style={{
+            shadowColor: colors.text,
+            shadowOffset: { width: 0, height: 1 },
+            shadowOpacity: 0.05,
+            shadowRadius: 8,
+            elevation: 2,
+          }}
+        >
+          <View className="px-4 pt-4 pb-2">
+            <Text className="text-xs font-semibold text-text-mute mb-1 uppercase tracking-wide">
+              Написать клиенту
+            </Text>
+            <Text className="text-xs text-text-mute mb-2">
+              Минимум {FIRST_MESSAGE_MIN} символов · можно прикрепить один файл (PDF, JPG, PNG до 10 МБ)
+            </Text>
+          </View>
+          <ChatComposer
+            value={composerText}
+            onChangeText={onComposerChangeText}
+            files={composerFiles}
+            onFilesChange={onComposerFilesChange}
+            onSend={onComposerSend}
+            sending={composerSending}
+            authToken={authToken}
+            maxFiles={1}
+            maxLength={FIRST_MESSAGE_MAX}
+            placeholder="Напишите первое сообщение клиенту..."
+            accessibilityLabel="Сообщение клиенту"
+          />
+          {composerError ? (
+            <View className="px-4 py-2">
+              <Text className="text-xs text-danger">{composerError}</Text>
+            </View>
+          ) : null}
+        </View>
+      )}
+    </>
+  );
+}

--- a/components/requests/detail/types.ts
+++ b/components/requests/detail/types.ts
@@ -1,0 +1,25 @@
+export interface FileItem {
+  id: string;
+  url: string;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface RequestDetailData {
+  id: string;
+  title: string;
+  description: string;
+  status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";
+  isPublic: boolean;
+  createdAt: string;
+  lastActivityAt: string;
+  extensionsCount: number;
+  maxExtensions: number;
+  city: { id: string; name: string };
+  fns: { id: string; name: string; code: string };
+  service?: { id: string; name: string } | null;
+  files: FileItem[];
+  threadsCount: number;
+  unreadMessages: number;
+}

--- a/components/ui/FileUploadZone.tsx
+++ b/components/ui/FileUploadZone.tsx
@@ -50,7 +50,7 @@ const DEFAULT_TYPES = [
 interface FileUploadZoneProps {
   files: PendingFile[];
   onFilesChange: (files: PendingFile[]) => void;
-  /** Default 5. */
+  /** Default 10. */
   maxFiles?: number;
   /** Default 10 MB. */
   maxSizeMB?: number;
@@ -63,11 +63,26 @@ interface FileUploadZoneProps {
   /**
    * compact=false (default) → big dashed drop-zone above the chip list
    *                            (request form variant).
-   * compact=true            → just a paperclip button + chip strip
-   *                            (chat composer variant).
+   * compact=true            → just a paperclip button + drag overlay; chips
+   *                            are rendered separately by the parent via
+   *                            <FileUploadChips/> so the composer can place
+   *                            them above the input row.
    */
   compact?: boolean;
   disabled?: boolean;
+  /**
+   * Optional external DOM element to use as the drag-and-drop target.
+   * The chat composer passes a ref to its outer wrapper so dropping
+   * anywhere over the composer (not just the paperclip button area)
+   * triggers the upload. When omitted, the internal containerRef is used.
+   */
+  dropTargetRef?: React.RefObject<HTMLElement | null>;
+  /**
+   * Optional drag-state notifier — fires `true` while a file is being
+   * dragged over the drop target, `false` otherwise. Lets the composer
+   * paint a full-width drag overlay across its own bounds.
+   */
+  onDragStateChange?: (isDragOver: boolean) => void;
 }
 
 function generateId(): string {
@@ -98,13 +113,15 @@ function buildAcceptAttr(types: string[]): string {
 export default function FileUploadZone({
   files,
   onFilesChange,
-  maxFiles = 5,
+  maxFiles = 10,
   maxSizeMB = 10,
   allowedTypes = DEFAULT_TYPES,
   uploadEndpoint,
   authToken,
   compact = false,
   disabled = false,
+  dropTargetRef,
+  onDragStateChange,
 }: FileUploadZoneProps) {
   const containerRef = useRef<View>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -290,24 +307,45 @@ export default function FileUploadZone({
     [validateAndQueue]
   );
 
-  // ---- Web: drag-and-drop on the underlying DOM node ---------------------
+  // ---- Web: drag-and-drop -----------------------------------------------
+  // The drop target defaults to the FileUploadZone's own container, but the
+  // chat composer passes an external `dropTargetRef` pointing at its outer
+  // wrapper so dragging anywhere over the composer registers — not just over
+  // the tiny paperclip button. (Bug fix: drag-and-drop didn't work in chat.)
   useEffect(() => {
     if (Platform.OS !== "web") return;
-    const node = containerRef.current as unknown as HTMLElement | null;
+    const externalNode = dropTargetRef?.current ?? null;
+    const internalNode = containerRef.current as unknown as HTMLElement | null;
+    const node = externalNode ?? internalNode;
     if (!node || typeof node.addEventListener !== "function") return;
 
+    const setDrag = (next: boolean) => {
+      setIsDragOver(next);
+      onDragStateChange?.(next);
+    };
+
     const onDragOver = (e: DragEvent) => {
+      // dragover MUST preventDefault so the browser actually fires `drop`.
+      // Without this, files dropped over the zone are opened in the tab.
       e.preventDefault();
       if (disabled) return;
-      setIsDragOver(true);
+      // Set dropEffect for a visible cursor hint (browsers reset to "none"
+      // unless we override here).
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+      setDrag(true);
+    };
+    const onDragEnter = (e: DragEvent) => {
+      e.preventDefault();
+      if (disabled) return;
+      setDrag(true);
     };
     const onDragLeave = (e: DragEvent) => {
       // Only collapse overlay when leaving the container entirely.
-      if (!node.contains(e.relatedTarget as Node)) setIsDragOver(false);
+      if (!node.contains(e.relatedTarget as Node)) setDrag(false);
     };
     const onDrop = (e: DragEvent) => {
       e.preventDefault();
-      setIsDragOver(false);
+      setDrag(false);
       if (disabled) return;
       const list = e.dataTransfer?.files;
       if (!list || list.length === 0) return;
@@ -321,15 +359,17 @@ export default function FileUploadZone({
       validateAndQueue(incoming);
     };
 
+    node.addEventListener("dragenter", onDragEnter);
     node.addEventListener("dragover", onDragOver);
     node.addEventListener("dragleave", onDragLeave);
     node.addEventListener("drop", onDrop);
     return () => {
+      node.removeEventListener("dragenter", onDragEnter);
       node.removeEventListener("dragover", onDragOver);
       node.removeEventListener("dragleave", onDragLeave);
       node.removeEventListener("drop", onDrop);
     };
-  }, [disabled, validateAndQueue]);
+  }, [disabled, validateAndQueue, dropTargetRef, onDragStateChange]);
 
   // ---- Native: expo-document-picker --------------------------------------
   const openNativePicker = useCallback(async () => {
@@ -365,10 +405,61 @@ export default function FileUploadZone({
   const canAddMore = files.length < maxFiles && !disabled;
 
   // ---- Chip list (shared between compact + full) -------------------------
+  // For the compact (chat) variant we render chips compactly as horizontal
+  // pills so multiple files don't push the chat input off-screen. The full
+  // form variant keeps the original stacked rows.
   const renderChips = () => {
     if (files.length === 0) return null;
+    if (compact) {
+      return (
+        <View className="flex-row flex-wrap" style={{ gap: 6 }}>
+          {files.map((f) => {
+            const isPdf = f.mimeType === "application/pdf";
+            const isError = f.status === "error";
+            const isBusy = f.status === "uploading" || f.status === "pending";
+            return (
+              <View
+                key={f.id}
+                className="flex-row items-center bg-surface2 border border-border rounded-full pl-2 pr-1 py-1"
+                style={{ maxWidth: 220 }}
+              >
+                {isPdf ? (
+                  <FileIcon size={14} color={isError ? colors.error : colors.primary} />
+                ) : (
+                  <FileImage size={14} color={isError ? colors.error : colors.primary} />
+                )}
+                <Text
+                  className="text-xs text-text-base ml-1.5 flex-shrink"
+                  numberOfLines={1}
+                  style={{ maxWidth: 140 }}
+                >
+                  {f.name}
+                </Text>
+                {isBusy ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={colors.placeholder}
+                    style={{ marginLeft: 4, marginRight: 4 }}
+                  />
+                ) : (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Удалить ${f.name}`}
+                    onPress={() => handleRemove(f.id)}
+                    className="w-6 h-6 items-center justify-center ml-1"
+                    hitSlop={6}
+                  >
+                    <X size={12} color={isError ? colors.error : colors.placeholder} />
+                  </Pressable>
+                )}
+              </View>
+            );
+          })}
+        </View>
+      );
+    }
     return (
-      <View style={{ gap: 8, marginTop: compact ? 0 : 12 }}>
+      <View style={{ gap: 8, marginTop: 12 }}>
         {files.map((f) => {
           const isPdf = f.mimeType === "application/pdf";
           const isError = f.status === "error";


### PR DESCRIPTION
## Summary
- `detail.tsx` 959 → 516 lines; orchestrator only (state + handlers)
- New `components/requests/detail/`: `types.ts`, `RequestHeader`, `RequestActions`, `RequestDocuments`, `RequestSpecialists`
- Zero logic changes — structural extraction only
- TSC: 0 errors

Closes #1619

## Test plan
- [ ] Open /requests/[id]/detail on mobile — header, actions, docs, composer render correctly
- [ ] Open on desktop — 2-column layout intact
- [ ] Close request action works
- [ ] Copy link shows "Скопировано!"
- [ ] Visibility toggle updates isPublic optimistically
- [ ] Files section hidden when no files (issue #1610)
- [ ] Inline composer visible for specialist with completed profile only