### PR TITLE
feat(messages): full-width + round avatars + on-brand empty state + preview/download fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,15 @@ Before claiming "done" on any visual/chrome change:
 |---|---|---|
 | Content / list / catalog / detail | 960 | 24 |
 | Forms (profile, requests/new, admin settings) | 720 | 24 |
-| Two-pane (messages) outer | 960 | 0 |
+| Two-pane (messages) outer | none | 0 |
 | Legal prose | 720 | 24 |
 | Auth (login/otp) | 400 | 24 |
+
+> Two-pane chat is the **only** screen without a maxWidth cap. Rationale: the
+> 360-px thread list + flexible chat pane benefit from every pixel — capping
+> at 960 leaves a wide blank on the right at 1440+ desktops and makes the
+> chat pane feel cramped. All other authenticated content stays at 960 to
+> preserve readability.
 
 Sidebar = 240px on ≥768px. Optimal viewport 1200px → 960px content.
 

--- a/api/src/routes/messages.ts
+++ b/api/src/routes/messages.ts
@@ -11,6 +11,30 @@ import { minioClient, MINIO_BUCKET, presignAvatarUrl } from "../lib/minio";
 
 const router = Router();
 
+// 1-hour presigned URL so the <Image> component (web + native) can load
+// attachments without auth headers and without relying on the
+// API-relative `/p2ptax/<key>` proxy. Why presign on every fetch:
+//
+//   - Stored DB url is `/<bucket>/<key>` (a relative path). On web the
+//     RN `<Image>` resolves that relative to the page origin (Expo dev
+//     port 8081), 404'ing instead of hitting the API proxy on 3812.
+//   - Presigned URLs are absolute https://<minio-host>/... — they work
+//     identically on web, iOS, Android.
+//   - 1-hour TTL means thumbnails never go stale within a session.
+async function presignAttachmentUrl(storedUrl: string): Promise<string> {
+  if (storedUrl.startsWith("http")) return storedUrl;
+  const withoutLeadingSlash = storedUrl.replace(/^\/+/, "");
+  const prefix = `${MINIO_BUCKET}/`;
+  const key = withoutLeadingSlash.startsWith(prefix)
+    ? withoutLeadingSlash.slice(prefix.length)
+    : withoutLeadingSlash;
+  try {
+    return await minioClient.presignedGetObject(MINIO_BUCKET, key, 60 * 60);
+  } catch {
+    return storedUrl; // graceful fallback — better a broken thumb than 500
+  }
+}
+
 const messageRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 30,
@@ -304,11 +328,20 @@ router.get("/:threadId", authMiddleware, async (req: Request, res: Response) => 
     }
 
     const result = await Promise.all(
-      messages.map(async (m) => ({
-        ...m,
-        sender: { ...m.sender, avatarUrl: await presignAvatarUrl(m.sender.avatarUrl) },
-        files: filesByMessage[m.id] || [],
-      }))
+      messages.map(async (m) => {
+        const rawFiles = filesByMessage[m.id] || [];
+        const signedFiles = await Promise.all(
+          rawFiles.map(async (f) => ({
+            ...f,
+            url: await presignAttachmentUrl(f.url),
+          }))
+        );
+        return {
+          ...m,
+          sender: { ...m.sender, avatarUrl: await presignAvatarUrl(m.sender.avatarUrl) },
+          files: signedFiles,
+        };
+      })
     );
 
     if (!paginated) {
@@ -523,11 +556,20 @@ router.post("/:threadId", authMiddleware, messageRateLimiter, async (req: Reques
       });
     }).catch((err: Error) => console.warn("[email] new_message email failed:", err.message));
 
