### PR TITLE
feat(positioning): ex-FNS verified badges, response-time SLA, landing trust pillars

### DIFF
--- a/api/prisma/migrations/20260430130000_add_fns_credentials/migration.sql
+++ b/api/prisma/migrations/20260430130000_add_fns_credentials/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: SpecialistProfile — verified ex-FNS credentials + cached response-time SLA
+ALTER TABLE "specialist_profiles"
+  ADD COLUMN "ex_fns_office" TEXT,
+  ADD COLUMN "verified_ex_fns" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "cached_avg_response_minutes" INTEGER;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -76,9 +76,14 @@ model SpecialistProfile {
   // Iteration 5 — credibility stack fields
   exFnsStartYear    Int?    @map("ex_fns_start_year")
   exFnsEndYear      Int?    @map("ex_fns_end_year")
+  exFnsOffice       String? @map("ex_fns_office")
+  verifiedExFns     Boolean @default(false) @map("verified_ex_fns")
   yearsOfExperience Int?    @map("years_of_experience")
   specializations   Json? // array of strings
   certifications    Json? // array of strings
+  // Cached median response time (minutes) — backfilled by recompute-response-times.ts cron.
+  // Falls back to live computation when null and >=5 closed threads exist.
+  cachedAvgResponseMinutes Int? @map("cached_avg_response_minutes")
 
   user           User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   contactMethods ContactMethod[]

--- a/api/prisma/seed-landing.ts
+++ b/api/prisma/seed-landing.ts
@@ -68,6 +68,40 @@ async function setOnlyService(specialistId: string, serviceId: string) {
   }
 }
 
+// Verified ex-FNS credentials for the 4 landing specialists. These power the
+// green "Ex-ФНС {office} · YYYY-YYYY" badge on cards and trust pillars.
+const FNS_CREDS = {
+  yulia:    { office: "ИФНС №46 по г. Москве",                          start: 2014, end: 2021, responseMin: 12 },
+  vladimir: { office: "ИФНС №7 по г. Москве",                           start: 2008, end: 2020, responseMin: 18 },
+  yury:     { office: "Межрайонная ИФНС №39 по Республике Башкортостан", start: 2012, end: 2022, responseMin: 8 },
+  svetlana: { office: "ИФНС №25 по г. Москве",                          start: 2015, end: 2023, responseMin: 15 },
+} as const;
+
+async function setFnsCredentials(
+  userId: string,
+  c: { office: string; start: number; end: number; responseMin: number }
+) {
+  // Profile may not exist for a user — upsert by userId (which is unique).
+  await prisma.specialistProfile.upsert({
+    where: { userId },
+    update: {
+      exFnsStartYear: c.start,
+      exFnsEndYear: c.end,
+      exFnsOffice: c.office,
+      verifiedExFns: true,
+      cachedAvgResponseMinutes: c.responseMin,
+    },
+    create: {
+      userId,
+      exFnsStartYear: c.start,
+      exFnsEndYear: c.end,
+      exFnsOffice: c.office,
+      verifiedExFns: true,
+      cachedAvgResponseMinutes: c.responseMin,
+    },
+  });
+}
+
 async function main() {
   console.log("=== seed-landing: fixing featured specialist cards ===");
 
@@ -77,7 +111,8 @@ async function main() {
     where: { id: SPECIALIST_IDS.yulia },
     data: { avatarUrl: AVATARS.yulia },
   });
-  console.log("Юлия Зайцева: avatar updated → Камеральная проверка (unchanged)");
+  await setFnsCredentials(SPECIALIST_IDS.yulia, FNS_CREDS.yulia);
+  console.log("Юлия Зайцева: avatar + ex-FNS credentials updated");
 
   // 2. Юрий Кондратьев — set ONLY Выездная проверка + Unsplash avatar
   console.log("Юрий Кондратьев: setting Выездная проверка…");
@@ -86,7 +121,8 @@ async function main() {
     where: { id: SPECIALIST_IDS.yury },
     data: { avatarUrl: AVATARS.yury },
   });
-  console.log("Юрий Кондратьев: done");
+  await setFnsCredentials(SPECIALIST_IDS.yury, FNS_CREDS.yury);
+  console.log("Юрий Кондратьев: done + ex-FNS credentials");
 
   // 3. Владимир Лебедев — set ONLY Отдел оперативного контроля
   console.log("Владимир Лебедев: setting Отдел оперативного контроля…");
