### PR TITLE
refactor(RequestCard): simplify card — name+initial, files, remove status/responseCount/city

### DIFF
--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -129,6 +129,7 @@ router.get("/public", async (req: Request, res: Response) => {
       fns: { id: r.fns.id, name: r.fns.name, code: r.fns.code },
       threadsCount: r._count.threads,
       hasFiles: r._count.files > 0,
+      filesCount: r._count.files,
       user: {
         firstName: r.user.firstName,
         lastName: r.user.lastName,
@@ -309,7 +310,8 @@ router.get("/my", authMiddleware, async (req: Request, res: Response) => {
         include: {
           city: true,
           fns: true,
-          _count: { select: { threads: true } },
+          user: { select: { firstName: true, lastName: true, avatarUrl: true } },
+          _count: { select: { threads: true, files: true } },
         },
       }),
       prisma.request.count({ where: { userId } }),
@@ -326,6 +328,12 @@ router.get("/my", authMiddleware, async (req: Request, res: Response) => {
       city: { id: r.city.id, name: r.city.name },
       fns: { id: r.fns.id, name: r.fns.name, code: r.fns.code },
       threadsCount: r._count.threads,
+      hasFiles: r._count.files > 0,
+      filesCount: r._count.files,
+      user: {
+        firstName: r.user.firstName,
+        lastName: r.user.lastName,
+      },
     }));
 
     res.json({ items: mapped, total, limit, offset, hasMore: offset + limit < total });

--- a/components/RequestCard.tsx
+++ b/components/RequestCard.tsx
@@ -1,173 +1,98 @@
-import { View, Text, Pressable, Image } from "react-native";
-import StatusBadge from "./StatusBadge";
-import { colors, AVATAR_COLORS } from "@/lib/theme";
-import { pluralizeRu } from "@/lib/ru";
+import { View, Text, Pressable } from "react-native";
 import { Paperclip } from "lucide-react-native";
+import { colors } from "@/lib/theme";
 
-interface UserInfo {
-  firstName: string;
-  lastName: string;
-  avatarUrl?: string | null;
-  memberSince: number;
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}м назад`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}ч назад`;
+  const days = Math.floor(hrs / 24);
+  return `${days}д назад`;
 }
 
 interface RequestCardProps {
   id: string;
   title: string;
   description: string;
-  status: "ACTIVE" | "CLOSING_SOON" | "CLOSED";
-  city: { id: string; name: string };
   fns: { id: string; name: string; code: string };
-  threadsCount: number;
+  createdAt: string;
   hasFiles?: boolean;
-  user?: UserInfo;
-  createdAt?: string;
+  filesCount?: number;
+  user?: { firstName: string | null; lastName: string | null };
   onPress: (id: string) => void;
-}
-
-function getInitials(firstName: string, lastName: string): string {
-  const f = firstName?.[0] ?? "";
-  const l = lastName?.[0] ?? "";
-  return (f + l).toUpperCase();
-}
-
-function getAvatarColor(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
-  return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
-}
-
-function formatRelative(isoDate: string): string {
-  const now = Date.now();
-  const then = new Date(isoDate).getTime();
-  const diffMs = now - then;
-  const diffMin = Math.floor(diffMs / 60000);
-  const diffH = Math.floor(diffMin / 60);
-  const diffD = Math.floor(diffH / 24);
-  if (diffMin < 60) return "только что";
-  if (diffH < 24) return `${diffH} ${pluralizeRu(diffH, ["час", "часа", "часов"])} назад`;
-  if (diffD < 7) return `${diffD} ${pluralizeRu(diffD, ["день", "дня", "дней"])} назад`;
-  return new Date(isoDate).toLocaleDateString("ru-RU", { day: "numeric", month: "short" });
 }
 
 export default function RequestCard({
   id,
   title,
   description,
-  status,
-  city,
   fns,
-  threadsCount,
-  hasFiles,
-  user,
   createdAt,
+  hasFiles,
+  filesCount,
+  user,
   onPress,
 }: RequestCardProps) {
-  const initials = user ? getInitials(user.firstName, user.lastName) : "?";
-  const avatarBg = user ? getAvatarColor(user.firstName + user.lastName) : colors.primary;
-  const displayName = user
-    ? `${user.firstName}${user.lastName ? " " + user.lastName[0] + "." : ""}`
+  const authorName = user
+    ? [user.firstName, user.lastName ? user.lastName[0] + "." : null]
+        .filter(Boolean)
+        .join(" ")
     : null;
-  const snippet = description ? description.slice(0, 100) + (description.length > 100 ? "…" : "") : null;
+
+  const shortDesc =
+    description.length > 120 ? description.slice(0, 120) + "…" : description;
 
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={title}
       onPress={() => onPress(id)}
-      className="bg-white border border-border rounded-xl p-4 mb-3"
+      className="bg-white border border-border rounded-2xl p-4 mb-3"
       style={({ pressed }) => [
         { shadowColor: colors.black, shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.06, shadowRadius: 4, elevation: 2 },
         pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
       ]}
     >
-      {/* Header row: avatar + name + date + status */}
-      <View className="flex-row items-center mb-2" style={{ gap: 8 }}>
-        {/* Avatar */}
-        {user?.avatarUrl ? (
-          <Image
-            source={{ uri: user.avatarUrl }}
-            className="rounded-full"
-            style={{ width: 32, height: 32, flexShrink: 0 }}
-            accessibilityLabel={displayName ?? "Аватар"}
-          />
+      {/* top row: author + time */}
+      <View className="flex-row items-center justify-between mb-1">
+        {authorName ? (
+          <Text className="text-xs font-medium text-text-mute">{authorName}</Text>
         ) : (
-          <View
-            className="items-center justify-center rounded-full"
-            style={{ width: 32, height: 32, backgroundColor: avatarBg, flexShrink: 0 }}
-          >
-            <Text className="text-xs font-semibold text-white">{initials}</Text>
-          </View>
+          <View />
         )}
-
-        {/* Name + member since */}
-        <View className="flex-1 min-w-0">
-          {displayName && (
-            <Text className="text-xs font-medium text-text-base" numberOfLines={1}>
-              {displayName}
-              {user?.memberSince ? (
-                <Text className="text-xs font-normal" style={{ color: colors.textMuted }}>
-                  {"  ·  На сайте с " + user.memberSince}
-                </Text>
-              ) : null}
-            </Text>
-          )}
-        </View>
-
-        {/* Date + attachment icon */}
-        <View className="flex-row items-center" style={{ gap: 4, flexShrink: 0 }}>
-          {hasFiles && <Paperclip size={13} color={colors.textMuted} />}
-          {createdAt && (
-            <Text className="text-xs" style={{ color: colors.textMuted }}>
-              {formatRelative(createdAt)}
-            </Text>
-          )}
-        </View>
+        <Text className="text-xs text-text-mute">{timeAgo(createdAt)}</Text>
       </View>
 
-      {/* Title + status */}
-      <View className="flex-row items-center justify-between mb-2">
-        <Text
-          className="text-lg font-semibold text-text-base flex-1 mr-2"
-          numberOfLines={2}
-          style={{ flexShrink: 1, minWidth: 0 }}
-        >
-          {title}
-        </Text>
-        <StatusBadge status={status} />
-      </View>
-
-      {/* City + FNS chips */}
-      <View className="flex-row flex-wrap gap-1.5 mb-2">
-        <View className="bg-surface2 px-2 py-0.5 rounded">
-          <Text className="text-xs text-text-mute">{city.name}</Text>
-        </View>
-        <View className="bg-surface2 px-2 py-0.5 rounded">
-          <Text className="text-xs text-text-mute">{fns.name}</Text>
-        </View>
-      </View>
-
-      {/* Description snippet */}
-      {snippet && (
-        <Text className="text-sm text-text-mute mb-2" numberOfLines={2}>
-          {snippet}
-        </Text>
-      )}
-
-      {/* Threads count */}
-      <Text className="text-xs text-text-mute">
-        {threadsCount === 0
-          ? "Никто пока не откликнулся"
-          : `${threadsCount} ${pluralizeRu(threadsCount, [
-              "специалист",
-              "специалиста",
-              "специалистов",
-            ])} уже ${pluralizeRu(threadsCount, [
-              "написал",
-              "написали",
-              "написали",
-            ])}`}
+      {/* title */}
+      <Text
+        className="text-base font-semibold text-text-base mb-1"
+        numberOfLines={2}
+        style={{ flexShrink: 1, minWidth: 0 }}
+      >
+        {title}
       </Text>
+
+      {/* description */}
+      <Text className="text-sm text-text-mute mb-2" numberOfLines={3}>
+        {shortDesc}
+      </Text>
+
+      {/* bottom row: FNS chip + files */}
+      <View className="flex-row items-center justify-between">
+        <View className="bg-surface2 px-2 py-0.5 rounded" style={{ maxWidth: "80%" }}>
+          <Text className="text-xs text-text-mute" numberOfLines={1}>{fns.name}</Text>
+        </View>
+        {hasFiles ? (
+          <View className="flex-row items-center gap-1">
+            <Paperclip size={14} color={colors.textMuted} />
+            {filesCount != null && filesCount > 0 ? (
+              <Text className="text-xs text-text-mute">{filesCount}</Text>
+            ) : null}
+          </View>
+        ) : null}
+      </View>
     </Pressable>
   );
 }

--- a/components/requests/RequestsFeed.tsx
+++ b/components/requests/RequestsFeed.tsx
@@ -49,6 +49,9 @@ interface RequestItem {
   city: { id: string; name: string };
   fns: { id: string; name: string; code: string };
   threadsCount: number;
+  hasFiles?: boolean;
+  filesCount?: number;
+  user?: { firstName: string | null; lastName: string | null };
 }
 
 interface RequestsResponse {
@@ -344,11 +347,11 @@ export default function RequestsFeed({
             id={item.id}
             title={item.title}
             description={item.description}
-            status={item.status}
-            city={item.city}
             fns={item.fns}
-            threadsCount={item.threadsCount}
             createdAt={item.createdAt}
+            hasFiles={item.hasFiles}
+            filesCount={item.filesCount}
+            user={item.user}
             onPress={handleRequestPress}
           />
         )}


### PR DESCRIPTION
Closes #1678

## Changes

- `RequestCard`: removed `status` badge, `responseCount`/`threadsCount`, `city` chip (city already in FNS name)
- Added: author name+initial (`Сергей К.`), relative time (`1ч назад`), file attachment icon+count (`Paperclip`)
- Description truncated to 120 chars
- Rounded to `rounded-2xl`, padding 16px
- API `/public` and `/my`: added `filesCount`, `user` fields to list response
- Frontend `RequestItem` interfaces updated in both screens

## Verification

- `npx tsc --noEmit` → 0 errors (frontend)
- `cd api && npx tsc --noEmit` → 0 errors (backend)