### PR TITLE
fix(dev): disable browser cache in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,20 @@ User opens app
 
 See `api/.env.example` for all required variables.
 
+## Browser Cache in Development
+
+The landing page (`landing/index.html`) includes `no-store` / `no-cache` meta
+tags so the browser does not serve stale assets during active development.
+
+For the Expo web app, disable cache in Chrome DevTools:
+
+1. Open DevTools (F12) -> Network tab -> check **Disable cache** (active while DevTools is open).
+2. Hard refresh: **Cmd+Shift+R** (macOS) / **Ctrl+Shift+R** (Windows/Linux).
+3. Or use Incognito mode — it starts with an empty cache every time.
+
+If you see outdated JS after a code change, hard-refresh first before debugging
+further.
+
 ## License
 
 MIT

--- a/app/requests/[id]/detail.tsx
+++ b/app/requests/[id]/detail.tsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Linking,
   TextInput,
+  ActivityIndicator,
   useWindowDimensions,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";

--- a/landing/index.html
+++ b/landing/index.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" />
 <title>P2PTax — Специалисты по вашей ФНС</title>
 <link rel="icon" type="image/png" href="../assets/images/favicon.png" />
 <meta property="og:title" content="P2PTax — Специалисты по вашей ФНС" />


### PR DESCRIPTION
## Summary

- Add `no-store` / `no-cache` meta tags to `landing/index.html` so browsers do not serve stale landing assets during development.
- Document DevTools cache-disable workflow (Disable cache checkbox, hard-refresh shortcuts, Incognito mode) in `README.md`.
- Fix pre-existing missing `ActivityIndicator` import in `app/requests/[id]/detail.tsx` (was blocking tsc).

No service workers found — SW unregister code is not needed.

Closes #1699

## Test plan

- [ ] Open landing in browser during dev — Network tab should show `Cache-Control: no-store` (or no caching headers from meta).
- [ ] Hard-refresh (Cmd+Shift+R) should reload all assets without stale content.
- [ ] `npx tsc --noEmit` (frontend + `api/`) — 0 errors.