### PR TITLE
feat(request-detail): redesign — owner/specialist/anonymous views #1683

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -457,8 +457,8 @@ router.get("/:id", authMiddleware, async (req: Request, res: Response) => {
   }
 });
 
-// GET /api/requests/:id/detail — request detail (auth required, accessible to owner AND specialists)
-// Returns isOwner: boolean so the frontend can gate edit controls without a second request.
+// GET /api/requests/:id/detail — request detail (auth required)
+// Returns owner view (full data + threads) or specialist view (preview + respond CTA).
 router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
@@ -470,6 +470,7 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
         city: true,
         fns: true,
         files: true,
+        user: { select: { id: true, firstName: true, lastName: true } },
         _count: { select: { threads: true } },
       },
     });
@@ -481,10 +482,10 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
 
     const isOwner = request.userId === userId;
 
-    // Count unread messages across threads — only meaningful for the owner (client).
-    // Specialists do not track per-request unread counts here.
-    let unreadMessages = 0;
     if (isOwner) {
+      // Owner view: full detail + threads list + unread count
+
+      // Count unread messages across threads
       const threads = await prisma.thread.findMany({
         where: { requestId: id, clientId: userId },
         select: {
@@ -493,6 +494,8 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
         },
       });
 
+      // Batch unread count: one query per group (has lastReadAt vs no lastReadAt)
+      let unreadMessages = 0;
       if (threads.length > 0) {
         const threadsWithReadAt = threads.filter((t) => t.clientLastReadAt);
         const threadsWithoutReadAt = threads.filter((t) => !t.clientLastReadAt);
@@ -529,38 +532,83 @@ router.get("/:id/detail", authMiddleware, async (req: Request, res: Response) =>
           unreadMessages += counts[withoutIdx];
         }
       }
+
+      // Get max extensions from settings
+      const extSetting = await prisma.setting.findUnique({
+        where: { key: "max_extensions" },
+      });
+      const maxExtensions = extSetting ? parseInt(extSetting.value, 10) : 3;
+
+      res.json({
+        viewType: "owner" as const,
+        id: request.id,
+        title: request.title,
+        description: request.description,
+        status: request.status,
+        createdAt: request.createdAt,
+        lastActivityAt: request.lastActivityAt,
+        extensionsCount: request.extensionsCount,
+        maxExtensions,
+        city: { id: request.city.id, name: request.city.name },
+        fns: { id: request.fns.id, name: request.fns.name, code: request.fns.code },
+        files: request.files.map((f) => ({
+          id: f.id,
+          url: f.url,
+          filename: f.filename,
+          size: f.size,
+          mimeType: f.mimeType,
+        })),
+        threadsCount: request._count.threads,
+        unreadMessages,
+        // owner-only fields
+        isOwner: true,
+        hasExistingThread: false,
+        existingThreadId: null,
+        client: null,
+      });
+    } else {
+      // Specialist view: check for existing thread with this request
+      const existingThread = await prisma.thread.findFirst({
+        where: { requestId: id, specialistId: userId },
+        select: { id: true },
+      });
+
+      // Mask client name: firstName + lastName[0] + "."
+      const clientName = [
+        request.user.firstName,
+        request.user.lastName ? request.user.lastName[0] + "." : null,
+      ]
+        .filter(Boolean)
+        .join(" ") || "Клиент";
+
+      res.json({
+        viewType: "specialist" as const,
+        id: request.id,
+        title: request.title,
+        description: request.description,
+        status: request.status,
+        createdAt: request.createdAt,
+        lastActivityAt: request.lastActivityAt,
+        extensionsCount: request.extensionsCount,
+        maxExtensions: 0,
+        city: { id: request.city.id, name: request.city.name },
+        fns: { id: request.fns.id, name: request.fns.name, code: request.fns.code },
+        files: request.files.map((f) => ({
+          id: f.id,
+          url: f.url,
+          filename: f.filename,
+          size: f.size,
+          mimeType: f.mimeType,
+        })),
+        threadsCount: request._count.threads,
+        unreadMessages: 0,
+        // specialist-only fields
+        isOwner: false,
+        hasExistingThread: !!existingThread,
+        existingThreadId: existingThread?.id ?? null,
+        client: { name: clientName },
+      });
     }
