### PR TITLE
fix: remove Статистика block + unified textarea padding #1682

### DIFF
--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -465,26 +465,6 @@ export default function MyRequestDetail() {
               onToggleVisibility={handleToggleVisibility}
             />
 
-            {/* Meta stats */}
-            <View
-              className="bg-white rounded-2xl p-4 mb-6"
-              style={{
-                shadowColor: colors.text,
-                shadowOffset: { width: 0, height: 1 },
-                shadowOpacity: 0.05,
-                shadowRadius: 8,
-                elevation: 2,
-              }}
-            >
-              <View className="flex-row justify-between mb-2">
-                <Text className="text-sm text-text-mute">Диалогов</Text>
-                <Text className="text-sm text-text-base">{request.threadsCount}</Text>
-              </View>
-              <View className="flex-row justify-between">
-                <Text className="text-sm text-text-mute">Город</Text>
-                <Text className="text-sm text-text-base">{request.city.name}</Text>
-              </View>
-            </View>
           </View>
         </View>
       </ScrollView>

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -74,19 +74,19 @@ export default function Input({
     ? {
         flexDirection: "row",
         alignItems: multiline ? "flex-start" : "center",
-        minHeight: multiline ? 96 : 48,
+        minHeight: multiline ? 80 : 48,
         width: "100%",
         borderWidth: 1,
         borderColor,
         borderRadius: 8,
         backgroundColor: editable ? "#ffffff" : "#f9fafb",
-        paddingHorizontal: 14,
-        paddingVertical: 12,
+        paddingHorizontal: 12,
+        paddingVertical: 8,
       }
     : {
         flexDirection: "row",
         alignItems: "center",
-        minHeight: multiline ? 96 : 48,
+        minHeight: multiline ? 80 : 48,
         // Line-style: no top/left/right border, no radius, transparent bg.
         borderTopWidth: 0,
         borderLeftWidth: 0,


### PR DESCRIPTION
## Summary
- Remove desktop and mobile "Статистика/Meta stats" block from `/requests/[id]/detail.tsx`
- Reduce `Input` bordered multiline padding: `paddingHorizontal 14→12`, `paddingVertical 12→8`, `minHeight 96→80`
- Reduce `Input` line variant multiline `minHeight 96→80`

## Test plan
- [ ] `/requests/<id>/detail` — no "Статистика" block on desktop or mobile
- [ ] Multiline TextInput (new request form, chat composer) — compact padding, fontSize 14
- [ ] `npx tsc --noEmit` — 0 errors (verified)

Closes #1682