+    // Presign attachment URLs so the FE can render them in <Image> /
+    // <a download> without prefixing API_URL or adding auth headers.
+    const signedSavedFiles = await Promise.all(
+      savedFiles.map(async (f) => ({
+        ...f,
+        url: await presignAttachmentUrl(f.url),
+      }))
+    );
+
     res.json({
       message: {
         ...message,
         sender: { ...message.sender, avatarUrl: await presignAvatarUrl(message.sender.avatarUrl) },
-        files: savedFiles,
+        files: signedSavedFiles,
       },
     });
   } catch (error) {

--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -167,10 +167,11 @@ export default function UnifiedInbox() {
         <View className="flex-1 items-center" style={{ width: "100%", overflow: "hidden" }}>
           <View
             className="flex-1 flex-row"
-            // House rule: two-pane outer caps at 960 (CLAUDE.md).
+            // CHAT EXCEPTION: messages benefit from full width — no maxWidth cap.
+            // All other authenticated screens use 960 (forms 720). See CLAUDE.md
+            // Layout House Rules row "Two-pane (messages)".
             style={{
               width: "100%",
-              maxWidth: isWide ? 960 : "100%",
               borderWidth: isWide ? 1 : 0,
               borderColor: colors.border,
               borderRadius: isWide ? 12 : 0,
@@ -217,8 +218,12 @@ export default function UnifiedInbox() {
                 <InlineChatView threadId={selectedThreadId} />
               ) : (
                 <MessengerEmptyPane
-                  title="Выберите диалог слева"
-                  hint={emptyPaneHint}
+                  title="Начните общение"
+                  hint={
+                    sorted.length > 0
+                      ? `Выберите ${isSpecialistUser ? "запрос клиента" : "переписку со специалистом"} слева, чтобы открыть чат.`
+                      : emptyPaneHint
+                  }
                   primary={emptyPanePrimary}
                   secondary={emptyPaneSecondary}
                 />

--- a/components/InlineChatView.tsx
+++ b/components/InlineChatView.tsx
@@ -12,7 +12,7 @@ import {
 } from "react-native";
 import { router } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
-import { FileText, ChevronRight } from "lucide-react-native";
+import { FileText, ChevronRight, MessageCircle } from "lucide-react-native";
 import MessageBubble from "@/components/MessageBubble";
 import ChatComposer, { type PendingFile } from "@/components/ChatComposer";
 import Lightbox, { type LightboxFile } from "@/components/files/Lightbox";
@@ -336,11 +336,32 @@ export default function InlineChatView({ threadId }: InlineChatViewProps) {
             ) : null
           }
           ListEmptyComponent={
-            <View className="flex-1 items-center justify-center py-16">
-              <FontAwesome name="comments-o" size={48} color={colors.textSecondary} />
-              <Text className="text-base font-medium mt-4" style={{ color: colors.textSecondary }}>Начните общение</Text>
-              <Text className="text-sm mt-1 text-center px-4" style={{ color: colors.textSecondary }}>
-                Напишите сообщение, чтобы начать диалог
+            <View className="flex-1 items-center justify-center py-16 px-6">
+              {/* On-brand empty state: soft accent circle (80×80) with the
+                  brand-color MessageCircle icon (32×32). Replaces the prior
+                  off-brand lucide/FontAwesome grey "comments-o" stock icon.
+                  Matches RequestsFeed empty-state design language. */}
+              <View
+                className="rounded-full items-center justify-center"
+                style={{
+                  width: 80,
+                  height: 80,
+                  backgroundColor: colors.accentSoft,
+                }}
+              >
+                <MessageCircle size={32} color={colors.accent} strokeWidth={2} />
+              </View>
+              <Text
+                className="text-lg font-bold text-center mt-4"
+                style={{ color: colors.text }}
+              >
+                Начните общение
+              </Text>
+              <Text
+                className="text-sm mt-2 text-center max-w-xs"
+                style={{ color: colors.textMuted, lineHeight: 20 }}
+              >
+                Напишите первое сообщение, чтобы начать диалог
               </Text>
             </View>
           }

--- a/components/MessageBubble.tsx
+++ b/components/MessageBubble.tsx
@@ -2,6 +2,19 @@ import { View, Text, Pressable, Image, Modal, TouchableOpacity } from "react-nat
 import { useState } from "react";
 import { File, FileText, Download, X } from "lucide-react-native";
 import { colors } from "@/lib/theme";
+import { API_URL } from "@/lib/api";
+
+/**
+ * Resolve a stored attachment URL to a fully-qualified URL the platform
+ * <Image>/<a> can fetch. Backend now presigns to absolute https URLs,
+ * but we keep the relative fallback so legacy bubbles (and the brief
+ * window between deploy + DB rewrite) still render.
+ */
+function resolveAttachmentUrl(url: string): string {
+  if (!url) return url;
+  if (url.startsWith("http")) return url;
+  return `${API_URL}${url.startsWith("/") ? "" : "/"}${url}`;
+}
 
 interface FileAttachment {
   id: string;
@@ -48,6 +61,7 @@ export default function MessageBubble({
   const docFiles = files.filter((f) => !isImage(f.mimeType));
 
   const handleImagePress = (url: string, filename: string) => {
+    // url is already resolved (caller passed `resolvedUri`). Forwarded as-is.
     if (onImagePress) {
       onImagePress(url, filename);
     } else {
@@ -101,23 +115,26 @@ export default function MessageBubble({
         }}
       >
         {/* Image thumbnails */}
-        {imageFiles.map((img) => (
-          <Pressable
-            accessibilityRole="button"
-            key={img.id}
-            accessibilityLabel={`Изображение ${img.filename}. Нажмите для просмотра.`}
-            onPress={() => handleImagePress(img.url, img.filename)}
-            className="mb-1"
-            style={({ pressed }) => [pressed && { opacity: 0.85 }]}
-          >
-            <Image
-              source={{ uri: img.url }}
-              style={{ width: 200, height: 200, borderRadius: 12 }}
-              resizeMode="cover"
-              accessibilityLabel={img.filename}
-            />
-          </Pressable>
-        ))}
+        {imageFiles.map((img) => {
+          const resolvedUri = resolveAttachmentUrl(img.url);
+          return (
+            <Pressable
+              accessibilityRole="button"
+              key={img.id}
+              accessibilityLabel={`Изображение ${img.filename}. Нажмите для просмотра.`}
+              onPress={() => handleImagePress(resolvedUri, img.filename)}
+              className="mb-1"
+              style={({ pressed }) => [pressed && { opacity: 0.85 }]}
+            >
+              <Image
+                source={{ uri: resolvedUri }}
+                style={{ width: 200, height: 200, borderRadius: 12 }}
+                resizeMode="cover"
+                accessibilityLabel={img.filename}
+              />
+            </Pressable>
+          );
+        })}
 
         {/* Document files */}
         {docFiles.map((file) => (

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -61,22 +61,32 @@ export default function Avatar({
   const ink = inkColor ?? colors.white;
 
   if (imageUrl) {
+    // Web rendering bug: when `border-radius: 9999` is applied only to the
+    // outer wrapper (with overflow:hidden) the inner <img> can still bleed
+    // square corners on certain DPR/browser combos — the avatar reads
+    // "square". Fix: round BOTH the wrapper AND the inner image, and shrink
+    // the image by `borderWidth*2` so it fits inside the bordered box
+    // (instead of overflowing it and being clipped by overflow:hidden).
+    const borderW = 2;
+    const inner = wh - borderW * 2;
     return (
       <View
         style={{
           width: wh,
           height: wh,
-          borderRadius: 9999,
+          borderRadius: wh / 2,
           overflow: "hidden",
-          borderWidth: 2,
+          borderWidth: borderW,
           borderColor: colors.border,
           backgroundColor: colors.background,
+          alignItems: "center",
+          justifyContent: "center",
         }}
       >
         <Image
           source={{ uri: imageUrl }}
           accessibilityLabel={name}
-          style={{ width: wh, height: wh }}
+          style={{ width: inner, height: inner, borderRadius: inner / 2 }}
         />
       </View>
     );


### PR DESCRIPTION
Four user-reported issues addressed in one branch.

## TASK 1 — Messages full-width

Reverted the 960px cap from PR #1711 — chat is the **only** authenticated
screen that benefits from full width. CLAUDE.md Layout House Rules table
updated: `Two-pane (messages)` row now `none` (no maxWidth) with a paragraph
explaining the exception.

- `app/(tabs)/messages.tsx:172-181` — removed `maxWidth: isWide ? 960 : "100%"` line, replaced with comment explaining chat exception.
- `CLAUDE.md` — updated table + added rationale paragraph.

## TASK 2 — Round avatars

Real bug was in `components/ui/Avatar.tsx`: the wrapper had `borderRadius:9999`
+ `overflow:hidden` + `borderWidth:2`, but the inner `<Image>` had no
borderRadius and was sized to the full wrapper width. On certain web
DPR/browser combos the image bleeds square corners past the rounded outer
border.

Fix: round BOTH layers AND shrink the inner image by `borderWidth*2` so it
fits inside the bordered box (instead of overflowing it and being clipped by
overflow:hidden).

- `components/ui/Avatar.tsx:63-87` — round both layers, fit inner.

## TASK 3 — On-brand empty state

In-chat ListEmptyComponent replaced its off-brand grey FontAwesome `comments-o`
with the planned **Option A**: 80×80 `accent-soft` circle + accent-color
`MessageCircle` lucide icon (32×32). Linear/Notion style. Title + subtitle
restyled to match `RequestsFeed` empty-state design language.

Also updated `MessengerEmptyPane` title from "Выберите диалог слева" →
"Начните общение" so all empty states use the same hero phrase.

- `components/InlineChatView.tsx` — soft accent circle empty state.
- `app/(tabs)/messages.tsx` — empty pane title.

## TASK 4 — Attachment preview/download (THE HARD ONE)

**Root cause**: `GET /api/messages/:threadId` returned attachment URLs as
raw stored paths (`/p2ptax/<key>`). On web the RN `<Image>` resolves a
relative URL against the **page origin** (Expo dev :8081), which 404s
because the MinIO proxy lives on the API on :3812. Lightbox worked because
`useLightbox` already prepends `API_URL`; the inline thumbnail in
`MessageBubble` did not — that's why "preview doesn't show" but click
into lightbox did try to load (just, again, against the wrong origin
unless the proxy was reachable).

**Fix**: server now presigns every attachment URL on every fetch — 1-hour
TTL keeps it fresh within a session. Same approach already used for
`/api/threads/my` last-message attachments. Now `<Image>` gets absolute
`https://<minio-host>/...` URLs that work identically on web, iOS, and
Android — no API_URL prefixing, no auth headers, no proxy hop.

**Defense in depth**: `components/MessageBubble.tsx` got a
`resolveAttachmentUrl()` helper so legacy bubbles in flight (and any race
between deploy and DB rewrite) still resolve correctly.

- `api/src/routes/messages.ts` — added `presignAttachmentUrl()`, applied to GET + POST file results.
- `components/MessageBubble.tsx` — defensive `resolveAttachmentUrl` fallback for image thumbnails.

## TSC

- `npx tsc --noEmit` (frontend): 0 errors
- `cd api && npx tsc --noEmit`: 0 errors

## Test plan

- [ ] Open `/(tabs)/messages` on a 1440-px desktop → two-pane fills viewport minus sidebar (no 960 cap).
- [ ] Avatar in thread list and in chat header reads as a perfect circle on web (no square corners on Slavic landing portraits).
- [ ] Empty chat (selected thread with no messages) shows soft accent circle + MessageCircle icon, not grey FontAwesome.
- [ ] Send an image attachment in chat → thumbnail renders inline.
- [ ] Click thumbnail → lightbox opens fullscreen.
- [ ] Click download in lightbox → file downloads on web (`<a download>`) / opens in native browser.
- [ ] Send a PDF/doc attachment → file chip shows, click triggers lightbox with download CTA.