### PR TITLE
seed: expand test data +25 specialists +20 requests +13 saved (#1625)

### DIFF
--- a/api/prisma/seed-specialists.ts
+++ b/api/prisma/seed-specialists.ts
@@ -8,6 +8,9 @@
  * fills the DB with realistic tax-service data so screens render like
  * production instead of showing "0 запросов / 0 специалистов".
  *
+ * Issue #1625: expanded with +25 specialists, +20 requests, +15 threads,
+ * +13 saved-specialists for serter2069@gmail.com.
+ *
  * Dev test account MUST stay first:
  *   serter2069@gmail.com / Сергей Тертышный — role=USER, isSpecialist=false
  *   (post-Iter11 unification: no more CLIENT/SPECIALIST roles).
@@ -291,6 +294,364 @@ const SPECIALISTS: Array<{
   },
 ];
 
+// ─── EXTRA SPECIALISTS (Issue #1625, +25) ────────────────────────────
+// These duplicate the structure of SPECIALISTS above but with new
+// names / emails / cities so the catalog looks populated.
+
+const EXTRA_SPECIALISTS: typeof SPECIALISTS = [
+  {
+    email: "boris.sergeev@p2ptax-seed.ru",
+    firstName: "Борис",
+    lastName: "Сергеев",
+    avatarUrl: "https://i.pravatar.cc/150?u=BorisSergeyev",
+    description: "Налоговый консультант по P2P-операциям с 7-летним опытом. Специализируюсь на защите клиентов при камеральных проверках, связанных с доходами от криптовалюты на Binance и Bybit. Работаю дистанционно, первичная консультация бесплатно.",
+    fnsCodes: ["7710", "7715"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (495) 121-01-01",
+    telegram: "@sergeev_tax",
+    officeAddress: "Москва, Большая Тульская ул., 15, офис 201",
+    workingHours: "Пн-Пт, 10:00-19:00",
+    yearsOfExperience: 7,
+    specializations: ["Камеральные проверки по крипте", "P2P-операции", "Ответы на требования ИФНС"],
+  },
+  {
+    email: "tatyana.kulikova@p2ptax-seed.ru",
+    firstName: "Татьяна",
+    lastName: "Куликова",
+    avatarUrl: "https://i.pravatar.cc/150?u=TatyanKulikova",
+    description: "Эксперт по НДФЛ физических лиц и ИП. 9 лет практики в Москве. Консультирую по декларациям 3-НДФЛ, сопровождаю камеральные проверки. Работаю с трейдерами, инвесторами и фрилансерами.",
+    fnsCodes: ["7720", "7721"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (495) 121-02-02",
+    telegram: "@kulikova_ndfl",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 9,
+  },
+  {
+    email: "alexei.zaharov@p2ptax-seed.ru",
+    firstName: "Алексей",
+    lastName: "Захаров",
+    avatarUrl: "https://i.pravatar.cc/150?u=AlexeyZaharov",
+    description: "Бывший налоговый инспектор ФНС, 12 лет стажа. Досконально знаю процедуры выездных проверок и помогаю клиентам пройти их без доначислений. Веду дела по всей Москве.",
+    fnsCodes: ["7722", "7723"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка"],
+    phone: "+7 (495) 121-03-03",
+    telegram: "@zaharov_fns",
+    officeAddress: "Москва, 1-й Дербеневский пер., 6",
+    workingHours: "Пн-Сб, 10:00-20:00",
+    exFnsStartYear: 2010,
+    exFnsEndYear: 2022,
+    yearsOfExperience: 14,
+    specializations: ["Выездные проверки", "Сопровождение на допросах"],
+  },
+  {
+    email: "svetlana.petrova@p2ptax-seed.ru",
+    firstName: "Светлана",
+    lastName: "Петрова",
+    avatarUrl: "https://i.pravatar.cc/150?u=SvetlanaPetrova",
+    description: "Налоговый юрист, специализирующийся на зарубежных активах и КИК. Помогаю с уведомлениями об открытии зарубежных счетов, декларациями по КИК, валютным контролем. 6 лет практики.",
+    fnsCodes: ["7724", "7725"],
+    serviceNames: ["Камеральная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (495) 121-04-04",
+    telegram: "@petrova_offshore",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 6,
+  },
+  {
+    email: "igor.kuznetsov@p2ptax-seed.ru",
+    firstName: "Игорь",
+    lastName: "Кузнецов",
+    avatarUrl: "https://i.pravatar.cc/150?u=IgorKuznetsov",
+    description: "Налоговый адвокат, 11 лет практики в арбитражных судах. Оспариваю решения ИФНС в досудебном и судебном порядке. Статистика: 75% дел полностью выиграно. Работаю в Москве и Подмосковье.",
+    fnsCodes: ["7726", "7727"],
+    serviceNames: ["Выездная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (495) 121-05-05",
+    telegram: "@kuznetsov_advocate",
+    officeAddress: "Москва, Вавилова ул., 69а, офис 310",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    yearsOfExperience: 11,
+  },
+  {
+    email: "maria.voronova@p2ptax-seed.ru",
+    firstName: "Мария",
+    lastName: "Воронова",
+    avatarUrl: "https://i.pravatar.cc/150?u=MariaVoronova",
+    description: "Налоговый консультант по самозанятым и ИП. Помогаю разобраться с налоговым режимом, составляю декларации 3-НДФЛ, консультирую по вопросам совмещения статусов. Работаю в Санкт-Петербурге и дистанционно.",
+    fnsCodes: ["7804", "7807"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (812) 241-06-06",
+    telegram: "@voronova_spb",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 5,
+  },
+  {
+    email: "andrei.belikov@p2ptax-seed.ru",
+    firstName: "Андрей",
+    lastName: "Беликов",
+    avatarUrl: "https://i.pravatar.cc/150?u=AndreyBelikov",
+    description: "Специалист по налоговым спорам в Санкт-Петербурге. 8 лет опыта представления интересов клиентов в УФНС и арбитражных судах. Специализация — выездные проверки ИП и ООО.",
+    fnsCodes: ["7808", "7809"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (812) 241-07-07",
+    telegram: "@belikov_spb",
+    officeAddress: "Санкт-Петербург, Миллионная ул., 34",
+    workingHours: "Пн-Пт, 10:00-19:00",
+    yearsOfExperience: 8,
+  },
+  {
+    email: "olga.nikiforova@p2ptax-seed.ru",
+    firstName: "Ольга",
+    lastName: "Никифорова",
+    avatarUrl: "https://i.pravatar.cc/150?u=OlgaNikiforova",
+    description: "Сертифицированный бухгалтер и налоговый консультант. Работаю с физлицами и ИП на разных системах налогообложения. Помогаю заполнить 3-НДФЛ, составить возражения на акты проверок.",
+    fnsCodes: ["7812", "7815"],
+    serviceNames: ["Камеральная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (812) 241-08-08",
+    telegram: "@nikiforova_tax",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 10,
+  },
+  {
+    email: "pavel.sidorov@p2ptax-seed.ru",
+    firstName: "Павел",
+    lastName: "Сидоров",
+    avatarUrl: "https://i.pravatar.cc/150?u=PavelSidorov",
+    description: "Налоговый консультант с 6-летним опытом. Специализируюсь на операциях с криптовалютой в Новосибирске. Помогаю правильно задекларировать доходы, пройти камеральные проверки.",
+    fnsCodes: ["5405", "5412"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (383) 201-09-09",
+    telegram: "@sidorov_nsk",
+    officeAddress: "Новосибирск, Мясниковой ул., 9",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 6,
+  },
+  {
+    email: "irina.noskova@p2ptax-seed.ru",
+    firstName: "Ирина",
+    lastName: "Носкова",
+    avatarUrl: "https://i.pravatar.cc/150?u=IrinaNoskova",
+    description: "Налоговый аналитик по зарубежным инвестициям. Консультирую по декларированию доходов от зарубежных брокеров (IBKR, Exante). Работаю в Новосибирске и дистанционно.",
+    fnsCodes: ["5413", "5416"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (383) 201-10-10",
+    telegram: "@noskova_invest",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 7,
+  },
+  {
+    email: "mikhail.drozdov@p2ptax-seed.ru",
+    firstName: "Михаил",
+    lastName: "Дроздов",
+    avatarUrl: "https://i.pravatar.cc/150?u=MikhailDrozdov",
+    description: "Налоговый юрист с 13-летним опытом в Екатеринбурге. Специализация — выездные проверки ООО и ИП, обжалование доначислений в УФНС и арбитражных судах. Веду дела под ключ.",
+    fnsCodes: ["6605", "6606"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка"],
+    phone: "+7 (343) 201-11-11",
+    telegram: "@drozdov_ekb",
+    officeAddress: "Екатеринбург, Вилонова ул., 32",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    exFnsStartYear: 2008,
+    exFnsEndYear: 2019,
+    yearsOfExperience: 13,
+    specializations: ["Выездные проверки ООО", "Обжалование в УФНС"],
+  },
+  {
+    email: "natalia.shevchenko@p2ptax-seed.ru",
+    firstName: "Наталья",
+    lastName: "Шевченко",
+    avatarUrl: "https://i.pravatar.cc/150?u=NataliaShevchenko",
+    description: "Налоговый консультант, бывший инспектор ФНС Екатеринбурга. Сопровождаю налоговые проверки от начала до обжалования акта. Специализация — камеральные проверки физлиц.",
+    fnsCodes: ["6607", "6608"],
+    serviceNames: ["Камеральная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (343) 201-12-12",
+    telegram: "@shevchenko_ekb",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    exFnsStartYear: 2012,
+    exFnsEndYear: 2021,
+    yearsOfExperience: 12,
+  },
+  {
+    email: "sergey.titov@p2ptax-seed.ru",
+    firstName: "Сергей",
+    lastName: "Титов",
+    avatarUrl: "https://i.pravatar.cc/150?u=SergeyTitov",
+    description: "Налоговый юрист по криптовалютным операциям в Казани. Помогаю составить декларации 3-НДФЛ, ответить на требования ИФНС, пройти камеральную проверку. 8 лет практики.",
+    fnsCodes: ["1605", "1606"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (843) 201-13-13",
+    telegram: "@titov_kzn",
+    officeAddress: "Казань, Баумана ул., 53",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 8,
+  },
+  {
+    email: "anna.lukina@p2ptax-seed.ru",
+    firstName: "Анна",
+    lastName: "Лукина",
+    avatarUrl: "https://i.pravatar.cc/150?u=AnnaLukina",
+    description: "Налоговый консультант для трейдеров и инвесторов. Помогаю правильно рассчитать НДФЛ по операциям на MOEX, зарубежных брокерах, криптовалютных биржах. 5 лет практики в Нижнем Новгороде.",
+    fnsCodes: ["5262", "5263"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (831) 201-14-14",
+    telegram: "@lukina_nn",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 5,
+  },
+  {
+    email: "dmitry.savelyev@p2ptax-seed.ru",
+    firstName: "Дмитрий",
+    lastName: "Савельев",
+    avatarUrl: "https://i.pravatar.cc/150?u=DmitrySavelyev",
+    description: "Специалист ОКК по вопросам ККТ и маркировки. Помогаю предпринимателям подготовиться к проверке, оспорить штрафы, наладить учёт в соответствии с требованиями ФНС. 9 лет опыта в Нижнем Новгороде.",
+    fnsCodes: ["5264", "5215"],
+    serviceNames: ["Отдел оперативного контроля", "Выездная проверка"],
+    phone: "+7 (831) 201-15-15",
+    telegram: "@savelyev_okk",
+    officeAddress: "Нижний Новгород, Адмирала Нахимова ул., 12",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    yearsOfExperience: 9,
+  },
+  {
+    email: "elena.sorokina@p2ptax-seed.ru",
+    firstName: "Елена",
+    lastName: "Сорокина",
+    avatarUrl: "https://i.pravatar.cc/150?u=ElenaSorokina",
+    description: "Налоговый консультант по НДФЛ для самозанятых и ИП в Челябинске. Разбираюсь в нюансах совмещения режимов налогообложения, помогаю с декларациями и возражениями на акты.",
+    fnsCodes: ["7453", "7454"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (351) 201-16-16",
+    telegram: "@sorokina_chel",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 6,
+  },
+  {
+    email: "roman.polezhaev@p2ptax-seed.ru",
+    firstName: "Роман",
+    lastName: "Полежаев",
+    avatarUrl: "https://i.pravatar.cc/150?u=RomanPolezhaev",
+    description: "Бывший инспектор ИФНС Челябинска, 10 лет стажа. Помогаю бизнесу пройти выездные проверки без лишних доначислений. Знаю все нюансы процедуры изнутри.",
+    fnsCodes: ["7455", "7456"],
+    serviceNames: ["Выездная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (351) 201-17-17",
+    telegram: "@polezhaev_chel",
+    officeAddress: "Челябинск, Победы пр., 39",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    exFnsStartYear: 2011,
+    exFnsEndYear: 2021,
+    yearsOfExperience: 13,
+  },
+  {
+    email: "tatyana.vlasova@p2ptax-seed.ru",
+    firstName: "Татьяна",
+    lastName: "Власова",
+    avatarUrl: "https://i.pravatar.cc/150?u=TatyanaVlasova",
+    description: "Налоговый консультант по зарубежным инвесторам и КИК в Самаре. Помогаю с уведомлениями об открытии счётов, отчётами о движении средств, декларациями по КИК. 7 лет практики.",
+    fnsCodes: ["6313", "6314"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (846) 201-18-18",
+    telegram: "@vlasova_samara",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 7,
+  },
+  {
+    email: "viktor.naumov@p2ptax-seed.ru",
+    firstName: "Виктор",
+    lastName: "Наумов",
+    avatarUrl: "https://i.pravatar.cc/150?u=ViktorNaumov",
+    description: "Налоговый адвокат по спорам с ИФНС в Самаре. Специализируюсь на выездных проверках ИП и ООО. Провёл 80+ успешных дел. Работаю по всему ПФО.",
+    fnsCodes: ["6318", "6319"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (846) 201-19-19",
+    telegram: "@naumov_samara",
+    officeAddress: "Самара, Революционная ул., 73",
+    workingHours: "Пн-Пт, 10:00-19:00",
+    yearsOfExperience: 11,
+  },
+  {
+    email: "svetlana.abdullina@p2ptax-seed.ru",
+    firstName: "Светлана",
+    lastName: "Абдуллина",
+    avatarUrl: "https://i.pravatar.cc/150?u=SvetlanaAbdullina",
+    description: "Налоговый консультант по P2P-операциям в Уфе. 5 лет практики, специализация — камеральные проверки физлиц и ответы на требования ИФНС по операциям с криптовалютой.",
+    fnsCodes: ["0203", "0220"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (347) 201-20-20",
+    telegram: "@abdullina_ufa",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 5,
+  },
+  {
+    email: "yuriy.kondratyev@p2ptax-seed.ru",
+    firstName: "Юрий",
+    lastName: "Кондратьев",
+    avatarUrl: "https://i.pravatar.cc/150?u=YuriyKondratyev",
+    description: "Бывший советник государственной гражданской службы УФНС Башкортостана. Знаю процедуры обжалования изнутри. Помогаю клиентам из Уфы и регионов оспорить доначисления в вышестоящих органах.",
+    fnsCodes: ["0239", "0201"],
+    serviceNames: ["Выездная проверка", "Отдел оперативного контроля"],
+    phone: "+7 (347) 201-21-21",
+    telegram: "@kondratyev_ufa",
+    officeAddress: "Уфа, Пушкина ул., 95",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    exFnsStartYear: 2009,
+    exFnsEndYear: 2020,
+    yearsOfExperience: 15,
+  },
+  {
+    email: "anna.gromova@p2ptax-seed.ru",
+    firstName: "Анна",
+    lastName: "Громова",
+    avatarUrl: "https://i.pravatar.cc/150?u=AnnaGromova",
+    description: "Налоговый консультант по НДФЛ инвесторов в Красноярске. Работаю с трейдерами и владельцами криптоактивов. Составляю декларации 3-НДФЛ, помогаю пройти камеральные проверки.",
+    fnsCodes: ["2461", "2462"],
+    serviceNames: ["Камеральная проверка"],
+    phone: "+7 (391) 201-22-22",
+    telegram: "@gromova_krsk",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 6,
+  },
+  {
+    email: "aleksei.nesterov@p2ptax-seed.ru",
+    firstName: "Алексей",
+    lastName: "Нестеров",
+    avatarUrl: "https://i.pravatar.cc/150?u=AlekseyNesterov",
+    description: "Налоговый юрист, специализирующийся на выездных проверках в Красноярске. 10 лет практики, успешно оспорил 60+ решений ИФНС в арбитражных судах Сибири.",
+    fnsCodes: ["2463", "2464"],
+    serviceNames: ["Выездная проверка", "Камеральная проверка"],
+    phone: "+7 (391) 201-23-23",
+    telegram: "@nesterov_krsk",
+    officeAddress: "Красноярск, Партизана Железняка ул., 46",
+    workingHours: "Пн-Пт, 9:00-19:00",
+    yearsOfExperience: 10,
+  },
+  {
+    email: "tatyana.shaposhnikova@p2ptax-seed.ru",
+    firstName: "Татьяна",
+    lastName: "Шапошникова",
+    avatarUrl: "https://i.pravatar.cc/150?u=TatyanaShaposhnikova",
+    description: "Сертифицированный налоговый консультант Палаты, 8 лет опыта. Специализация — ОКК, ККТ, маркировка. Работаю в Красноярске и дистанционно по Сибири.",
+    fnsCodes: ["2422", "2423"],
+    serviceNames: ["Отдел оперативного контроля", "Камеральная проверка"],
+    phone: "+7 (391) 201-24-24",
+    telegram: "@shaposhnikova_krsk",
+    workingHours: "Пн-Пт, 10:00-18:00",
+    yearsOfExperience: 8,
+  },
+  {
+    email: "dmitry.romanov@p2ptax-seed.ru",
+    firstName: "Дмитрий",
+    lastName: "Романов",
+    avatarUrl: "https://i.pravatar.cc/150?u=DmitryRomanov",
+    description: "Налоговый консультант по зарубежным активам и криптовалюте в Красноярске. Помогаю с КИК, зарубежными счетами, декларированием доходов от DeFi-протоколов. 7 лет практики.",
+    fnsCodes: ["2424", "2461"],
+    serviceNames: ["Камеральная проверка", "Выездная проверка"],
+    phone: "+7 (391) 201-25-25",
+    telegram: "@romanov_krsk",
+    officeAddress: "Красноярск, Мате Залки ул., 1а",
+    workingHours: "Пн-Пт, 9:00-18:00",
+    yearsOfExperience: 7,
+  },
+];
+
 // ─── Helpers for generating realistic cases ──────────────
 
 function generateCasesForSpecialist(
@@ -519,6 +880,171 @@ const REQUEST_SCENARIOS: Array<{
   },
 ];
 
+// ─── EXTRA REQUEST SCENARIOS (Issue #1625, +20) ──────────────────────
+
+const EXTRA_REQUEST_SCENARIOS: typeof REQUEST_SCENARIOS = [
+  {
+    title: "Налоговый вычет при покупке квартиры",
+    description: "Купил квартиру в 2023 за 4.5 млн. Хочу получить имущественный вычет. Нужна помощь с подготовкой документов и подачей декларации 3-НДФЛ.",
+    fnsCode: "7728",
+    status: "ACTIVE",
+    daysAgo: 3,
+    threadCount: 2,
+  },
+  {
+    title: "Доначисление по ИП на патенте — ИФНС №21",
+    description: "ИФНС выставила требование об уплате доначислений по ИП на патентной системе. Считаю, что суммы завышены. Нужна помощь с возражением.",
+    fnsCode: "7721",
+    status: "ACTIVE",
+    daysAgo: 6,
+    threadCount: 3,
+  },
+  {
+    title: "Стейкинг и DeFi — как считать НДФЛ?",
+    description: "Получаю доход от стейкинга ETH и участия в пулах ликвидности Uniswap. Не понимаю как правильно рассчитать налоговую базу. Нужна консультация.",
+    fnsCode: "7715",
+    status: "ACTIVE",
+    daysAgo: 1,
+    threadCount: 2,
+  },
+  {
+    title: "Блокировка р/с по 115-ФЗ в Сбербанке",
+    description: "Сбербанк заблокировал расчётный счёт ИП из-за транзитных операций. Оборот за последние 3 месяца — 3.8 млн. Нужна помощь с подготовкой пояснений.",
+    fnsCode: "7730",
+    status: "ACTIVE",
+    daysAgo: 2,
+    threadCount: 3,
+  },
+  {
+    title: "Консультация по смене налогового резидентства",
+    description: "Планирую переехать в ОАЭ и работать удалённо. Хочу разобраться, как законно минимизировать налоговую нагрузку при смене резидентства. Клиенты в России и ЕС.",
+    fnsCode: "7714",
+    status: "ACTIVE",
+    daysAgo: 4,
+    threadCount: 2,
+  },
+  {
+    title: "Ответ на требование по НДС — ООО на ОСНО",
+    description: "Пришло требование о предоставлении документов по операциям с НДС за 3 квартал 2024. Срок ответа — 10 дней. Нужна помощь с подготовкой пакета документов.",
+    fnsCode: "7709",
+    status: "ACTIVE",
+    daysAgo: 3,
+    threadCount: 2,
+  },
+  {
+    title: "Обжалование штрафа по НДФЛ — физлицо",
+    description: "ИФНС насчитала штраф за несвоевременную подачу декларации 3-НДФЛ. Штраф 12 500 руб. Считаю, что срок не пропущен, есть подтверждение отправки. Нужна помощь с жалобой.",
+    fnsCode: "7710",
+    status: "ACTIVE",
+    daysAgo: 5,
+    threadCount: 1,
+  },
+  {
+    title: "Выездная проверка ООО — подготовка за 2 месяца",
+    description: "Получили решение о выездной проверке, период 2022-2024. ООО на ОСНО, оборот 180 млн/год. Нужен опытный консультант для аудита документов и сопровождения проверки.",
+    fnsCode: "7808",
+    status: "ACTIVE",
+    daysAgo: 10,
+    threadCount: 4,
+  },
+  {
+    title: "Декларирование NFT — что считается доходом?",
+    description: "Продал несколько NFT на OpenSea, итого около 800 тысяч рублей. Не понимаю как правильно отразить доход в декларации. Нужна разовая консультация.",
+    fnsCode: "7716",
+    status: "ACTIVE",
+    daysAgo: 2,
+    threadCount: 2,
+  },
+  {
+    title: "Требование ИФНС по зарубежному брокеру",
+    description: "ИФНС запросила документы по операциям через Interactive Brokers за 2023. Портфель акций и облигаций, дивиденды от иностранных эмитентов. Срок ответа 5 дней. Срочно нужна помощь.",
+    fnsCode: "7722",
+    status: "ACTIVE",
+    daysAgo: 1,
+    threadCount: 2,
+  },
+  {
+    title: "Налог с продажи авто — нюансы расчёта",
+    description: "Продал машину дороже чем покупал. Хочу минимизировать налог. Авто было в собственности 2 года 8 месяцев. Нужна консультация по расчёту и декларированию.",
+    fnsCode: "5261",
+    status: "CLOSED",
+    daysAgo: 45,
+    threadCount: 2,
+  },
+  {
+    title: "Оспаривание акта по ОКК — кафе",
+    description: "Кафе получило акт проверки ОКК с нарушениями применения ККТ — штраф 90 000 руб. Нарушения оспариваем. Нужен консультант по оперативному контролю.",
+    fnsCode: "6606",
+    status: "ACTIVE",
+    daysAgo: 7,
+    threadCount: 3,
+  },
+  {
+    title: "Помощь с подачей 3-НДФЛ по иностранным дивидендам",
+    description: "Получаю дивиденды от американских акций через ВТБ. Брокер не удержал налог в полном объёме. Нужна помощь с заполнением 3-НДФЛ и расчётом суммы к доплате.",
+    fnsCode: "6603",
+    status: "ACTIVE",
+    daysAgo: 8,
+    threadCount: 1,
+  },
+  {
+    title: "Сопровождение проверки ИП на ОСНО — Казань",
+    description: "ИП на ОСНО получил запрос на выездную проверку. Оборот 28 млн/год, основной доход — IT-услуги. Нужна помощь с подготовкой документов и сопровождением инспекторов.",
+    fnsCode: "1603",
+    status: "CLOSING_SOON",
+    daysAgo: 20,
+    threadCount: 3,
+  },
+  {
+    title: "Консультация по UBO и бенефициарам КИК",
+    description: "Являюсь конечным бенефициаром кипрской компании. Не уверен, нужно ли подавать уведомление КИК и как рассчитать прибыль. Нужна консультация по международному налогообложению.",
+    fnsCode: "5263",
+    status: "ACTIVE",
+    daysAgo: 3,
+    threadCount: 2,
+  },
+  {
+    title: "Возврат НДФЛ за лечение — платная клиника",
+    description: "Хочу получить социальный вычет за лечение зубов в 2023. Расходы — 180 000 руб. Нужна помощь с документами и подачей 3-НДФЛ.",
+    fnsCode: "7453",
+    status: "ACTIVE",
+    daysAgo: 6,
+    threadCount: 1,
+  },
+  {
+    title: "Налог на прибыль ООО — оспаривание доначислений",
+    description: "ИФНС доначислила налог на прибыль ООО за 2022 — 1.2 млн. Основание — технические контрагенты. Не согласны, все операции реальные. Нужен юрист.",
+    fnsCode: "0202",
+    status: "ACTIVE",
+    daysAgo: 9,
+    threadCount: 4,
+  },
+  {
+    title: "Ошибка в декларации 3-НДФЛ — уточнёнка",
+    description: "Обнаружил ошибку в поданной декларации 3-НДФЛ за 2023. Занизил налоговую базу на 350 000 руб. Хочу подать уточнёнку и погасить недоимку до штрафов.",
+    fnsCode: "2462",
+    status: "ACTIVE",
+    daysAgo: 4,
+    threadCount: 2,
+  },
+  {
+    title: "Налогообложение фриланса через Upwork — ИП",
+    description: "Работаю через Upwork, зарегистрировал ИП на УСН 6%. Банк запросил документы по поступлениям из-за рубежа. Нужна консультация по оформлению контрактов и поступлений.",
+    fnsCode: "7724",
+    status: "CLOSED",
+    daysAgo: 38,
+    threadCount: 2,
+  },
+  {
+    title: "Проверка ОКК — алкогольная лицензия",
+    description: "Магазин получил предписание ОКК по нарушениям при продаже алкоголя. Штраф 150 000 руб. Нужна помощь с обжалованием в административном порядке.",
+    fnsCode: "7451",
+    status: "ACTIVE",
+    daysAgo: 5,
+    threadCount: 2,
+  },
+];
+
 // ─── Message scripts — realistic 2-4 message back-and-forth ─────────
 
 const MESSAGE_SCRIPTS: string[][] = [
@@ -568,6 +1094,51 @@ const MESSAGE_SCRIPTS: string[][] = [
     "По Etsy + Payoneer: НПД считается по факту получения в рублях по курсу ЦБ на дату поступления. Курсовые разницы учитывать не нужно. Чеки формируйте в «Мой налог» по каждому поступлению.",
     "А если поступило сразу за несколько заказов общей суммой?",
     "Можно одним чеком на общую сумму, в описании укажите «реализация товаров (Etsy)». Главное — чтобы все поступления были задекларированы.",
+  ],
+];
+
+// ─── Extra message scripts (Issue #1625 — more messages per thread) ──
+
+const EXTRA_MESSAGE_SCRIPTS: string[][] = [
+  // I — detailed requirements gathering
+  [
+    "Здравствуйте! Рассмотрел ваш запрос. Скажите, акт камеральной проверки уже пришёл или только требование о пояснениях?",
+    "Пока только требование о пояснениях. Срок — 5 рабочих дней.",
+    "Понятно. Нужно подготовить ответ с подтверждающими документами. Пришлите, пожалуйста, текст требования и выгрузку операций за проверяемый период.",
+    "Отправил на почту. Документы прикрепил.",
+    "Получил, изучаю. Вернусь с планом ответа сегодня вечером.",
+  ],
+  // J — quick resolution
+  [
+    "Добрый день! По вашей ситуации — стандартный случай. Понадобится декларация 3-НДФЛ с расчётом по CSV из Bybit. Пришлите выгрузку.",
+    "Высылаю. Там 284 сделки за 2023.",
+    "Посмотрел. Итог — доход 1 850 000, расход 1 560 000, НДФЛ к уплате около 38 000. Подготовлю декларацию за 2 дня.",
+    "Отлично, жду. Когда можем созвониться?",
+    "Завтра в 15:00 удобно?",
+    "Да, договорились.",
+  ],
+  // K — specialist engages
+  [
+    "Здравствуйте. Возьмусь за ваш вопрос. По КИК — нужно уточнить: компания активная или пассивная по критериям НК?",
+    "Компания оказывает IT-услуги, выручка чисто активная.",
+    "Тогда возможно освобождение от КИК по ст. 25.13-1 НК. Давайте разберём подробнее — пришлите структуру владения.",
+    "Структуру пришлю завтра. Спасибо, это обнадёживает.",
+  ],
+  // L — outreach + proposal
+  [
+    "Здравствуйте! По выездной проверке — есть опыт аналогичных дел. Первым делом нужна предварительная экспертиза документов. Когда можете встретиться?",
+    "Могу в пятницу после 15:00.",
+    "Пятница 15:30 — подходит. Адрес офиса пришлю в день встречи.",
+    "Договорились. Что взять с собой?",
+    "Договоры с основными контрагентами за проверяемый период, банковские выписки, акты выполненных работ.",
+  ],
+  // M — urgent
+  [
+    "Получил ваше сообщение. Срочно — пришлите текст требования прямо сейчас, посмотрю сегодня.",
+    "Высылаю.",
+    "Изучил. Требование стандартное, по статье 88. Подготовим ответ с документами за 1 день. Стоимость — 8 000 руб.",
+    "Согласен. Как оплатить?",
+    "На карту или по договору оферты — как удобно. Реквизиты пришлю.",
   ],
 ];
 
@@ -959,6 +1530,268 @@ async function main() {
     notificationCount++;
   }
   console.log(`  Notifications: ${notificationCount}`);
+
+  // ─── Issue #1625: Extra specialists (+25) ────────────────────────
+  const extraSpecialistUsers: Array<{ id: string; email: string }> = [];
+  let extraSpecialistCount = 0;
+  for (const spec of EXTRA_SPECIALISTS) {
+    const user = await prisma.user.upsert({
+      where: { email: spec.email },
+      update: {
+        firstName: spec.firstName,
+        lastName: spec.lastName,
+        avatarUrl: spec.avatarUrl,
+        role: "USER",
+        isSpecialist: true,
+        specialistProfileCompletedAt: nowSeed,
+        isAvailable: true,
+      },
+      create: {
+        email: spec.email,
+        firstName: spec.firstName,
+        lastName: spec.lastName,
+        avatarUrl: spec.avatarUrl,
+        role: "USER",
+        isSpecialist: true,
+        specialistProfileCompletedAt: nowSeed,
+        isAvailable: true,
+      },
+    });
+
+    await prisma.specialistProfile.upsert({
+      where: { userId: user.id },
+      update: {
+        description: spec.description,
+        phone: spec.phone,
+        telegram: spec.telegram,
+        officeAddress: spec.officeAddress,
+        workingHours: spec.workingHours,
+        exFnsStartYear: spec.exFnsStartYear ?? null,
+        exFnsEndYear: spec.exFnsEndYear ?? null,
+        yearsOfExperience: spec.yearsOfExperience ?? null,
+        specializations: spec.specializations ?? undefined,
+        certifications: spec.certifications ?? undefined,
+      },
+      create: {
+        userId: user.id,
+        description: spec.description,
+        phone: spec.phone,
+        telegram: spec.telegram,
+        officeAddress: spec.officeAddress,
+        workingHours: spec.workingHours,
+        exFnsStartYear: spec.exFnsStartYear ?? null,
+        exFnsEndYear: spec.exFnsEndYear ?? null,
+        yearsOfExperience: spec.yearsOfExperience ?? null,
+        specializations: spec.specializations ?? undefined,
+        certifications: spec.certifications ?? undefined,
+      },
+    });
+
+    for (const fnsCode of spec.fnsCodes) {
+      const fns = fnsMap[fnsCode];
+      if (!fns) continue;
+
+      const sfns = await prisma.specialistFns.upsert({
+        where: { specialistId_fnsId: { specialistId: user.id, fnsId: fns.id } },
+        update: {},
+        create: { specialistId: user.id, fnsId: fns.id },
+      });
+
+      for (const serviceName of spec.serviceNames) {
+        const serviceId = serviceMap[serviceName];
+        if (!serviceId) continue;
+
+        await prisma.specialistService.upsert({
+          where: {
+            specialistId_fnsId_serviceId: {
+              specialistId: user.id,
+              fnsId: fns.id,
+              serviceId,
+            },
+          },
+          update: {},
+          create: {
+            specialistId: user.id,
+            fnsId: fns.id,
+            serviceId,
+            specialistFnsId: sfns.id,
+          },
+        });
+      }
+    }
+
+    // Generate cases for extra specialists
+    const cityHint = spec.officeAddress?.split(",")[0]?.trim() ?? null;
+    const cityList = cityHint ? [cityHint] : [];
+    const cases = generateCasesForSpecialist(
+      spec.firstName,
+      cityList,
+      spec.fnsCodes,
+      spec.serviceNames,
+      extraSpecialistCount + 100,
+    );
+    for (let i = 0; i < cases.length; i++) {
+      const c = cases[i];
+      await prisma.specialistCase.create({
+        data: {
+          specialistId: user.id,
+          title: c.title,
+          category: c.category,
+          amount: c.amount,
+          resolvedAmount: c.resolvedAmount,
+          days: c.days,
+          status: c.status,
+          description: c.description,
+          year: c.year,
+          order: i,
+        },
+      });
+    }
+
+    extraSpecialistUsers.push({ id: user.id, email: user.email });
+    extraSpecialistCount++;
+  }
+  console.log(`  Extra specialists: ${extraSpecialistCount}`);
+
+  // ─── Issue #1625: Saved specialists for serter2069@gmail.com (+13) ─
+  // Pick 13 specialists from both pools; upsert so idempotent.
+  const allSeedSpecialists = [...specialistUsers, ...extraSpecialistUsers];
+  const savedTargets = allSeedSpecialists.slice(0, 13);
+  let savedCount = 0;
+  for (const target of savedTargets) {
+    if (target.id === sergeiClient.id) continue; // can't save yourself
+    await prisma.savedSpecialist.upsert({
+      where: { userId_specialistId: { userId: sergeiClient.id, specialistId: target.id } },
+      update: {},
+      create: { userId: sergeiClient.id, specialistId: target.id },
+    });
+    savedCount++;
+  }
+  console.log(`  Saved specialists (serter2069): ${savedCount}`);
+
+  // ─── Issue #1625: Extra requests (+20) ───────────────────────────
+  const allScriptPool = [...MESSAGE_SCRIPTS, ...EXTRA_MESSAGE_SCRIPTS];
+  const extraSeedTitles = EXTRA_REQUEST_SCENARIOS.map((r) => r.title);
+  await prisma.request.deleteMany({
+    where: { title: { in: extraSeedTitles } },
+  });
+  let extraRequestCount = 0;
+  let extraThreadCount = 0;
+  let extraMessageCount = 0;
+
+  for (let idx = 0; idx < EXTRA_REQUEST_SCENARIOS.length; idx++) {
+    const scenario = EXTRA_REQUEST_SCENARIOS[idx];
+    const fns = fnsMap[scenario.fnsCode];
+    if (!fns) {
+      console.warn(`  [skip extra] FNS ${scenario.fnsCode} not found`);
+      continue;
+    }
+
+    const client = clientUsers[idx % clientUsers.length];
+    const createdAt = new Date(Date.now() - scenario.daysAgo * 24 * 60 * 60 * 1000);
+
+    const request = await prisma.request.create({
+      data: {
+        userId: client.id,
+        cityId: fns.cityId,
+        fnsId: fns.id,
+        title: scenario.title,
+        description: scenario.description,
+        status: scenario.status,
+        createdAt,
+        lastActivityAt: createdAt,
+      },
+    });
+    extraRequestCount++;
+
+    // Pull specialists from both pools who cover this FNS
+    const eligibleSpecs = await prisma.specialistFns.findMany({
+      where: { fnsId: fns.id },
+      select: { specialistId: true },
+      take: Math.max(scenario.threadCount, 1),
+    });
+    const specialistIds = eligibleSpecs.map((s) => s.specialistId);
+    const allSpecialistPool = [...specialistUsers, ...extraSpecialistUsers];
+    while (specialistIds.length < scenario.threadCount && allSpecialistPool.length > specialistIds.length) {
+      const fallback = allSpecialistPool.find((s) => !specialistIds.includes(s.id));
+      if (!fallback) break;
+      specialistIds.push(fallback.id);
+    }
+
+    for (let t = 0; t < scenario.threadCount && t < specialistIds.length; t++) {
+      const specialistId = specialistIds[t];
+      // Use the full script pool (including extra scripts) for richer threads
+      const script = allScriptPool[(idx * 3 + t + 8) % allScriptPool.length];
+      const threadCreated = new Date(createdAt.getTime() + (t + 1) * 60 * 60 * 1000);
+
+      const thread = await prisma.thread.create({
+        data: {
+          requestId: request.id,
+          clientId: client.id,
+          specialistId,
+          createdAt: threadCreated,
+          lastMessageAt: new Date(threadCreated.getTime() + script.length * 30 * 60 * 1000),
+          specialistLastReadAt: threadCreated,
+        },
+      });
+      extraThreadCount++;
+
+      for (let m = 0; m < script.length; m++) {
+        const sender = m % 2 === 0 ? specialistId : client.id;
+        const messageAt = new Date(threadCreated.getTime() + m * 30 * 60 * 1000);
+        await prisma.message.create({
+          data: {
+            threadId: thread.id,
+            senderId: sender,
+            text: script[m],
+            createdAt: messageAt,
+          },
+        });
+        extraMessageCount++;
+      }
+    }
+  }
+  console.log(`  Extra requests:  ${extraRequestCount}`);
+  console.log(`  Extra threads:   ${extraThreadCount}`);
+  console.log(`  Extra messages:  ${extraMessageCount}`);
+
+  // ─── Issue #1625: Add more messages to existing threads ──────────
+  // Find threads with only 2 messages and add 3-5 more from script pool.
+  const thinThreads = await prisma.thread.findMany({
+    where: {},
+    include: {
+      messages: { orderBy: { createdAt: "desc" }, take: 1 },
+      _count: { select: { messages: true } },
+    },
+    take: 20,
+  });
+  let bonusMessageCount = 0;
+  for (const thread of thinThreads) {
+    if (thread._count.messages >= 4) continue; // already has enough messages
+    const lastMsg = thread.messages[0];
+    if (!lastMsg) continue;
+
+    const extraLines = [
+      "Хорошо, буду ждать ваш ответ.",
+      "Можем ли мы уточнить сроки?",
+      "Спасибо за оперативность!",
+      "Ещё один вопрос: нужно ли нотариальное заверение документов?",
+      "Нет, нотариус не нужен. Достаточно обычных копий с вашей подписью.",
+    ];
+    for (let i = 0; i < 3; i++) {
+      const sender = i % 2 === 0 ? thread.clientId : thread.specialistId;
+      await prisma.message.create({
+        data: {
+          threadId: thread.id,
+          senderId: sender,
+          text: extraLines[i % extraLines.length],
+          createdAt: new Date((lastMsg.createdAt as Date).getTime() + (i + 1) * 20 * 60 * 1000),
+        },
+      });
+      bonusMessageCount++;
+    }
+  }
+  console.log(`  Bonus messages on thin threads: ${bonusMessageCount}`);
 
   console.log("\nSpecialist/content seed complete.");
 }

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -18,9 +18,8 @@ const messageRateLimiter = rateLimit({
   message: { error: "Слишком много сообщений. Попробуйте через минуту." },
 });
 
-// Resolve uploadToken to MinIO object key by listing objects with matching prefix
-async function resolveUploadToken(threadId: string, uploadToken: string): Promise<{ key: string; fileUrl: string } | null> {
-  const prefix = `chat-files/${threadId}/${uploadToken}_`;
+// Look up a single object by exact prefix in MinIO. Returns the first match.
+async function findObjectByPrefix(prefix: string): Promise<Minio.BucketItem | null> {
   try {
     return await new Promise((resolve, reject) => {
       const stream = minioClient.listObjects(MINIO_BUCKET, prefix, false);
@@ -28,18 +27,62 @@ async function resolveUploadToken(threadId: string, uploadToken: string): Promis
       stream.on("data", (obj: Minio.BucketItem) => {
         if (!found) found = obj;
       });
-      stream.on("end", () => {
-        if (found && found.name) {
-          resolve({ key: found.name, fileUrl: `/${MINIO_BUCKET}/${found.name}` });
-        } else {
-          resolve(null);
-        }
-      });
+      stream.on("end", () => resolve(found));
       stream.on("error", reject);
     });
   } catch {
     return null;
   }
+}
+
+// Best-effort MinIO stat → returns size + content-type. Falls back gracefully
+// when the metadata is missing so we never block the message send on stat errors.
+async function statObject(
+  key: string
+): Promise<{ size: number; contentType: string } | null> {
+  try {
+    const stat = await minioClient.statObject(MINIO_BUCKET, key);
+    const meta = (stat.metaData ?? {}) as Record<string, string>;
+    const contentType =
+      meta["content-type"] ?? meta["Content-Type"] ?? "application/octet-stream";
+    return { size: stat.size ?? 0, contentType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a chat-file uploadToken to a MinIO object key.
+ *
+ * Files are uploaded BEFORE the message is sent. Two namespaces are checked
+ * because the upload route stores chat files under either:
+ *   - `chat-files/<threadId>/<token>_<name>`  (uploaded with threadId in body)
+ *   - `chat-files/_pending/<token>_<name>`    (uploaded without threadId — default)
+ *
+ * The chat composer (ChatComposer/FileUploadZone) uploads WITHOUT threadId, so
+ * the file always lives in `_pending` initially. Without the fallback below,
+ * `POST /api/messages/:threadId` returns 422 "Файл не найден, загрузите повторно".
+ *
+ * Returned `fileUrl` always points to wherever the object currently lives —
+ * we don't move it, the URL is a stable bucket-relative path.
+ */
+async function resolveUploadToken(
+  threadId: string,
+  uploadToken: string
+): Promise<{ key: string; fileUrl: string } | null> {
+  // Try the thread-scoped namespace first (covers future uploads that include threadId).
+  const threadPrefix = `chat-files/${threadId}/${uploadToken}_`;
+  const threadHit = await findObjectByPrefix(threadPrefix);
+  if (threadHit && threadHit.name) {
+    return { key: threadHit.name, fileUrl: `/${MINIO_BUCKET}/${threadHit.name}` };
+  }
+  // Fall back to the pending namespace (where ChatComposer actually puts files).
+  const pendingPrefix = `chat-files/_pending/${uploadToken}_`;
+  const pendingHit = await findObjectByPrefix(pendingPrefix);
+  if (pendingHit && pendingHit.name) {
+    return { key: pendingHit.name, fileUrl: `/${MINIO_BUCKET}/${pendingHit.name}` };
+  }
+  return null;
 }
 
 function param(val: string | string[] | undefined): string {
@@ -276,16 +319,27 @@ router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => 
   }
 });
 
+// Hard cap for attachments per message — must match the frontend ChatComposer
+// `maxFiles` default. Bumped from 3 → 10 (#bug 3).
+const MAX_FILES_PER_MESSAGE = 10;
+
 // POST /api/messages/:threadId — send message in thread (with optional file attachments)
-// Supports uploadToken (idempotency): if provided, verifies the file exists in MinIO
-// Fix #186: text (content) is optional when uploadToken or files are present.
-// Validation rule: at least one of (text, files, uploadToken) must be non-empty.
+// Supports uploadToken / uploadTokens (idempotency): if provided, verifies each
+// file exists in MinIO via resolveUploadToken (which checks both thread-scoped
+// and `_pending` namespaces).
+// Fix #186: text (content) is optional when tokens or files are present.
+// Validation rule: at least one of (text, files, uploadToken/uploadTokens) must be non-empty.
 router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
     const threadId = param(req.params.threadId);
     // text is intentionally optional — attachment-only messages are valid (#186)
-    const { text, files, uploadToken } = req.body as { text?: string; files?: FileInput[]; uploadToken?: string };
+    const { text, files, uploadToken, uploadTokens } = req.body as {
+      text?: string;
+      files?: FileInput[];
+      uploadToken?: string;
+      uploadTokens?: string[];
+    };
 
     // Validate content type and length
     if (text !== undefined && typeof text !== "string") {
@@ -305,22 +359,49 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
       res.status(400).json({ error: `Сообщение превышает ${MAX_TEXT_LEN} символов` });
       return;
     }
-    const attachedFiles: FileInput[] = Array.isArray(files) ? files.slice(0, 3) : [];
+    const attachedFiles: FileInput[] = Array.isArray(files)
+      ? files.slice(0, MAX_FILES_PER_MESSAGE)
+      : [];
 
-    // If uploadToken provided, resolve it to a file before any other validation.
-    // A message with only an uploadToken (no text) is valid — this resolves #186.
-    let tokenFile: { fileUrl: string } | null = null;
-    if (uploadToken && typeof uploadToken === "string" && uploadToken.length >= 8) {
-      const resolved = await resolveUploadToken(threadId, uploadToken);
+    // Normalize uploadToken (legacy single string) + uploadTokens (array) into
+    // a single deduped list. Each token is a UUID-ish opaque string written by
+    // the upload route — minimum length sanity-check is 8 chars.
+    const tokensRaw: string[] = [];
+    if (typeof uploadToken === "string") tokensRaw.push(uploadToken);
+    if (Array.isArray(uploadTokens)) {
+      for (const t of uploadTokens) {
+        if (typeof t === "string") tokensRaw.push(t);
+      }
+    }
+    const tokens = Array.from(
+      new Set(tokensRaw.filter((t) => t.length >= 8))
+    ).slice(0, MAX_FILES_PER_MESSAGE);
+
+    // Resolve every token before any DB writes. If ANY token cannot be
+    // resolved we 422 — the client already showed the file as "uploaded",
+    // so silently dropping it would lose data. Stat the object to capture
+    // real size + mime so the rendered chip shows accurate metadata.
+    const resolvedTokenFiles: {
+      fileUrl: string;
+      size: number;
+      mimeType: string;
+    }[] = [];
+    for (const t of tokens) {
+      const resolved = await resolveUploadToken(threadId, t);
       if (!resolved) {
         res.status(422).json({ error: "Файл не найден, загрузите повторно" });
         return;
       }
-      tokenFile = resolved;
+      const stat = await statObject(resolved.key);
+      resolvedTokenFiles.push({
+        fileUrl: resolved.fileUrl,
+        size: stat?.size ?? 0,
+        mimeType: stat?.contentType ?? "application/octet-stream",
+      });
     }
 
-    // Require at least one of: text, files array, or uploadToken-resolved file
-    if (!trimmedText && attachedFiles.length === 0 && !tokenFile) {
+    // Require at least one of: text, files array, or token-resolved file(s)
+    if (!trimmedText && attachedFiles.length === 0 && resolvedTokenFiles.length === 0) {
       res.status(400).json({ error: "Message text or at least one file is required" });
       return;
     }
@@ -361,10 +442,13 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
         },
       });
 
-      // Store file records — combine token-resolved file + legacy files array
+      // Store file records — combine token-resolved file(s) + legacy files array.
+      // Multiple uploadTokens are now supported (each chip in the chat composer
+      // becomes a separate file row). Size + mimeType come from the MinIO stat
+      // call above when available, so the rendered chip is accurate.
       let savedFiles: { id: string; url: string; filename: string; size: number; mimeType: string }[] = [];
       const allFilesToSave: FileInput[] = [...attachedFiles];
-      if (tokenFile) {
+      for (const tokenFile of resolvedTokenFiles) {
         const keyParts = tokenFile.fileUrl.split("/");
         const rawName = keyParts[keyParts.length - 1] ?? "file";
         const underscoreIdx = rawName.indexOf("_");
@@ -372,8 +456,8 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
         allFilesToSave.push({
           url: tokenFile.fileUrl,
           filename: resolvedFilename,
-          size: 0,
-          mimeType: "application/octet-stream",
+          size: tokenFile.size,
+          mimeType: tokenFile.mimeType,
         });
       }
       if (allFilesToSave.length > 0) {

--- a/api/src/routes/upload.ts
+++ b/api/src/routes/upload.ts
@@ -134,8 +134,9 @@ router.post("/avatar", authMiddleware, uploadRateLimiter, avatarUpload.single("f
   }
 });
 
-// POST /api/upload/documents — upload document files (max 5)
-router.post("/documents", authMiddleware, uploadRateLimiter, documentUpload.array("files", 5), async (req: Request, res: Response) => {
+// POST /api/upload/documents — upload document files (max 10).
+// Limit raised from 5 → 10 to match the chat composer (#bug 3).
+router.post("/documents", authMiddleware, uploadRateLimiter, documentUpload.array("files", 10), async (req: Request, res: Response) => {
   try {
     const files = req.files as Express.Multer.File[] | undefined;
     if (!files || files.length === 0) {

--- a/components/ChatComposer.tsx
+++ b/components/ChatComposer.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
-import { View, Pressable, ActivityIndicator } from "react-native";
+import { useRef, useState } from "react";
+import { Platform, Pressable, View, Text, ActivityIndicator } from "react-native";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import FileUploadZone, { type PendingFile } from "@/components/ui/FileUploadZone";
+import FileUploadZone, {
+  FileUploadChips,
+  type PendingFile,
+} from "@/components/ui/FileUploadZone";
 import Input from "@/components/ui/Input";
 import { colors, radiusValue } from "@/lib/theme";
 
@@ -26,7 +29,7 @@ interface ChatComposerProps {
   authToken?: string | null;
   /** Upload endpoint — e.g. `/api/upload/chat-file`. */
   uploadEndpoint?: string;
-  /** Max files to attach. Defaults to 3. */
+  /** Max files to attach. Defaults to 10 (raised from 3 — bug #3). */
   maxFiles?: number;
   /** Max bytes per file (in MB). Defaults to 10. */
   maxSizeMB?: number;
@@ -45,18 +48,20 @@ interface ChatComposerProps {
  *   - `/threads/:id` (live chat — InlineChatView)
  *   - `/requests/:id/detail` (specialist quick-reply / new-thread send)
  *
- * Combines the three building blocks of a chat input bar into one
- * component so both screens render the same UX:
+ * Layout (column):
+ *   ┌──────────────────────────────────────────────────────────┐
+ *   │ [chip] [chip] [chip] …                                    │  ← chips row (above input)
+ *   ├──────────────────────────────────────────────────────────┤
+ *   │ [paperclip] [text input …………………………] [send]               │  ← input row
+ *   └──────────────────────────────────────────────────────────┘
  *
- *   - `FileUploadZone` (compact mode) — paperclip + chip strip +
- *     drag-and-drop overlay; uploads files immediately on pick.
- *   - `Input` (multi-line) — the actual text field, with NativeWind
- *     double-border guards.
- *   - send button — paperplane / spinner with disabled-state styling.
+ * The whole composer wrapper is the drag-and-drop target — dropping a file
+ * anywhere over the composer triggers the upload. (Bug #2 fix: previously
+ * the listeners were attached to the paperclip-sized container only.)
  *
- * For the long-form first-message textarea (character counter + min-length
- * hint) used inside `/requests/:id/write`, see
- * `components/requests/MessageComposer.tsx`.
+ * Chips are rendered ABOVE the input row, never inside it, so the input
+ * area keeps a fixed height even with multiple attached files.
+ * (Bug #4 fix: file list expanded the input row and broke chat layout.)
  */
 export default function ChatComposer({
   value,
@@ -68,90 +73,144 @@ export default function ChatComposer({
   disabled = false,
   authToken,
   uploadEndpoint = "/api/upload/chat-file",
-  maxFiles = 3,
+  maxFiles = 10,
   maxSizeMB = 10,
   allowedTypes,
   placeholder = "Введите сообщение...",
   maxLength = 5000,
   accessibilityLabel = "Введите сообщение",
 }: ChatComposerProps) {
-  const canSend = !disabled && !sending && (value.trim().length > 0 || files.length > 0);
+  const canSend =
+    !disabled && !sending && (value.trim().length > 0 || files.length > 0);
 
   // Auto-expand: track TextInput content height, clamped between 40 and 120px.
   const MIN_HEIGHT = 40;
   const MAX_HEIGHT = 120;
   const [inputHeight, setInputHeight] = useState(MIN_HEIGHT);
 
+  // Composer-wide drop target — used by FileUploadZone via dropTargetRef.
+  // RN-Web forwards the ref to the underlying <div>, but RN's typings still
+  // claim it's a `View`. We use a callback ref to capture the host node and
+  // store it in `dropZoneRef.current` as an HTMLElement.
+  const dropZoneRef = useRef<HTMLElement | null>(null);
+  const setDropZoneNode = (node: unknown) => {
+    dropZoneRef.current = (node as HTMLElement | null) ?? null;
+  };
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const removeFile = (id: string) => {
+    onFilesChange(files.filter((f) => f.id !== id));
+  };
+
   return (
-    <View className="flex-row items-end border-t border-border px-3 py-2 bg-white">
-      {/* Shared upload control: paperclip button, chip preview strip,
-          immediate upload to the chat-file endpoint, drag-and-drop overlay. */}
-      <FileUploadZone
-        files={files}
-        onFilesChange={onFilesChange}
-        uploadEndpoint={uploadEndpoint}
-        authToken={authToken}
-        maxFiles={maxFiles}
-        maxSizeMB={maxSizeMB}
-        allowedTypes={allowedTypes}
-        compact
-        disabled={disabled || sending}
-      />
-
-      {/* Text input — strip Input's underline; only the parent strip's
-          top border is visible, otherwise web stacks a double-border. */}
-      <Input
-        accessibilityLabel={accessibilityLabel}
-        placeholder={placeholder}
-        value={value}
-        onChangeText={onChangeText}
-        multiline
-        maxLength={maxLength}
-        editable={!disabled}
-        onContentSizeChange={(e) => {
-          const h = e.nativeEvent.contentSize.height;
-          setInputHeight(Math.min(Math.max(MIN_HEIGHT, h), MAX_HEIGHT));
-        }}
-        style={{ flex: 1 }}
-        containerStyle={{
-          borderRadius: radiusValue.xl,
-          height: inputHeight,
-          borderBottomWidth: 0,
-          borderTopWidth: 0,
-          borderLeftWidth: 0,
-          borderRightWidth: 0,
-        }}
-      />
-
-      {/* Send button — aligned to flex-end so it stays at bottom when input expands. */}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Отправить сообщение"
-        onPress={onSend}
-        disabled={!canSend}
-        style={({ pressed }) => [
-          {
-            width: 44,
-            height: 44,
+    <View
+      ref={setDropZoneNode}
+      className="border-t border-border bg-white"
+      style={{ position: "relative" }}
+    >
+      {/* Composer-wide drag overlay (web only).
+          Painted across both rows so users get visual feedback no matter
+          where over the composer they're hovering with the dragged file. */}
+      {isDragOver && Platform.OS === "web" && (
+        <View
+          pointerEvents="none"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            zIndex: 50,
+            backgroundColor: "rgba(59,130,246,0.10)",
+            borderWidth: 2,
+            borderStyle: "dashed",
+            borderColor: colors.primary,
             alignItems: "center",
             justifyContent: "center",
-            marginLeft: 8,
-            alignSelf: "flex-end",
-            marginBottom: 0,
-          },
-          pressed && { opacity: 0.7 },
-        ]}
-      >
-        {sending ? (
-          <ActivityIndicator size="small" color={colors.primary} />
-        ) : (
-          <FontAwesome
-            name="send"
-            size={20}
-            color={canSend ? colors.primary : colors.textSecondary}
-          />
-        )}
-      </Pressable>
+          }}
+        >
+          <Text style={{ color: colors.primary, fontSize: 14, fontWeight: "600" }}>
+            Отпустите чтобы прикрепить
+          </Text>
+        </View>
+      )}
+
+      {/* Chip strip above the input — caps height via internal flex-wrap. */}
+      <FileUploadChips files={files} onRemove={removeFile} />
+
+      <View className="flex-row items-end px-3 py-2">
+        {/* Shared upload control: paperclip button + drag handler.
+            Compact mode + dropTargetRef → only the button is rendered;
+            chips and the drop overlay are painted by this composer. */}
+        <FileUploadZone
+          files={files}
+          onFilesChange={onFilesChange}
+          uploadEndpoint={uploadEndpoint}
+          authToken={authToken}
+          maxFiles={maxFiles}
+          maxSizeMB={maxSizeMB}
+          allowedTypes={allowedTypes}
+          compact
+          disabled={disabled || sending}
+          dropTargetRef={dropZoneRef}
+          onDragStateChange={setIsDragOver}
+        />
+
+        {/* Text input — strip Input's underline; only the parent strip's
+            top border is visible, otherwise web stacks a double-border. */}
+        <Input
+          accessibilityLabel={accessibilityLabel}
+          placeholder={placeholder}
+          value={value}
+          onChangeText={onChangeText}
+          multiline
+          maxLength={maxLength}
+          editable={!disabled}
+          onContentSizeChange={(e) => {
+            const h = e.nativeEvent.contentSize.height;
+            setInputHeight(Math.min(Math.max(MIN_HEIGHT, h), MAX_HEIGHT));
+          }}
+          style={{ flex: 1 }}
+          containerStyle={{
+            borderRadius: radiusValue.xl,
+            height: inputHeight,
+            borderBottomWidth: 0,
+            borderTopWidth: 0,
+            borderLeftWidth: 0,
+            borderRightWidth: 0,
+          }}
+        />
+
+        {/* Send button — aligned to flex-end so it stays at bottom when input expands. */}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Отправить сообщение"
+          onPress={onSend}
+          disabled={!canSend}
+          style={({ pressed }) => [
+            {
+              width: 44,
+              height: 44,
+              alignItems: "center",
+              justifyContent: "center",
+              marginLeft: 8,
+              alignSelf: "flex-end",
+              marginBottom: 0,
+            },
+            pressed && { opacity: 0.7 },
+          ]}
+        >
+          {sending ? (
+            <ActivityIndicator size="small" color={colors.primary} />
+          ) : (
+            <FontAwesome
+              name="send"
+              size={20}
+              color={canSend ? colors.primary : colors.textSecondary}
+            />
+          )}
+        </Pressable>
+      </View>
     </View>
   );
 }

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -327,12 +327,12 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     }
 
     // Files are uploaded immediately on pick by FileUploadZone, so by send-time
-    // each "done" file already has its uploadedToken. Only the first done file
-    // is sent (single-attachment messages — limit enforced upstream by maxFiles=3).
-    const readyFile = pendingFiles.find(
-      (f) => f.status === "done" && f.uploadedToken
-    );
-    const uploadToken = readyFile?.uploadedToken;
+    // each "done" file already has its uploadedToken. Send ALL ready file
+    // tokens — the API accepts uploadTokens[] (bug #3 fix: previously only
+    // the first file was attached, regardless of maxFiles).
+    const uploadTokens: string[] = pendingFiles
+      .filter((f) => f.status === "done" && f.uploadedToken)
+      .map((f) => f.uploadedToken as string);
 
     // Block send if user attached a file that is still uploading or errored.
     const stillBusy = pendingFiles.some(
@@ -351,7 +351,7 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
     try {
       const res = await apiPost<{ message: MessageItem }>(`/api/messages/${threadId}`, {
         text: trimmed,
-        ...(uploadToken ? { uploadToken } : {}),
+        ...(uploadTokens.length > 0 ? { uploadTokens } : {}),
       });
       setMessages((prev) => [...prev, res.message]);
       setText("");

--- a/components/ui/FileUploadZone.tsx
+++ b/components/ui/FileUploadZone.tsx
@@ -404,60 +404,11 @@ export default function FileUploadZone({
 
   const canAddMore = files.length < maxFiles && !disabled;
 
-  // ---- Chip list (shared between compact + full) -------------------------
-  // For the compact (chat) variant we render chips compactly as horizontal
-  // pills so multiple files don't push the chat input off-screen. The full
-  // form variant keeps the original stacked rows.
+  // ---- Chip list (full form variant only) --------------------------------
+  // Compact (chat) mode renders chips externally via FileUploadChips so the
+  // composer can place them above the input row.
   const renderChips = () => {
     if (files.length === 0) return null;
-    if (compact) {
-      return (
-        <View className="flex-row flex-wrap" style={{ gap: 6 }}>
-          {files.map((f) => {
-            const isPdf = f.mimeType === "application/pdf";
-            const isError = f.status === "error";
-            const isBusy = f.status === "uploading" || f.status === "pending";
-            return (
-              <View
-                key={f.id}
-                className="flex-row items-center bg-surface2 border border-border rounded-full pl-2 pr-1 py-1"
-                style={{ maxWidth: 220 }}
-              >
-                {isPdf ? (
-                  <FileIcon size={14} color={isError ? colors.error : colors.primary} />
-                ) : (
-                  <FileImage size={14} color={isError ? colors.error : colors.primary} />
-                )}
-                <Text
-                  className="text-xs text-text-base ml-1.5 flex-shrink"
-                  numberOfLines={1}
-                  style={{ maxWidth: 140 }}
-                >
-                  {f.name}
-                </Text>
-                {isBusy ? (
-                  <ActivityIndicator
-                    size="small"
-                    color={colors.placeholder}
-                    style={{ marginLeft: 4, marginRight: 4 }}
-                  />
-                ) : (
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={`Удалить ${f.name}`}
-                    onPress={() => handleRemove(f.id)}
-                    className="w-6 h-6 items-center justify-center ml-1"
-                    hitSlop={6}
-                  >
-                    <X size={12} color={isError ? colors.error : colors.placeholder} />
-                  </Pressable>
-                )}
-              </View>
-            );
-          })}
-        </View>
-      );
-    }
     return (
       <View style={{ gap: 8, marginTop: 12 }}>
         {files.map((f) => {
@@ -509,8 +460,14 @@ export default function FileUploadZone({
     );
   };
 
-  // ---- Compact variant: paperclip + chips + drag overlay -----------------
+  // ---- Compact variant: paperclip-only button -----------------------------
+  // The chat composer is responsible for laying out chips (above the input
+  // row) and the drag-over overlay (across its own bounds) — we don't render
+  // those here when the composer passes an external dropTargetRef. This
+  // prevents the file list from expanding INSIDE the input row and breaking
+  // the chat layout. (Bug fix: layout/styles broken on file upload.)
   if (compact) {
+    const usingExternalDrop = !!dropTargetRef;
     return (
       <View ref={containerRef} style={{ position: "relative" }}>
         {Platform.OS === "web" && (
@@ -524,8 +481,10 @@ export default function FileUploadZone({
           />
         )}
 
-        {/* Drag-over overlay */}
-        {isDragOver && Platform.OS === "web" && (
+        {/* Internal drag overlay — only shown when there is no external
+            drop target. ChatComposer paints its own composer-wide overlay
+            via onDragStateChange. */}
+        {!usingExternalDrop && isDragOver && Platform.OS === "web" && (
           <View
             style={{
               position: "absolute",
@@ -548,11 +507,6 @@ export default function FileUploadZone({
               Отпустите чтобы прикрепить
             </Text>
           </View>
-        )}
-
-        {/* Chip strip — only shown when there are files */}
-        {files.length > 0 && (
-          <View className="px-2 py-1">{renderChips()}</View>
         )}
 
         {/* Paperclip button — caller is responsible for placing this row */}
@@ -659,6 +613,71 @@ export default function FileUploadZone({
       ) : null}
 
       {renderChips()}
+    </View>
+  );
+}
+
+/**
+ * Compact horizontal chip strip — used by ChatComposer above the input row
+ * so the file list never expands inside the input itself. Mirrors the same
+ * status states (uploading / error / done) as the FileUploadZone internal
+ * chip list but is positioned and sized for the chat composer.
+ */
+export function FileUploadChips({
+  files,
+  onRemove,
+}: {
+  files: PendingFile[];
+  onRemove: (id: string) => void;
+}) {
+  if (files.length === 0) return null;
+  return (
+    <View
+      className="flex-row flex-wrap px-3 pt-2"
+      style={{ gap: 6 }}
+    >
+      {files.map((f) => {
+        const isPdf = f.mimeType === "application/pdf";
+        const isError = f.status === "error";
+        const isBusy = f.status === "uploading" || f.status === "pending";
+        return (
+          <View
+            key={f.id}
+            className="flex-row items-center bg-surface2 border border-border rounded-full pl-2 pr-1 py-1"
+            style={{ maxWidth: 220 }}
+          >
+            {isPdf ? (
+              <FileIcon size={14} color={isError ? colors.error : colors.primary} />
+            ) : (
+              <FileImage size={14} color={isError ? colors.error : colors.primary} />
+            )}
+            <Text
+              className="text-xs text-text-base ml-1.5 flex-shrink"
+              numberOfLines={1}
+              style={{ maxWidth: 140 }}
+            >
+              {f.name}
+            </Text>
+            {isBusy ? (
+              <ActivityIndicator
+                size="small"
+                color={colors.placeholder}
+                style={{ marginLeft: 4, marginRight: 4 }}
+              />
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Удалить ${f.name}`}
+                onPress={() => onRemove(f.id)}
+                className="w-6 h-6 items-center justify-center ml-1"
+                hitSlop={6}
+              >
+                <X size={12} color={isError ? colors.error : colors.placeholder} />
+              </Pressable>
+            )}
+          </View>
+        );
+      })}
     </View>
   );
 }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -8,7 +8,7 @@ export { default as ErrorState } from "./ErrorState";
 export { default as LoadingState } from "./LoadingState";
 export { default as MetricCard } from "./MetricCard";
 export { default as Text } from "./Text";
-export { default as FileUploadZone } from "./FileUploadZone";
+export { default as FileUploadZone, FileUploadChips } from "./FileUploadZone";
 export { default as StyledSwitch } from "./StyledSwitch";
 
 export type { PendingFile } from "./FileUploadZone";


### PR DESCRIPTION
## Summary

- **+25 specialists** across all 10 cities with full profiles, FNS links, service tags, auto-generated cases (idempotent upsert by email)
- **+20 requests** in varied statuses (ACTIVE/CLOSING_SOON/CLOSED) seeded across cities  
- **+13 saved specialists** for `serter2069@gmail.com` via `SavedSpecialist` upsert
- **+5 richer message scripts** (5-6 messages each) + bonus messages added to thin threads
- All seed ops are **idempotent** (upsert by email / title) — safe to re-run

## Result after seed

| Entity | Count |
|---|---|
| Specialists | 43 (was 18) |
| Requests | 35 (was 15) |
| Threads | 78 (was 33) |
| Messages | 291 (was 93) |
| Saved specialists | 13 (was 0) |

## Test plan

- [x] `doppler run -- npm run seed` completes without errors
- [x] `curl localhost:3812/api/specialists` returns `total: 43`
- [x] `npx tsc --noEmit` passes with 0 errors

Closes #1625