### PR TITLE
refactor(ui): unified Input/Textarea styles #1674

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Image, Pressable, TextInput, Platform } from "react-native";
+import { View, Text, Image, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
@@ -8,6 +8,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { api } from "@/lib/api";
 import { colors } from "@/lib/theme";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -31,7 +32,6 @@ export default function AuthEmailScreen() {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [focused, setFocused] = useState(false);
 
   useEffect(() => {
     if (isAuthenticated && user) {
@@ -138,60 +138,25 @@ export default function AuthEmailScreen() {
             </View>
           ) : null}
 
-          {/* Email input — line-style (bottom border only) */}
-          <View
-            className="flex-row items-center"
-            style={{
-              borderTopWidth: 0,
-              borderLeftWidth: 0,
-              borderRightWidth: 0,
-              borderBottomWidth: focused ? 2 : 1,
-              borderBottomColor: error ? colors.error : focused ? colors.accent : colors.borderStrong,
-              paddingBottom: 2,
-              marginBottom: error ? 6 : 16,
-            }}
-          >
-            <Mail size={18} color={focused ? colors.accent : colors.placeholder} />
-            <TextInput
+          {/* Email input with leading icon */}
+          <View style={{ marginBottom: 16 }}>
+            <Input
               accessibilityLabel="Email адрес"
               placeholder="your@email.com"
-              placeholderTextColor={colors.placeholder}
               value={email}
               onChangeText={(t) => {
                 setEmail(t);
                 if (error) setError("");
               }}
-              onFocus={() => setFocused(true)}
-              onBlur={() => setFocused(false)}
+              icon={Mail}
               keyboardType="email-address"
               autoCapitalize="none"
               autoComplete="email"
               editable={!isLoading}
               onSubmitEditing={handleContinue}
-              style={{
-                flex: 1,
-                marginLeft: 10,
-                fontSize: 15,
-                color: colors.text,
-                borderWidth: 0,
-                backgroundColor: "transparent",
-                ...(Platform.OS === "web" ? {
-                  minHeight: 44,
-                  alignSelf: "stretch" as never,
-                  borderColor: "transparent",
-                  outlineStyle: "none" as never,
-                  outlineWidth: 0,
-                  appearance: "none" as never,
-                } : {}),
-              }}
+              error={error || undefined}
             />
           </View>
-
-          {error ? (
-            <Text className="text-sm text-danger mb-3" style={{ fontSize: 13 }}>
-              {error}
-            </Text>
-          ) : null}
 
           {/* CTA */}
           <Button

--- a/components/requests/InlineOtpFlow.tsx
+++ b/components/requests/InlineOtpFlow.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { View, Text, TextInput, Platform } from "react-native";
 import { Mail } from "lucide-react-native";
 import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
 import { api } from "@/lib/api";
 import { useAuth, UserData } from "@/contexts/AuthContext";
 import { useTypedRouter } from "@/lib/navigation";
@@ -124,62 +125,25 @@ export default function InlineOtpFlow({
 
       {stage === "email" && (
         <View>
-          <Text className="text-sm font-medium text-text-base mb-1.5">
-            Email <Text className="text-danger">*</Text>
-          </Text>
-          {/* Email — line-style (bottom border only) */}
-          <View
-            className="flex-row items-center"
-            style={{
-              borderTopWidth: 0,
-              borderLeftWidth: 0,
-              borderRightWidth: 0,
-              borderBottomWidth: 1,
-              borderBottomColor: emailError ? colors.error : colors.borderStrong,
-              paddingBottom: 2,
-              marginBottom: emailError ? 6 : 12,
-            }}
-          >
-            <Mail size={18} color={colors.placeholder} />
-            <TextInput
+          <View style={{ marginBottom: 12 }}>
+            <Input
+              label="Email"
               accessibilityLabel="Email адрес"
               placeholder="your@email.com"
-              placeholderTextColor={colors.placeholder}
               value={email}
               onChangeText={(t) => {
                 setEmail(t);
                 if (emailError) setEmailError("");
               }}
+              icon={Mail}
               keyboardType="email-address"
               autoCapitalize="none"
               autoComplete="email"
               editable={!requesting}
               onSubmitEditing={handleRequestOtp}
-              style={{
-                flex: 1,
-                marginLeft: 10,
-                fontSize: 15,
-                color: colors.text,
-                borderWidth: 0,
-                backgroundColor: "transparent",
-                ...(Platform.OS === "web"
-                  ? {
-                      minHeight: 44,
-                      alignSelf: "stretch" as never,
-                      borderColor: "transparent",
-                      outlineStyle: "none" as never,
-                      outlineWidth: 0,
-                      appearance: "none" as never,
-                    }
-                  : {}),
-              }}
+              error={emailError || undefined}
             />
           </View>
-          {emailError ? (
-            <Text className="text-sm text-danger mb-3" style={{ fontSize: 13 }}>
-              {emailError}
-            </Text>
-          ) : null}
           <Button
             label="Получить код"
             onPress={handleRequestOtp}

--- a/components/requests/MessageComposer.tsx
+++ b/components/requests/MessageComposer.tsx
@@ -1,5 +1,5 @@
-import { View, Text, TextInput } from "react-native";
-import { colors, fontSizeValue } from "@/lib/theme";
+import { View, Text } from "react-native";
+import Input from "@/components/ui/Input";
 
 interface MessageComposerProps {
   value: string;
@@ -34,55 +34,19 @@ export default function MessageComposer({
 }: MessageComposerProps) {
   return (
     <>
-      <Text className="text-sm font-semibold text-text-base mb-2">{label}</Text>
-      {/* Outer View — line-style (bottom border only). Prevents double-input on web. */}
-      <View
-        style={{
-          minHeight: 140,
-          borderTopWidth: 0,
-          borderLeftWidth: 0,
-          borderRightWidth: 0,
-          borderBottomWidth: 1,
-          borderBottomColor: disabled ? colors.border : colors.borderStrong,
-          backgroundColor: "transparent",
-          opacity: disabled ? 0.5 : 1,
-          paddingBottom: 2,
+      <Input
+        label={label}
+        accessibilityLabel={label}
+        value={value}
+        maxLength={maxLength}
+        onChangeText={(t) => {
+          if (t.length <= maxLength) onChange(t);
         }}
-      >
-        <TextInput
-          accessibilityLabel={label}
-          value={value}
-          maxLength={maxLength}
-          onChangeText={(t) => {
-            if (t.length <= maxLength) onChange(t);
-          }}
-          placeholder={placeholder}
-          placeholderTextColor={colors.placeholder}
-          multiline
-          editable={!disabled}
-          // Border/outline reset is applied unconditionally so the inner
-          // <input>/<textarea> never paints its own edge — only the outer
-          // wrapper View owns the bottom underline. Native silently drops
-          // unknown CSS keys, so this is safe across web + native.
-          // @ts-expect-error — outlineStyle/outlineWidth/appearance are
-          // web-only CSS properties; RN's TextStyle typing rejects them
-          // but the runtime drops unknown keys on native.
-          style={{
-            flex: 1,
-            paddingHorizontal: 0,
-            paddingVertical: 8,
-            fontSize: fontSizeValue.base,
-            color: colors.text,
-            textAlignVertical: "top",
-            borderWidth: 0,
-            borderColor: "transparent",
-            backgroundColor: "transparent",
-            outlineStyle: "none",
-            outlineWidth: 0,
-            appearance: "none",
-          }}
-        />
-      </View>
+        placeholder={placeholder}
+        multiline
+        editable={!disabled}
+        containerStyle={{ minHeight: 140, opacity: disabled ? 0.5 : 1 }}
+      />
 
       <View className="flex-row justify-between items-center mt-1 mb-1">
         {minLength !== undefined && value.length > 0 && value.length < minLength ? (

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -36,7 +36,6 @@ const INPUT_BORDER_FOCUS = "#3b82f6";
 const INPUT_BORDER_ERROR = "#c6365a";
 const INPUT_PLACEHOLDER = "#9ca3af";
 const INPUT_TEXT = "#111111";
-const INPUT_FONT_SIZE = 15;
 
 export default function Input({
   label,
@@ -149,8 +148,9 @@ export default function Input({
               minHeight: 44,
               alignSelf: "stretch",
             } : {}),
-            fontSize: variant === "bordered" ? INPUT_FONT_SIZE : 16,
+            fontSize: 14,
             color: variant === "bordered" ? INPUT_TEXT : colors.text,
+            lineHeight: multiline ? 20 : undefined,
             // On web multiline, explicit paddingTop ensures the cursor renders
             // at the right vertical position when wrapper uses flex-start.
             paddingTop: multiline ? spacing.sm : 0,


### PR DESCRIPTION
## Summary
- Standardized `Input.tsx`: fontSize 14px, paddingHorizontal 12, borderRadius 8, multiline minHeight 80, lineHeight 20
- `app/login.tsx`: replaced inline TextInput+icon block with `<Input icon={Mail}>`
- `components/requests/InlineOtpFlow.tsx`: replaced inline email TextInput (stage=email) with `<Input icon={Mail}>`
- `components/requests/MessageComposer.tsx`: replaced inline multiline TextInput with `<Input multiline>`

## Out of scope (kept as-is)
- `SpecialistSearchBar.tsx` — specific search UX
- `CityFnsCascade.tsx` — typeahead UX
- `AppHeader.tsx` — search bar
- `OtpCodeInput.tsx` — 6-box OTP (intentionally large font/letter-spacing)
- `InlineOtpFlow.tsx` code stage — digit input with centering/letter-spacing

## Verification
- `npx tsc --noEmit` → 0 errors (frontend)
- `cd api && npx tsc --noEmit` → 0 errors

Closes #1674