### PR TITLE
feat: 'Написать' → direct thread + filter z-index (#1648 #1649)

### DIFF
--- a/api/prisma/migrations/20260430000000_thread_optional_request/migration.sql
+++ b/api/prisma/migrations/20260430000000_thread_optional_request/migration.sql
@@ -1,0 +1,8 @@
+-- Make requestId optional on threads (enables direct threads without a request)
+ALTER TABLE "threads" ALTER COLUMN "request_id" DROP NOT NULL;
+
+-- Add partial unique index for direct threads (request_id IS NULL)
+-- Prevents duplicate direct threads between same client+specialist pair
+CREATE UNIQUE INDEX "threads_direct_unique"
+  ON "threads" ("client_id", "specialist_id")
+  WHERE "request_id" IS NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -226,7 +226,7 @@ model Request {
 
 model Thread {
   id                   String    @id @default(uuid())
-  requestId            String    @map("request_id")
+  requestId            String?   @map("request_id")
   clientId             String    @map("client_id")
   specialistId         String    @map("specialist_id")
   lastMessageAt        DateTime? @map("last_message_at")
@@ -236,7 +236,7 @@ model Thread {
   deletedAt            DateTime? @map("deleted_at")
   deletedBy            String?   @map("deleted_by")
 
-  request    Request   @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  request    Request?  @relation(fields: [requestId], references: [id], onDelete: Cascade)
   client     User      @relation("ClientThreads", fields: [clientId], references: [id])
   specialist User      @relation("SpecialistThreads", fields: [specialistId], references: [id])
   messages   Message[]

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -429,7 +429,7 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
       return;
     }
 
-    if (thread.request.status === "CLOSED") {
+    if (thread.request && thread.request.status === "CLOSED") {
       res.status(422).json({ error: "Request is closed. Chat is read-only." });
       return;
     }
@@ -518,7 +518,7 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
         toName,
         fromName: senderName,
         threadId,
-        requestTitle: thread.request.title,
+        requestTitle: thread.request?.title ?? "Прямое сообщение",
         recipientId,
       });
     }).catch((err: Error) => console.warn("[email] new_message email failed:", err.message));

--- a/api/src/routes/threads.ts
+++ b/api/src/routes/threads.ts
@@ -534,6 +534,55 @@ router.delete("/:id", async (req: Request, res: Response) => {
   }
 });
 