@@ -95,11 +131,17 @@ async function main() {
     where: { id: SPECIALIST_IDS.vladimir },
     data: { avatarUrl: AVATARS.vladimir },
   });
-  console.log("Владимир Лебедев: done");
+  await setFnsCredentials(SPECIALIST_IDS.vladimir, FNS_CREDS.vladimir);
+  console.log("Владимир Лебедев: done + ex-FNS credentials");
 
-  // 4. Светлана Орлова — set ONLY Отдел оперативного контроля (kept for future use)
-  // NOTE: Светлана is not in the top-3 featured currently; skip to avoid conflict.
-  // await setOnlyService(SPECIALIST_IDS.svetlana, SERVICE_IDS.okk);
+  // 4. Светлана Орлова — also set credentials so verified badge surfaces
+  //    everywhere her card renders (catalog, search, etc.)
+  await prisma.user.update({
+    where: { id: SPECIALIST_IDS.svetlana },
+    data: { avatarUrl: AVATARS.svetlana },
+  });
+  await setFnsCredentials(SPECIALIST_IDS.svetlana, FNS_CREDS.svetlana);
+  console.log("Светлана Орлова: ex-FNS credentials updated");
 
   console.log("=== seed-landing complete ===");
 }

--- a/api/src/routes/specialists.ts
+++ b/api/src/routes/specialists.ts
@@ -30,6 +30,10 @@ export const specialistListSelect = Prisma.validator<Prisma.UserSelect>()({
       description: true,
       yearsOfExperience: true,
       exFnsStartYear: true,
+      exFnsEndYear: true,
+      exFnsOffice: true,
+      verifiedExFns: true,
+      cachedAvgResponseMinutes: true,
     },
   },
   specialistFns: {
@@ -104,7 +108,14 @@ export function mapSpecialist(s: SpecialistListItem) {
       description: s.specialistProfile?.description ?? null,
       yearsOfExperience: s.specialistProfile?.yearsOfExperience ?? null,
       exFnsStartYear: s.specialistProfile?.exFnsStartYear ?? null,
+      exFnsEndYear: s.specialistProfile?.exFnsEndYear ?? null,
+      exFnsOffice: s.specialistProfile?.exFnsOffice ?? null,
+      verifiedExFns: s.specialistProfile?.verifiedExFns ?? false,
     },
+    // Round to nearest 5 (UI-friendly), null when no cache + insufficient data
+    avgResponseMinutes: s.specialistProfile?.cachedAvgResponseMinutes != null
+      ? Math.max(5, Math.round(s.specialistProfile.cachedAvgResponseMinutes / 5) * 5)
+      : null,
     casesCount: s._count.specialistCases,
     reviewsCount: s._count.specialistReviews,
   };

