### PR TITLE
fix: detail page broken + permission for non-owners (#1680 #1681)

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -457,7 +457,8 @@ router.get("/:id", authMiddleware, async (req: Request, res: Response) => {
   }
 });
 
-// GET /api/requests/:id/detail — own request detail (auth required)
+// GET /api/requests/:id/detail — request detail (auth required, accessible to owner AND specialists)
+// Returns isOwner: boolean so the frontend can gate edit controls without a second request.
 router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
@@ -478,68 +479,68 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
       return;
     }
 
-    if (request.userId !== userId) {
-      res.status(403).json({ error: "Access denied" });
-      return;
-    }
+    const isOwner = request.userId === userId;
 
-    // Count unread messages across threads
-    const threads = await prisma.thread.findMany({
-      where: { requestId: id, clientId: userId },
-      select: {
-        id: true,
-        clientLastReadAt: true,
-      },
-    });
-
-    // Batch unread count: one query per group (has lastReadAt vs no lastReadAt)
+    // Count unread messages across threads — only meaningful for the owner (client).
+    // Specialists do not track per-request unread counts here.
     let unreadMessages = 0;
-    const threadIds = threads.map((t) => t.id);
-    if (threadIds.length > 0) {
-      const threadsWithReadAt = threads.filter((t) => t.clientLastReadAt);
-      const threadsWithoutReadAt = threads.filter((t) => !t.clientLastReadAt);
+    if (isOwner) {
+      const threads = await prisma.thread.findMany({
+        where: { requestId: id, clientId: userId },
+        select: {
+          id: true,
+          clientLastReadAt: true,
+        },
+      });
 
-      const counts = await Promise.all([
-        // Threads where client has read — count messages after lastReadAt
-        ...(threadsWithReadAt.length > 0
-          ? threadsWithReadAt.map((t) =>
-              prisma.message.count({
-                where: {
-                  threadId: t.id,
-                  createdAt: { gt: t.clientLastReadAt! },
-                  senderId: { not: userId },
-                },
-              })
-            )
-          : []),
-        // Threads never read — count all messages from others
-        ...(threadsWithoutReadAt.length > 0
-          ? [
-              prisma.message.count({
-                where: {
-                  threadId: { in: threadsWithoutReadAt.map((t) => t.id) },
-                  senderId: { not: userId },
-                },
-              }),
-            ]
-          : []),
-      ]);
+      if (threads.length > 0) {
+        const threadsWithReadAt = threads.filter((t) => t.clientLastReadAt);
+        const threadsWithoutReadAt = threads.filter((t) => !t.clientLastReadAt);
 
-      const withoutIdx = threadsWithReadAt.length;
-      unreadMessages = counts.slice(0, withoutIdx).reduce((s, c) => s + c, 0);
-      if (threadsWithoutReadAt.length > 0) {
-        unreadMessages += counts[withoutIdx];
+        const counts = await Promise.all([
+          // Threads where client has read — count messages after lastReadAt
+          ...(threadsWithReadAt.length > 0
+            ? threadsWithReadAt.map((t) =>
+                prisma.message.count({
+                  where: {
+                    threadId: t.id,
+                    createdAt: { gt: t.clientLastReadAt! },
+                    senderId: { not: userId },
+                  },
+                })
+              )
+            : []),
+          // Threads never read — count all messages from others
+          ...(threadsWithoutReadAt.length > 0
+            ? [
+                prisma.message.count({
+                  where: {
+                    threadId: { in: threadsWithoutReadAt.map((t) => t.id) },
+                    senderId: { not: userId },
+                  },
+                }),
+              ]
+            : []),
+        ]);
+
+        const withoutIdx = threadsWithReadAt.length;
+        unreadMessages = counts.slice(0, withoutIdx).reduce((s, c) => s + c, 0);
+        if (threadsWithoutReadAt.length > 0) {
+          unreadMessages += counts[withoutIdx];
+        }
       }
     }
 
-    // Get max extensions from settings
-    const extSetting = await prisma.setting.findUnique({
-      where: { key: "max_extensions" },
-    });
+    // Get max extensions from settings — only relevant for owner UI
+    const extSetting = isOwner
+      ? await prisma.setting.findUnique({ where: { key: "max_extensions" } })
+      : null;
     const maxExtensions = extSetting ? parseInt(extSetting.value, 10) : 3;
 
     res.json({
       id: request.id,
+      userId: request.userId,
+      isOwner,
       title: request.title,
       description: request.description,
       status: request.status,

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -373,6 +373,7 @@ export default function MyRequestDetail() {
               <View style={{ flex: 1, minWidth: 280, maxWidth: 360 }}>
                 <RequestActions
                   request={request}
+                  isOwner={request.isOwner}
                   isActive={isActive}
                   closing={closing}
                   copied={copied}
@@ -479,6 +480,7 @@ export default function MyRequestDetail() {
 
             <RequestActions
               request={request}
+              isOwner={request.isOwner}
               isActive={isActive}
               closing={closing}
               copied={copied}

--- a/components/requests/detail/RequestActions.tsx
+++ b/components/requests/detail/RequestActions.tsx
@@ -6,6 +6,7 @@ import { RequestDetailData } from "./types";
 
 interface Props {
   request: RequestDetailData;
+  isOwner: boolean;
   isActive: boolean;
   closing: boolean;
   copied: boolean;
@@ -18,6 +19,7 @@ interface Props {
 
 export default function RequestActions({
   request,
+  isOwner,
   isActive,
   closing,
   copied,
@@ -28,6 +30,53 @@ export default function RequestActions({
   isDesktop,
 }: Props) {
   const padding = isDesktop ? "p-5" : "p-4";
+
+  // Non-owners see only the copy-link button (read-only view).
+  if (!isOwner) {
+    return (
+      <View
+        className={`bg-white rounded-2xl ${padding} mb-4`}
+        style={{
+          borderWidth: 1,
+          borderColor: colors.border,
+          shadowColor: colors.text,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.08,
+          shadowRadius: 12,
+          elevation: 4,
+        }}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Скопировать ссылку"
+          onPress={onCopyLink}
+          className="flex-row items-center justify-center rounded-xl px-4"
+          style={({ pressed }) => [
+            {
+              backgroundColor: colors.surface2,
+              borderWidth: 1,
+              borderColor: colors.border,
+              minHeight: 48,
+              paddingVertical: 14,
+            },
+            pressed && { opacity: 0.7 },
+          ]}
+        >
+          <Link size={16} color={copied ? colors.success : colors.text} />
+          <Text
+            className="ml-2"
+            style={{
+              fontSize: 14,
+              fontWeight: "600",
+              color: copied ? colors.success : "#111",
+            }}
+          >
+            {copied ? "Скопировано!" : "Скопировать ссылку"}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View
@@ -132,7 +181,7 @@ export default function RequestActions({
         </Text>
       </Pressable>
 
-      {/* Visibility toggle */}
+      {/* Visibility toggle — owner only */}
       <View
         className="flex-row items-center justify-between mt-4 pt-3"
         style={{ borderTopWidth: 1, borderTopColor: colors.border }}

--- a/components/requests/detail/types.ts
+++ b/components/requests/detail/types.ts
@@ -8,6 +8,8 @@ export interface FileItem {
 
 export interface RequestDetailData {
   id: string;
+  userId: string;
+  isOwner: boolean;
   title: string;
   description: string;
   status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";


### PR DESCRIPTION
## Summary

- **#1680**: `GET /api/requests/:id/detail` was owner-only (403 for specialists/non-owners), making the page inaccessible for anyone but the request creator. Fixed by removing the ownership gate — any authenticated user can now load the page.
- **#1681**: `RequestActions` showed close-request and visibility-toggle controls to ALL authenticated users, regardless of ownership. Fixed by adding `isOwner: boolean` to the API response and gating all edit controls in the frontend behind `isOwner`.

## Changes

- `api/src/routes/requests.ts` — `GET /:id/detail` now returns `isOwner` + `userId`; no more 403 for non-owners; unread-count and max-extensions queries skip for non-owners (perf)
- `components/requests/detail/types.ts` — `RequestDetailData` gains `userId` + `isOwner` fields
- `components/requests/detail/RequestActions.tsx` — non-owners see copy-link only; owner sees full controls
- `app/requests/[id]/detail.tsx` — passes `isOwner={request.isOwner}` to `RequestActions`

Backend PATCH/DELETE ownership checks (already present, unchanged) remain as the authoritative security layer.

## Test plan

- [ ] As specialist: open another user's `/requests/<id>/detail` — page loads, no close/toggle-visibility controls visible
- [ ] As owner: open own `/requests/<id>/detail` — full controls visible (close, visibility toggle)
- [ ] `npx tsc --noEmit` → 0 errors (frontend + backend)
- [ ] PATCH `/api/requests/<id>` as non-owner → 403 (backend unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)