+// POST /api/threads/direct — get or create a direct thread between caller and a specialist
+// Used by the catalog "Написать" button: no requestId, no firstMessage required.
+router.post("/direct", async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const { specialistId } = req.body as { specialistId?: string };
+
+    if (!specialistId || typeof specialistId !== "string") {
+      res.status(400).json({ error: "specialistId is required" });
+      return;
+    }
+
+    if (userId === specialistId) {
+      res.status(400).json({ error: "Cannot start a thread with yourself" });
+      return;
+    }
+
+    const specialist = await prisma.user.findUnique({
+      where: { id: specialistId },
+      select: { id: true, isSpecialist: true },
+    });
+
+    if (!specialist || !specialist.isSpecialist) {
+      res.status(404).json({ error: "Specialist not found" });
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const existing = await (prisma.thread as any).findFirst({
+      where: { requestId: null, clientId: userId, specialistId },
+    }) as { id: string } | null;
+
+    if (existing) {
+      res.json({ threadId: existing.id, created: false });
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const thread = await (prisma.thread as any).create({
+      data: { requestId: null, clientId: userId, specialistId },
+    }) as { id: string };
+
+    res.status(201).json({ threadId: thread.id, created: true });
+  } catch (error) {
+    console.error("threads/direct error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 // POST /api/threads — create thread with first message (specialist only)
 router.post("/", async (req: Request, res: Response) => {
   try {
@@ -680,7 +729,7 @@ router.post("/", async (req: Request, res: Response) => {
     sendNotification({
       userId: request.userId,
       type: "new_message_from_specialist",
-      title: `Новое сообщение от специалиста по запросу «${thread.request.title}»`,
+      title: `Новое сообщение от специалиста по запросу «${thread.request?.title ?? ""}»`,
       body: firstMessage.slice(0, 200),
       entityId: thread.id,
     }).catch((err: Error) => console.warn("[notifications] new_message_from_specialist trigger failed:", err.message));

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable, Image } from "react-native";
-import { Bookmark } from "lucide-react-native";
+import { Bookmark, MessageCircle } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 
 interface FnsGroup {
@@ -26,6 +26,7 @@ interface SpecialistCardProps {
   horizontal?: boolean;
   onBookmark?: (id: string) => void;
   bookmarked?: boolean;
+  onWrite?: (id: string) => void;
   /** When set, only the matching FNS group is shown (cascade narrows to active filter). */
   activeFnsId?: string | null;
 }
@@ -58,6 +59,7 @@ export default function SpecialistCard({
   horizontal = false,
   onBookmark,
   bookmarked = false,
+  onWrite,
   activeFnsId,
 }: SpecialistCardProps) {
   const resolvedVariant = variant ?? (horizontal ? "horizontal" : "vertical");
@@ -284,6 +286,22 @@ export default function SpecialistCard({
           {desc}
         </Text>
       ) : null}
+
+      {/* Row 4: "Написать" CTA — direct chat without a request */}
+      {onWrite && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Написать специалисту"
+          onPress={(e) => { e.stopPropagation?.(); onWrite(id); }}
+          className="flex-row items-center justify-center mt-2 py-1.5 rounded-xl border border-border"
+          style={{ gap: 6 }}
+        >
+          <MessageCircle size={14} color={colors.primary} />
+          <Text className="text-xs font-medium" style={{ color: colors.primary }}>
+            Написать
+          </Text>
+        </Pressable>
+      )}
     </Pressable>
   );
 }

--- a/components/filters/SpecialistSearchBar.tsx
+++ b/components/filters/SpecialistSearchBar.tsx
@@ -153,7 +153,7 @@ export default function SpecialistSearchBar({
 
       {/* Search input */}
       {!selectedFns && (
-        <View className="relative" style={{ zIndex: 10 }}>
+        <View className="relative" style={{ zIndex: 100 }}>
           <View className="flex-row items-center bg-white border border-border rounded-xl h-10 px-3">
             <Search size={14} color={colors.placeholder} style={{ marginRight: 8 }} />
             <TextInput
@@ -208,7 +208,7 @@ export default function SpecialistSearchBar({
               style={{
                 top: 44,
                 maxHeight: 360,
-                zIndex: 50,
+                zIndex: 200,
                 elevation: 8,
                 shadowColor: "#000",
                 shadowOffset: { width: 0, height: 4 },

--- a/components/specialists/SpecialistFeed.tsx
+++ b/components/specialists/SpecialistFeed.tsx
@@ -350,6 +350,25 @@ export default function SpecialistFeed({ mode }: SpecialistFeedProps) {
     [nav]
   );
 
+  const handleWrite = useCallback(
+    async (specialistId: string) => {
+      if (!isAuthenticated) {
+        nav.routes.login();
+        return;
+      }
+      try {
+        const res = await apiPost<{ threadId: string; created: boolean }>(
+          "/api/threads/direct",
+          { specialistId }
+        );
+        nav.any(`/threads/${res.threadId}`);
+      } catch {
+        nav.dynamic.specialist(specialistId);
+      }
+    },
+    [nav, isAuthenticated]
+  );
+
   // ── Bookmark toggle ──
   const handleBookmark = useCallback(
     async (id: string) => {
@@ -514,6 +533,7 @@ export default function SpecialistFeed({ mode }: SpecialistFeedProps) {
         onLoadMore={handleLoadMore}
         onPress={handleSpecialistPress}
         onBookmark={handleBookmark}
+        onWrite={handleWrite}
         onScroll={handleScroll}
       />
     );

--- a/components/specialists/SpecialistFilter.tsx
+++ b/components/specialists/SpecialistFilter.tsx
@@ -46,7 +46,7 @@ export default function SpecialistFilter({
 }: Props) {
   return (
     <View>
-      <View className="px-4 pt-2" style={{ zIndex: 20 }}>
+      <View className="px-4 pt-2" style={{ zIndex: 100 }}>
         <SpecialistSearchBar
           cities={cities}
           fnsAll={fnsAll}

--- a/components/specialists/SpecialistsGrid.tsx
+++ b/components/specialists/SpecialistsGrid.tsx
@@ -54,6 +54,7 @@ interface Props {
   onLoadMore: () => void;
   onPress: (id: string) => void;
   onBookmark: (id: string) => void;
+  onWrite?: (id: string) => void;
   onScroll?: (e: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
@@ -69,12 +70,14 @@ function DesktopSpecialistRow({
   onPress,
   bookmarked,
   onBookmark,
+  onWrite,
   activeFnsId,
 }: {
   item: SpecialistItem;
   onPress: (id: string) => void;
   bookmarked: boolean;
   onBookmark: (id: string) => void;
+  onWrite?: (id: string) => void;
   activeFnsId?: string | null;
 }) {
   const [hovered, setHovered] = useState(false);
@@ -269,7 +272,8 @@ function DesktopSpecialistRow({
             accessibilityLabel="Написать"
             onPress={(e) => {
               e.stopPropagation?.();
-              onPress(item.id);
+              if (onWrite) onWrite(item.id);
+              else onPress(item.id);
             }}
             style={({ pressed }) => [
               {
@@ -383,6 +387,7 @@ export default function SpecialistsGrid({
   onLoadMore,
   onPress,
   onBookmark,
+  onWrite,
   onScroll,
 }: Props) {
   // On desktop we always render 1 column of horizontal rows
@@ -407,6 +412,7 @@ export default function SpecialistsGrid({
             onPress={onPress}
             bookmarked={bookmarkedIds.has(item.id)}
             onBookmark={onBookmark}
+            onWrite={onWrite}
             activeFnsId={activeFnsId}
           />
         )}
@@ -464,6 +470,7 @@ export default function SpecialistsGrid({
             onPress={onPress}
             onBookmark={onBookmark}
             bookmarked={bookmarkedIds.has(item.id)}
+            onWrite={onWrite}
             variant="vertical"
             activeFnsId={activeFnsId}
           />


### PR DESCRIPTION
## #1648 — Кнопка 'Написать' открывает чат напрямую

**Backend**
- New endpoint: \`POST /api/threads/direct { specialistId }\`
- Find-or-create thread between caller and specialist, no requestId
- Schema: \`Thread.requestId\` теперь nullable + relation \`Request?\`
- Migration: \`ALTER COLUMN DROP NOT NULL\` + partial unique index (clientId, specialistId WHERE request_id IS NULL)
- Null guards в \`messages.ts\` и \`threads.ts\` для thread.request

**Frontend**
- \`SpecialistCard\` (mobile vertical): новая кнопка 'Написать' с MessageCircle iconом
- \`SpecialistsGrid\` desktop: 'Написать' использует onWrite если передан, иначе fallback к onPress (профиль)
- \`SpecialistFeed.handleWrite\`: вызов /api/threads/direct → nav.any('/threads/:id'); fallback к профилю при ошибке
- Auth check: если не авторизован → /login

## #1649 — z-index фильтра не перекрывается списком

- \`SpecialistFilter\` wrapper: 20 → 100
- \`SpecialistSearchBar\` input wrapper: 10 → 100
- \`SpecialistSearchBar\` dropdown: 50 → 200

## Verify
- \`tsc --noEmit\` 0 errors (frontend + api)
- POST /api/threads/direct без auth → 401 (auth-protected)
- Открой /specialists, search 'Москва' → dropdown поверх списка
- Нажми 'Написать' → переходит в /threads/:id

Closes #1648, closes #1649