-
-    // Get max extensions from settings — only relevant for owner UI
-    const extSetting = isOwner
-      ? await prisma.setting.findUnique({ where: { key: "max_extensions" } })
-      : null;
-    const maxExtensions = extSetting ? parseInt(extSetting.value, 10) : 3;
-
-    res.json({
-      id: request.id,
-      userId: request.userId,
-      isOwner,
-      title: request.title,
-      description: request.description,
-      status: request.status,
-      isPublic: request.isPublic,
-      createdAt: request.createdAt,
-      lastActivityAt: request.lastActivityAt,
-      extensionsCount: request.extensionsCount,
-      maxExtensions,
-      city: { id: request.city.id, name: request.city.name },
-      fns: { id: request.fns.id, name: request.fns.name, code: request.fns.code },
-      files: request.files.map((f) => ({
-        id: f.id,
-        url: f.url,
-        filename: f.filename,
-        size: f.size,
-        mimeType: f.mimeType,
-      })),
-      threadsCount: request._count.threads,
-      unreadMessages,
-    });
   } catch (error) {
     console.error("requests/:id/detail error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -6,96 +6,381 @@ import {
   Pressable,
   Alert,
   Linking,
-  Platform,
+  TextInput,
   useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useLocalSearchParams, useRouter, usePathname } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
-import { ChevronLeft } from "lucide-react-native";
+import { File, FileImage, Download, ChevronLeft, MessageSquare } from "lucide-react-native";
+import StatusBadge from "@/components/StatusBadge";
 import Button from "@/components/ui/Button";
 import LoadingState from "@/components/ui/LoadingState";
-import { type PendingFile } from "@/components/ChatComposer";
-import { api, apiPatch, ApiError } from "@/lib/api";
+import ThreadsList, { ThreadSummary } from "@/components/requests/ThreadsList";
+import { api, apiPost, apiPatch } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import { colors, BREAKPOINT } from "@/lib/theme";
-import { SpecialistCard } from "@/components/requests/SpecialistRecommendations";
 
-import RequestHeader from "@/components/requests/detail/RequestHeader";
-import RequestActions from "@/components/requests/detail/RequestActions";
-import RequestDocuments from "@/components/requests/detail/RequestDocuments";
-import RequestSpecialists from "@/components/requests/detail/RequestSpecialists";
-import { RequestDetailData, FileItem } from "@/components/requests/detail/types";
+import { FileItem } from "@/components/requests/detail/types";
 
-const FIRST_MESSAGE_MIN = 10;
-const FIRST_MESSAGE_MAX = 2000;
+interface RequestDetailData {
+  viewType: "owner" | "specialist";
+  id: string;
+  title: string;
+  description: string;
+  status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";
+  createdAt: string;
+  lastActivityAt: string;
+  extensionsCount: number;
+  maxExtensions: number;
+  city: { id: string; name: string };
+  fns: { id: string; name: string; code: string };
+  files: FileItem[];
+  threadsCount: number;
+  unreadMessages: number;
+  isOwner: boolean;
+  hasExistingThread: boolean;
+  existingThreadId: string | null;
+  client: { name: string } | null;
+}
 
-export default function MyRequestDetail() {
+// ─── Shared file list ─────────────────────────────────────────────────────────
+
+function FileList({ files, onPress }: { files: FileItem[]; onPress: (f: FileItem) => void }) {
+  if (files.length === 0) return null;
+  return (
+    <View
+      className="bg-white rounded-2xl p-4 mb-4"
+      style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2 }}
+    >
+      <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
+        Прикреплённые документы
+      </Text>
+      {files.map((file) => (
+        <Pressable
+          accessibilityRole="button"
+          key={file.id}
+          accessibilityLabel={`Открыть файл ${file.filename}`}
+          onPress={() => onPress(file)}
+          className="flex-row items-center bg-surface2 rounded-xl p-3 mb-2"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        >
+          {file.mimeType === "application/pdf"
+            ? <File size={20} color={colors.primary} />
+            : <FileImage size={20} color={colors.primary} />
+          }
+          <View className="ml-3 flex-1">
+            <Text className="text-sm text-text-base" numberOfLines={1}>{file.filename}</Text>
+            <Text className="text-xs text-text-mute">{(file.size / 1024).toFixed(0)} КБ</Text>
+          </View>
+          <Download size={14} color={colors.placeholder} />
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+// ─── Shared info block ────────────────────────────────────────────────────────
+
+function RequestInfoBlock({ request }: { request: RequestDetailData }) {
+  const createdDate = new Date(request.createdAt).toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      {/* Status + date */}
+      <View className="flex-row items-center mb-3">
+        <StatusBadge status={request.status} />
+        <Text className="text-sm text-text-mute ml-3">{createdDate}</Text>
+      </View>
+
+      {/* City + FNS chips */}
+      <View className="flex-row flex-wrap gap-2 mb-4">
+        <View className="bg-white border border-border px-3 py-1 rounded-lg">
+          <Text className="text-sm text-text-base">{request.city.name}</Text>
+        </View>
+        <View className="bg-white border border-border px-3 py-1 rounded-lg">
+          <Text className="text-sm text-text-base">
+            {request.fns.name} ({request.fns.code})
+          </Text>
+        </View>
+      </View>
+
+      {/* Description */}
+      <View
+        className="bg-white rounded-2xl p-4 mb-4"
+        style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2 }}
+      >
+        <Text className="text-xs font-semibold text-text-mute mb-2 uppercase tracking-wide">
+          Описание
+        </Text>
+        <Text className="text-base text-text-base leading-6">{request.description}</Text>
+      </View>
+    </>
+  );
+}
+
+// ─── OwnerView ────────────────────────────────────────────────────────────────
+
+function OwnerView({
+  request,
+  threads,
+  onFilePress,
+  onExtend,
+  extending,
+  onClose,
+}: {
+  request: RequestDetailData;
+  threads: ThreadSummary[];
+  onFilePress: (f: FileItem) => void;
+  onExtend: () => void;
+  extending: boolean;
+  onClose: () => void;
+}) {
+  const nav = useTypedRouter();
+  const canExtend =
+    request.status === "CLOSING_SOON" &&
+    request.extensionsCount < request.maxExtensions;
+
+  return (
+    <>
+      <RequestInfoBlock request={request} />
+
+      <FileList files={request.files} onPress={onFilePress} />
+
+      {/* Extend button */}
+      {canExtend && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Продлить заявку"
+          onPress={onExtend}
+          disabled={extending}
+          className="bg-warning rounded-xl py-3 items-center mb-4"
+          style={({ pressed }) => [pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] }]}
+        >
+          {extending ? (
+            <ActivityIndicator color={colors.surface} />
+          ) : (
+            <Text className="text-white font-semibold text-base">
+              Продлить заявку — Продлений: {request.extensionsCount}/{request.maxExtensions}
+            </Text>
+          )}
+        </Pressable>
+      )}
+
+      {/* Extend limit banner */}
+      {request.status === "CLOSING_SOON" && request.extensionsCount >= request.maxExtensions && (
+        <View className="bg-warning-soft border border-amber-200 rounded-xl px-4 py-3 mb-4">
+          <Text className="text-sm text-warning text-center font-medium">
+            Продление использовано ({request.extensionsCount}/{request.maxExtensions})
+          </Text>
+        </View>
+      )}
+
+      <ThreadsList
+        threads={threads}
+        requestId={request.id}
+        threadsCount={request.threadsCount}
+        unreadMessages={request.unreadMessages}
+        onOpenThread={(threadId) => nav.any(`/threads/${threadId}`)}
+      />
+
+      {/* Close request button */}
+      {request.status !== "CLOSED" && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Закрыть заявку"
+          onPress={onClose}
+          className="border border-danger rounded-xl py-3 items-center mb-6"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        >
+          <Text className="text-danger font-semibold text-sm">Закрыть заявку</Text>
+        </Pressable>
+      )}
+    </>
+  );
+}
+
+// ─── SpecialistView ───────────────────────────────────────────────────────────
+
+function SpecialistView({
+  request,
+  onFilePress,
+  onThreadCreated,
+}: {
+  request: RequestDetailData;
+  onFilePress: (f: FileItem) => void;
+  onThreadCreated: (threadId: string) => void;
+}) {
+  const nav = useTypedRouter();
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [msgError, setMsgError] = useState<string | null>(null);
+
+  const handleRespond = useCallback(async () => {
+    if (sending) return;
+    const trimmed = message.trim();
+    if (trimmed.length < 10) {
+      setMsgError("Сообщение слишком короткое (минимум 10 символов)");
+      return;
+    }
+    setMsgError(null);
+    setSending(true);
+    try {
+      const res = await apiPost<{ id: string }>("/api/threads", {
+        requestId: request.id,
+        firstMessage: trimmed,
+      });
+      onThreadCreated(res.id);
+    } catch (e: unknown) {
+      // Thread already exists — server returns threadId in 409
+      if (e && typeof e === "object" && "threadId" in e) {
+        onThreadCreated((e as { threadId: string }).threadId);
+        return;
+      }
+      const msg = e instanceof Error ? e.message : "Не удалось отправить сообщение";
+      setMsgError(msg);
+    } finally {
+      setSending(false);
+    }
+  }, [message, sending, request.id, onThreadCreated]);
+
+  return (
+    <>
+      <RequestInfoBlock request={request} />
+
+      {/* Client info */}
+      {request.client && (
+        <View
+          className="bg-white rounded-2xl p-4 mb-4"
+          style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2 }}
+        >
+          <Text className="text-xs font-semibold text-text-mute mb-1 uppercase tracking-wide">Клиент</Text>
+          <Text className="text-base text-text-base">{request.client.name}</Text>
+        </View>
+      )}
+
+      <FileList files={request.files} onPress={onFilePress} />
+
+      {/* CTA: go to existing thread OR compose */}
+      {request.hasExistingThread && request.existingThreadId ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Перейти к диалогу"
+          onPress={() => nav.any(`/threads/${request.existingThreadId}`)}
+          className="bg-accent rounded-xl py-3.5 items-center mb-6 flex-row justify-center gap-2"
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        >
+          <MessageSquare size={18} color="#fff" />
+          <Text className="text-white font-semibold text-base ml-2">Перейти к диалогу</Text>
+        </Pressable>
+      ) : (
+        <View className="mb-6">
+          <View
+            className="bg-white rounded-2xl p-4 mb-3"
+            style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2 }}
+          >
+            <Text className="text-xs font-semibold text-text-mute mb-2 uppercase tracking-wide">
+              Откликнуться
+            </Text>
+            <TextInput
+              value={message}
+              onChangeText={(t) => { setMessage(t); setMsgError(null); }}
+              placeholder="Напишите сообщение клиенту (минимум 10 символов)..."
+              multiline
+              numberOfLines={4}
+              className="text-base text-text-base"
+              style={{ minHeight: 96, textAlignVertical: "top" }}
+              accessibilityLabel="Ваше сообщение"
+            />
+          </View>
+          {msgError && (
+            <Text className="text-danger text-sm mb-3 px-1">{msgError}</Text>
+          )}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Отправить отклик"
+            onPress={handleRespond}
+            disabled={sending}
+            className="bg-accent rounded-xl py-3.5 items-center"
+            style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+          >
+            {sending ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text className="text-white font-semibold text-base">Отправить</Text>
+            )}
+          </Pressable>
+        </View>
+      )}
+    </>
+  );
+}
+
+// ─── AnonymousView ────────────────────────────────────────────────────────────
+
+function AnonymousView({ request, onLogin }: { request: Partial<RequestDetailData> & { title: string; description: string }; onLogin: () => void }) {
+  return (
+    <>
+      <View
+        className="bg-white rounded-2xl p-4 mb-4"
+        style={{ shadowColor: colors.text, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.05, shadowRadius: 8, elevation: 2 }}
+      >
+        <Text className="text-base font-semibold text-text-base mb-2">{request.title}</Text>
+        <Text className="text-base text-text-mute leading-6">
+          {request.description.slice(0, 200)}{request.description.length > 200 ? "…" : ""}
+        </Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Войти, чтобы откликнуться"
+        onPress={onLogin}
+        className="bg-accent rounded-xl py-3.5 items-center mb-6"
+        style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+      >
+        <Text className="text-white font-semibold text-base">Войти, чтобы откликнуться</Text>
+      </Pressable>
+    </>
+  );
+}
+
+// ─── Root screen ──────────────────────────────────────────────────────────────
+
+export default function RequestDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const nav = useTypedRouter();
-  const pathname = usePathname();
   const { width } = useWindowDimensions();
   const isDesktop = width >= BREAKPOINT;