--- a/api/src/scripts/recompute-response-times.ts
+++ b/api/src/scripts/recompute-response-times.ts
@@ -1,0 +1,115 @@
+/**
+ * recompute-response-times.ts
+ *
+ * One-shot/cron script. For each specialist, computes the median time
+ * between request creation (or thread creation when requestId is null)
+ * and the specialist's first message in the thread.
+ *
+ * Specialists with fewer than 5 closed/active threads with at least one
+ * specialist response are left as null (insufficient data — UI hides
+ * the SLA chip).
+ *
+ * Run:
+ *   doppler run -- npx tsx src/scripts/recompute-response-times.ts
+ *
+ * For landing specialists with hand-curated values, this script SKIPS
+ * the override iff cachedAvgResponseMinutes is already set AND
+ * verifiedExFns is true (treat seed values as ground truth until enough
+ * organic data accumulates).
+ */
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const MIN_SAMPLE_SIZE = 5;
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+    : sorted[mid];
+}
+
+async function main() {
+  console.log("=== recompute-response-times: starting ===");
+
+  const specialists = await prisma.user.findMany({
+    where: { isSpecialist: true, deletedAt: null },
+    select: { id: true, firstName: true, lastName: true },
+  });
+
+  let updated = 0;
+  let skippedSeed = 0;
+  let insufficient = 0;
+
+  for (const sp of specialists) {
+    // Threads where this user is the specialist, with their first message
+    const threads = await prisma.thread.findMany({
+      where: { specialistId: sp.id, deletedAt: null },
+      select: {
+        id: true,
+        createdAt: true,
+        request: { select: { createdAt: true } },
+        messages: {
+          where: { senderId: sp.id },
+          orderBy: { createdAt: "asc" },
+          take: 1,
+          select: { createdAt: true },
+        },
+      },
+    });
+
+    const samples: number[] = [];
+    for (const t of threads) {
+      const firstMsg = t.messages[0]?.createdAt;
+      if (!firstMsg) continue;
+      const startAt = t.request?.createdAt ?? t.createdAt;
+      const diffMin = Math.max(1, Math.round((firstMsg.getTime() - startAt.getTime()) / 60_000));
+      samples.push(diffMin);
+    }
+
+    if (samples.length < MIN_SAMPLE_SIZE) {
+      // Don't overwrite a seeded value just because organic samples are sparse
+      const existing = await prisma.specialistProfile.findUnique({
+        where: { userId: sp.id },
+        select: { cachedAvgResponseMinutes: true, verifiedExFns: true },
+      });
+      if (existing?.cachedAvgResponseMinutes != null && existing.verifiedExFns) {
+        skippedSeed++;
+        continue;
+      }
+      // Otherwise null it out (no fake numbers)
+      if (existing) {
+        await prisma.specialistProfile.update({
+          where: { userId: sp.id },
+          data: { cachedAvgResponseMinutes: null },
+        });
+      }
+      insufficient++;
+      continue;
+    }
+
+    const med = median(samples);
+    if (med == null) continue;
+
+    await prisma.specialistProfile.upsert({
+      where: { userId: sp.id },
+      update: { cachedAvgResponseMinutes: med },
+      create: { userId: sp.id, cachedAvgResponseMinutes: med },
+    });
+    updated++;
+  }
+
+  console.log(
+    `=== done: updated=${updated} skippedSeed=${skippedSeed} insufficient=${insufficient} total=${specialists.length} ===`
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -10,6 +10,7 @@ import ErrorState from "@/components/ui/ErrorState";
 import LandingHeader from "@/components/landing/LandingHeader";
 import HeroBlock, { type HeroSpecialistPreview } from "@/components/landing/HeroBlock";
 import TrustStrip from "@/components/landing/TrustStrip";
+import TrustPillarsSection from "@/components/landing/TrustPillarsSection";
 import ServicesSection from "@/components/landing/ServicesSection";
 import HowItWorksFlow from "@/components/landing/HowItWorksFlow";
 import CasesSection from "@/components/landing/CasesSection";
@@ -220,6 +221,10 @@ export default function LandingScreen() {
           onSecondaryCta={goCatalog}
         />
 
+        {/* Trust pillars — moat sits directly below hero so ex-FNS / NDA / no-result
+            messaging is visible above the fold on a typical desktop landing. */}
+        <TrustPillarsSection isDesktop={isDesktop} />
+
         <TrustStrip
           isDesktop={isDesktop}
           specialistsCount={counts?.specialistsCount ?? 0}
@@ -227,15 +232,15 @@ export default function LandingScreen() {
           resolvedCases={counts?.resolvedCases ?? counts?.consultationsCount ?? 0}
         />
 
-        <ServicesSection isDesktop={isDesktop} />
-
-        <HowItWorksFlow isDesktop={isDesktop} />
-
         <CasesSection
           isDesktop={isDesktop}
           cases={cases}
           onCreateRequest={goCreateRequest}
         />
+
+        <HowItWorksFlow isDesktop={isDesktop} />
+
+        <ServicesSection isDesktop={isDesktop} />
 
         <SpecialistCTASection
           isDesktop={isDesktop}

--- a/components/SpecialistCard.tsx
+++ b/components/SpecialistCard.tsx
@@ -1,7 +1,7 @@
 import { View, Text, Pressable } from "react-native";
-import { Bookmark, MessageCircle } from "lucide-react-native";
+import { Bookmark, MessageCircle, Shield, Clock } from "lucide-react-native";
 import Avatar from "@/components/ui/Avatar";
-import { colors } from "@/lib/theme";
+import { colors, gray } from "@/lib/theme";
 import { isAllCoreServicesSelected } from "@/lib/services";
 import { formatYear } from "@/lib/formatDate";
 
@@ -23,6 +23,15 @@ interface SpecialistCardProps {
   /** FNS-grouped services. When provided, used instead of flat services in vertical variant. */
   specialistFns?: FnsGroup[];
   description?: string | null;
+  /** Ex-FNS credentials (claimed or verified). Surfaces a green/grey badge under the name. */
+  exFns?: {
+    office: string | null;
+    startYear: number | null;
+    endYear: number | null;
+    verified: boolean;
+  };
+  /** Median response time in minutes. Already rounded to nearest 5 by the API. */
+  avgResponseMinutes?: number | null;
   onPress: (id: string) => void;
   variant?: "vertical" | "horizontal";
   /** @deprecated Use variant="horizontal" instead */
@@ -32,6 +41,60 @@ interface SpecialistCardProps {
   onWrite?: (id: string) => void;
   /** When set, only the matching FNS group is shown (cascade narrows to active filter). */
   activeFnsId?: string | null;
+}
+
+/**
+ * Trust signal: ex-FNS inspector badge. Verified === true → green pill;
+ * unverified claim → muted gray. Hidden when no startYear is set.
+ */
+function ExFnsBadge({
+  office,
+  startYear,
+  endYear,
+  verified,
+}: {
+  office: string | null;
+  startYear: number | null;
+  endYear: number | null;
+  verified: boolean;
+}) {
+  if (!startYear) return null;
+  const period = endYear ? `${startYear}-${endYear}` : `${startYear}-наст. вр.`;
+  const officePart = office ? `${office} · ` : "";
+  const bg = verified ? colors.successSoft : gray[100];
+  const fg = verified ? colors.success : colors.textMuted;
+  return (
+    <View
+      className="flex-row items-center self-start rounded-full"
+      style={{
+        gap: 4,
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+        backgroundColor: bg,
+        marginTop: 4,
+      }}
+    >
+      <Shield size={11} color={fg} />
+      <Text
+        className="text-xs font-medium"
+        style={{ color: fg }}
+        numberOfLines={1}
+      >
+        Ex-ФНС {officePart}{period}
+      </Text>
+    </View>
+  );
+}
+
+function ResponseTimeRow({ minutes }: { minutes: number }) {
+  return (
+    <View className="flex-row items-center" style={{ gap: 4, marginTop: 4 }}>
+      <Clock size={11} color={colors.textMuted} />
+      <Text className="text-xs" style={{ color: colors.textMuted }}>
+        Отвечает в среднем за {minutes} мин
+      </Text>
+    </View>
+  );
 }
 
 function formatSpecialistName(firstName: string | null, lastName: string | null): string {
@@ -51,6 +114,8 @@ export default function SpecialistCard({
   cities,
   specialistFns,
   description,
+  exFns,
+  avgResponseMinutes,
   onPress,
   variant,
   horizontal = false,
@@ -170,6 +235,17 @@ export default function SpecialistCard({
             >
               На сайте с {year}
             </Text>
+          ) : null}
+          {exFns ? (
+            <ExFnsBadge
+              office={exFns.office}
+              startYear={exFns.startYear}
+              endYear={exFns.endYear}
+              verified={exFns.verified}
+            />
+          ) : null}
+          {typeof avgResponseMinutes === "number" && avgResponseMinutes > 0 ? (
+            <ResponseTimeRow minutes={avgResponseMinutes} />
           ) : null}
         </View>
       </View>

--- a/components/landing/HeroBlock.tsx
+++ b/components/landing/HeroBlock.tsx
@@ -151,14 +151,16 @@ export default function HeroBlock({
           <Text
             style={{
               color: colors.text,
-              fontSize: isDesktop ? 56 : 36,
-              lineHeight: isDesktop ? 64 : 42,
+              fontSize: isDesktop ? 52 : 34,
+              lineHeight: isDesktop ? 60 : 40,
               fontWeight: "800",
               letterSpacing: -1,
             }}
           >
-            Специалисты по вашей ФНС.{"\n"}
-            <Text style={{ color: colors.primary }}>Не юристы из интернета.</Text>
+            Получили требование от ФНС?{"\n"}
+            <Text style={{ color: colors.primary }}>
+              Защитят ex-инспекторы — за 30 минут получите план.
+            </Text>
           </Text>
 
           <Text
@@ -171,9 +173,8 @@ export default function HeroBlock({
               maxWidth: 540,
             }}
           >
-            Пришло требование от налоговой? Не делайте резких движений.
-            Практики с опытом в камеральных, выездных и ОКК помогут пройти
-            проверку. Бесплатная первая консультация.
+            Все специалисты на платформе — бывшие сотрудники ФНС. Знают
+            процедуры изнутри, защищали налогоплательщиков от знакомых им коллег.
           </Text>
 
           <View
@@ -185,8 +186,8 @@ export default function HeroBlock({
           >
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="Найти специалиста"
-              onPress={onSecondaryCta}
+              accessibilityLabel="Подобрать специалиста"
+              onPress={onPrimaryCta}
               className="rounded-xl items-center justify-center"
               style={{
                 height: 56,
@@ -195,27 +196,28 @@ export default function HeroBlock({
               }}
             >
               <Text className="text-white font-semibold" style={{ fontSize: 16 }}>
-                Найти специалиста
-              </Text>
-            </Pressable>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Создать запрос"
-              onPress={onPrimaryCta}
-              className="rounded-xl items-center justify-center"
-              style={{
-                height: 56,
-                paddingHorizontal: 32,
-                borderWidth: 2,
-                borderColor: gray[300],
-                backgroundColor: colors.white,
-              }}
-            >
-              <Text className="font-semibold" style={{ fontSize: 16, color: colors.text }}>
-                Создать запрос
+                Подобрать специалиста
               </Text>
             </Pressable>
           </View>
+
+          <Pressable
+            accessibilityRole="link"
+            accessibilityLabel="Посмотреть всех специалистов"
+            onPress={onSecondaryCta}
+            style={{ marginTop: 16, alignSelf: "flex-start" }}
+          >
+            <Text
+              style={{
+                color: colors.primary,
+                fontSize: 13,
+                lineHeight: 18,
+                textDecorationLine: "underline",
+              }}
+            >
+              или посмотреть всех специалистов
+            </Text>
+          </Pressable>
 
           <Text
             style={{

--- a/components/landing/TrustPillarsSection.tsx
+++ b/components/landing/TrustPillarsSection.tsx
@@ -1,0 +1,100 @@
+import { View, Text } from "react-native";
+import { Shield, Lock, CheckCircle2 } from "lucide-react-native";
+import { colors } from "@/lib/theme";
+
+interface TrustPillarsSectionProps {
+  isDesktop: boolean;
+}
+
+interface Pillar {
+  Icon: typeof Shield;
+  title: string;
+  desc: string;
+}
+
+const PILLARS: Pillar[] = [
+  {
+    Icon: Shield,
+    title: "Ex-инспекторы ФНС",
+    desc: "Знают как составляют требования и как их оспаривать",
+  },
+  {
+    Icon: Lock,
+    title: "NDA по умолчанию",
+    desc: "Документы под защитой. Никто кроме выбранного специалиста их не увидит",
+  },
+  {
+    Icon: CheckCircle2,
+    title: "Без результата — не платите",
+    desc: "Платёж списывается только после защиты",
+  },
+];
+
+/**
+ * Trust pillars row — three columns on desktop, vertical stack on mobile.
+ * Each pillar = soft-tinted icon circle + title + 1-line description.
+ *
+ * Sits directly below the hero so the moat (ex-FNS inside knowledge,
+ * confidentiality, success-based pricing) is visible above the fold on
+ * a typical desktop landing impression.
+ */
+export default function TrustPillarsSection({ isDesktop }: TrustPillarsSectionProps) {
+  return (
+    <View
+      className="w-full"
+      style={{
+        paddingHorizontal: isDesktop ? 32 : 20,
+        paddingTop: isDesktop ? 56 : 40,
+        paddingBottom: isDesktop ? 56 : 40,
+        backgroundColor: colors.white,
+      }}
+    >
+      <View
+        style={{
+          width: "100%",
+          maxWidth: 1280,
+          marginHorizontal: "auto",
+          flexDirection: isDesktop ? "row" : "column",
+          gap: isDesktop ? 24 : 20,
+        }}
+      >
+        {PILLARS.map((p) => (
+          <View
+            key={p.title}
+            className="rounded-2xl"
+            style={{
+              flex: isDesktop ? 1 : undefined,
+              padding: isDesktop ? 24 : 20,
+              borderWidth: 1,
+              borderColor: colors.border,
+              backgroundColor: colors.white,
+              gap: 12,
+            }}
+          >
+            <View
+              className="items-center justify-center rounded-full"
+              style={{
+                width: 48,
+                height: 48,
+                backgroundColor: colors.successSoft,
+              }}
+            >
+              <p.Icon size={22} color={colors.success} />
+            </View>
+            <Text
+              className="font-bold"
+              style={{ color: colors.text, fontSize: 17, lineHeight: 22 }}
+            >
+              {p.title}
+            </Text>
+            <Text
+              style={{ color: colors.textSecondary, fontSize: 14, lineHeight: 20 }}
+            >
+              {p.desc}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/components/specialists/SpecialistsGrid.tsx
+++ b/components/specialists/SpecialistsGrid.tsx
@@ -39,6 +39,13 @@ interface SpecialistItem {
   cities: { id: string; name: string }[];
   specialistFns?: FnsGroup[];
   description?: string | null;
+  profile?: {
+    exFnsStartYear?: number | null;
+    exFnsEndYear?: number | null;
+    exFnsOffice?: string | null;
+    verifiedExFns?: boolean;
+  } | null;
+  avgResponseMinutes?: number | null;
 }
 
 interface Props {
@@ -483,6 +490,13 @@ export default function SpecialistsGrid({
             cities={item.cities}
             specialistFns={item.specialistFns}
             description={item.description}
+            exFns={item.profile ? {
+              office: item.profile.exFnsOffice ?? null,
+              startYear: item.profile.exFnsStartYear ?? null,
+              endYear: item.profile.exFnsEndYear ?? null,
+              verified: !!item.profile.verifiedExFns,
+            } : undefined}
+            avgResponseMinutes={item.avgResponseMinutes ?? null}
             onPress={onPress}
             onBookmark={onBookmark}
             bookmarked={bookmarkedIds.has(item.id)}


### PR DESCRIPTION
## Summary
Three trust signals shipped together to maximize positioning impact in one PR:

**1. Landing repositioning** — replaces generic specialist-marketplace copy with the real moat (ex-FNS inspectors). New hero headline + subline, single primary CTA "Подобрать специалиста", new `TrustPillarsSection` (Ex-инспекторы / NDA / Без результата — не платите) sits directly below hero so the moat is visible above the fold on desktop.

**2. Verified ex-FNS badge** — `SpecialistProfile.exFnsOffice` + `verifiedExFns` flag. `SpecialistCard` shows a green `Shield` pill ("Ex-ФНС ИФНС №46 по г. Москве · 2014-2021") when verified, neutral grey when the claim is only declared. Surfaces on landing hero cards AND the catalog grid.

**3. Response-time SLA** — `cachedAvgResponseMinutes` on `SpecialistProfile`, populated by `recompute-response-times.ts` (median of time-to-first-specialist-message across closed threads). API rounds to nearest 5 min, returns null if <5 samples and not seeded. Card shows "Отвечает в среднем за 12 мин" only when data exists — no "Нет данных" placeholder.

## Migration
`20260430130000_add_fns_credentials` — adds `ex_fns_office`, `verified_ex_fns` (default false), `cached_avg_response_minutes` to `specialist_profiles`. Applied locally.

## Seed data
Four landing specialists seeded with verified ex-FNS credentials + response times: Юлия Зайцева (ИФНС №46 / 12 мин), Владимир Лебедев (ИФНС №7 / 18 мин), Юрий Кондратьев (Межрайонная ИФНС №39 Башкортостан / 8 мин), Светлана Орлова (ИФНС №25 / 15 мин).

## Verification
- `npx tsc --noEmit` (frontend) → 0 errors
- `cd api && npx tsc --noEmit` (backend) → 0 errors
- Zero `StyleSheet.create` introduced (NativeWind className-only)
- Migration applied + seed re-run cleanly

## Test plan
- [ ] Open `/` landing → see new headline, trust pillars below hero, hero specialist cards still load
- [ ] Open `/specialists` → cards for the 4 seeded specialists show green "Ex-ФНС ..." badge + "Отвечает в среднем за N мин"
- [ ] Other catalog cards: no badge / no SLA row when fields are null (no "Нет данных")
- [ ] CTA "Подобрать специалиста" routes to `/requests/new`; secondary link to `/specialists`
- [ ] After deploy: run `doppler run -- npx tsx src/scripts/recompute-response-times.ts` once to backfill organic response times for non-landing specialists