### PR TITLE
feat(intake): structured wizard replaces free-text request form

### DIFF
--- a/api/prisma/migrations/20260430130000_intake_fields/migration.sql
+++ b/api/prisma/migrations/20260430130000_intake_fields/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "DocumentType" AS ENUM ('TREBOVANIE', 'RESHENIE', 'VYEZDNAYA', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "requests"
+  ADD COLUMN "document_type" "DocumentType",
+  ADD COLUMN "incident_date" TIMESTAMP(3),
+  ADD COLUMN "urgency" BOOLEAN DEFAULT false,
+  ADD COLUMN "disputed_amount" INTEGER;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -19,6 +19,15 @@ enum RequestStatus {
   CLOSED
 }
 
+// Intake wizard — document type that triggered the request.
+// Drives auto-deadline computation and screen flow.
+enum DocumentType {
+  TREBOVANIE
+  RESHENIE
+  VYEZDNAYA
+  OTHER
+}
+
 model User {
   id                           String    @id @default(uuid())
   email                        String    @unique
@@ -214,6 +223,12 @@ model Request {
   lastActivityAt  DateTime      @default(now()) @map("last_activity_at")
   extensionsCount Int           @default(0) @map("extensions_count")
   createdAt       DateTime      @default(now()) @map("created_at")
+  // Intake wizard fields (#feat-intake-wizard) — optional so legacy rows
+  // and any non-wizard creation paths keep working.
+  documentType    DocumentType? @map("document_type")
+  incidentDate    DateTime?     @map("incident_date")
+  urgency         Boolean?      @default(false)
+  disputedAmount  Int?          @map("disputed_amount")
 
   user    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   city    City      @relation(fields: [cityId], references: [id])

--- a/api/src/routes/requests.ts
+++ b/api/src/routes/requests.ts
@@ -348,7 +348,20 @@ router.get("/my", authMiddleware, async (req: Request, res: Response) => {
 router.post("/", authMiddleware, createRequestRateLimiter, async (req: Request, res: Response) => {
   try {
     const userId = req.user!.userId;
-    const { title, cityId, fnsId, description, fileIds, isPublic } = req.body;
+    const {
+      title,
+      cityId,
+      fnsId,
+      description,
+      fileIds,
+      isPublic,
+      // Intake wizard (#feat-intake-wizard) — all optional, legacy callers
+      // continue to work without these fields.
+      documentType,
+      incidentDate,
+      urgency,
+      disputedAmount,
+    } = req.body;
 
     // Validate
     if (!title || title.length < 3 || title.length > 100) {
@@ -362,6 +375,36 @@ router.post("/", authMiddleware, createRequestRateLimiter, async (req: Request, 
     if (!description || description.length < 10 || description.length > 5000) {
       res.status(400).json({ error: "Description must be 10-5000 characters" });
       return;
+    }
+
+    // Validate intake wizard fields when present.
+    const ALLOWED_DOC_TYPES = ["TREBOVANIE", "RESHENIE", "VYEZDNAYA", "OTHER"] as const;
+    type DocType = typeof ALLOWED_DOC_TYPES[number];
+    let normalizedDocType: DocType | null = null;
+    if (documentType !== undefined && documentType !== null) {
+      if (typeof documentType !== "string" || !ALLOWED_DOC_TYPES.includes(documentType as DocType)) {
+        res.status(400).json({ error: "Invalid documentType" });
+        return;
+      }
+      normalizedDocType = documentType as DocType;
+    }
+    let normalizedIncidentDate: Date | null = null;
+    if (incidentDate !== undefined && incidentDate !== null && incidentDate !== "") {
+      const d = new Date(incidentDate);
+      if (Number.isNaN(d.getTime())) {
+        res.status(400).json({ error: "Invalid incidentDate" });
+        return;
+      }
+      normalizedIncidentDate = d;
+    }
+    let normalizedDisputedAmount: number | null = null;
+    if (disputedAmount !== undefined && disputedAmount !== null && disputedAmount !== "") {
+      const n = typeof disputedAmount === "number" ? disputedAmount : parseInt(String(disputedAmount), 10);
+      if (!Number.isFinite(n) || n < 0 || n > 1_000_000_000_000) {
+        res.status(400).json({ error: "Invalid disputedAmount" });
+        return;
+      }
+      normalizedDisputedAmount = Math.round(n);
     }
 
     // Check limit
@@ -399,6 +442,10 @@ router.post("/", authMiddleware, createRequestRateLimiter, async (req: Request, 
         description: stripHtml(description),
         userId,
         isPublic: typeof isPublic === "boolean" ? isPublic : true,
+        documentType: normalizedDocType,
+        incidentDate: normalizedIncidentDate,
+        urgency: typeof urgency === "boolean" ? urgency : undefined,
+        disputedAmount: normalizedDisputedAmount,
       },
       include: {
         city: true,

--- a/app/requests/new.tsx
+++ b/app/requests/new.tsx
@@ -1,15 +1,14 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   View,
   Text,
-  ScrollView,
   ActivityIndicator,
   Alert,
   Platform,
   Pressable,
   useWindowDimensions,
+  ScrollView,
 } from "react-native";
-import StyledSwitch from "@/components/ui/StyledSwitch";
 import LandingHeader from "@/components/landing/LandingHeader";
 import PageTitle from "@/components/layout/PageTitle";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -17,33 +16,19 @@ import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTypedRouter } from "@/lib/navigation";
 import { ChevronLeft, X } from "lucide-react-native";
 import Button from "@/components/ui/Button";
-import Card from "@/components/ui/Card";
-import Input from "@/components/ui/Input";
 import { apiPost, api } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
-import { useCities } from "@/lib/hooks/useCities";
-import { useServices } from "@/lib/hooks/useServices";
 import { colors } from "@/lib/theme";
-import CityFnsCascade, {
-  type CityFnsValue,
-  type FnsCascadeOption,
-} from "@/components/filters/CityFnsCascade";
 import InlineOtpFlow from "@/components/requests/InlineOtpFlow";
-import FileUploadSection, { type AttachedFile } from "@/components/requests/FileUploadSection";
+import type { AttachedFile } from "@/components/requests/FileUploadSection";
 import { draftStorage } from "@/lib/draftStorage";
-
-// Single canonical key (v1). Replaces legacy "pending_request_draft".
-const DRAFT_KEY = "p2ptax_request_draft_v1";
-const LEGACY_DRAFT_KEY = "pending_request_draft";
-
-interface RequestDraft {
-  title: string;
-  description: string;
-  cityId: string | null;
-  citySlug: string | null;
-  fnsId: string | null;
-  serviceId: string | null;
-}
+import IntakeWizard from "@/components/intake/IntakeWizard";
+import {
+  EMPTY_INTAKE,
+  INTAKE_DRAFT_KEY,
+  deriveTitle,
+  type IntakeData,
+} from "@/components/intake/types";
 
 interface SpecialistMini {
   id: string;
@@ -51,39 +36,41 @@ interface SpecialistMini {
   lastName: string | null;
 }
 
+/**
+ * /requests/new — structured 4-step intake wizard.
+ *
+ * Replaces the previous free-text form. The screen is a thin shell:
+ *   - top chrome (landing header for anon, back-button on mobile, page title)
+ *   - <IntakeWizard> (steps 1-4, sticky progress + nav, owns wizard data)
+ *   - inline OTP flow shown after step 4 for anon users (preserves the
+ *     existing "fill → email-OTP → submit" path)
+ *   - inline error / specialist-targeting banner
+ *
+ * Submit pipeline (final step "Отправить запрос" press):
+ *   1. wizard requests submit → if !isAuthenticated, show InlineOtpFlow
+ *      (lock the wizard so user can't keep editing while OTP is up)
+ *   2. when authed, POST /api/requests with all wizard fields + legacy
+ *      title/description/cityId/fnsId for back-compat
+ *   3. on success, drop the draft, navigate to /requests/<id>/detail
+ */
 export default function CreateRequest() {
   const router = useRouter();
   const nav = useTypedRouter();
   const { isAuthenticated, isLoading: authLoading, token } = useAuth();
   const { width } = useWindowDimensions();
-  const params = useLocalSearchParams<{ restore?: string; specialistId?: string }>();
-  const restoreMode = params.restore === "1";
+  const params = useLocalSearchParams<{ specialistId?: string }>();
 
-  // Specialist targeting — optional, set via specialistId query param
   const [targetSpecialistId, setTargetSpecialistId] = useState<string | null>(
     typeof params.specialistId === "string" ? params.specialistId : null
   );
-  const [targetSpecialist, setTargetSpecialist] = useState<SpecialistMini | null>(null);
+  const [targetSpecialist, setTargetSpecialist] =
+    useState<SpecialistMini | null>(null);
 
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [selectedCityId, setSelectedCityId] = useState<string | null>(null);
-  const [selectedFnsId, setSelectedFnsId] = useState<string | null>(null);
-  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(null);
-
-  const { cities: citiesRaw, loading: citiesLoading } = useCities();
-  const { services, loading: servicesLoading } = useServices();
-  const cities = citiesRaw;
-  const [fnsAll, setFnsAll] = useState<FnsCascadeOption[]>([]);
-
-  const [isPublic, setIsPublic] = useState(true);
-  const [submitting, setSubmitting] = useState(false);
-  const loadingInit = citiesLoading || servicesLoading;
-  const [submitted, setSubmitted] = useState(false);
-  const [submitError, setSubmitError] = useState("");
-  const [draftLoaded, setDraftLoaded] = useState(false);
-  const [showOtpFlow, setShowOtpFlow] = useState(false);
+  const [wizardData, setWizardData] = useState<IntakeData>(EMPTY_INTAKE);
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [showOtpFlow, setShowOtpFlow] = useState(false);
 
   // Fetch targeted specialist name when specialistId is present.
   useEffect(() => {
@@ -91,185 +78,93 @@ export default function CreateRequest() {
       setTargetSpecialist(null);
       return;
     }
-    api<{ id: string; firstName: string | null; lastName: string | null }>(
-      `/api/specialists/${targetSpecialistId}`,
-      { noAuth: true }
-    )
-      .then((s) => setTargetSpecialist({ id: s.id, firstName: s.firstName, lastName: s.lastName }))
+    api<{
+      id: string;
+      firstName: string | null;
+      lastName: string | null;
+    }>(`/api/specialists/${targetSpecialistId}`, { noAuth: true })
+      .then((s) =>
+        setTargetSpecialist({
+          id: s.id,
+          firstName: s.firstName,
+          lastName: s.lastName,
+        })
+      )
       .catch(() => setTargetSpecialist(null));
   }, [targetSpecialistId]);
 
-  // Load all FNS offices once cities are available — needed for typeahead.
-  useEffect(() => {
-    if (cities.length === 0) return;
-    let cancelled = false;
-    (async () => {
+  /**
+   * Posts the request once the user is authenticated. Called both directly
+   * (auth path) and from InlineOtpFlow's onAuthenticated callback (anon path).
+   */
+  const submitRequestAuthed = useCallback(
+    async (_freshToken?: string) => {
+      setSubmitting(true);
+      setSubmitError("");
       try {
-        const ids = cities.map((c) => c.id).join(",");
-        const res = await api<{ offices: { id: string; name: string; code: string; cityId: string; city?: { name: string } }[] }>(
-          `/api/fns?city_ids=${ids}`,
-          { noAuth: true }
-        );
-        if (cancelled) return;
-        setFnsAll(
-          res.offices.map((f) => ({
-            id: f.id,
-            name: f.name,
-            code: f.code,
-            cityId: f.cityId,
-            cityName: f.city?.name,
-          }))
-        );
-      } catch {
-        /* typeahead degrades gracefully */
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [cities]);
+        const fileIds = attachedFiles
+          .filter((f) => !!f.uploadedId && !f.uploading && !f.error)
+          .map((f) => f.uploadedId as string);
 
-  // Restore draft on mount (anyone — anon or returning post-login).
-  // Reads new key first, falls back to legacy key for in-flight users.
-  // FNS list is fetched internally by CityFnsCascade once selectedCityId is set.
-  useEffect(() => {
-    if (loadingInit || draftLoaded) return;
-    (async () => {
-      try {
-        let raw = await draftStorage.get(DRAFT_KEY);
-        if (!raw) {
-          raw = await draftStorage.get(LEGACY_DRAFT_KEY);
-          if (raw) {
-            // Migrate legacy → v1 key, then drop the old one.
-            await draftStorage.set(DRAFT_KEY, raw);
-            await draftStorage.del(LEGACY_DRAFT_KEY);
-          }
+        const description = wizardData.description.trim();
+        const title = deriveTitle(wizardData);
+
+        const body: Record<string, unknown> = {
+          title,
+          cityId: wizardData.cityId,
+          fnsId: wizardData.fnsId,
+          description,
+          fileIds,
+          isPublic: true,
+          documentType: wizardData.documentType,
+          incidentDate: wizardData.incidentDate || undefined,
+          urgency: wizardData.urgency,
+        };
+        if (wizardData.disputedAmount) {
+          body.disputedAmount = parseInt(wizardData.disputedAmount, 10);
         }
-        if (raw) {
-          const draft: RequestDraft = JSON.parse(raw);
-          if (draft.title) setTitle(draft.title);
-          if (draft.description) setDescription(draft.description);
-          if (draft.cityId) setSelectedCityId(draft.cityId);
-          if (draft.fnsId) setSelectedFnsId(draft.fnsId);
-          if (draft.serviceId) setSelectedServiceId(draft.serviceId);
+        if (targetSpecialistId) body.targetSpecialistId = targetSpecialistId;
+
+        const result = await apiPost<{ id: string }>("/api/requests", body);
+
+        await draftStorage.del(INTAKE_DRAFT_KEY).catch(() => {});
+
+        const goToDetail = () =>
+          nav.replaceAny(`/requests/${result.id}/detail`);
+        if (Platform.OS === "web") {
+          goToDetail();
+        } else {
+          Alert.alert(
+            "Запрос опубликован",
+            "Специалисты по вашей ФНС увидят его и напишут вам. Обычно первый отклик приходит в течение 24 часов.",
+            [{ text: "OK", onPress: goToDetail }],
+            { onDismiss: goToDetail }
+          );
         }
-      } catch {
-        /* ignore parse / storage errors */
+      } catch (e: unknown) {
+        const msg =
+          e instanceof Error
+            ? e.message
+            : "Не удалось опубликовать запрос. Проверьте данные и попробуйте ещё раз.";
+        setSubmitError(msg);
       } finally {
-        setDraftLoaded(true);
-        if (restoreMode) {
-          // legacy returnTo path — already restored, nothing else to do.
-        }
+        setSubmitting(false);
       }
-    })();
-  }, [loadingInit, draftLoaded, restoreMode]);
-
-  // Persist draft on every form-field change (after initial load to avoid wiping).
-  useEffect(() => {
-    if (!draftLoaded) return;
-    const selectedCity = cities.find((c) => c.id === selectedCityId);
-    const draft: RequestDraft = {
-      title,
-      description,
-      cityId: selectedCityId,
-      citySlug: selectedCity?.slug ?? null,
-      fnsId: selectedFnsId,
-      serviceId: selectedServiceId,
-    };
-    const isEmpty =
-      !draft.title &&
-      !draft.description &&
-      !draft.cityId &&
-      !draft.fnsId &&
-      !draft.serviceId;
-    if (isEmpty) return;
-    draftStorage.set(DRAFT_KEY, JSON.stringify(draft)).catch(() => {});
-  }, [
-    draftLoaded,
-    title,
-    description,
-    selectedCityId,
-    selectedFnsId,
-    selectedServiceId,
-    cities,
-  ]);
-
-  const handleCascadeChange = useCallback(
-    (v: CityFnsValue) => {
-      setSelectedCityId(v.cities[0] ?? null);
-      setSelectedFnsId(v.fns[0] ?? null);
     },
-    []
+    [wizardData, attachedFiles, nav, targetSpecialistId]
   );
 
-  const titleValid = title.trim().length >= 3 && title.trim().length <= 100;
-  const descriptionValid =
-    description.trim().length >= 10 && description.trim().length <= 2000;
-
-  const formValid =
-    titleValid && descriptionValid && !!selectedCityId && !!selectedFnsId;
-
-  // Actually post the request — used by both auth and post-OTP paths.
-  // freshToken: when provided (post-OTP path), passed explicitly to avoid
-  // stale-closure race on AuthContext update settling.
-  const submitRequestAuthed = useCallback(async (_freshToken?: string) => {
-    setSubmitting(true);
+  const handleSubmitRequested = useCallback(() => {
     setSubmitError("");
-    try {
-      const fileIds = attachedFiles
-        .filter((f) => !!f.uploadedId && !f.uploading && !f.error)
-        .map((f) => f.uploadedId as string);
-      // api() reads token from AsyncStorage automatically; explicit token not
-      // needed here since signIn() stores it before calling this callback.
-      const result = await apiPost<{ id: string }>("/api/requests", {
-        title: title.trim(),
-        cityId: selectedCityId,
-        fnsId: selectedFnsId,
-        serviceId: selectedServiceId || undefined,
-        description: description.trim(),
-        fileIds,
-        isPublic,
-        ...(targetSpecialistId ? { targetSpecialistId } : {}),
-      });
-      // Clear draft on success.
-      await draftStorage.del(DRAFT_KEY).catch(() => {});
-      await draftStorage.del(LEGACY_DRAFT_KEY).catch(() => {});
-
-      const goToDetail = () => nav.replaceAny(`/requests/${result.id}/detail`);
-      if (Platform.OS === "web") {
-        goToDetail();
-      } else {
-        Alert.alert(
-          "Запрос опубликован",
-          "Специалисты по вашей ФНС увидят его и напишут вам. Обычно первый отклик приходит в течение 24 часов.",
-          [{ text: "OK", onPress: goToDetail }],
-          { onDismiss: goToDetail }
-        );
-      }
-    } catch (e: unknown) {
-      const msg =
-        e instanceof Error
-          ? e.message
-          : "Не удалось опубликовать запрос. Проверьте данные и попробуйте ещё раз.";
-      setSubmitError(msg);
-    } finally {
-      setSubmitting(false);
-    }
-  }, [title, description, selectedCityId, selectedFnsId, selectedServiceId, nav, attachedFiles, isPublic, targetSpecialistId]);
-
-  const handleSubmit = useCallback(async () => {
-    setSubmitted(true);
-    setSubmitError("");
-    if (!formValid || submitting) return;
-
+    if (submitting) return;
     if (isAuthenticated) {
-      await submitRequestAuthed();
+      void submitRequestAuthed();
       return;
     }
-
-    // Anonymous path — open inline OTP block.
     setShowOtpFlow(true);
-  }, [formValid, submitting, isAuthenticated, submitRequestAuthed]);
+  }, [isAuthenticated, submitRequestAuthed, submitting]);
 
-  if (authLoading || loadingInit) {
+  if (authLoading) {
     return (
       <SafeAreaView className="flex-1 bg-surface2">
         <View className="flex-1 items-center justify-center">
@@ -294,7 +189,9 @@ export default function CreateRequest() {
       <View
         className="bg-surface2"
         style={{
-          ...(Platform.OS === "web" ? ({ position: "sticky", top: 0, zIndex: 10 } as object) : {}),
+          ...(Platform.OS === "web"
+            ? ({ position: "sticky", top: 0, zIndex: 10 } as object)
+            : {}),
         }}
       >
         {width < 640 && (
@@ -313,189 +210,109 @@ export default function CreateRequest() {
         )}
         <PageTitle title="Новый запрос" />
       </View>
-      <ScrollView
-        className="flex-1"
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingBottom: 32 }}
-      >
-        <View
-          style={{
-            width: "100%",
-            maxWidth: 640,
-            alignSelf: "center",
-            paddingHorizontal: 16,
-            paddingTop: 8,
-          }}
+
+      {!showOtpFlow ? (
+        <IntakeWizard
+          isAuthenticated={isAuthenticated}
+          authToken={token}
+          attachedFiles={attachedFiles}
+          onChangeAttachedFiles={setAttachedFiles}
+          submitting={submitting}
+          onDataChange={setWizardData}
+          onSubmitRequested={handleSubmitRequested}
+        />
+      ) : (
+        <ScrollView
+          className="flex-1"
+          contentContainerStyle={{ paddingBottom: 24 }}
+          keyboardShouldPersistTaps="handled"
         >
-          {!isAuthenticated && (
-            <View className="bg-accent-soft border border-accent rounded-xl p-4 mb-4">
-              <Text className="text-sm font-semibold text-accent mb-0.5">
-                Заполните запрос — войдёте в один шаг при отправке
-              </Text>
-              <Text className="text-sm text-accent">
-                Подтверждение по email кодом. Без паролей.
-              </Text>
-            </View>
-          )}
-
-          {/* Specialist targeting banner */}
-          {targetSpecialistId && (
-            <View
-              className="flex-row items-center justify-between rounded-xl px-4 py-3 mb-4 border"
-              style={{ backgroundColor: colors.greenSoft, borderColor: colors.success }}
-            >
-              <View className="flex-row items-center flex-1" style={{ gap: 8 }}>
-                <View
-                  className="rounded-full"
-                  style={{ width: 8, height: 8, backgroundColor: colors.success, flexShrink: 0 }}
-                />
-                <Text className="text-sm font-medium flex-1" style={{ color: colors.success }}>
-                  {targetSpecialist
-                    ? `Запрос для: ${[targetSpecialist.firstName, targetSpecialist.lastName].filter(Boolean).join(" ")}`
-                    : "Адресован специалисту"}
-                </Text>
-              </View>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Убрать адресацию специалисту"
-                onPress={() => setTargetSpecialistId(null)}
-                className="ml-2 p-1"
-                hitSlop={8}
-              >
-                <X size={14} color={colors.success} />
-              </Pressable>
-            </View>
-          )}
-
-          <Card className="mb-4">
-            <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider mb-3">
-              Описание запроса
-            </Text>
-
-            <View className="mb-4">
-              <Text className="text-sm font-medium text-text-base mb-1.5">
-                Заголовок <Text className="text-danger">*</Text>
-              </Text>
-              <Input
-                variant="bordered"
-                placeholder="Кратко опишите суть проблемы"
-                value={title}
-                onChangeText={setTitle}
-                error={
-                  (submitted || title.length > 0) && !titleValid
-                    ? title.trim().length < 3
-                      ? "Минимум 3 символа"
-                      : "Максимум 100 символов"
-                    : undefined
-                }
-                maxLength={100}
-                editable={!submitting}
-              />
-              <Text
-                className={`text-xs text-right mt-1 ${
-                  title.length >= 100 ? "text-danger" : "text-text-dim"
-                }`}
-              >
-                {title.length}/100
-              </Text>
-            </View>
-
-            {/* City + FNС typeahead — unified flow */}
-            <View className="mb-4">
-              <Text className="text-sm font-medium text-text-base mb-1.5">
-                Инспекция ФНС <Text className="text-danger">*</Text>
-              </Text>
-              <CityFnsCascade
-                mode="typeahead"
-                value={{
-                  cities: selectedCityId ? [selectedCityId] : [],
-                  fns: selectedFnsId ? [selectedFnsId] : [],
+          <View
+            style={{
+              width: "100%",
+              maxWidth: 640,
+              alignSelf: "center",
+              paddingHorizontal: 16,
+              paddingTop: 16,
+            }}
+          >
+            {/* Specialist targeting banner — keep visible during OTP step. */}
+            {targetSpecialistId && (
+              <View
+                className="flex-row items-center justify-between rounded-xl px-4 py-3 mb-4 border"
+                style={{
+                  backgroundColor: colors.greenSoft,
+                  borderColor: colors.success,
                 }}
-                onChange={handleCascadeChange}
-                citiesSource={cities.map((c) => ({ id: c.id, name: c.name }))}
-                fnsSource={fnsAll}
-                services={services}
-                selectedServiceId={selectedServiceId}
-                onServiceChange={setSelectedServiceId}
-                labelFns="Инспекция ФНС"
-              />
-              {submitted && !selectedCityId && (
-                <Text className="text-xs text-danger mt-1">Выберите город</Text>
-              )}
-              {submitted && selectedCityId && !selectedFnsId && (
-                <Text className="text-xs text-danger mt-1">Выберите инспекцию ФНС</Text>
-              )}
-            </View>
-
-            <View className="mb-4">
-              <Text className="text-sm font-medium text-text-base mb-1.5">
-                Описание <Text className="text-danger">*</Text>
-              </Text>
-              <Input
-                variant="bordered"
-                placeholder="Подробно опишите ситуацию: что произошло, какие документы получили, что требует инспекция, какая помощь нужна"
-                value={description}
-                onChangeText={setDescription}
-                multiline
-                error={
-                  (submitted || description.length > 0) && !descriptionValid
-                    ? description.trim().length < 10
-                      ? "Минимум 10 символов"
-                      : "Максимум 2000 символов"
-                    : undefined
-                }
-                maxLength={2000}
-                editable={!submitting}
-                containerStyle={{ minHeight: 120 }}
-              />
-              <Text
-                className={`text-xs text-right mt-1 ${
-                  description.length >= 2000 ? "text-danger" : "text-text-dim"
-                }`}
               >
-                {description.length}/2000
-              </Text>
-            </View>
-
-            {/* Visibility toggle */}
-            <View className="flex-row items-center justify-between py-3 mb-1">
-              <View className="flex-1 mr-4">
-                <Text className="text-sm font-medium text-text-base mb-0.5">
-                  Публичный запрос
-                </Text>
-                <Text className="text-xs text-text-mute leading-4">
-                  Виден всем в каталоге. Выключите, если хотите показывать только авторизованным пользователям.
-                </Text>
+                <View
+                  className="flex-row items-center flex-1"
+                  style={{ gap: 8 }}
+                >
+                  <View
+                    className="rounded-full"
+                    style={{
+                      width: 8,
+                      height: 8,
+                      backgroundColor: colors.success,
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Text
+                    className="text-sm font-medium flex-1"
+                    style={{ color: colors.success }}
+                  >
+                    {targetSpecialist
+                      ? `Запрос для: ${[
+                          targetSpecialist.firstName,
+                          targetSpecialist.lastName,
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}`
+                      : "Адресован специалисту"}
+                  </Text>
+                </View>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Убрать адресацию специалисту"
+                  onPress={() => setTargetSpecialistId(null)}
+                  className="ml-2 p-1"
+                  hitSlop={8}
+                >
+                  <X size={14} color={colors.success} />
+                </Pressable>
               </View>
-              <StyledSwitch
-                value={isPublic}
-                onValueChange={setIsPublic}
-                disabled={submitting}
-              />
-            </View>
-
-            {/* File upload — only for authenticated users (endpoint requires auth). */}
-            {isAuthenticated && (
-              <FileUploadSection
-                files={attachedFiles}
-                disabled={submitting}
-                onFilesChange={setAttachedFiles}
-                authToken={token}
-              />
             )}
-          </Card>
 
-          {submitError ? (
-            <View className="bg-danger-soft border border-danger rounded-xl p-3 mb-4">
-              <Text className="text-sm font-semibold text-danger mb-0.5">
-                Ошибка публикации
+            <View
+              className="rounded-xl p-4 mb-4"
+              style={{
+                backgroundColor: colors.accentSoft,
+                borderColor: colors.primary,
+                borderWidth: 1,
+              }}
+            >
+              <Text
+                className="text-sm font-semibold mb-1"
+                style={{ color: colors.primary }}
+              >
+                Подтвердите email — последний шаг
               </Text>
-              <Text className="text-sm text-danger">{submitError}</Text>
+              <Text className="text-sm" style={{ color: colors.primary }}>
+                Мы отправим 6-значный код. Без паролей. После подтверждения
+                запрос опубликуется автоматически.
+              </Text>
             </View>
-          ) : null}
 
-          {/* Inline OTP block — anon submit only */}
-          {!isAuthenticated && showOtpFlow && (
+            {submitError ? (
+              <View className="bg-danger-soft border border-danger rounded-xl p-3 mb-4">
+                <Text className="text-sm font-semibold text-danger mb-0.5">
+                  Ошибка публикации
+                </Text>
+                <Text className="text-sm text-danger">{submitError}</Text>
+              </View>
+            ) : null}
+
             <InlineOtpFlow
               onAuthenticated={submitRequestAuthed}
               onCancel={() => setShowOtpFlow(false)}
@@ -506,23 +323,69 @@ export default function CreateRequest() {
                   : "/requests/new"
               }
             />
-          )}
 
-          {/* Primary submit button — hidden once inline OTP block is open. */}
-          {(isAuthenticated || !showOtpFlow) && (
-            <Button
-              label={
-                isAuthenticated
-                  ? "Опубликовать запрос"
-                  : "Отправить запрос"
-              }
-              onPress={handleSubmit}
-              disabled={submitting}
-              loading={submitting}
+            <View className="mt-3">
+              <Button
+                label="Вернуться к редактированию"
+                variant="secondary"
+                onPress={() => setShowOtpFlow(false)}
+                disabled={submitting}
+              />
+            </View>
+          </View>
+        </ScrollView>
+      )}
+
+      {/* Targeting banner for the wizard view (above scroll). */}
+      {!showOtpFlow && targetSpecialistId && (
+        <View
+          className="flex-row items-center justify-between border-t border-border px-4 py-2"
+          style={{ backgroundColor: colors.greenSoft }}
+        >
+          <View className="flex-row items-center flex-1" style={{ gap: 8 }}>
+            <View
+              className="rounded-full"
+              style={{
+                width: 8,
+                height: 8,
+                backgroundColor: colors.success,
+                flexShrink: 0,
+              }}
             />
-          )}
+            <Text
+              className="text-xs font-medium flex-1"
+              style={{ color: colors.success }}
+            >
+              {targetSpecialist
+                ? `Запрос для: ${[
+                    targetSpecialist.firstName,
+                    targetSpecialist.lastName,
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}`
+                : "Адресован специалисту"}
+            </Text>
+          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Убрать адресацию специалисту"
+            onPress={() => setTargetSpecialistId(null)}
+            className="ml-2 p-1"
+            hitSlop={8}
+          >
+            <X size={14} color={colors.success} />
+          </Pressable>
         </View>
-      </ScrollView>
+      )}
+
+      {/* Error banner for the wizard view (under sticky nav, above bottom). */}
+      {!showOtpFlow && submitError ? (
+        <View className="px-4 py-2 border-t border-danger" style={{ backgroundColor: colors.dangerSoft }}>
+          <Text className="text-xs font-semibold text-danger">
+            {submitError}
+          </Text>
+        </View>
+      ) : null}
     </SafeAreaView>
   );
 }

--- a/components/intake/IntakeNav.tsx
+++ b/components/intake/IntakeNav.tsx
@@ -1,0 +1,107 @@
+import { View, Pressable, Text, ActivityIndicator } from "react-native";
+import { ChevronLeft, ChevronRight } from "lucide-react-native";
+import { colors, gray } from "@/lib/theme";
+
+interface IntakeNavProps {
+  step: number;
+  total: number;
+  onBack: () => void;
+  onNext: () => void;
+  /** Disable Next when current step is invalid. */
+  nextDisabled: boolean;
+  /** Submitting flag — applies to the final step's "Отправить запрос" press. */
+  submitting?: boolean;
+  /**
+   * Override the next-button label. Final step = "Отправить запрос";
+   * intermediate steps = "Далее".
+   */
+  nextLabel?: string;
+}
+
+/**
+ * Sticky bottom nav. Back disabled on step 1. Next either advances or, on the
+ * last step, triggers submit (parent decides via onNext).
+ */
+export default function IntakeNav({
+  step,
+  total,
+  onBack,
+  onNext,
+  nextDisabled,
+  submitting = false,
+  nextLabel,
+}: IntakeNavProps) {
+  const backDisabled = step === 1;
+  const isFinal = step === total;
+  const label = nextLabel ?? (isFinal ? "Отправить запрос" : "Далее");
+
+  return (
+    <View
+      className="flex-row gap-3 px-4 py-3 border-t border-border bg-white"
+    >
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Назад"
+        accessibilityState={{ disabled: backDisabled }}
+        onPress={onBack}
+        disabled={backDisabled}
+        className="flex-row items-center justify-center rounded-xl px-4"
+        style={{
+          minHeight: 48,
+          minWidth: 100,
+          backgroundColor: backDisabled ? gray[100] : colors.surface,
+          borderWidth: 1,
+          borderColor: backDisabled ? gray[200] : colors.border,
+          opacity: backDisabled ? 0.6 : 1,
+        }}
+      >
+        <ChevronLeft size={18} color={backDisabled ? gray[400] : colors.text} />
+        <Text
+          className="text-base font-medium ml-1"
+          style={{ color: backDisabled ? gray[400] : colors.text }}
+        >
+          Назад
+        </Text>
+      </Pressable>
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={label}
+        accessibilityState={{ disabled: nextDisabled || submitting, busy: submitting }}
+        onPress={onNext}
+        disabled={nextDisabled || submitting}
+        className="flex-1 flex-row items-center justify-center rounded-xl px-4"
+        style={{
+          minHeight: 48,
+          backgroundColor:
+            nextDisabled && !submitting ? gray[200] : colors.primary,
+          shadowColor:
+            !nextDisabled && !submitting ? colors.primary : "transparent",
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: !nextDisabled && !submitting ? 0.2 : 0,
+          shadowRadius: 4,
+        }}
+      >
+        {submitting ? (
+          <ActivityIndicator color={colors.white} />
+        ) : (
+          <>
+            <Text
+              className="text-base font-semibold"
+              style={{ color: nextDisabled ? gray[600] : colors.white }}
+            >
+              {label}
+            </Text>
+            {!isFinal && (
+              <ChevronRight
+                size={18}
+                color={nextDisabled ? gray[600] : colors.white}
+                style={{ marginLeft: 4 }}
+              />
+            )}
+          </>
+        )}
+      </Pressable>
+    </View>
+  );
+}

--- a/components/intake/IntakeProgress.tsx
+++ b/components/intake/IntakeProgress.tsx
@@ -1,0 +1,39 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+interface IntakeProgressProps {
+  step: number;
+  total: number;
+}
+
+/**
+ * Sticky top progress bar. "Шаг N из M" + filled bar — purely decorative,
+ * no interactivity (back/next nav lives in IntakeNav).
+ */
+export default function IntakeProgress({ step, total }: IntakeProgressProps) {
+  const pct = Math.max(0, Math.min(1, step / total));
+  return (
+    <View className="px-4 pt-3 pb-3 bg-surface2 border-b border-border">
+      <View className="flex-row items-baseline justify-between mb-2">
+        <Text className="text-xs font-semibold text-text-mute uppercase tracking-wider">
+          Шаг {step} из {total}
+        </Text>
+        <Text className="text-xs text-text-dim">
+          {Math.round(pct * 100)}%
+        </Text>
+      </View>
+      <View
+        className="rounded-full overflow-hidden"
+        style={{ height: 6, backgroundColor: colors.border }}
+      >
+        <View
+          style={{
+            width: `${pct * 100}%`,
+            height: "100%",
+            backgroundColor: colors.primary,
+          }}
+        />
+      </View>
+    </View>
+  );
+}

--- a/components/intake/IntakeWizard.tsx
+++ b/components/intake/IntakeWizard.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { View, ScrollView, Animated, Easing, Platform } from "react-native";
+import IntakeProgress from "./IntakeProgress";
+import IntakeNav from "./IntakeNav";
+import Step1DocumentType from "./Step1DocumentType";
+import Step2Date from "./Step2Date";
+import Step3CityFns from "./Step3CityFns";
+import Step4Description from "./Step4Description";
+import {
+  EMPTY_INTAKE,
+  INTAKE_DRAFT_KEY,
+  LEGACY_DRAFT_KEYS,
+  parseDateRu,
+  type IntakeData,
+  type DocumentType,
+} from "./types";
+import type { AttachedFile } from "@/components/requests/FileUploadSection";
+import { draftStorage } from "@/lib/draftStorage";
+
+type Action =
+  | { type: "SET_DOC_TYPE"; value: DocumentType }
+  | { type: "SET_INCIDENT_DATE"; value: string }
+  | { type: "SET_URGENCY"; value: boolean }
+  | { type: "SET_CITY_FNS"; cityId: string | null; fnsId: string | null }
+  | { type: "SET_DESCRIPTION"; value: string }
+  | { type: "SET_DISPUTED_AMOUNT"; value: string }
+  | { type: "REPLACE"; value: IntakeData };
+
+function reducer(state: IntakeData, action: Action): IntakeData {
+  switch (action.type) {
+    case "SET_DOC_TYPE":
+      return { ...state, documentType: action.value };
+    case "SET_INCIDENT_DATE":
+      return { ...state, incidentDate: action.value };
+    case "SET_URGENCY":
+      return { ...state, urgency: action.value };
+    case "SET_CITY_FNS":
+      return { ...state, cityId: action.cityId, fnsId: action.fnsId };
+    case "SET_DESCRIPTION":
+      return { ...state, description: action.value };
+    case "SET_DISPUTED_AMOUNT":
+      return { ...state, disputedAmount: action.value };
+    case "REPLACE":
+      return action.value;
+  }
+}
+
+const TOTAL_STEPS = 4;
+
+interface IntakeWizardProps {
+  isAuthenticated: boolean;
+  authToken: string | null;
+  attachedFiles: AttachedFile[];
+  onChangeAttachedFiles: (files: AttachedFile[]) => void;
+  /** Submitting state — bound to the underlying API submit on step 4 nav. */
+  submitting: boolean;
+  /** Current data — read by parent to construct the API payload. */
+  onDataChange: (d: IntakeData) => void;
+  /** Called when user advances past the final step. Parent submits. */
+  onSubmitRequested: () => void;
+  /** When set, the wizard locks at this step (used during inline OTP). */
+  lockToStep?: number;
+}
+
+/**
+ * IntakeWizard — controller for the 4-step structured intake.
+ *
+ * Owns:
+ *   - wizard data (useReducer)
+ *   - current step index
+ *   - draft persistence (load on mount, save on every change)
+ *   - step transition animation (opacity fade — Reanimated avoided to keep
+ *     the bundle lean & SSR-safe)
+ *   - per-step validation gating the "Далее" button
+ *
+ * Does NOT own:
+ *   - API submission (parent handles it via onSubmitRequested + onDataChange)
+ *   - OTP flow (parent embeds InlineOtpFlow under the wizard)
+ *   - file upload (parent owns AttachedFile[]; we pass through to step 4)
+ */
+export default function IntakeWizard({
+  isAuthenticated,
+  authToken,
+  attachedFiles,
+  onChangeAttachedFiles,
+  submitting,
+  onDataChange,
+  onSubmitRequested,
+  lockToStep,
+}: IntakeWizardProps) {
+  const [data, dispatch] = useReducer(reducer, EMPTY_INTAKE);
+  const [step, setStep] = useState(1);
+  const [hydrated, setHydrated] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(1)).current;
+
+  // Hydrate from draft on first mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Drop any legacy free-text drafts so they don't shadow this key.
+        for (const k of LEGACY_DRAFT_KEYS) {
+          await draftStorage.del(k).catch(() => {});
+        }
+        const raw = await draftStorage.get(INTAKE_DRAFT_KEY);
+        if (!raw || cancelled) return;
+        const parsed = JSON.parse(raw) as Partial<IntakeData> & {
+          step?: number;
+        };
+        const merged: IntakeData = {
+          documentType: parsed.documentType ?? null,
+          incidentDate: parsed.incidentDate ?? "",
+          urgency: !!parsed.urgency,
+          cityId: parsed.cityId ?? null,
+          fnsId: parsed.fnsId ?? null,
+          description: parsed.description ?? "",
+          disputedAmount: parsed.disputedAmount ?? "",
+        };
+        dispatch({ type: "REPLACE", value: merged });
+        if (typeof parsed.step === "number" && parsed.step >= 1 && parsed.step <= TOTAL_STEPS) {
+          setStep(parsed.step);
+        }
+      } catch {
+        /* ignore corrupt draft */
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Bubble data up.
+  useEffect(() => {
+    onDataChange(data);
+  }, [data, onDataChange]);
+
+  // Persist draft on every change after hydration.
+  useEffect(() => {
+    if (!hydrated) return;
+    const isEmpty =
+      !data.documentType &&
+      !data.incidentDate &&
+      !data.cityId &&
+      !data.fnsId &&
+      !data.description &&
+      !data.disputedAmount;
+    if (isEmpty) return;
+    const payload = JSON.stringify({ ...data, step });
+    draftStorage.set(INTAKE_DRAFT_KEY, payload).catch(() => {});
+  }, [hydrated, data, step]);
+
+  const isStepValid = useMemo(() => {
+    if (step === 1) return !!data.documentType;
+    if (step === 2) {
+      // For TREBOVANIE / RESHENIE / VYEZDNAYA the date is required so the
+      // deadline / visit-date math has meaning; OTHER also requires it so
+      // the specialist sees a timeline.
+      return !!data.incidentDate && !!parseDateRu(_formatBack(data.incidentDate));
+    }
+    if (step === 3) return !!data.cityId && !!data.fnsId;
+    if (step === 4) {
+      const len = data.description.trim().length;
+      return len >= 10 && len <= 2000;
+    }
+    return false;
+  }, [step, data]);
+
+  const goNext = () => {
+    if (lockToStep !== undefined) return;
+    if (!isStepValid) return;
+    if (step >= TOTAL_STEPS) {
+      onSubmitRequested();
+      return;
+    }
+    Animated.sequence([
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 120,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: Platform.OS !== "web",
+      }),
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 160,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: Platform.OS !== "web",
+      }),
+    ]).start();
+    setStep((s) => Math.min(TOTAL_STEPS, s + 1));
+  };
+
+  const goBack = () => {
+    if (lockToStep !== undefined) return;
+    if (step <= 1) return;
+    Animated.sequence([
+      Animated.timing(fadeAnim, {
+        toValue: 0,
+        duration: 120,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: Platform.OS !== "web",
+      }),
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 160,
+        easing: Easing.in(Easing.quad),
+        useNativeDriver: Platform.OS !== "web",
+      }),
+    ]).start();
+    setStep((s) => Math.max(1, s - 1));
+  };
+
+  const visibleStep = lockToStep ?? step;
+
+  return (
+    <View className="flex-1">
+      <IntakeProgress step={visibleStep} total={TOTAL_STEPS} />
+      <ScrollView
+        className="flex-1"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ paddingBottom: 24 }}
+      >
+        <View
+          style={{
+            width: "100%",
+            maxWidth: 640,
+            alignSelf: "center",
+            paddingHorizontal: 16,
+            paddingTop: 16,
+          }}
+        >
+          <Animated.View style={{ opacity: fadeAnim }}>
+            {visibleStep === 1 && (
+              <Step1DocumentType
+                value={data.documentType}
+                onChange={(v) => dispatch({ type: "SET_DOC_TYPE", value: v })}
+              />
+            )}
+            {visibleStep === 2 && (
+              <Step2Date
+                documentType={data.documentType}
+                incidentDate={data.incidentDate}
+                urgency={data.urgency}
+                onChangeIncidentDate={(v) =>
+                  dispatch({ type: "SET_INCIDENT_DATE", value: v })
+                }
+                onChangeUrgency={(v) =>
+                  dispatch({ type: "SET_URGENCY", value: v })
+                }
+              />
+            )}
+            {visibleStep === 3 && (
+              <Step3CityFns
+                cityId={data.cityId}
+                fnsId={data.fnsId}
+                onChange={(cityId, fnsId) =>
+                  dispatch({ type: "SET_CITY_FNS", cityId, fnsId })
+                }
+              />
+            )}
+            {visibleStep === 4 && (
+              <Step4Description
+                documentType={data.documentType}
+                description={data.description}
+                disputedAmount={data.disputedAmount}
+                files={attachedFiles}
+                authToken={authToken}
+                isAuthenticated={isAuthenticated}
+                submitting={submitting}
+                onChangeDescription={(v) =>
+                  dispatch({ type: "SET_DESCRIPTION", value: v })
+                }
+                onChangeDisputedAmount={(v) =>
+                  dispatch({ type: "SET_DISPUTED_AMOUNT", value: v })
+                }
+                onChangeFiles={onChangeAttachedFiles}
+              />
+            )}
+          </Animated.View>
+        </View>
+      </ScrollView>
+      {lockToStep === undefined && (
+        <IntakeNav
+          step={step}
+          total={TOTAL_STEPS}
+          onBack={goBack}
+          onNext={goNext}
+          nextDisabled={!isStepValid}
+          submitting={submitting}
+        />
+      )}
+    </View>
+  );
+}
+
+/**
+ * Step 2 stores ISO; this rebuilds the dd.mm.yyyy string and re-parses to
+ * confirm validity. Avoids re-implementing format detection in two places.
+ */
+function _formatBack(iso: string): string {
+  if (!iso) return "";
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return "";
+  return `${m[3]}.${m[2]}.${m[1]}`;
+}

--- a/components/intake/Step1DocumentType.tsx
+++ b/components/intake/Step1DocumentType.tsx
@@ -1,0 +1,134 @@
+import { View, Text, Pressable, useWindowDimensions } from "react-native";
+import {
+  FileWarning,
+  AlertTriangle,
+  Shield,
+  HelpCircle,
+  type LucideIcon,
+} from "lucide-react-native";
+import { colors } from "@/lib/theme";
+import type { DocumentType } from "./types";
+
+interface Option {
+  value: DocumentType;
+  title: string;
+  subtitle: string;
+  Icon: LucideIcon;
+}
+
+const OPTIONS: Option[] = [
+  {
+    value: "TREBOVANIE",
+    title: "Пришло требование от ФНС",
+    subtitle: "О предоставлении документов или пояснений",
+    Icon: FileWarning,
+  },
+  {
+    value: "RESHENIE",
+    title: "Получил решение / акт",
+    subtitle: "О привлечении к ответственности или доначислениях",
+    Icon: AlertTriangle,
+  },
+  {
+    value: "VYEZDNAYA",
+    title: "Назначена выездная проверка",
+    subtitle: "ФНС придёт к нам",
+    Icon: Shield,
+  },
+  {
+    value: "OTHER",
+    title: "Не уверен / другое",
+    subtitle: "Опишу своими словами",
+    Icon: HelpCircle,
+  },
+];
+
+interface Step1Props {
+  value: DocumentType | null;
+  onChange: (v: DocumentType) => void;
+}
+
+/**
+ * Step 1 — large tappable cards. Mobile = vertical stack, ≥640 = 2×2 grid.
+ * Picking an option auto-selects but does NOT auto-advance — user confirms
+ * via the sticky bottom "Далее" button (gives them a beat to second-guess).
+ */
+export default function Step1DocumentType({ value, onChange }: Step1Props) {
+  const { width } = useWindowDimensions();
+  const isGrid = width >= 640;
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-text-base mb-2">
+        Что произошло?
+      </Text>
+      <Text className="text-sm text-text-mute mb-6 leading-5">
+        Выберите тип ситуации — это определит подсказки и сроки на следующих
+        шагах. Если ничего не подходит, нажмите &laquo;Не уверен&raquo;.
+      </Text>
+
+      <View
+        style={{
+          flexDirection: isGrid ? "row" : "column",
+          flexWrap: isGrid ? "wrap" : "nowrap",
+          gap: 12,
+        }}
+      >
+        {OPTIONS.map((opt) => {
+          const selected = value === opt.value;
+          const Icon = opt.Icon;
+          return (
+            <Pressable
+              key={opt.value}
+              accessibilityRole="button"
+              accessibilityLabel={opt.title}
+              accessibilityState={{ selected }}
+              onPress={() => onChange(opt.value)}
+              className="rounded-2xl p-4"
+              style={{
+                // 2-up on >=640: each card is half the row minus half the gap.
+                // Use percentages with marginRight pattern instead of `calc()`
+                // (RN type system rejects calc strings in flex props).
+                width: isGrid ? "48%" : "100%",
+                minHeight: 120,
+                borderWidth: selected ? 2 : 1,
+                borderColor: selected ? colors.primary : colors.border,
+                backgroundColor: selected ? colors.accentSoft : colors.surface,
+              }}
+            >
+              <View
+                className="rounded-xl items-center justify-center mb-3"
+                style={{
+                  width: 44,
+                  height: 44,
+                  backgroundColor: selected ? colors.primary : colors.accentSoft,
+                }}
+              >
+                <Icon
+                  size={22}
+                  color={selected ? colors.white : colors.primary}
+                />
+              </View>
+              <Text
+                className="text-base font-semibold mb-1"
+                style={{
+                  color: selected ? colors.accentSoftInk : colors.text,
+                }}
+              >
+                {opt.title}
+              </Text>
+              <Text
+                className="text-sm leading-5"
+                style={{
+                  color: selected ? colors.accentSoftInk : colors.textMuted,
+                }}
+              >
+                {opt.subtitle}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/components/intake/Step2Date.tsx
+++ b/components/intake/Step2Date.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useMemo, useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { Check } from "lucide-react-native";
+import Input from "@/components/ui/Input";
+import { colors } from "@/lib/theme";
+import {
+  computeDeadline,
+  daysUntil,
+  formatDateRu,
+  parseDateRu,
+  DOCUMENT_TYPE_DATE_PROMPT,
+  type DocumentType,
+} from "./types";
+
+interface Step2Props {
+  documentType: DocumentType | null;
+  /** ISO yyyy-mm-dd. Empty string means user hasn't entered a date yet. */
+  incidentDate: string;
+  urgency: boolean;
+  onChangeIncidentDate: (iso: string) => void;
+  onChangeUrgency: (urgent: boolean) => void;
+}
+
+/**
+ * Step 2 — text-input date entry (dd.mm.yyyy) + auto-deadline + urgency
+ * checkbox. We deliberately don't pull in `react-native-modal-datetime-picker`
+ * — the dep isn't installed, web behavior is awkward, and a typed date
+ * gives keyboard-fast users a clean path. Native `<input type="date">` is
+ * used on web for the picker affordance via `Input` won't help, so we keep
+ * the text input universal and rely on the live preview below.
+ */
+export default function Step2Date({
+  documentType,
+  incidentDate,
+  urgency,
+  onChangeIncidentDate,
+  onChangeUrgency,
+}: Step2Props) {
+  const [text, setText] = useState(formatDateRu(incidentDate));
+
+  const deadline = useMemo(
+    () => computeDeadline(documentType, incidentDate),
+    [documentType, incidentDate]
+  );
+  const remaining = daysUntil(deadline);
+
+  // Auto-check "urgency" if deadline is <3 days away. User can still uncheck.
+  useEffect(() => {
+    if (remaining !== null && remaining < 3 && remaining >= 0 && !urgency) {
+      onChangeUrgency(true);
+    }
+  }, [remaining, urgency, onChangeUrgency]);
+
+  const dateError =
+    text.length > 0 && parseDateRu(text) === ""
+      ? "Введите дату в формате ДД.ММ.ГГГГ"
+      : undefined;
+
+  // Pick deadline-line color: green >7, yellow 3-7, red <3 (incl. negative).
+  const deadlineColor = (() => {
+    if (remaining === null) return colors.text;
+    if (remaining < 3) return colors.danger;
+    if (remaining <= 7) return colors.warning;
+    return colors.success;
+  })();
+
+  const prompt = documentType
+    ? DOCUMENT_TYPE_DATE_PROMPT[documentType]
+    : "Когда произошло событие?";
+
+  const showDeadline = !!documentType && documentType !== "VYEZDNAYA" && documentType !== "OTHER";
+  const showVisitNote = documentType === "VYEZDNAYA";
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-text-base mb-2">
+        Когда?
+      </Text>
+      <Text className="text-sm text-text-mute mb-6 leading-5">
+        {prompt}
+      </Text>
+
+      <View className="mb-4">
+        <Text className="text-sm font-medium text-text-base mb-1.5">
+          Дата <Text className="text-danger">*</Text>
+        </Text>
+        <Input
+          variant="bordered"
+          placeholder="ДД.ММ.ГГГГ"
+          value={text}
+          onChangeText={(v) => {
+            setText(v);
+            const iso = parseDateRu(v);
+            onChangeIncidentDate(iso);
+          }}
+          error={dateError}
+          keyboardType="numeric"
+          maxLength={10}
+        />
+      </View>
+
+      {showDeadline && deadline && remaining !== null && (
+        <View
+          className="rounded-xl p-4 mb-4"
+          style={{
+            backgroundColor:
+              remaining < 3
+                ? colors.dangerSoft
+                : remaining <= 7
+                  ? colors.warningTintBg
+                  : colors.successSoft,
+            borderWidth: 1,
+            borderColor: deadlineColor,
+          }}
+        >
+          <Text
+            className="text-sm font-semibold mb-0.5"
+            style={{ color: deadlineColor }}
+          >
+            {remaining < 0
+              ? `Дедлайн прошёл ${Math.abs(remaining)} дн. назад`
+              : remaining === 0
+                ? "Дедлайн сегодня"
+                : `До дедлайна ${remaining} дн.`}
+          </Text>
+          <Text className="text-xs" style={{ color: deadlineColor }}>
+            Дата: {formatDateRu(deadline)}
+            {documentType === "TREBOVANIE" &&
+              " · 10 рабочих дней с даты получения требования"}
+            {documentType === "RESHENIE" &&
+              " · 30 дней на возражения"}
+          </Text>
+        </View>
+      )}
+
+      {showVisitNote && incidentDate && (
+        <View
+          className="rounded-xl p-4 mb-4"
+          style={{
+            backgroundColor: colors.accentSoft,
+            borderWidth: 1,
+            borderColor: colors.primary,
+          }}
+        >
+          <Text
+            className="text-sm font-semibold mb-0.5"
+            style={{ color: colors.primary }}
+          >
+            Визит назначен на {formatDateRu(incidentDate)}
+          </Text>
+          <Text className="text-xs" style={{ color: colors.primary }}>
+            Подготовка к выездной — обсудим со специалистом по вашему ФНС.
+          </Text>
+        </View>
+      )}
+
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityLabel="Срочно"
+        accessibilityState={{ checked: urgency }}
+        onPress={() => onChangeUrgency(!urgency)}
+        className="flex-row items-start py-2"
+        style={{ minHeight: 44 }}
+      >
+        <View
+          className="rounded-md items-center justify-center mr-3"
+          style={{
+            width: 22,
+            height: 22,
+            marginTop: 2,
+            borderWidth: 2,
+            borderColor: urgency ? colors.danger : colors.borderStrong,
+            backgroundColor: urgency ? colors.danger : "transparent",
+          }}
+        >
+          {urgency && <Check size={14} color={colors.white} strokeWidth={3} />}
+        </View>
+        <View className="flex-1">
+          <Text className="text-sm font-medium text-text-base">
+            Срочно — дедлайн уже через несколько дней
+          </Text>
+          <Text className="text-xs text-text-mute mt-0.5 leading-4">
+            Специалистам уйдёт пометка о срочности — отвечают приоритетно.
+          </Text>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+

--- a/components/intake/Step3CityFns.tsx
+++ b/components/intake/Step3CityFns.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState, useMemo } from "react";
+import { View, Text } from "react-native";
+import CityFnsCascade, {
+  type CityFnsValue,
+  type FnsCascadeOption,
+  type CityCascadeOption,
+} from "@/components/filters/CityFnsCascade";
+import { useCities } from "@/lib/hooks/useCities";
+import { api } from "@/lib/api";
+
+interface Step3Props {
+  cityId: string | null;
+  fnsId: string | null;
+  onChange: (cityId: string | null, fnsId: string | null) => void;
+}
+
+/**
+ * Step 3 — thin wrapper over the existing typeahead CityFnsCascade.
+ * Loads cities + flat FNS list once, owns the typeahead state, normalizes
+ * the cascade's multi-style value object into our single (cityId, fnsId)
+ * pair via the parent callback.
+ */
+export default function Step3CityFns({
+  cityId,
+  fnsId,
+  onChange,
+}: Step3Props) {
+  const { cities: citiesRaw } = useCities();
+  const cities: CityCascadeOption[] = useMemo(
+    () => citiesRaw.map((c) => ({ id: c.id, name: c.name })),
+    [citiesRaw]
+  );
+  const [fnsAll, setFnsAll] = useState<FnsCascadeOption[]>([]);
+
+  useEffect(() => {
+    if (cities.length === 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const ids = cities.map((c) => c.id).join(",");
+        const res = await api<{
+          offices: {
+            id: string;
+            name: string;
+            code: string;
+            cityId: string;
+            city?: { name: string };
+          }[];
+        }>(`/api/fns?city_ids=${ids}`, { noAuth: true });
+        if (cancelled) return;
+        setFnsAll(
+          res.offices.map((f) => ({
+            id: f.id,
+            name: f.name,
+            code: f.code,
+            cityId: f.cityId,
+            cityName: f.city?.name,
+          }))
+        );
+      } catch {
+        /* typeahead degrades gracefully */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [cities]);
+
+  const value: CityFnsValue = {
+    cities: cityId ? [cityId] : [],
+    fns: fnsId ? [fnsId] : [],
+  };
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-text-base mb-2">
+        Где и кто?
+      </Text>
+      <Text className="text-sm text-text-mute mb-6 leading-5">
+        Какая ФНС прислала документ? Если не уверены — выберите свой город,
+        мы покажем все инспекции по нему.
+      </Text>
+
+      <CityFnsCascade
+        mode="typeahead"
+        value={value}
+        onChange={(v) => {
+          onChange(v.cities[0] ?? null, v.fns[0] ?? null);
+        }}
+        citiesSource={cities}
+        fnsSource={fnsAll}
+        labelFns="Инспекция ФНС"
+      />
+    </View>
+  );
+}

--- a/components/intake/Step4Description.tsx
+++ b/components/intake/Step4Description.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { View, Text, Pressable } from "react-native";
+import { ChevronDown, ChevronUp } from "lucide-react-native";
+import Input from "@/components/ui/Input";
+import FileUploadSection, {
+  type AttachedFile,
+} from "@/components/requests/FileUploadSection";
+import { colors } from "@/lib/theme";
+import type { DocumentType } from "./types";
+
+interface Step4Props {
+  documentType: DocumentType | null;
+  description: string;
+  disputedAmount: string;
+  files: AttachedFile[];
+  /** Auth token — null when anon (file upload then hidden until OTP completes). */
+  authToken: string | null;
+  isAuthenticated: boolean;
+  submitting: boolean;
+  onChangeDescription: (v: string) => void;
+  onChangeDisputedAmount: (v: string) => void;
+  onChangeFiles: (files: AttachedFile[]) => void;
+}
+
+const DESC_MAX = 2000;
+
+const PLACEHOLDER_BY_TYPE: Record<DocumentType, string> = {
+  TREBOVANIE:
+    "Например: ФНС запрашивает документы по контрагенту ООО Ромашка за 2024 год. Не понимаю, что предоставить.",
+  RESHENIE:
+    "Например: получили акт камеральной проверки с доначислением 1.2 млн, не согласны с выводами по контрагенту.",
+  VYEZDNAYA:
+    "Например: уведомили о выездной за 2022–2024 гг., нужно подготовить документы и сопровождение.",
+  OTHER:
+    "Опишите ситуацию своими словами — что произошло, какие документы есть, что хотите получить.",
+};
+
+/**
+ * Step 4 — narrative + optional fields + file upload. The "Дополнительно"
+ * accordion stays collapsed by default to keep the surface light; users
+ * with a disputed amount tap to reveal.
+ */
+export default function Step4Description({
+  documentType,
+  description,
+  disputedAmount,
+  files,
+  authToken,
+  isAuthenticated,
+  submitting,
+  onChangeDescription,
+  onChangeDisputedAmount,
+  onChangeFiles,
+}: Step4Props) {
+  const [extraOpen, setExtraOpen] = useState(false);
+
+  const placeholder = documentType
+    ? PLACEHOLDER_BY_TYPE[documentType]
+    : PLACEHOLDER_BY_TYPE.OTHER;
+
+  const showAmountByDefault =
+    documentType === "RESHENIE" || documentType === "VYEZDNAYA";
+  const extraExpanded = extraOpen || showAmountByDefault;
+
+  return (
+    <View>
+      <Text className="text-2xl font-bold text-text-base mb-2">
+        Кратко опишите ситуацию
+      </Text>
+      <Text className="text-sm text-text-mute mb-6 leading-5">
+        Чем подробнее, тем точнее специалисты оценят сложность и помогут.
+        Если можете — приложите сам документ от ФНС.
+      </Text>
+
+      <View className="mb-4">
+        <Text className="text-sm font-medium text-text-base mb-1.5">
+          Описание <Text className="text-danger">*</Text>
+        </Text>
+        <Input
+          variant="bordered"
+          placeholder={placeholder}
+          value={description}
+          onChangeText={onChangeDescription}
+          multiline
+          maxLength={DESC_MAX}
+          editable={!submitting}
+          containerStyle={{ minHeight: 140 }}
+        />
+        <Text
+          className={`text-xs text-right mt-1 ${
+            description.length >= DESC_MAX ? "text-danger" : "text-text-dim"
+          }`}
+        >
+          {description.length}/{DESC_MAX}
+        </Text>
+      </View>
+
+      {/* "Дополнительно" — collapsed by default; expanded for RESHENIE/VYEZDNAYA */}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Дополнительные поля"
+        onPress={() => setExtraOpen((s) => !s)}
+        className="flex-row items-center justify-between py-3"
+      >
+        <Text className="text-sm font-semibold text-text-base">
+          Дополнительно
+        </Text>
+        {extraExpanded ? (
+          <ChevronUp size={18} color={colors.text} />
+        ) : (
+          <ChevronDown size={18} color={colors.text} />
+        )}
+      </Pressable>
+      {extraExpanded && (
+        <View className="mb-4">
+          <Text className="text-sm font-medium text-text-base mb-1.5">
+            Сумма доначислений (если есть)
+          </Text>
+          <Input
+            variant="bordered"
+            placeholder="например, 1500000"
+            value={disputedAmount}
+            onChangeText={(v) => {
+              // Strip non-digits so backend math doesn't have to.
+              const digits = v.replace(/\D+/g, "").slice(0, 13);
+              onChangeDisputedAmount(digits);
+            }}
+            keyboardType="numeric"
+            editable={!submitting}
+          />
+          <Text className="text-xs text-text-dim mt-1">
+            В рублях, целое число. Поможет специалисту быстрее оценить кейс.
+          </Text>
+        </View>
+      )}
+
+      {/* File upload — auth-only; anon path defers until after OTP. */}
+      {isAuthenticated ? (
+        <FileUploadSection
+          files={files}
+          disabled={submitting}
+          onFilesChange={onChangeFiles}
+          authToken={authToken}
+        />
+      ) : (
+        <View
+          className="rounded-xl p-3 mt-2"
+          style={{
+            backgroundColor: colors.accentSoft,
+            borderWidth: 1,
+            borderColor: colors.primary,
+          }}
+        >
+          <Text className="text-sm" style={{ color: colors.accentSoftInk }}>
+            После подтверждения email вы сможете приложить документ от ФНС
+            (PDF, фото). Это сильно ускорит ответ.
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/intake/types.ts
+++ b/components/intake/types.ts
@@ -1,0 +1,160 @@
+/**
+ * Intake wizard — shared types & deadline math.
+ *
+ * Wizard data is owned by `IntakeWizard` via reducer; each step component is
+ * a controlled view that reads & dispatches into this shape. Persisted to
+ * AsyncStorage / localStorage under INTAKE_DRAFT_KEY between sessions.
+ */
+
+export type DocumentType = "TREBOVANIE" | "RESHENIE" | "VYEZDNAYA" | "OTHER";
+
+export interface IntakeData {
+  /** Step 1 — what kind of paper / event triggered the request. */
+  documentType: DocumentType | null;
+  /**
+   * Step 2 — date of the incident (date the document was received, OR the
+   * date of the on-site visit for VYEZDNAYA). Stored as ISO yyyy-mm-dd.
+   */
+  incidentDate: string;
+  /** Step 2 — explicit "this is urgent" flag. Auto-checked when <3 days left. */
+  urgency: boolean;
+  /** Step 3 — selected city / FNS office (existing CityFnsCascade contract). */
+  cityId: string | null;
+  fnsId: string | null;
+  /** Step 4 — free-text narrative + optional disputed amount. */
+  description: string;
+  /** Optional disputed-amount in rubles (RESHENIE / VYEZDNAYA tracks). */
+  disputedAmount: string;
+}
+
+export const EMPTY_INTAKE: IntakeData = {
+  documentType: null,
+  incidentDate: "",
+  urgency: false,
+  cityId: null,
+  fnsId: null,
+  description: "",
+  disputedAmount: "",
+};
+
+/**
+ * AsyncStorage key — single source of truth for wizard draft state.
+ * Bumped from the legacy `pending_request_draft` / `p2ptax_request_draft_v1`
+ * keys (free-text form). Migration is one-way (legacy is dropped on first
+ * wizard mount; nothing meaningful to carry over since fields don't overlap).
+ */
+export const INTAKE_DRAFT_KEY = "p2ptax_intake_draft_v1";
+
+/** Legacy free-text draft keys — purged once on wizard mount. */
+export const LEGACY_DRAFT_KEYS = [
+  "p2ptax_request_draft_v1",
+  "pending_request_draft",
+] as const;
+
+/**
+ * Adds N business days (Mon–Fri) to a base date and returns the result.
+ * Holidays are NOT modeled — TREBOVANIE deadline is a planning aid, not
+ * a legal countdown; we surface the date so the user can verify with their
+ * specialist.
+ */
+function addBusinessDays(base: Date, days: number): Date {
+  const out = new Date(base.getTime());
+  let added = 0;
+  while (added < days) {
+    out.setDate(out.getDate() + 1);
+    const dow = out.getDay();
+    if (dow !== 0 && dow !== 6) added += 1;
+  }
+  return out;
+}
+
+function addCalendarDays(base: Date, days: number): Date {
+  const out = new Date(base.getTime());
+  out.setDate(out.getDate() + days);
+  return out;
+}
+
+/**
+ * Compute deadline given documentType + incidentDate.
+ *
+ *   TREBOVANIE → +10 business days from receipt (ст. 93/93.1 НК РФ — base case).
+ *   RESHENIE   → +30 calendar days for objections (ст. 101.4 НК РФ).
+ *   VYEZDNAYA  → no auto deadline; "incidentDate" = visit date (informational).
+ *   OTHER      → no auto deadline.
+ */
+export function computeDeadline(
+  documentType: DocumentType | null,
+  incidentDateIso: string
+): Date | null {
+  if (!documentType || !incidentDateIso) return null;
+  const base = new Date(incidentDateIso);
+  if (Number.isNaN(base.getTime())) return null;
+
+  if (documentType === "TREBOVANIE") return addBusinessDays(base, 10);
+  if (documentType === "RESHENIE") return addCalendarDays(base, 30);
+  return null;
+}
+
+/** Days remaining until deadline (negative = past). Null when no deadline. */
+export function daysUntil(deadline: Date | null): number | null {
+  if (!deadline) return null;
+  const now = new Date();
+  // Strip time-of-day on both sides so "today" reads as 0, not -0.5.
+  const a = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const b = new Date(deadline.getFullYear(), deadline.getMonth(), deadline.getDate()).getTime();
+  return Math.round((b - a) / (1000 * 60 * 60 * 24));
+}
+
+/** Formats yyyy-mm-dd → dd.mm.yyyy for display. */
+export function formatDateRu(iso: string | Date | null): string {
+  if (!iso) return "";
+  const d = typeof iso === "string" ? new Date(iso) : iso;
+  if (Number.isNaN(d.getTime())) return "";
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  return `${dd}.${mm}.${yyyy}`;
+}
+
+/** Parses dd.mm.yyyy → ISO yyyy-mm-dd. Returns "" if invalid. */
+export function parseDateRu(input: string): string {
+  const m = input.trim().match(/^(\d{1,2})[.\-/](\d{1,2})[.\-/](\d{4})$/);
+  if (!m) return "";
+  const [, ddRaw, mmRaw, yyyyRaw] = m;
+  const dd = parseInt(ddRaw!, 10);
+  const mm = parseInt(mmRaw!, 10);
+  const yyyy = parseInt(yyyyRaw!, 10);
+  if (mm < 1 || mm > 12 || dd < 1 || dd > 31 || yyyy < 1900 || yyyy > 2200) return "";
+  const iso = `${yyyy}-${String(mm).padStart(2, "0")}-${String(dd).padStart(2, "0")}`;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return iso;
+}
+
+/** Human label for a doc type — used in summary banner / step subtitles. */
+export const DOCUMENT_TYPE_LABEL: Record<DocumentType, string> = {
+  TREBOVANIE: "Требование от ФНС",
+  RESHENIE: "Решение / акт",
+  VYEZDNAYA: "Выездная проверка",
+  OTHER: "Другое",
+};
+
+/** Per-doc-type prompt for step 2 ("when did this happen"). */
+export const DOCUMENT_TYPE_DATE_PROMPT: Record<DocumentType, string> = {
+  TREBOVANIE: "Когда вы получили требование?",
+  RESHENIE: "Когда вы получили решение / акт?",
+  VYEZDNAYA: "Когда назначен визит инспекции?",
+  OTHER: "Когда произошло событие?",
+};
+
+/** Default title used when wizard sends the legacy `title` field. */
+export function deriveTitle(data: IntakeData): string {
+  const base = data.documentType
+    ? DOCUMENT_TYPE_LABEL[data.documentType]
+    : "Запрос";
+  // Snip the first line of the description for human-readable context.
+  const firstLine = data.description.split(/\r?\n/)[0]?.trim() ?? "";
+  if (!firstLine) return base;
+  const snippet = firstLine.length > 60 ? `${firstLine.slice(0, 57)}…` : firstLine;
+  return `${base}: ${snippet}`;
+}


### PR DESCRIPTION
## Motivation

Stressed/fearful clients (just received an FNS demand notice or audit decision) need a guided path, not a blank textarea. The current `/requests/new` is a single free-text form — high cognitive load, low signal for specialists.

## What's new

A 4-step intake wizard with sticky progress bar, sticky bottom nav (Назад/Далее), opacity-fade transitions, and persisted draft (AsyncStorage on native, localStorage on web).

### Steps
1. **Что произошло?** — 4 large cards: TREBOVANIE / RESHENIE / VYEZDNAYA / OTHER. Mobile = vertical stack, ≥640 = 2×2 grid.
2. **Когда?** — date input (`ДД.ММ.ГГГГ`) + auto-computed deadline:
   - TREBOVANIE → +10 business days (ст. 93/93.1 НК РФ)
   - RESHENIE → +30 calendar days (ст. 101.4 НК РФ — на возражения)
   - VYEZDNAYA → no auto deadline; date interpreted as visit date
   Deadline banner colored green (>7 дн), yellow (3–7), red (<3). "Срочно" auto-toggles when <3.
3. **Где и кто?** — thin wrapper around the existing `<CityFnsCascade mode="typeahead">`.
4. **Кратко опишите ситуацию** — multiline description (10–2000 chars), optional `disputedAmount` (auto-expanded for RESHENIE/VYEZDNAYA), file upload (auth users only — anon flow defers until OTP).

### API extension
`POST /api/requests` now accepts (all optional, validated):
- `documentType: "TREBOVANIE" | "RESHENIE" | "VYEZDNAYA" | "OTHER"`
- `incidentDate: ISO date string`
- `urgency: boolean`
- `disputedAmount: integer rubles`

Legacy callers continue to work — fields are nullable.

### Migration
`20260430130000_intake_fields` — adds `DocumentType` enum + 4 columns to `requests`.

### OTP flow preserved
Anon path: fill steps 1–4 → press "Отправить запрос" → InlineOtpFlow appears → after auth, request POSTs automatically with all wizard fields.

### Draft persistence
- New key: `p2ptax_intake_draft_v1` (data + current step)
- Legacy keys (`p2ptax_request_draft_v1`, `pending_request_draft`) purged on first mount

## Files
- **New** — `components/intake/{IntakeWizard,IntakeProgress,IntakeNav,Step1DocumentType,Step2Date,Step3CityFns,Step4Description,types}.tsx`
- **Modified** — `app/requests/new.tsx`, `api/prisma/schema.prisma`, `api/src/routes/requests.ts`
- **Migration** — `api/prisma/migrations/20260430130000_intake_fields/migration.sql`

## Verification
- `npx tsc --noEmit` (frontend) — 0 errors
- `cd api && npx tsc --noEmit` — 0 errors
- `npx eslint components/intake app/requests/new.tsx` — 0 issues
- Zero `StyleSheet.create`
- Migration applied to local Postgres (`prisma migrate deploy`)

## Test plan
- [ ] Anon flow: fill all 4 steps → submit → OTP `000000` → request appears in `/dashboard`
- [ ] Auth flow: same with logged-in user, files attached on step 4
- [ ] Specialist-targeted flow: `/requests/new?specialistId=...` — banner persists across steps + OTP
- [ ] Draft restore: fill step 2, refresh page — wizard resumes at step 2 with data intact
- [ ] Deadline math: TREBOVANIE today → 10 BD ≈ 2 weeks. RESHENIE today → ~30 days. <3 days auto-checks Срочно.
- [ ] Mobile + desktop chrome (≥640 grid for step 1, sticky bottom nav)

## Risks / deferred
- **Date picker**: kept text input (`ДД.ММ.ГГГГ`) — no native picker dep added. Works on web + native. Future: optional `react-native-modal-datetime-picker` swap-in.
- **Keyboard handling on mobile**: `keyboardShouldPersistTaps="handled"` + sticky nav buttons — should be fine but worth manual QA on iOS / Android.
- **No `react-native-reanimated`** — used Animated API opacity fade instead. Keeps the bundle lean and avoids the SSR-on-web edge.