-  const { isLoading: authLoading, isAuthenticated, isSpecialistUser, user, token } = useAuth();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
 
   const [request, setRequest] = useState<RequestDetailData | null>(null);
-  const [recommendations, setRecommendations] = useState<SpecialistCard[]>([]);
+  const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [closing, setClosing] = useState(false);
-  const [copied, setCopied] = useState(false);
-  const [togglingVisibility, setTogglingVisibility] = useState(false);
+  const [extending, setExtending] = useState(false);
 
-  // Inline message composer state — issue #1566 (specialist quick-reply).
-  const [composerText, setComposerText] = useState("");
-  const [composerFiles, setComposerFiles] = useState<PendingFile[]>([]);
-  const [composerSending, setComposerSending] = useState(false);
-  const [composerError, setComposerError] = useState<string | null>(null);
-
-  const handleCopyLink = useCallback(async () => {
-    const url =
-      Platform.OS === "web" && typeof window !== "undefined"
-        ? window.location.href
-        : `https://p2ptax.ru/requests/${id}/detail`;
-    try {
-      if (typeof navigator !== "undefined" && navigator.clipboard) {
-        await navigator.clipboard.writeText(url);
-      }
-    } catch {
-      // silent — clipboard not critical
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [id]);
-
-  const handleToggleVisibility = useCallback(async (newValue: boolean) => {
-    if (togglingVisibility) return;
-    setTogglingVisibility(true);
-    // Optimistic update
-    setRequest((prev) => prev ? { ...prev, isPublic: newValue } : null);
-    try {
-      await apiPatch(`/api/requests/${id}`, { isPublic: newValue });
-    } catch {
-      // Revert on failure
-      setRequest((prev) => prev ? { ...prev, isPublic: !newValue } : null);
-    } finally {
-      setTogglingVisibility(false);
-    }
-  }, [id, togglingVisibility]);
+  // Public fallback for anonymous / unauthenticated
+  const [publicRequest, setPublicRequest] = useState<{ title: string; description: string } | null>(null);
 
   const fetchAll = useCallback(async () => {
+    if (!id) return;
+    setLoading(true);
     try {
-      // Public detail endpoint — no auth required
-      const detail = await api<RequestDetailData>(`/api/requests/${id}/detail`);
-      setRequest(detail);
-
-      // Auth-gated: load recommendations only for authenticated users
-      if (isAuthenticated) {
-        // Load recommendations in background — non-blocking
-        api<{ items: SpecialistCard[] }>(`/api/requests/${id}/recommendations`)
-          .then((r) => setRecommendations(r.items))
-          .catch(() => {/* silent — not critical */});
+      if (!isAuthenticated) {
+        // Anonymous: load public endpoint
+        const pub = await api<{ title: string; description: string }>(`/api/requests/${id}/public`);
+        setPublicRequest(pub);
+      } else {
+        const [detail, threadsRes] = await Promise.all([
+          api<RequestDetailData>(`/api/requests/${id}/detail`),
+          api<{ items: ThreadSummary[] }>(`/api/threads?request_id=${id}`),
+        ]);
+        setRequest(detail);
+        setThreads(threadsRes.items);
       }
     } catch (e) {
       setError("Не удалось загрузить запрос");
@@ -105,127 +390,8 @@ export default function MyRequestDetail() {
   }, [id, isAuthenticated]);
 
   useEffect(() => {
-    if (id && !authLoading) fetchAll();
-  }, [id, authLoading, fetchAll]);
-
-  // For action buttons: redirect to login with returnTo when not authenticated
-  const handleAuthRequired = useCallback((action: () => void) => {
-    if (!isAuthenticated) {
-      nav.replaceAny({ pathname: "/login", params: { returnTo: pathname } });
-      return;
-    }
-    action();
-  }, [isAuthenticated, nav, pathname]);
-
-  // Inline composer send — creates a thread (mirrors /requests/:id/write).
-  const handleComposerSend = useCallback(async () => {
-    if (!isAuthenticated) {
-      nav.replaceAny({ pathname: "/login", params: { returnTo: pathname } });
-      return;
-    }
-    const trimmed = composerText.trim();
-    if (trimmed.length < FIRST_MESSAGE_MIN) {
-      setComposerError(`Минимум ${FIRST_MESSAGE_MIN} символов`);
-      return;
-    }
-    if (trimmed.length > FIRST_MESSAGE_MAX) {
-      setComposerError(`Максимум ${FIRST_MESSAGE_MAX} символов`);
-      return;
-    }
-    const stillBusy = composerFiles.some(
-      (f) => f.status === "uploading" || f.status === "pending",
-    );
-    if (stillBusy) {
-      setComposerError("Файл ещё загружается. Подождите.");
-      return;
-    }
-    const failedFile = composerFiles.find((f) => f.status === "error");
-    if (failedFile) {
-      setComposerError(failedFile.errorMessage ?? "Не удалось загрузить файл");
-      return;
-    }
-    const readyFile = composerFiles.find(
-      (f) => f.status === "done" && f.uploadedToken,
-    );
-    const uploadToken = readyFile?.uploadedToken;
-
-    setComposerSending(true);
-    setComposerError(null);
-    try {
-      const result = await api<{ id: string }>("/api/threads", {
-        method: "POST",
-        body: {
-          requestId: id,
-          firstMessage: trimmed,
-          ...(uploadToken ? { uploadToken } : {}),
-        },
-      });
-      setComposerText("");
-      setComposerFiles([]);
-      nav.replaceAny(`/threads/${result.id}`);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        if (err.status === 409) {
-          const existingThreadId =
-            typeof err.data?.threadId === "string" ? err.data.threadId : null;
-          if (existingThreadId) {
-            nav.replaceAny(`/threads/${existingThreadId}`);
-          } else {
-            setComposerError("Запрос закрыт — сообщение отправить невозможно");
-          }
-        } else if (err.status === 429) {
-          setComposerError(
-            "Лимит новых диалогов на сегодня исчерпан (20 в день). Попробуйте завтра.",
-          );
-        } else if (err.status === 403) {
-          setComposerError("Только специалисты могут начать диалог");
-        } else {
-          setComposerError("Не удалось отправить сообщение. Попробуйте ещё раз.");
-        }
-      } else {
-        setComposerError("Не удалось отправить сообщение. Попробуйте ещё раз.");
-      }
-    } finally {
-      setComposerSending(false);
-    }
-  }, [composerText, composerFiles, id, isAuthenticated, nav, pathname]);
-
-  const handleCloseRequest = useCallback(async () => {
-    if (closing) return;
-    const doClose = async () => {
-      setClosing(true);
-      try {
-        await apiPatch(`/api/requests/${id}/status`, { status: "CLOSED" });
-        setRequest((prev) => prev ? { ...prev, status: "CLOSED" } : null);
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : "Не удалось закрыть запрос";
-        if (Platform.OS === "web") {
-          if (typeof window !== "undefined" && typeof window.alert === "function") {
-            window.alert(`Ошибка: ${msg}`);
-          }
-        } else {
-          Alert.alert("Ошибка", msg);
-        }
-      } finally {
-        setClosing(false);
-      }
-    };
-
-    if (typeof window !== "undefined" && typeof window.confirm === "function") {
-      if (window.confirm("Закрыть запрос? Специалисты больше не смогут откликнуться.")) {
-        await doClose();
-      }
-    } else {
-      Alert.alert(
-        "Закрыть запрос",
-        "Специалисты больше не смогут откликнуться на этот запрос.",
-        [
-          { text: "Отмена", style: "cancel" },
-          { text: "Закрыть", style: "destructive", onPress: doClose },
-        ]
-      );
-    }
-  }, [id, closing]);
+    if (!authLoading) fetchAll();
+  }, [authLoading, fetchAll]);
 
   const handleFilePress = useCallback(async (file: FileItem) => {
     try {
@@ -233,20 +399,59 @@ export default function MyRequestDetail() {
         `/api/upload/signed-url/${encodeURIComponent(file.url.replace(/^\/p2ptax\//, ""))}`
       );
       await Linking.openURL(res.url);
-    } catch (e) {
+    } catch {
       // ignore
     }
   }, []);
 
-  const handleWriteSpecialist = useCallback((specialistId: string) => {
-    handleAuthRequired(() => nav.any(`/messages?specialist=${specialistId}`));
-  }, [handleAuthRequired, nav]);
+  const handleExtend = useCallback(async () => {
+    if (extending || !request) return;
+    setExtending(true);
+    try {
+      const res = await apiPost<{ extensionsCount: number; status: string }>(
+        `/api/requests/${id}/extend`,
+        {}
+      );
+      setRequest((prev) =>
+        prev
+          ? { ...prev, extensionsCount: res.extensionsCount, status: res.status as RequestDetailData["status"] }
+          : null
+      );
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Не удалось продлить заявку";
+      Alert.alert("Ошибка", msg);
+    } finally {
+      setExtending(false);
+    }
+  }, [id, extending, request]);
 
-  const handleOpenSpecialistProfile = useCallback((specialistId: string) => {
-    nav.dynamic.specialist(specialistId);
-  }, [nav]);
+  const handleClose = useCallback(() => {
+    Alert.alert(
+      "Закрыть заявку",
+      "Закрыть заявку? Специалисты больше не смогут откликнуться.",
+      [
+        { text: "Отмена", style: "cancel" },
+        {
+          text: "Закрыть",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await apiPatch(`/api/requests/${id}/status`, { status: "CLOSED" });
+              setRequest((prev) => prev ? { ...prev, status: "CLOSED" } : null);
+            } catch {
+              Alert.alert("Ошибка", "Не удалось закрыть заявку");
+            }
+          },
+        },
+      ]
+    );
+  }, [id]);
 
