### PR TITLE
feat(layout): unified PageTitle #1657

### DIFF
--- a/app/(tabs)/my-requests.tsx
+++ b/app/(tabs)/my-requests.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useTypedRouter } from "@/lib/navigation";
 import { BREAKPOINT } from "@/lib/theme";
 import DesktopScreen from "@/components/layout/DesktopScreen";
+import PageTitle from "@/components/layout/PageTitle";
 import { FileText } from "lucide-react-native";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
@@ -208,11 +209,9 @@ export default function MyRequests() {
 
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
+      <PageTitle title="Мои заявки" />
       <DesktopScreen>
         <View className="flex-row items-center justify-between mb-4">
-          {!isDesktop && (
-            <Text className="text-xl font-bold text-text-base">Мои заявки</Text>
-          )}
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Создать заявку"

--- a/app/(tabs)/requests.tsx
+++ b/app/(tabs)/requests.tsx
@@ -16,8 +16,9 @@ import EmptyState from "@/components/ui/EmptyState";
 import ErrorState from "@/components/ui/ErrorState";
 import LoadingState from "@/components/ui/LoadingState";
 import RequestCard from "@/components/RequestCard";
+import PageTitle from "@/components/layout/PageTitle";
 import { api } from "@/lib/api";
-import { colors, overlay, textStyle, BREAKPOINT } from "@/lib/theme";
+import { colors, BREAKPOINT } from "@/lib/theme";
 
 interface CityOption {
   id: string;
@@ -214,20 +215,7 @@ export default function PublicRequestsTab() {
 
   return (
     <SafeAreaView className="flex-1 bg-surface2" edges={["top"]}>
-      {/* Accent hero — no back button (this is a tab, not a stacked screen) */}
-      <View className="bg-accent px-4 py-4">
-        <Text style={{ ...textStyle.h3, color: colors.white, marginBottom: 2 }}>
-          Заявки
-        </Text>
-        <Text style={{ ...textStyle.small, color: overlay.white90 }}>
-          Открытая биржа: задайте вопрос — получите предложения от специалистов
-        </Text>
-        {total > 0 && (
-          <Text className="text-sm font-semibold text-white mt-2">
-            {total} активных запросов
-          </Text>
-        )}
-      </View>
+      <PageTitle title="Биржа запросов" subtitle="Открытая биржа: задайте вопрос — получите предложения от специалистов" />
 
       {/* Filter bar: city → FNS cascade + services chips */}
       <View className="bg-white border-b border-border py-2">

--- a/app/legal/index.tsx
+++ b/app/legal/index.tsx
@@ -4,6 +4,7 @@ import { useTypedRouter } from "@/lib/navigation";
 import { FileText, Shield, ChevronRight, ChevronLeft } from "lucide-react-native";
 import { colors } from "@/lib/theme";
 import DesktopScreen from "@/components/layout/DesktopScreen";
+import PageTitle from "@/components/layout/PageTitle";
 
 const LEGAL_DOCS = [
   {
@@ -37,10 +38,7 @@ export default function LegalIndexPage() {
             <Text className="text-sm font-medium text-accent ml-1">Назад</Text>
           </Pressable>
 
-          <View className="mb-6">
-            <Text className="text-2xl font-bold text-text-base mb-1">Правовая информация</Text>
-            <Text className="text-sm text-text-mute">Документы и соглашения P2PTax</Text>
-          </View>
+          <PageTitle title="Правовая информация" subtitle="Документы и соглашения P2PTax" />
 
           <View className="bg-white border border-border rounded-2xl overflow-hidden">
             {LEGAL_DOCS.map((doc, idx) => {

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import StyledSwitch from "@/components/ui/StyledSwitch";
 import LandingHeader from "@/components/landing/LandingHeader";
+import PageTitle from "@/components/layout/PageTitle";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
@@ -280,16 +281,8 @@ export default function CreateRequest() {
           ...(Platform.OS === "web" ? ({ position: "sticky", top: 0, zIndex: 10 } as object) : {}),
         }}
       >
-        <View
-          style={{
-            width: "100%",
-            maxWidth: 640,
-            alignSelf: "center",
-            paddingHorizontal: 16,
-            paddingTop: 16,
-          }}
-        >
-          {width < 640 && (
+        {width < 640 && (
+          <View style={{ paddingHorizontal: 16, paddingTop: 16 }}>
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Назад"
@@ -300,9 +293,9 @@ export default function CreateRequest() {
               <ChevronLeft size={20} color={colors.text} />
               <Text className="text-text-base ml-1">Назад</Text>
             </Pressable>
-          )}
-          <Text className="text-2xl font-extrabold text-text-base mb-3">Создать запрос</Text>
-        </View>
+          </View>
+        )}
+        <PageTitle title="Новая заявка" />
       </View>
       <ScrollView
         className="flex-1"

--- a/app/saved-specialists/index.tsx
+++ b/app/saved-specialists/index.tsx
@@ -1,5 +1,5 @@
 import SpecialistFeed from "@/components/specialists/SpecialistFeed";
 
 export default function SavedSpecialistsScreen() {
-  return <SpecialistFeed mode="favorites" />;
+  return <SpecialistFeed mode="favorites" title="Мои специалисты" />;
 }

--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import Constants from "expo-constants";
 import { View, Text, ScrollView, Pressable, Alert, Platform, useWindowDimensions } from "react-native";
+import PageTitle from "@/components/layout/PageTitle";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams } from "expo-router";
 import { ChevronLeft, LogOut, Trash2 } from "lucide-react-native";
@@ -150,8 +151,8 @@ export default function UnifiedSettings() {
   if (!ready) {
     return (
       <SafeAreaView className="flex-1 bg-surface2">
-        <View className="px-4 pt-4">
-          {!isDesktop && (
+        {!isDesktop && (
+          <View className="px-4 pt-4">
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Назад"
@@ -162,9 +163,9 @@ export default function UnifiedSettings() {
               <ChevronLeft size={20} color={colors.text} />
               <Text className="text-text-base ml-1">Назад</Text>
             </Pressable>
-          )}
-          <Text className="text-2xl font-extrabold text-text-base mb-4">Настройки</Text>
-        </View>
+          </View>
+        )}
+        <PageTitle title="Настройки" />
         <LoadingState variant="skeleton" lines={5} />
       </SafeAreaView>
     );
@@ -172,8 +173,8 @@ export default function UnifiedSettings() {
 
   return (
     <SafeAreaView className="flex-1 bg-surface2">
-      <View className="px-4 pt-4">
-        {!isDesktop && (
+      {!isDesktop && (
+        <View className="px-4 pt-4">
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Назад"
@@ -184,9 +185,9 @@ export default function UnifiedSettings() {
             <ChevronLeft size={20} color={colors.text} />
             <Text className="text-text-base ml-1">Назад</Text>
           </Pressable>
-        )}
-        <Text className="text-2xl font-extrabold text-text-base mb-3">Настройки</Text>
-      </View>
+        </View>
+      )}
+      <PageTitle title="Настройки" />
 
       {/* Tabs hidden during inline onboarding — content takes full screen */}
       {!inlineOnboarding && (

--- a/app/specialists/index.tsx
+++ b/app/specialists/index.tsx
@@ -1,5 +1,5 @@
 import SpecialistFeed from "@/components/specialists/SpecialistFeed";
 
 export default function SpecialistsCatalog() {
-  return <SpecialistFeed mode="all" />;
+  return <SpecialistFeed mode="all" title="Специалисты" />;
 }

--- a/components/layout/PageTitle.tsx
+++ b/components/layout/PageTitle.tsx
@@ -1,0 +1,16 @@
+import { View, Text } from 'react-native';
+import { colors } from '@/lib/theme';
+
+interface PageTitleProps {
+  title: string;
+  subtitle?: string;
+}
+
+export default function PageTitle({ title, subtitle }: PageTitleProps) {
+  return (
+    <View style={{ paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 }}>
+      <Text style={{ fontSize: 20, fontWeight: '700', color: colors.text }}>{title}</Text>
+      {subtitle ? <Text style={{ fontSize: 13, color: colors.textMuted, marginTop: 2 }}>{subtitle}</Text> : null}
+    </View>
+  );
+}

--- a/components/specialists/SpecialistFeed.tsx
+++ b/components/specialists/SpecialistFeed.tsx
@@ -30,6 +30,7 @@ import CatalogSkeleton from "@/components/specialists/CatalogSkeleton";
 import SpecialistFilter from "@/components/specialists/SpecialistFilter";
 import SpecialistsGrid from "@/components/specialists/SpecialistsGrid";
 import LandingHeader from "@/components/landing/LandingHeader";
+import PageTitle from "@/components/layout/PageTitle";
 import { CityOpt, FnsOpt } from "@/components/filters/SpecialistSearchBar";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -86,13 +87,15 @@ interface FnsResponse {
 export interface SpecialistFeedProps {
   /** 'all' = public catalog; 'favorites' = current user's saved list */
   mode: "all" | "favorites";
+  title?: string;
+  subtitle?: string;
 }
 
 const PAGE_SIZE = 12;
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export default function SpecialistFeed({ mode }: SpecialistFeedProps) {
+export default function SpecialistFeed({ mode, title, subtitle }: SpecialistFeedProps) {
   const nav = useTypedRouter();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
   const { width } = useWindowDimensions();
@@ -555,36 +558,29 @@ export default function SpecialistFeed({ mode }: SpecialistFeedProps) {
 
       {/* Page header */}
       {mode === "all" ? (
-        <CatalogHeader isDesktop={isDesktop} count={null} />
+        <>
+          {title && <PageTitle title={title} subtitle={subtitle} />}
+          <CatalogHeader isDesktop={isDesktop} count={null} />
+        </>
       ) : (
-        <View
-          className="flex-row items-center justify-between"
-          style={{
-            paddingHorizontal: 16,
-            paddingTop: 16,
-            paddingBottom: 4,
-            width: "100%",
-            maxWidth: isDesktop ? 1100 : undefined,
-            alignSelf: "center",
-          }}
-        >
-          <Text className="text-xl font-bold" style={{ color: colors.text }}>
-            Мои специалисты
-          </Text>
+        <>
+          {title && <PageTitle title={title} subtitle={subtitle} />}
           {hasFilters && (
-            <Pressable
-              accessibilityRole="button"
-              onPress={resetFilters}
-              style={({ pressed }) => [pressed && { opacity: 0.7 }]}
-            >
-              <Text
-                style={{ color: colors.primary, fontSize: 13, fontWeight: "600" }}
+            <View style={{ paddingHorizontal: 16, paddingBottom: 4, alignItems: "flex-end" }}>
+              <Pressable
+                accessibilityRole="button"
+                onPress={resetFilters}
+                style={({ pressed }) => [pressed && { opacity: 0.7 }]}
               >
-                Сбросить
-              </Text>
-            </Pressable>
+                <Text
+                  style={{ color: colors.primary, fontSize: 13, fontWeight: "600" }}
+                >
+                  Сбросить
+                </Text>
+              </Pressable>
+            </View>
           )}
-        </View>
+        </>
       )}
 
       {/* Cascade filter — hides on scroll-down, reveals on scroll-up */}


### PR DESCRIPTION
## Summary
- Add `components/layout/PageTitle.tsx` — single unified title component (20px/700)
- Apply to: specialists, saved-specialists, settings, legal, requests/new, (tabs)/requests, (tabs)/my-requests
- Excluded: messages, login, otp, threads/[id], requests/[id]/*, landing
- tsc --noEmit: 0 errors

Closes #1657