### PR TITLE
refactor(chat): split InlineChatView 762→249 lines #1633

### DIFF
--- a/components/chat/ChatComposer.tsx
+++ b/components/chat/ChatComposer.tsx
@@ -1,0 +1,158 @@
+import { View, Text, Pressable, ActivityIndicator, Platform } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import Input from "@/components/ui/Input";
+import { colors, radiusValue } from "@/lib/theme";
+import { formatFileSize } from "./chatUtils";
+
+interface PendingFile {
+  uri: string;
+  name: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface ChatComposerProps {
+  text: string;
+  onChangeText: (t: string) => void;
+  pendingFiles: PendingFile[];
+  sending: boolean;
+  uploading: boolean;
+  isClosed: boolean;
+  dragOver: boolean;
+  onSend: () => void;
+  onAttachFile: () => void;
+  onRemovePendingFile: (index: number) => void;
+  onWebFileDrop: (file: File) => void;
+  onDragOver: () => void;
+  onDragLeave: () => void;
+}
+
+export default function ChatComposer({
+  text,
+  onChangeText,
+  pendingFiles,
+  sending,
+  uploading,
+  isClosed,
+  dragOver,
+  onSend,
+  onAttachFile,
+  onRemovePendingFile,
+  onWebFileDrop,
+  onDragOver,
+  onDragLeave,
+}: ChatComposerProps) {
+  return (
+    <>
+      {/* Request closed banner */}
+      {isClosed && (
+        <View className="border-t px-4 py-3" style={{ backgroundColor: colors.yellowSoft, borderTopColor: colors.warning }}>
+          <Text className="text-sm text-center" style={{ color: colors.primary }}>
+            Заявка закрыта. Чат доступен только для чтения.
+          </Text>
+        </View>
+      )}
+
+      {/* Pending files preview strip */}
+      {pendingFiles.length > 0 && (
+        <View className="flex-row flex-wrap px-3 py-2 border-t border-border bg-surface2">
+          {pendingFiles.map((f, i) => (
+            <View
+              key={i}
+              className="flex-row items-center bg-white border border-border rounded-lg px-2 py-1 mr-2 mb-1"
+            >
+              <FontAwesome name="file-o" size={13} color={colors.primary} />
+              <Text className="text-xs mx-1 max-w-[90px]" style={{ color: colors.text }} numberOfLines={1}>
+                {f.name}
+              </Text>
+              <Text className="text-xs mr-1" style={{ color: colors.textSecondary }}>{formatFileSize(f.size)}</Text>
+              <Pressable
+                accessibilityRole="button"
+                onPress={() => onRemovePendingFile(i)}
+                accessibilityLabel={`Удалить файл ${f.name}`}
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+              >
+                <FontAwesome name="times" size={11} color={colors.textSecondary} />
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Input bar */}
+      {!isClosed && (
+        <View
+          className="flex-row items-end border-t border-border px-3 py-2 bg-white"
+          style={dragOver ? { backgroundColor: colors.accentSoft } as object : undefined}
+          {...(Platform.OS === "web" ? {
+            onDragOver: (e: React.DragEvent) => { e.preventDefault(); onDragOver(); },
+            onDragLeave: () => onDragLeave(),
+            onDrop: (e: React.DragEvent) => {
+              e.preventDefault();
+              onDragLeave();
+              const file = e.dataTransfer.files[0];
+              if (file) onWebFileDrop(file);
+            },
+          } as object : {})}
+        >
+          {dragOver && Platform.OS === "web" && (
+            <View
+              className="absolute inset-0 items-center justify-center rounded-lg"
+              style={{ backgroundColor: "rgba(0,0,0,0.05)", zIndex: 10 }}
+              pointerEvents="none"
+            >
+              <Text className="text-sm font-medium text-text-dim">Перетащите файл сюда</Text>
+            </View>
+          )}
+
+          {/* Attach button */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Прикрепить файл (PDF, JPG, PNG — до 10 МБ, не более 3)"
+            onPress={onAttachFile}
+            disabled={pendingFiles.length >= 3 || sending}
+            className="w-11 h-11 items-center justify-center mr-1"
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+          >
+            <FontAwesome
+              name="paperclip"
+              size={20}
+              color={pendingFiles.length >= 3 ? colors.border : colors.textSecondary}
+            />
+          </Pressable>
+
+          {/* Text input */}
+          <Input
+            accessibilityLabel="Введите сообщение"
+            placeholder="Введите сообщение..."
+            value={text}
+            onChangeText={onChangeText}
+            multiline
+            style={{ flex: 1 }}
+            containerStyle={{ borderRadius: radiusValue.xl, minHeight: 40, maxHeight: 120 }}
+          />
+
+          {/* Send button */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Отправить сообщение"
+            onPress={onSend}
+            disabled={(!text.trim() && pendingFiles.length === 0) || sending}
+            className="w-11 h-11 items-center justify-center ml-2"
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+          >
+            {sending || uploading ? (
+              <ActivityIndicator size="small" color={colors.primary} />
+            ) : (
+              <FontAwesome
+                name="send"
+                size={20}
+                color={(text.trim() || pendingFiles.length > 0) ? colors.primary : colors.textSecondary}
+              />
+            )}
+          </Pressable>
+        </View>
+      )}
+    </>
+  );
+}

--- a/components/chat/ChatHeader.tsx
+++ b/components/chat/ChatHeader.tsx
@@ -1,0 +1,148 @@
+import { View, Text, Pressable } from "react-native";
+import { router } from "expo-router";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { FileText, ChevronRight } from "lucide-react-native";
+import { Avatar } from "@/components/ui";
+import PerspectiveBadge from "@/components/ui/PerspectiveBadge";
+import { colors } from "@/lib/theme";
+import { displayName } from "./chatUtils";
+
+interface OtherUser {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  isDeleted?: boolean;
+}
+
+interface RequestInfo {
+  id: string;
+  title: string;
+  status: string;
+}
+
+export interface ChatHeaderProps {
+  otherUser: OtherUser | null;
+  otherName: string;
+  myId: string | undefined;
+  clientId?: string;
+  specialistId?: string;
+  requestId?: string;
+  request?: RequestInfo;
+  isDesktop: boolean;
+  /** Instrumental-case name for the "Вы переписываетесь с X" hint */
+  counterpartyInstrumental: string;
+}
+
+/** Minimal header shown during loading / error states before thread data is available. */
+export function ChatShellHeader({ isDesktop }: { isDesktop: boolean }) {
+  return (
+    <View className="flex-row items-center px-4 py-3 border-b border-border bg-white">
+      {!isDesktop && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Назад"
+          onPress={() => router.back()}
+          className="mr-3 w-11 h-11 items-center justify-center"
+        >
+          <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+        </Pressable>
+      )}
+      <Text className="text-base font-semibold" style={{ color: colors.primary }}>Чат</Text>
+    </View>
+  );
+}
+
+export default function ChatHeader({
+  otherUser,
+  otherName,
+  myId,
+  clientId,
+  specialistId,
+  requestId,
+  request,
+  isDesktop,
+  counterpartyInstrumental,
+}: ChatHeaderProps) {
+  const myPerspective: "as_client" | "as_specialist" | null =
+    myId && clientId && specialistId
+      ? clientId === myId
+        ? "as_client"
+        : specialistId === myId
+        ? "as_specialist"
+        : null
+      : null;
+
+  return (
+    <>
+      {/* Header row */}
+      <View className="flex-row items-start px-4 py-3 border-b border-border bg-white">
+        {!isDesktop && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Назад"
+            onPress={() => router.back()}
+            className="mr-3 w-11 h-11 items-center justify-center"
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+          >
+            <FontAwesome name="chevron-left" size={18} color={colors.primary} />
+          </Pressable>
+        )}
+        {otherUser ? (
+          <Avatar
+            name={displayName(otherUser)}
+            imageUrl={otherUser.avatarUrl ?? undefined}
+            size="sm"
+          />
+        ) : (
+          <View className="w-9 h-9 rounded-full items-center justify-center" style={{ backgroundColor: colors.border }}>
+            <FontAwesome name="user" size={16} color={colors.textSecondary} />
+          </View>
+        )}
+        <View className="ml-3 flex-1" style={{ gap: 4 }}>
+          <View className="flex-row items-center" style={{ gap: 8 }}>
+            <Text className="text-base font-semibold flex-shrink" style={{ color: colors.text }} numberOfLines={1}>
+              {otherName}
+            </Text>
+            {myPerspective ? (
+              <PerspectiveBadge perspective={myPerspective} size="md" />
+            ) : null}
+          </View>
+          {myPerspective ? (
+            <Text className="text-xs" style={{ color: colors.textSecondary }} numberOfLines={1}>
+              Вы переписываетесь с {counterpartyInstrumental}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+
+      {/* Source request link strip */}
+      {requestId ? (
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel={`Открыть заявку ${request?.title ?? ""}`}
+          onPress={() => router.push(`/requests/${requestId}/detail` as never)}
+          style={({ pressed }) => [
+            {
+              flexDirection: "row",
+              alignItems: "center",
+              paddingHorizontal: 16,
+              paddingVertical: 8,
+              backgroundColor: colors.surface2,
+              borderBottomWidth: 1,
+              borderBottomColor: colors.border,
+              gap: 8,
+            },
+            pressed && { opacity: 0.7 },
+          ]}
+        >
+          <FileText size={14} color={colors.accent} />
+          <Text style={{ flex: 1, fontSize: 13, color: colors.text }} numberOfLines={1}>
+            По заявке: {request?.title || "Заявка"}
+          </Text>
+          <ChevronRight size={14} color={colors.textMuted} />
+        </Pressable>
+      ) : null}
+    </>
+  );
+}

--- a/components/chat/ChatMessageList.tsx
+++ b/components/chat/ChatMessageList.tsx
@@ -1,0 +1,115 @@
+import { useRef, useCallback } from "react";
+import { View, Text, FlatList, Pressable, ActivityIndicator } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import MessageBubble from "@/components/MessageBubble";
+import { colors } from "@/lib/theme";
+
+interface FileAttachment {
+  id: string;
+  url: string;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface MessageItem {
+  id: string;
+  threadId: string;
+  senderId: string;
+  text: string;
+  createdAt: string;
+  sender: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  files: FileAttachment[];
+}
+
+export interface ChatMessageListProps {
+  messages: MessageItem[];
+  myId: string | undefined;
+  hasMoreOlder: boolean;
+  loadingOlder: boolean;
+  onLoadOlder: () => void;
+  onFilePress: (file: FileAttachment) => void;
+  /** Ref exposed so orchestrator can call scrollToEnd */
+  flatListRef: React.RefObject<FlatList | null>;
+}
+
+export default function ChatMessageList({
+  messages,
+  myId,
+  hasMoreOlder,
+  loadingOlder,
+  onLoadOlder,
+  onFilePress,
+  flatListRef,
+}: ChatMessageListProps) {
+  const renderMessage = useCallback(
+    ({ item }: { item: MessageItem }) => (
+      <MessageBubble
+        text={item.text}
+        createdAt={item.createdAt}
+        isOwn={item.senderId === myId}
+        files={item.files}
+        onFilePress={onFilePress}
+      />
+    ),
+    [myId, onFilePress]
+  );
+
+  return (
+    <FlatList
+      ref={flatListRef}
+      data={messages}
+      keyExtractor={(item) => item.id}
+      renderItem={renderMessage}
+      contentContainerStyle={{ padding: 16, flexGrow: 1, justifyContent: "flex-end" }}
+      onContentSizeChange={() => {
+        // Scroll to bottom only on initial load / new messages.
+        // When loading older messages, prepended items would otherwise
+        // jerk the list to the bottom. `loadingOlder` short-circuits that.
+        if (!loadingOlder) {
+          flatListRef.current?.scrollToEnd({ animated: false });
+        }
+      }}
+      ListHeaderComponent={
+        hasMoreOlder ? (
+          <View className="items-center py-3">
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Загрузить старые сообщения"
+              onPress={onLoadOlder}
+              disabled={loadingOlder}
+              className="px-4 py-2 rounded-xl border border-slate-200"
+              style={({ pressed }) => [
+                { backgroundColor: "#f8fafc" },
+                pressed && { opacity: 0.7 },
+                loadingOlder && { opacity: 0.6 },
+              ]}
+            >
+              {loadingOlder ? (
+                <ActivityIndicator size="small" color="#1e3a8a" />
+              ) : (
+                <Text className="text-sm font-medium" style={{ color: "#1e3a8a" }}>
+                  Загрузить старые сообщения
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        ) : null
+      }
+      ListEmptyComponent={
+        <View className="flex-1 items-center justify-center py-16">
+          <FontAwesome name="comments-o" size={48} color={colors.textSecondary} />
+          <Text className="text-base font-medium mt-4" style={{ color: colors.textSecondary }}>Начните общение</Text>
+          <Text className="text-sm mt-1 text-center px-4" style={{ color: colors.textSecondary }}>
+            Напишите сообщение, чтобы начать диалог
+          </Text>
+        </View>
+      }
+    />
+  );
+}

--- a/components/chat/chatUtils.ts
+++ b/components/chat/chatUtils.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared utility functions and types for the chat components.
+ */
+
+import { API_URL } from "@/lib/api";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export interface PendingFile {
+  uri: string;
+  name: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface OtherUser {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  avatarUrl: string | null;
+  isDeleted?: boolean;
+}
+
+export interface ThreadInfo {
+  id: string;
+  requestId: string;
+  clientId: string;
+  specialistId: string;
+  request: { id: string; title: string; status: string };
+  client: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null; isDeleted?: boolean };
+  specialist: { id: string; firstName: string | null; lastName: string | null; avatarUrl: string | null; isDeleted?: boolean };
+  otherUser: OtherUser;
+}
+
+// ─── Upload helper ────────────────────────────────────────────────────────────
+
+export async function uploadChatFile(file: PendingFile, threadId: string): Promise<string> {
+  const uploadToken = crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const formData = new FormData();
+  formData.append("file", { uri: file.uri, name: file.name, type: file.mimeType } as unknown as Blob);
+  formData.append("uploadToken", uploadToken);
+  formData.append("threadId", threadId);
+  const token = await AsyncStorage.getItem("p2ptax_access_token");
+  const res = await fetch(`${API_URL}/api/upload/chat-file`, {
+    method: "POST",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    body: formData,
+  });
+  if (!res.ok) throw new Error("Ошибка загрузки файла");
+  return ((await res.json()) as { uploadToken: string }).uploadToken;
+}
+
+export function displayName(user: { firstName: string | null; lastName: string | null; isDeleted?: boolean }): string {
+  if (user.isDeleted) return "Аккаунт удалён";
+  const parts = [user.firstName, user.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : "Пользователь";
+}
+
+/**
+ * Russian instrumental case for a single name token.
+ * Pragmatic suffix rules — covers common Russian first/last names.
+ */
+export function tokenInInstrumental(token: string): string {
+  if (!token) return token;
+  const lower = token.toLowerCase();
+  // Female surnames
+  if (/(?:ова|ева|ёва|ина|ына)$/.test(lower)) return token.slice(0, -1) + "ой";
+  if (/ская$/.test(lower)) return token.slice(0, -2) + "ой";
+  // Male surnames
+  if (/(?:ов|ев|ёв|ин|ын)$/.test(lower)) return token + "ым";
+  if (/(?:ский|цкий)$/.test(lower)) return token.slice(0, -2) + "им";
+  // Names ending in -ей, -й, -ий, -ия, -я, -а
+  if (/ей$/.test(lower)) return token.slice(0, -2) + "еем";
+  if (/[аоу]й$/.test(lower)) return token.slice(0, -1) + "ем";
+  if (/ий$/.test(lower)) return token.slice(0, -2) + "ием";
+  if (/й$/.test(lower)) return token.slice(0, -1) + "ем";
+  if (/ия$/.test(lower)) return token.slice(0, -1) + "ей";
+  if (/я$/.test(lower)) return token.slice(0, -1) + "ей";
+  if (/[жшщчц]а$/.test(lower)) return token.slice(0, -1) + "ей";
+  if (/а$/.test(lower)) return token.slice(0, -1) + "ой";
+  if (/ь$/.test(lower)) return token.slice(0, -1) + "ем";
+  if (/[бвгджзйклмнпрстфхцчшщ]$/.test(lower)) return token + "ом";
+  return token;
+}
+
+export function nameInInstrumental(name: string): string {
+  return name ? name.split(/\s+/).map(tokenInInstrumental).join(" ") : name;
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -1,0 +1,8 @@
+export { default as ChatHeader, ChatShellHeader } from "./ChatHeader";
+export type { ChatHeaderProps } from "./ChatHeader";
+
+export { default as ChatMessageList } from "./ChatMessageList";
+export type { ChatMessageListProps, MessageItem } from "./ChatMessageList";
+
+export { default as ChatComposer } from "./ChatComposer";
+export type { ChatComposerProps } from "./ChatComposer";


### PR DESCRIPTION
## Summary

- Extracted `ChatHeader` (avatar, name, perspective badge, back button, request link strip)
- Extracted `ChatMessageList` (FlatList, load-older button, empty state)
- Extracted `ChatComposer` (attach, text input, send button, file preview strip, drag/drop, closed banner)
- Created `chatUtils.ts` (shared types: `PendingFile`, `ThreadInfo`, `OtherUser`; helpers: `displayName`, `nameInInstrumental`, `uploadChatFile`)
- `InlineChatView.tsx` is now a pure orchestrator: 762 → 249 lines

## Verification

- `npx tsc --noEmit` → 0 errors (frontend)
- `cd api && npx tsc --noEmit` → 0 errors
- Public props unchanged: `InlineChatView` still accepts `{ threadId: string }`
- All callbacks/handlers preserved with same names

## Test plan

- [ ] Open a thread — messages render, scroll works
- [ ] Send a message — optimistic append, scroll to bottom
- [ ] Attach file — preview strip shows, can remove
- [ ] Load older messages — button appears, prepends correctly
- [ ] Mobile: back button visible in header
- [ ] Desktop: back button hidden
- [ ] Closed thread: banner shown, composer hidden