-  if (loading) {
+  const containerStyle = isDesktop
+    ? { maxWidth: 520, width: "100%" as const, alignSelf: "center" as const }
+    : undefined;
+
+  if (authLoading || loading) {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <LoadingState />
@@ -254,137 +459,40 @@ export default function MyRequestDetail() {
     );
   }
 
-  if (error || !request) {
+  if (error) {
     return (
       <SafeAreaView className="flex-1 bg-white">
         <View className="flex-1 items-center justify-center px-4">
-          <Text className="text-base text-danger text-center">
-            {error || "Запрос не найден"}
-          </Text>
+          <Text className="text-base text-danger text-center">{error}</Text>
           <View className="mt-4">
-            <Button
-              label="Назад"
-              onPress={() => router.back()}
-              fullWidth={false}
-            />
+            <Button label="Назад" onPress={() => router.back()} fullWidth={false} />
           </View>
         </View>
       </SafeAreaView>
     );
   }
 
-  const createdDate = new Date(request.createdAt).toLocaleDateString("ru-RU", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-
-  const isActive = request.status !== "CLOSED";
-
-  // Service is shown in the chip only when actually selected — issue #1578.
-  const serviceName = request.service?.name?.trim() || null;
-
-  // Inline composer eligibility — specialist with completed profile, request open.
-  const showInlineComposer =
-    isActive &&
-    isAuthenticated &&
-    isSpecialistUser &&
-    !!user?.specialistProfileCompletedAt;
-
-  // ── DESKTOP LAYOUT ────────────────────────────────────────────────────
-  if (isDesktop) {
+  // Anonymous
+  if (!isAuthenticated) {
+    const pub = publicRequest ?? { title: "Заявка", description: "" };
     return (
       <SafeAreaView className="flex-1 bg-surface2">
-        <ScrollView className="flex-1" contentContainerStyle={{ paddingBottom: 40 }}>
-          <View
-            style={{
-              width: "100%",
-              maxWidth: 1100,
-              alignSelf: "center",
-              paddingHorizontal: 32,
-              paddingTop: 24,
-            }}
-          >
-            {/* Back nav */}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Назад"
-              onPress={() => router.back()}
-              className="flex-row items-center mb-6"
-              style={{ minHeight: 44, alignSelf: "flex-start" }}
-            >
-              <ChevronLeft size={20} color={colors.text} />
-              <Text className="text-text-base ml-1">Назад</Text>
-            </Pressable>
-
-            {/* 2-column grid */}
-            <View className="flex-row gap-6" style={{ alignItems: "flex-start" }}>
-              {/* LEFT: main info */}
-              <View style={{ flex: 2, minWidth: 0 }}>
-                <RequestHeader
-                  request={request}
-                  createdDate={createdDate}
-                  serviceName={serviceName}
-                  isDesktop
-                />
-
-                {/* Description */}
-                <View
-                  className="bg-white rounded-2xl p-5 mb-4"
-                  style={{
-                    shadowColor: colors.text,
-                    shadowOffset: { width: 0, height: 1 },
-                    shadowOpacity: 0.05,
-                    shadowRadius: 8,
-                    elevation: 2,
-                  }}
-                >
-                  <Text className="text-xs font-semibold text-text-mute mb-3 uppercase tracking-wide">
-                    Описание
-                  </Text>
-                  <Text className="text-base text-text-base leading-6">
-                    {request.description}
-                  </Text>
-                </View>
-
-                <RequestDocuments
-                  files={request.files}
-                  onFilePress={handleFilePress}
-                  isDesktop
-                />
-
-                <RequestSpecialists
-                  recommendations={recommendations}
-                  onOpenProfile={handleOpenSpecialistProfile}
-                  onWrite={handleWriteSpecialist}
-                  showInlineComposer={showInlineComposer}
-                  composerText={composerText}
-                  composerFiles={composerFiles}
-                  composerSending={composerSending}
-                  composerError={composerError}
-                  authToken={token}
-                  onComposerChangeText={setComposerText}
-                  onComposerFilesChange={setComposerFiles}
-                  onComposerSend={handleComposerSend}
-                />
-              </View>
-
-              {/* RIGHT: actions + meta stats */}
-              <View style={{ flex: 1, minWidth: 280, maxWidth: 360 }}>
-                <RequestActions
-                  request={request}
-                  isOwner={request.isOwner}
-                  isActive={isActive}
-                  closing={closing}
-                  copied={copied}
-                  togglingVisibility={togglingVisibility}
-                  onClose={handleCloseRequest}
-                  onCopyLink={handleCopyLink}
-                  onToggleVisibility={handleToggleVisibility}
-                  isDesktop
-                />
-
-              </View>
+        <ScrollView className="flex-1">
+          <View style={containerStyle} className={isDesktop ? "" : "px-4"}>
+            <View className="flex-row items-center pt-4 pb-2">
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Назад"
+                onPress={() => router.back()}
+                className="flex-row items-center"
+                style={{ minHeight: 44 }}
+              >
+                <ChevronLeft size={20} color={colors.text} />
+                <Text className="text-text-base ml-1">Назад</Text>
+              </Pressable>
+            </View>
+            <View className="py-4">
+              <AnonymousView request={pub} onLogin={() => nav.any("/login")} />
             </View>
           </View>
         </ScrollView>
@@ -392,11 +500,25 @@ export default function MyRequestDetail() {
     );
   }
 
-  // ── MOBILE LAYOUT ─────────────────────────────────────────────────────
+  if (!request) {
+    return (
+      <SafeAreaView className="flex-1 bg-white">
+        <View className="flex-1 items-center justify-center px-4">
+          <Text className="text-base text-danger text-center">Заявка не найдена</Text>
+          <View className="mt-4">
+            <Button label="Назад" onPress={() => router.back()} fullWidth={false} />
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // ── MOBILE + DESKTOP LAYOUT ───────────────────────────────────────────
   return (
     <SafeAreaView className="flex-1 bg-surface2">
       <ScrollView className="flex-1">
-        <View className="px-4">
+        <View style={containerStyle} className={isDesktop ? "" : "px-4"}>
+          {/* Header */}
           <View className="flex-row items-center justify-between pt-4 pb-2">
             <Pressable
               accessibilityRole="button"
@@ -409,64 +531,24 @@ export default function MyRequestDetail() {
               <Text className="text-text-base ml-1">Назад</Text>
             </Pressable>
           </View>
+
           <View className="py-4">
-            <RequestHeader
-              request={request}
-              createdDate={createdDate}
-              serviceName={serviceName}
-            />
-
-            {/* Description */}
-            <View
-              className="bg-white rounded-2xl p-4 mb-4"
-              style={{
-                shadowColor: colors.text,
-                shadowOffset: { width: 0, height: 1 },
-                shadowOpacity: 0.05,
-                shadowRadius: 8,
-                elevation: 2,
-              }}
-            >
-              <Text className="text-xs font-semibold text-text-mute mb-2 uppercase tracking-wide">
-                Описание
-              </Text>
-              <Text className="text-base text-text-base leading-6">
-                {request.description}
-              </Text>
-            </View>
-
-            <RequestDocuments
-              files={request.files}
-              onFilePress={handleFilePress}
-            />
-
-            <RequestSpecialists
-              recommendations={recommendations}
-              onOpenProfile={handleOpenSpecialistProfile}
-              onWrite={handleWriteSpecialist}
-              showInlineComposer={showInlineComposer}
-              composerText={composerText}
-              composerFiles={composerFiles}
-              composerSending={composerSending}
-              composerError={composerError}
-              authToken={token}
-              onComposerChangeText={setComposerText}
-              onComposerFilesChange={setComposerFiles}
-              onComposerSend={handleComposerSend}
-            />
-
-            <RequestActions
-              request={request}
-              isOwner={request.isOwner}
-              isActive={isActive}
-              closing={closing}
-              copied={copied}
-              togglingVisibility={togglingVisibility}
-              onClose={handleCloseRequest}
-              onCopyLink={handleCopyLink}
-              onToggleVisibility={handleToggleVisibility}
-            />
-
+            {request.isOwner ? (
+              <OwnerView
+                request={request}
+                threads={threads}
+                onFilePress={handleFilePress}
+                onExtend={handleExtend}
+                extending={extending}
+                onClose={handleClose}
+              />
+            ) : (
+              <SpecialistView
+                request={request}
+                onFilePress={handleFilePress}
+                onThreadCreated={(threadId) => nav.any(`/threads/${threadId}`)}
+              />
+            )}
           </View>
         </View>
       </ScrollView>


### PR DESCRIPTION
## Summary

- **Backend** (`api/src/routes/requests.ts`): `GET /api/requests/:id/detail` now serves owner vs specialist views instead of returning 403 for non-owners. Returns `viewType: "owner"|"specialist"`, `isOwner`, `hasExistingThread`, `existingThreadId`, masked `client.name`.
- **Frontend** (`app/requests/[id]/detail.tsx`): Three-branch render:
  - `OwnerView` — threads list, close/extend buttons, files
  - `SpecialistView` — respond form (textarea + send) or "go to thread" CTA if thread already exists; masked client name
  - `AnonymousView` — title + 200-char preview + "login to respond" button
- Removed old "Статистика" block

## Test plan

- [ ] Owner opens their own request → sees threads list, close/extend
- [ ] Specialist opens client request → sees respond form or thread CTA
- [ ] Anonymous user opens request → sees preview + login button
- [ ] `tsc --noEmit` passes (frontend + backend both 0 errors)
- [ ] CI green

Closes #1683