### PR TITLE
feat(cards): short service names + 'Все' chip when all 3 core services selected

### DIFF
--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,6 +1,7 @@
 import { View, Text, Pressable, Image } from "react-native";
 import { Bookmark, MessageCircle } from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import { isAllCoreServicesSelected } from "@/lib/services";
 
 interface FnsGroup {
   fnsId: string;
@@ -213,17 +214,28 @@ export default function SpecialistCard({
               </Text>
               {g.services.length > 0 && (
                 <View className="flex-row flex-wrap items-center" style={{ gap: 6 }}>
-                  {g.services.map((s) => (
+                  {isAllCoreServicesSelected(g.services.map((s) => s.name)) ? (
                     <View
-                      key={`${g.fnsId}-${s.id}`}
                       className="px-2 py-0.5 rounded-full"
                       style={{ backgroundColor: colors.accentSoft }}
                     >
                       <Text className="text-xs" style={{ color: colors.primary }} numberOfLines={1}>
-                        {s.name}
+                        Все
                       </Text>
                     </View>
-                  ))}
+                  ) : (
+                    g.services.map((s) => (
+                      <View
+                        key={`${g.fnsId}-${s.id}`}
+                        className="px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: colors.accentSoft }}
+                      >
+                        <Text className="text-xs" style={{ color: colors.primary }} numberOfLines={1}>
+                          {s.name}
+                        </Text>
+                      </View>
+                    ))
+                  )}
                 </View>
               )}
             </View>

--- a/components/specialists/SpecialistsGrid.tsx
+++ b/components/specialists/SpecialistsGrid.tsx
@@ -12,6 +12,7 @@ import {
   NativeScrollEvent,
 } from "react-native";
 import { colors } from "@/lib/theme";
+import { getShortServiceName, isAllCoreServicesSelected } from "@/lib/services";
 import { MessageCircle, Bookmark } from "lucide-react-native";
 
 function formatSpecialistName(firstName: string | null, lastName: string | null): string {
@@ -195,9 +196,8 @@ function DesktopSpecialistRow({
                   >
                     {g.fnsName}
                   </Text>
-                  {g.services.map((s) => (
+                  {isAllCoreServicesSelected(g.services.map((s) => s.name)) ? (
                     <View
-                      key={`${g.fnsId}-${s.id}`}
                       style={{
                         backgroundColor: colors.accentSoft,
                         borderRadius: 99,
@@ -206,10 +206,26 @@ function DesktopSpecialistRow({
                       }}
                     >
                       <Text style={{ color: colors.primary, fontSize: 11 }} numberOfLines={1}>
-                        {s.name}
+                        Все
                       </Text>
                     </View>
-                  ))}
+                  ) : (
+                    g.services.map((s) => (
+                      <View
+                        key={`${g.fnsId}-${s.id}`}
+                        style={{
+                          backgroundColor: colors.accentSoft,
+                          borderRadius: 99,
+                          paddingHorizontal: 8,
+                          paddingVertical: 2,
+                        }}
+                      >
+                        <Text style={{ color: colors.primary, fontSize: 11 }} numberOfLines={1}>
+                          {getShortServiceName(s.name)}
+                        </Text>
+                      </View>
+                    ))
+                  )}
                 </View>
               ))}
               {fnsOverflow > 0 && (

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,0 +1,33 @@
+/**
+ * Service name utilities for specialist cards.
+ * Short names are used on desktop chip display; full names on mobile.
+ */
+
+export const SERVICE_SHORT_NAMES: Record<string, string> = {
+  'выездная проверка': 'Выездная',
+  'отдел оперативного контроля': 'Опер.контроль',
+  'камеральная проверка': 'Камеральная',
+  'анализ финансово-хозяйственной деятельности': 'АФХД',
+  'проверка контрагентов': 'Контрагенты',
+};
+
+export function getShortServiceName(fullName: string): string {
+  const key = fullName.trim().toLowerCase();
+  return SERVICE_SHORT_NAMES[key] ?? fullName;
+}
+
+/** The three core FNS services that together represent full coverage. */
+export const CORE_SERVICE_NAMES = [
+  'выездная проверка',
+  'отдел оперативного контроля',
+  'камеральная проверка',
+];
+
+/**
+ * Returns true when all three core services are present in the given list.
+ * Used to collapse three chips into a single "Все" chip.
+ */
+export function isAllCoreServicesSelected(serviceNames: string[]): boolean {
+  const lower = serviceNames.map((n) => n.trim().toLowerCase());
+  return CORE_SERVICE_NAMES.every((n) => lower.includes(n));
+}


### PR DESCRIPTION
## Summary
- Closes #1651, closes #1656
- Add `lib/services.ts` — `getShortServiceName()`, `isAllCoreServicesSelected()`, `CORE_SERVICE_NAMES`
- Desktop (`DesktopSpecialistRow`): service chips use abbreviated names (Выездная / Опер.контроль / Камеральная / АФХД / Контрагенты); when all 3 core services present → single "Все" chip
- Mobile (`SpecialistCard` vertical): same "Все" collapse logic; full service names otherwise

## Test plan
- [ ] Open /specialists on desktop — specialist with 3 core services shows single "Все" chip per FNS group
- [ ] Specialist with 2 services shows 2 short-name chips (e.g. "Выездная", "Камеральная")
- [ ] Mobile — same specialist shows "Все" chip
- [ ] Mobile — specialist with 2 services shows full names
- [ ] `npx tsc --noEmit` → 0 errors (frontend + backend)